### PR TITLE
Fix disappearing notifications bug

### DIFF
--- a/functions/push-notification-with-fcm/src/main.js
+++ b/functions/push-notification-with-fcm/src/main.js
@@ -176,6 +176,7 @@ export default async ({ req, res, log, error }) => {
       const response = await sendPushNotification({
         notification: notification,
         data: {
+          $id: req.body.$id,
           roomId: roomId,
         },
         apns: {

--- a/functions/visit-notifications/src/main.js
+++ b/functions/visit-notifications/src/main.js
@@ -150,6 +150,7 @@ export default async ({ req, res, log, error }) => {
       const response = await sendPushNotification({
         notification: notification,
         data: {
+          $id: req.body.$id,
           userId: sender,
         },
         apns: {

--- a/src/app/components/chat-box/chat-box.component.ts
+++ b/src/app/components/chat-box/chat-box.component.ts
@@ -24,6 +24,7 @@ import {
 } from '@angular/core';
 
 import { MessageService } from 'src/app/services/chat/message.service';
+import { FcmService } from 'src/app/services/fcm/fcm.service';
 import { PreviewPhotoComponent } from 'src/app/components/preview-photo/preview-photo.component';
 import { urlify } from 'src/app/extras/utils';
 import { Message } from 'src/app/models/Message';
@@ -66,6 +67,7 @@ export class ChatBoxComponent implements OnInit, OnChanges {
   constructor(
     private store: Store,
     private messageService: MessageService,
+    private fcmService: FcmService,
     private modalCtrl: ModalController,
     private toastController: ToastController,
     private changeDetectorRef: ChangeDetectorRef,
@@ -328,6 +330,9 @@ export class ChatBoxComponent implements OnInit, OnChanges {
         };
         // Dispatch action to update message seen status
         this.store.dispatch(updateMessageAction({ request }));
+
+        // Delete local notification if exists
+        this.fcmService.deleteNotificationById(this.msg.$id);
       }
     }
   }

--- a/src/app/components/visit-list/visit-list.component.ts
+++ b/src/app/components/visit-list/visit-list.component.ts
@@ -3,6 +3,8 @@ import { Observable } from 'rxjs';
 import { Router } from '@angular/router';
 
 import { UserService } from 'src/app/services/user/user.service';
+import { FcmService } from 'src/app/services/fcm/fcm.service';
+
 import { Visit } from 'src/app/models/Visit';
 import { User } from 'src/app/models/User';
 import {
@@ -28,6 +30,7 @@ export class VisitListComponent implements OnInit {
   constructor(
     private route: Router,
     private userService: UserService,
+    private fcmService: FcmService,
     private el: ElementRef
   ) {}
 
@@ -60,23 +63,10 @@ export class VisitListComponent implements OnInit {
 
   handleIntersect(entry) {
     if (entry.isIntersecting) {
-      console.log('Intersecting: ', this.item.from.$id);
+      // console.log('Intersecting: ', this.item.from.$id);
+      // Delete local notification if exists
+      this.fcmService.deleteNotificationById(this.item.$id);
     }
-    // if (entry.isIntersecting) {
-    //   if (this.msg.to === this.current_user_id && this.msg.seen === false) {
-    //     const request: updateMessageRequestInterface = {
-    //       $id: this.msg.$id,
-    //       data: {
-    //         seen: true,
-    //       },
-    //     };
-    //     // Dispatch action to update message seen status
-    //     this.store.dispatch(updateMessageAction({ request }));
-
-    //     // Delete local notification if exists
-    //     this.fcmService.deleteNotificationById(this.msg.$id);
-    //   }
-    // }
   }
 
   exactDateAndTime(d: any) {

--- a/src/app/components/visit-list/visit-list.component.ts
+++ b/src/app/components/visit-list/visit-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, ElementRef, Input, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Router } from '@angular/router';
 
@@ -20,10 +20,28 @@ import {
 export class VisitListComponent implements OnInit {
   @Input() item: Visit;
 
+  private observer: IntersectionObserver;
+
   user: User;
   profilePic$: Observable<URL> = null;
 
-  constructor(private route: Router, private userService: UserService) {}
+  constructor(
+    private route: Router,
+    private userService: UserService,
+    private el: ElementRef
+  ) {}
+
+  ngAfterViewInit() {
+    // This is for the seen action when the message is in view
+    this.observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => this.handleIntersect(entry));
+    });
+    this.observer.observe(this.el.nativeElement);
+  }
+
+  ngAfterViewLeave() {
+    this.observer.disconnect();
+  }
 
   ngOnInit() {
     this.user = this.item.from;
@@ -39,6 +57,27 @@ export class VisitListComponent implements OnInit {
   //
   // Utils
   //
+
+  handleIntersect(entry) {
+    if (entry.isIntersecting) {
+      console.log('Intersecting: ', this.item.from.$id);
+    }
+    // if (entry.isIntersecting) {
+    //   if (this.msg.to === this.current_user_id && this.msg.seen === false) {
+    //     const request: updateMessageRequestInterface = {
+    //       $id: this.msg.$id,
+    //       data: {
+    //         seen: true,
+    //       },
+    //     };
+    //     // Dispatch action to update message seen status
+    //     this.store.dispatch(updateMessageAction({ request }));
+
+    //     // Delete local notification if exists
+    //     this.fcmService.deleteNotificationById(this.msg.$id);
+    //   }
+    // }
+  }
 
   exactDateAndTime(d: any) {
     if (!d) return null;

--- a/src/app/services/fcm/fcm.service.ts
+++ b/src/app/services/fcm/fcm.service.ts
@@ -154,12 +154,6 @@ export class FcmService {
     );
   }
 
-  // Example method for managing push notifications
-  async getDeliveredNotifications() {
-    const notificationList =
-      await PushNotifications.getDeliveredNotifications();
-  }
-
   async deleteNotificationById(dataId: string) {
     const notificationList =
       await PushNotifications.getDeliveredNotifications();

--- a/src/app/services/fcm/fcm.service.ts
+++ b/src/app/services/fcm/fcm.service.ts
@@ -158,7 +158,24 @@ export class FcmService {
   async getDeliveredNotifications() {
     const notificationList =
       await PushNotifications.getDeliveredNotifications();
-    console.log('delivered notifications', notificationList);
+  }
+
+  async deleteNotificationById(dataId: string) {
+    const notificationList =
+      await PushNotifications.getDeliveredNotifications();
+
+    // Find the notification with the specified data.$id
+    const notification = notificationList.notifications.find(
+      (notification) => notification.data.$id === dataId
+    );
+
+    if (notification) {
+      // If the notification is found, delete it
+      await PushNotifications.removeDeliveredNotifications({
+        notifications: [notification],
+      });
+      // console.log(`Notification with data.$id ${dataId} has been deleted.`);
+    }
   }
 
   handleTokenForIOS(token: Token) {


### PR DESCRIPTION
This pull request fixes the bug where notifications for read messages do not disappear. It includes changes to the deleteNotificationById method in FcmService, the IntersectionObserver in VisitListComponent, and the getDeliveredNotifications method in FcmService. Fixes #506.