### PR TITLE
Fix empty chat page bug

### DIFF
--- a/src/app/store/reducers/message.reducer.ts
+++ b/src/app/store/reducers/message.reducer.ts
@@ -133,6 +133,9 @@ const messageReducer = createReducer(
       (msg) => msg.$id === action.payload.$id
     );
 
+    // Check if there is any room in the state
+    if (!state.room) return { ...state };
+
     return {
       ...state,
       isLoading: false,


### PR DESCRIPTION
This pull request fixes the bug where the chat page is empty. The bug occurs when a user sends a message and quickly clicks back before the message is delivered, and then tries to open another room. The fix checks if there is any room in the state before updating the messages in the room. This ensures that the messages are properly displayed in the chat page. Fixes #468.