### PR TITLE
: Add Badges Documentation Link to Badges Section within the App

### DIFF
--- a/src/app/components/profile/badges-card/badges-card.component.html
+++ b/src/app/components/profile/badges-card/badges-card.component.html
@@ -11,7 +11,10 @@
           *ngFor="let badge of badgesList"
           class="ion-justify-content-center"
         >
-          <ion-card-content class="badge-content">
+          <ion-card-content
+            class="badge-content"
+            (click)="openPage(badge['pageURL'])"
+          >
             <img [src]="badge['url']" class="badge-image" />
             <p class="badge-text ion-padding-top">{{ badge["name"] }}</p>
           </ion-card-content>

--- a/src/app/components/profile/badges-card/badges-card.component.ts
+++ b/src/app/components/profile/badges-card/badges-card.component.ts
@@ -1,3 +1,4 @@
+import { Browser } from '@capacitor/browser';
 import { isEqual } from 'lodash';
 import {
   Component,
@@ -6,6 +7,8 @@ import {
   OnInit,
   SimpleChanges,
 } from '@angular/core';
+
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-badges-card',
@@ -39,7 +42,16 @@ export class BadgesCardComponent implements OnInit, OnChanges {
         .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
         .join(' ');
 
-      return { name, url: `/assets/image/badges/${badge}.png` };
+      return {
+        name,
+        url: `/assets/image/badges/${badge}.png`,
+        pageURL: `${environment.ext.token.LITEPAPER}/litepaper/welcome/badges#${badge}-badge`,
+      };
     });
+  }
+
+  async openPage(pageURL: any) {
+    console.log(pageURL);
+    await Browser.open({ url: pageURL });
   }
 }


### PR DESCRIPTION
This pull request adds a link to the badges documentation within the badges section of the app. This allows users to easily access relevant documentation when interacting with badges. The link directs users to the [badges documentation](https://docs.langx.io/litepaper/welcome/badges).

Fixes #707