### PR TITLE
Convert user birthdate to age in user.page

### DIFF
--- a/src/app/components/profile/aboutme-card/aboutme-card.component.html
+++ b/src/app/components/profile/aboutme-card/aboutme-card.component.html
@@ -26,7 +26,7 @@
       </ion-item>
       <ion-item>
         <ion-icon name="calendar-number-outline"></ion-icon>
-        <ion-label>{{ user?.birthdate | date : "dd/MM/YYYY" }}</ion-label>
+        <ion-label>{{ getAge(user?.birthdate) }} years old</ion-label>
       </ion-item>
       <ion-item>
         <ion-icon name="time-outline"></ion-icon>

--- a/src/app/components/profile/aboutme-card/aboutme-card.component.ts
+++ b/src/app/components/profile/aboutme-card/aboutme-card.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { getFlagEmoji, lastSeenExt } from 'src/app/extras/utils';
+import { getAge, getFlagEmoji, lastSeenExt } from 'src/app/extras/utils';
 import { Account } from 'src/app/models/Account';
 import { User } from 'src/app/models/User';
 
@@ -42,5 +42,9 @@ export class AboutmeCardComponent implements OnInit {
 
   getFlagEmoji(item: User) {
     return getFlagEmoji(item);
+  }
+
+  getAge(date: Date) {
+    return getAge(date);
   }
 }


### PR DESCRIPTION
The user's birthdate is not being converted to their age on the user page. This pull request fixes the issue by adding a function to calculate the user's age based on their birthdate and displaying it on the user page. Fixes #712.