### PR TITLE
Fix blocking user for v0.9.x registered users

### DIFF
--- a/src/app/services/user/user.service.ts
+++ b/src/app/services/user/user.service.ts
@@ -352,25 +352,17 @@ export class UserService {
 
   blockUser(currentUser: User, userId: string): Observable<User> {
     return from(
-      this.api.updateDocument(
-        environment.appwrite.USERS_COLLECTION,
-        currentUser.$id,
-        {
-          blockedUsers: [...currentUser?.blockedUsers, userId],
-        }
-      )
+      this.updateUserDoc({
+        blockedUsers: [...currentUser?.blockedUsers, userId],
+      })
     );
   }
 
   unBlockUser(currentUser: User, userId: string): Observable<User> {
     return from(
-      this.api.updateDocument(
-        environment.appwrite.USERS_COLLECTION,
-        currentUser.$id,
-        {
-          blockedUsers: currentUser.blockedUsers.filter((id) => id !== userId),
-        }
-      )
+      this.updateUserDoc({
+        blockedUsers: currentUser.blockedUsers.filter((id) => id !== userId),
+      })
     );
   }
 


### PR DESCRIPTION
This pull request fixes the issue where users with v0.9.x registered accounts are unable to block other users. The bug prevented the blocking action and displayed an error message. This pull request updates the `UserService` to properly handle the blocking and unblocking of users for v0.9.x registered accounts. The changes include updating the `blockUser` and `unBlockUser` methods to correctly update the `blockedUsers` array in the user document. This fix ensures that users with v0.9.x registered accounts can effectively manage their interactions with other users on the platform.