### PR TITLE
Move emails to new domain langx.io from languagexchange.net

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-support@languageXchange.net.
+hi@langx.io.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -106,7 +106,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 The following versions of our project are currently being supported with security updates:
 
-| Version | Supported          |
-| ------- | ------------------ |
+| Version          | Supported          |
+| ---------------- | ------------------ |
 | Angular 16.x.x   | :white_check_mark: |
 | Angular < 16.0   | :x:                |
 | TypeScript 5.x.x | :white_check_mark: |
@@ -15,8 +15,8 @@ The following versions of our project are currently being supported with securit
 
 ## Reporting a Vulnerability
 
-If you discover a vulnerability in our project, please send an email to info@languageXchange.net. 
+If you discover a vulnerability in our project, please send an email to hi@langx.io.
 
-After reporting, you can expect to receive an update from us within a week. We will evaluate the reported vulnerability and determine whether it is applicable and severe. 
+After reporting, you can expect to receive an update from us within a week. We will evaluate the reported vulnerability and determine whether it is applicable and severe.
 
 If the vulnerability is accepted, we will work on a fix and release it as part of our next security update. If the vulnerability is declined, we will provide an explanation as to why it was not considered a valid vulnerability.

--- a/src/app/pages/home/profile/settings/account/account.page.ts
+++ b/src/app/pages/home/profile/settings/account/account.page.ts
@@ -222,8 +222,7 @@ export class AccountPage implements OnInit {
   async presentErrorAlertAfterDelete() {
     const alert = await this.alertController.create({
       header: 'Information',
-      message:
-        'Please send your deletion request via email to info@languageXchange.net',
+      message: 'Please send your deletion request via email to hi@langx.io',
       buttons: ['OK'],
     });
 


### PR DESCRIPTION
🚀 This pull request migrates all existing emails associated with our organization from the languagexchange.net domain to the new domain langx.io. This includes transferring all email accounts, aliases, and mailing lists seamlessly to the new domain. This migration will better represent our brand and improve user experience. Fixes #654.