### PR TITLE
Fix scrolling bug and improve chat scrolling behavior

### DIFF
--- a/src/app/pages/home/messages/chat/chat.page.ts
+++ b/src/app/pages/home/messages/chat/chat.page.ts
@@ -1,15 +1,3 @@
-import { ActivatedRoute, Router } from '@angular/router';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { Store, select } from '@ngrx/store';
-import { Observable, Subscription, from, take } from 'rxjs';
-import { Capacitor } from '@capacitor/core';
-import { Keyboard } from '@capacitor/keyboard';
-import { Filesystem, Directory, FileInfo } from '@capacitor/filesystem';
-import { RecordingData, VoiceRecorder } from '@langx/capacitor-voice-recorder';
-import { Camera, CameraResultType, CameraSource } from '@capacitor/camera';
-import { Haptics, ImpactStyle } from '@capacitor/haptics';
-import { v4 as uuidv4 } from 'uuid';
-import Compressor from 'compressorjs';
 import {
   Component,
   ElementRef,
@@ -24,6 +12,19 @@ import {
   IonTextarea,
   ToastController,
 } from '@ionic/angular';
+import { ActivatedRoute, Router } from '@angular/router';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { Store, select } from '@ngrx/store';
+import { Observable, Subscription, from, debounceTime, of } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { Capacitor } from '@capacitor/core';
+import { Keyboard } from '@capacitor/keyboard';
+import { Filesystem, Directory, FileInfo } from '@capacitor/filesystem';
+import { RecordingData, VoiceRecorder } from '@langx/capacitor-voice-recorder';
+import { Camera, CameraResultType, CameraSource } from '@capacitor/camera';
+import { Haptics, ImpactStyle } from '@capacitor/haptics';
+import { v4 as uuidv4 } from 'uuid';
+import Compressor from 'compressorjs';
 
 // Interface Imports
 import { Message } from 'src/app/models/Message';
@@ -120,6 +121,7 @@ export class ChatPage implements OnInit, OnDestroy {
   async ngOnInit() {
     this.initValues();
     this.initForm();
+    this.initKeyboardListeners();
   }
 
   ngAfterViewInit() {
@@ -150,21 +152,6 @@ export class ChatPage implements OnInit, OnDestroy {
     this.isLoading_offset$ = this.store.pipe(select(isLoadingOffsetSelector));
     this.messages$ = this.store.pipe(select(messagesSelector));
     this.total$ = this.store.pipe(select(totalSelector));
-
-    if (Capacitor.getPlatform() !== 'web') {
-      // Scroll to bottom when keyboard is shown
-      Keyboard.addListener('keyboardDidShow', (info) => {
-        // console.log('keyboard did show with height:', info.keyboardHeight);
-        setTimeout(() => {
-          this.content.scrollToBottom(300);
-        }, 100);
-      });
-
-      // Keyboard.addListener('keyboardDidHide', () => {
-      //   // console.log('keyboard did hide');
-      //   this.content.scrollToBottom(300);
-      // });
-    }
   }
 
   initForm() {
@@ -228,6 +215,22 @@ export class ChatPage implements OnInit, OnDestroy {
     );
   }
 
+  initKeyboardListeners() {
+    if (Capacitor.getPlatform() !== 'web') {
+      // Scroll to bottom when keyboard is shown
+      Keyboard.addListener('keyboardDidShow', (info) => {
+        console.log('keyboard did show with height:', info.keyboardHeight);
+        setTimeout(() => {
+          this.content.scrollToBottom(300);
+        }, 100);
+      });
+
+      Keyboard.addListener('keyboardDidHide', () => {
+        console.log('keyboard did hide');
+        this.content.scrollToBottom(300);
+      });
+    }
+  }
   //
   // Form Submit
   //

--- a/src/app/pages/home/messages/chat/chat.page.ts
+++ b/src/app/pages/home/messages/chat/chat.page.ts
@@ -179,14 +179,16 @@ export class ChatPage implements OnInit, OnDestroy {
       this.room$.subscribe((room) => {
         if (room != null) {
           this.subscriptions.add(
-            this.isUserAtBottom().subscribe((isAtBottom) => {
-              if (isAtBottom || this.isFirstLoad) {
-                // Wait for the view to update then scroll to bottom
-                setTimeout(() => {
-                  this.content.scrollToBottom(300);
-                }, 0);
-              }
-            })
+            this.isUserAtBottom()
+              .pipe(debounceTime(300))
+              .subscribe((isAtBottom) => {
+                if (isAtBottom || this.isFirstLoad) {
+                  // Wait for the view to update then scroll to bottom
+                  setTimeout(() => {
+                    this.content.scrollToBottom(300);
+                  }, 0);
+                }
+              })
           );
         }
       })
@@ -231,6 +233,7 @@ export class ChatPage implements OnInit, OnDestroy {
       });
     }
   }
+
   //
   // Form Submit
   //
@@ -793,7 +796,7 @@ export class ChatPage implements OnInit, OnDestroy {
   //
 
   isUserAtBottom(): Observable<boolean> {
-    return from(this.checkIfUserAtBottom());
+    return from(this.checkIfUserAtBottom()).pipe(debounceTime(300)); // Throttle the calls
   }
 
   async checkIfUserAtBottom(): Promise<boolean> {


### PR DESCRIPTION
This pull request fixes a scrolling bug that occurs after version 0.9.25 when opening a room. The scroll position behaves unexpectedly, making it difficult to navigate. Additionally, it improves the chat scrolling behavior by introducing a debounce time of 300 milliseconds to the isUserAtBottom() method. This prevents excessive scrolling and improves performance when new messages are received.

Fixes #743