### PR TITLE
Add Copilot Maintenance Mode functionality

### DIFF
--- a/src/app/pages/home/messages/chat/chat.page.ts
+++ b/src/app/pages/home/messages/chat/chat.page.ts
@@ -285,13 +285,19 @@ export class ChatPage implements OnInit, OnDestroy {
   copilotToggle(event: any) {
     this.user$.pipe(take(1)).subscribe((user) => {
       this.room$.pipe(take(1)).subscribe(async (room) => {
-        // Check Copilot Maintenance Mode Firstly
-        const copilotMaintenance =
-          await this.updateService.checkCopilotMaintenance();
-        if (copilotMaintenance) {
-          // If maintenance mode is enabled, show the alert and return early
-          await this.updateService.showCopilotMaintenance();
-          return;
+        // Check if the user is trying to activate Copilot
+        if (event.detail.checked) {
+          const copilotMaintenance =
+            await this.updateService.checkCopilotMaintenance();
+          if (copilotMaintenance) {
+            // If maintenance mode is enabled, show the alert and return early
+            await this.updateService.showCopilotMaintenance();
+            // Update Copilot Toggle
+            this.currentUser$.pipe(take(1)).subscribe(async (currentUser) => {
+              this.copilotEnabled = room?.copilot.includes(currentUser.$id);
+            });
+            return;
+          }
         }
 
         const request: updateRoomRequestInterface = {

--- a/src/app/pages/home/messages/chat/chat.page.ts
+++ b/src/app/pages/home/messages/chat/chat.page.ts
@@ -48,6 +48,7 @@ import { RoomExtendedInterface } from 'src/app/models/types/roomExtended.interfa
 
 // Service Imports
 import { UserService } from 'src/app/services/user/user.service';
+import { UpdateService } from 'src/app/services/update/update.service';
 
 // Selector and Action Imports
 import { currentUserSelector } from 'src/app/store/selectors/auth.selector';
@@ -133,6 +134,7 @@ export class ChatPage implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private router: Router,
     private userService: UserService,
+    private updateService: UpdateService,
     private toastController: ToastController,
     private gestureCtrl: GestureController
   ) {}
@@ -282,7 +284,16 @@ export class ChatPage implements OnInit, OnDestroy {
 
   copilotToggle(event: any) {
     this.user$.pipe(take(1)).subscribe((user) => {
-      this.room$.pipe(take(1)).subscribe((room) => {
+      this.room$.pipe(take(1)).subscribe(async (room) => {
+        // Check Copilot Maintenance Mode Firstly
+        const copilotMaintenance =
+          await this.updateService.checkCopilotMaintenance();
+        if (copilotMaintenance) {
+          // If maintenance mode is enabled, show the alert and return early
+          await this.updateService.showCopilotMaintenance();
+          return;
+        }
+
         const request: updateRoomRequestInterface = {
           roomId: this.roomId,
           data: { copilot: event.detail.checked },

--- a/src/app/services/update/update.service.ts
+++ b/src/app/services/update/update.service.ts
@@ -25,6 +25,10 @@ interface AppUpdate {
   };
 }
 
+interface CopilotUpdate {
+  maintenance_enabled: boolean;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -34,7 +38,6 @@ export class UpdateService {
   constructor(private AlertController: AlertController) {}
 
   checkForUpdates() {
-    // console.log('checkForUpdates');
     this.checkUpdate();
   }
 
@@ -54,6 +57,17 @@ export class UpdateService {
     } else {
       return;
     }
+  }
+
+  async checkCopilotMaintenance(): Promise<boolean> {
+    const endpoint = `${this.updateEndpoint}/copilot`;
+    const response = await fetch(endpoint);
+    const data = (await response.json()) as CopilotUpdate;
+
+    if (data.maintenance_enabled) {
+      return true;
+    }
+    return false;
   }
 
   async checkPlatformUpdate(platformPath: string) {
@@ -101,6 +115,21 @@ export class UpdateService {
       header: data.maintenace_msg.title,
       message: data.maintenace_msg.message,
       backdropDismiss: false, // prevent alert from being dismissed
+    });
+    await alert.present();
+  }
+
+  async showCopilotMaintenance() {
+    const alert = await this.AlertController.create({
+      header: 'Maintenance Mode',
+      message:
+        'Copilot is currently under maintenance. Please try again later.',
+      buttons: [
+        {
+          text: 'Ok',
+          role: 'cancel',
+        },
+      ],
     });
     await alert.present();
   }


### PR DESCRIPTION
This pull request adds the Copilot Maintenance Mode functionality to the ChatPage component. It includes the UpdateService to handle Copilot maintenance mode and shows an alert if enabled. Additionally, it adds the functionality to toggle Copilot on and off, handling Copilot maintenance mode accordingly. This enhancement improves the user experience by providing control over Copilot and informing the user about maintenance mode.

Fixes #762