### PR TITLE
Fix issue with links becoming clickable

### DIFF
--- a/src/app/extras/utils.ts
+++ b/src/app/extras/utils.ts
@@ -203,7 +203,7 @@ export function urlify(text: string): Array<{ type: string; content: string }> {
   }
 
   var urlRegex =
-    /(\b(https?:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.[a-z]{2,}([-a-z0-9@:%_+.~#?&//=]*)\b)/gi;
+    /(\b(https?:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.(com|org|net|edu|gov|mil|int|co|io|info|biz|online|tech|xyz|app|site|club|dev|shop|store|media|tv|live|me|world|space|guru|today|news|digital|website|cloud|global|solutions|services|community|technology|systems|company|support|management|international|academy|school|email|finance|ventures|capital|partners|group|consulting|agency|events|gallery|marketing|design|photography|press|publishing)([-a-z0-9@:%_+.~#?&//=]*)?\b)/gi;
   let segments = [];
   let match;
   let lastIndex = 0;


### PR DESCRIPTION
Fixes issue #774

This pull request fixes the issue where anything connected with a dot becomes a clickable link. The problem was that the regular expression used to identify URLs was too permissive and allowed any domain extension. This could potentially lead to malicious links being created within our app.

To address this, the regular expression has been updated to only allow common domain extensions that are less likely to be associated with illegal or harmful content. This change ensures that links are not created for arbitrary text connected with a dot.

By making this fix, we are ensuring the safety and integrity of our app and protecting our users from potential risks associated with clickable links.

Please review and merge this pull request to resolve the issue.