### PR TITLE
Add leaderboard for Test LangX Token Wallets

### DIFF
--- a/src/app/components/components.module.ts
+++ b/src/app/components/components.module.ts
@@ -15,6 +15,9 @@ import { TimestampComponent } from './chat-box/timestamp/timestamp.component';
 import { CheckoutListComponent } from './checkout-list/checkout-list.component';
 import { WalletListComponent } from './wallet-list/wallet-list.component';
 
+// Pipes
+import { AppExtrasModule } from 'src/app/app.extras.module';
+
 @NgModule({
   declarations: [
     EmptyScreenComponent,
@@ -30,7 +33,7 @@ import { WalletListComponent } from './wallet-list/wallet-list.component';
     BlockedUserListComponent,
     TimestampComponent,
   ],
-  imports: [CommonModule, IonicModule],
+  imports: [CommonModule, IonicModule, AppExtrasModule],
   exports: [
     EmptyScreenComponent,
     Oauth2Component,

--- a/src/app/components/components.module.ts
+++ b/src/app/components/components.module.ts
@@ -13,6 +13,7 @@ import { VisitListComponent } from './visit-list/visit-list.component';
 import { StreakListComponent } from './streak-list/streak-list.component';
 import { TimestampComponent } from './chat-box/timestamp/timestamp.component';
 import { CheckoutListComponent } from './checkout-list/checkout-list.component';
+import { WalletListComponent } from './wallet-list/wallet-list.component';
 
 @NgModule({
   declarations: [
@@ -24,6 +25,7 @@ import { CheckoutListComponent } from './checkout-list/checkout-list.component';
     UserListComponent,
     VisitListComponent,
     StreakListComponent,
+    WalletListComponent,
     CheckoutListComponent,
     BlockedUserListComponent,
     TimestampComponent,
@@ -38,6 +40,7 @@ import { CheckoutListComponent } from './checkout-list/checkout-list.component';
     UserListComponent,
     VisitListComponent,
     StreakListComponent,
+    WalletListComponent,
     CheckoutListComponent,
     BlockedUserListComponent,
     TimestampComponent,

--- a/src/app/components/profile/token-distribution/token-distribution.component.html
+++ b/src/app/components/profile/token-distribution/token-distribution.component.html
@@ -24,6 +24,10 @@
           <!-- <ion-note>#{{getLeaderBoardOrder()}}</ion-note> -->
         </div>
       </ion-item>
+      <ion-item class="hasIcon" (click)="openTokenLeaderboard()" detail>
+        <ion-icon name="trophy-outline"></ion-icon>
+        <ion-label>Token Leaderboard</ion-label>
+      </ion-item>
     </ion-list>
   </ion-card-content>
 </ion-card>

--- a/src/app/components/profile/token-distribution/token-distribution.component.html
+++ b/src/app/components/profile/token-distribution/token-distribution.component.html
@@ -26,7 +26,7 @@
       </ion-item>
       <ion-item class="hasIcon" (click)="openTokenLeaderboard()" detail>
         <ion-icon name="trophy-outline"></ion-icon>
-        <ion-label>Token Leaderboard</ion-label>
+        <ion-label>Leaderboard</ion-label>
       </ion-item>
     </ion-list>
   </ion-card-content>

--- a/src/app/components/profile/token-distribution/token-distribution.component.html
+++ b/src/app/components/profile/token-distribution/token-distribution.component.html
@@ -10,7 +10,7 @@
   </ion-card-header>
   <ion-card-content>
     <ion-list>
-      <ion-item lines="none" (click)="openLeaderboard()" detail>
+      <ion-item lines="none" (click)="openTokenDetails()" detail>
         <ion-thumbnail slot="start">
           <img alt="Do not break the chain" src="/assets/image/token.png" />
         </ion-thumbnail>

--- a/src/app/components/profile/token-distribution/token-distribution.component.scss
+++ b/src/app/components/profile/token-distribution/token-distribution.component.scss
@@ -10,3 +10,10 @@ ion-thumbnail {
   justify-content: space-between;
   align-items: center;
 }
+
+.hasIcon ion-icon {
+  align-self: start;
+  margin-top: 10px;
+  margin-right: 29px;
+  color: var(--ion-color-primary);
+}

--- a/src/app/components/profile/token-distribution/token-distribution.component.ts
+++ b/src/app/components/profile/token-distribution/token-distribution.component.ts
@@ -58,9 +58,9 @@ export class TokenDistributionComponent implements OnInit {
     this.router.navigate(['/', 'home', 'token-details']);
   }
 
-  // openLeaderboard() {
-  //   this.router.navigate(['/', 'home', 'token-leaderboard']);
-  // }
+  openTokenLeaderboard() {
+    this.router.navigate(['/', 'home', 'token-leaderboard']);
+  }
 
   async openPage(pageURL: any) {
     console.log(pageURL);

--- a/src/app/components/profile/token-distribution/token-distribution.component.ts
+++ b/src/app/components/profile/token-distribution/token-distribution.component.ts
@@ -54,9 +54,13 @@ export class TokenDistributionComponent implements OnInit {
     this.wallet$ = this.store.pipe(select(walletSelector));
   }
 
-  openLeaderboard() {
+  openTokenDetails() {
     this.router.navigate(['/', 'home', 'token-details']);
   }
+
+  // openLeaderboard() {
+  //   this.router.navigate(['/', 'home', 'token-leaderboard']);
+  // }
 
   async openPage(pageURL: any) {
     console.log(pageURL);

--- a/src/app/components/wallet-list/wallet-list.component.html
+++ b/src/app/components/wallet-list/wallet-list.component.html
@@ -1,0 +1,1 @@
+<p>wallet-list works!</p>

--- a/src/app/components/wallet-list/wallet-list.component.html
+++ b/src/app/components/wallet-list/wallet-list.component.html
@@ -7,6 +7,6 @@
     </h2>
   </ion-label>
   <div class="metadata-end-wrapper" slot="end">
-    <h1>{{ item?.balance }}</h1>
+    <h1>{{ item?.balance | bigNumbers }}</h1>
   </div>
 </ion-item>

--- a/src/app/components/wallet-list/wallet-list.component.html
+++ b/src/app/components/wallet-list/wallet-list.component.html
@@ -1,1 +1,12 @@
-<p>wallet-list works!</p>
+<ion-item>
+  <h1 slot="start" style="min-width: 40px">{{ order }}.</h1>
+  <ion-label>
+    <h2>
+      <code>{{ item?.$id | slice : -10 }}</code>
+      <!-- <code>{{ item?.$id }}</code> -->
+    </h2>
+  </ion-label>
+  <div class="metadata-end-wrapper" slot="end">
+    <h1>{{ item?.balance }}</h1>
+  </div>
+</ion-item>

--- a/src/app/components/wallet-list/wallet-list.component.spec.ts
+++ b/src/app/components/wallet-list/wallet-list.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { WalletListComponent } from './wallet-list.component';
+
+describe('WalletListComponent', () => {
+  let component: WalletListComponent;
+  let fixture: ComponentFixture<WalletListComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [WalletListComponent],
+      imports: [IonicModule.forRoot()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WalletListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/wallet-list/wallet-list.component.ts
+++ b/src/app/components/wallet-list/wallet-list.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-wallet-list',
+  templateUrl: './wallet-list.component.html',
+  styleUrls: ['./wallet-list.component.scss'],
+})
+export class WalletListComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/src/app/components/wallet-list/wallet-list.component.ts
+++ b/src/app/components/wallet-list/wallet-list.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
+import { Wallet } from 'src/app/models/Wallet';
 
 @Component({
   selector: 'app-wallet-list',
@@ -6,6 +7,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./wallet-list.component.scss'],
 })
 export class WalletListComponent implements OnInit {
+  @Input() item: Wallet;
+  @Input() order: number;
+
   constructor() {}
 
   ngOnInit() {}

--- a/src/app/models/types/responses/listWalletResponse.interface.ts
+++ b/src/app/models/types/responses/listWalletResponse.interface.ts
@@ -1,6 +1,0 @@
-import { Wallet } from 'src/app/models/Wallet';
-
-export interface listWalletResponseInterface {
-  total: number;
-  documents: Wallet[];
-}

--- a/src/app/models/types/responses/listWalletsResponse.interface.ts
+++ b/src/app/models/types/responses/listWalletsResponse.interface.ts
@@ -1,0 +1,6 @@
+import { Wallet } from '../../Wallet';
+
+export interface listWalletsResponseInterface {
+  total: number;
+  documents: Wallet[];
+}

--- a/src/app/models/types/states/walletState.interface.ts
+++ b/src/app/models/types/states/walletState.interface.ts
@@ -4,5 +4,6 @@ import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
 export interface WalletStateInterface {
   isLoading: boolean;
   wallet: Wallet | null;
+  leaderboard: Wallet[] | null;
   error: ErrorInterface | null;
 }

--- a/src/app/pages/home/home-routing.module.ts
+++ b/src/app/pages/home/home-routing.module.ts
@@ -157,6 +157,13 @@ const routes: Routes = [
         (m) => m.BackersPageModule
       ),
   },
+  {
+    path: 'token-leaderboard',
+    loadChildren: () =>
+      import(
+        './profile/settings/token-leaderboard/token-leaderboard.module'
+      ).then((m) => m.TokenLeaderboardPageModule),
+  },
 ];
 
 @NgModule({

--- a/src/app/pages/home/profile/settings/leaderboard/leaderboard.page.html
+++ b/src/app/pages/home/profile/settings/leaderboard/leaderboard.page.html
@@ -3,7 +3,7 @@
     <ion-buttons slot="start">
       <ion-back-button defaultHref="home/profile"></ion-back-button>
     </ion-buttons>
-    <ion-title>Leaderboard 🏆</ion-title>
+    <ion-title>Streaks Leaderboard 🏆</ion-title>
   </ion-toolbar>
 </ion-header>
 

--- a/src/app/pages/home/profile/settings/leaderboard/leaderboard.page.ts
+++ b/src/app/pages/home/profile/settings/leaderboard/leaderboard.page.ts
@@ -4,9 +4,7 @@ import { Store, select } from '@ngrx/store';
 import { Observable, Subscription, take } from 'rxjs';
 
 import { Streak } from 'src/app/models/Streak';
-import { User } from 'src/app/models/User';
 import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
-import { currentUserSelector } from 'src/app/store/selectors/auth.selector';
 import {
   getStreaksAction,
   getStreaksWithOffsetAction,
@@ -27,7 +25,6 @@ import {
 export class LeaderboardPage implements OnInit {
   subscription: Subscription;
 
-  currentUser$: Observable<User | null> = null;
   isLoading$: Observable<boolean> = null;
   streaks$: Observable<Streak[] | null> = null;
   total$: Observable<number | null> = null;
@@ -62,7 +59,6 @@ export class LeaderboardPage implements OnInit {
   }
 
   initValues() {
-    this.currentUser$ = this.store.pipe(select(currentUserSelector));
     this.isLoading$ = this.store.pipe(select(isLoadingSelector));
     this.streaks$ = this.store.pipe(select(streaksSelector));
     this.total$ = this.store.pipe(select(totalSelector));

--- a/src/app/pages/home/profile/settings/leaderboard/leaderboard.page.ts
+++ b/src/app/pages/home/profile/settings/leaderboard/leaderboard.page.ts
@@ -81,7 +81,7 @@ export class LeaderboardPage implements OnInit {
     this.streaks$.pipe(take(1)).subscribe((visits) => {
       const offset = visits.length;
       this.total$.pipe(take(1)).subscribe((total) => {
-        if (offset < 100) {
+        if (offset < 50) {
           this.store.dispatch(
             getStreaksWithOffsetAction({
               request: {

--- a/src/app/pages/home/profile/settings/token-details/token-details.page.html
+++ b/src/app/pages/home/profile/settings/token-details/token-details.page.html
@@ -12,31 +12,6 @@
     <ion-refresher-content></ion-refresher-content>
   </ion-refresher>
 
-  <ion-card>
-    <ion-card-header>
-      <ion-card-title>How It Works?</ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <p style="font-size: larger">
-        <a (click)="openPage(twitter)"><strong>#Learn2Earn</strong></a>
-        with LangX
-      </p>
-      <ul style="font-size: larger">
-        <li>
-          A fixed daily amount of 10,000 tokens is available on the testnet.
-        </li>
-        <li>
-          In the future, the Smart Contract will determine the distribution of
-          tokens each day.
-        </li>
-        <li>
-          Tokens are distributed based on your
-          <a (click)="openPage(infoURL)">in-app activity</a>.
-        </li>
-      </ul>
-    </ion-card-content>
-  </ion-card>
-
   <ion-card *ngIf="(checkouts$ | async)?.length > 0">
     <ion-card-header>
       <ion-card-subtitle>LangX Tokens 🪙</ion-card-subtitle>

--- a/src/app/pages/home/profile/settings/token-details/token-details.page.ts
+++ b/src/app/pages/home/profile/settings/token-details/token-details.page.ts
@@ -1,10 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { Store, select } from '@ngrx/store';
-import { Browser } from '@capacitor/browser';
 import { ToastController } from '@ionic/angular';
 import { Observable, Subscription, take } from 'rxjs';
 
-import { environment } from 'src/environments/environment';
 import { User } from 'src/app/models/User';
 import { Wallet } from 'src/app/models/Wallet';
 import { Checkout } from 'src/app/models/Checkout';
@@ -30,10 +28,6 @@ import {
   styleUrls: ['./token-details.page.scss'],
 })
 export class TokenDetailsPage implements OnInit {
-  infoURL =
-    environment.ext.token.LITEPAPER + '/litepaper/token/distibution#formula';
-  twitter = environment.ext.token.TWITTER;
-
   subscription: Subscription;
 
   currentUser$: Observable<User | null> = null;
@@ -82,11 +76,6 @@ export class TokenDetailsPage implements OnInit {
   listCheckouts() {
     // Dispatch action to get all visits
     this.store.dispatch(getCheckoutsAction());
-  }
-
-  async openPage(pageURL: any) {
-    // console.log(pageURL);
-    await Browser.open({ url: pageURL });
   }
 
   //

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard-routing.module.ts
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { TokenLeaderboardPage } from './token-leaderboard.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: TokenLeaderboardPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class TokenLeaderboardPageRoutingModule {}

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.module.ts
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { TokenLeaderboardPageRoutingModule } from './token-leaderboard-routing.module';
+
+import { TokenLeaderboardPage } from './token-leaderboard.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    TokenLeaderboardPageRoutingModule,
+  ],
+  declarations: [TokenLeaderboardPage],
+})
+export class TokenLeaderboardPageModule {}

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.module.ts
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.module.ts
@@ -7,6 +7,7 @@ import { IonicModule } from '@ionic/angular';
 import { TokenLeaderboardPageRoutingModule } from './token-leaderboard-routing.module';
 
 import { TokenLeaderboardPage } from './token-leaderboard.page';
+import { ComponentsModule } from 'src/app/components/components.module';
 
 @NgModule({
   imports: [
@@ -14,6 +15,7 @@ import { TokenLeaderboardPage } from './token-leaderboard.page';
     FormsModule,
     IonicModule,
     TokenLeaderboardPageRoutingModule,
+    ComponentsModule,
   ],
   declarations: [TokenLeaderboardPage],
 })

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.html
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.html
@@ -45,8 +45,7 @@
     <ion-card-content>
       <ion-list>
         <ng-container *ngFor="let wallet of (wallets$ | async); let i = index">
-          {{ wallet.$id }} {{ wallet.balance }}
-          <!-- <app-streak-list [item]="wallet" [order]="i+1"></app-streak-list> -->
+          <app-wallet-list [item]="wallet" [order]="i+1"></app-wallet-list>
         </ng-container>
       </ion-list>
 

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.html
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.html
@@ -39,7 +39,7 @@
 
   <ion-card *ngIf="(wallets$ | async)?.length > 0">
     <ion-card-header>
-      <ion-card-subtitle> Top Token Holders 🏆 </ion-card-subtitle>
+      <ion-card-subtitle> Top LangX Test Token Holders 🏆 </ion-card-subtitle>
       <ion-card-title>Token Leaderboard 🏆</ion-card-title>
     </ion-card-header>
     <ion-card-content>

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.html
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.html
@@ -36,4 +36,49 @@
       </ul>
     </ion-card-content>
   </ion-card>
+
+  <ion-card *ngIf="(wallets$ | async)?.length > 0">
+    <ion-card-header>
+      <ion-card-subtitle> Top Token Holders 🏆 </ion-card-subtitle>
+      <ion-card-title>Token Leaderboard 🏆</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-list>
+        <ng-container *ngFor="let wallet of (wallets$ | async); let i = index">
+          {{ wallet.$id }} {{ wallet.balance }}
+          <!-- <app-streak-list [item]="wallet" [order]="i+1"></app-streak-list> -->
+        </ng-container>
+      </ion-list>
+
+      <!-------------------->
+      <!-- SKELETON start -->
+      <!-------------------->
+
+      <ion-list *ngIf="(isLoading$ | async)">
+        <ion-item *ngFor="let i of '0123456789'.split('')" detail>
+          <ion-thumbnail slot="start">
+            <ion-skeleton-text [animated]="true"></ion-skeleton-text>
+          </ion-thumbnail>
+          <ion-label>
+            <h3>
+              <ion-skeleton-text
+                [animated]="true"
+                style="width: 60%"
+              ></ion-skeleton-text>
+            </h3>
+            <p>
+              <ion-skeleton-text
+                [animated]="true"
+                style="width: 30%"
+              ></ion-skeleton-text>
+            </p>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+
+      <!------------------>
+      <!-- SKELETON end -->
+      <!------------------>
+    </ion-card-content>
+  </ion-card>
 </ion-content>

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.html
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.html
@@ -1,0 +1,13 @@
+<ion-header [translucent]="true">
+  <ion-toolbar>
+    <ion-title>token-leaderboard</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content [fullscreen]="true">
+  <ion-header collapse="condense">
+    <ion-toolbar>
+      <ion-title size="large">token-leaderboard</ion-title>
+    </ion-toolbar>
+  </ion-header>
+</ion-content>

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.html
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.html
@@ -54,10 +54,7 @@
       <!-------------------->
 
       <ion-list *ngIf="(isLoading$ | async)">
-        <ion-item *ngFor="let i of '0123456789'.split('')" detail>
-          <ion-thumbnail slot="start">
-            <ion-skeleton-text [animated]="true"></ion-skeleton-text>
-          </ion-thumbnail>
+        <ion-item *ngFor="let i of '0123456789'.split('')">
           <ion-label>
             <h3>
               <ion-skeleton-text

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.html
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.html
@@ -1,13 +1,39 @@
 <ion-header [translucent]="true">
   <ion-toolbar>
-    <ion-title>token-leaderboard</ion-title>
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="home/profile"></ion-back-button>
+    </ion-buttons>
+    <ion-title>Token Leaderboard 🏆</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content [fullscreen]="true">
-  <ion-header collapse="condense">
-    <ion-toolbar>
-      <ion-title size="large">token-leaderboard</ion-title>
-    </ion-toolbar>
-  </ion-header>
+  <ion-refresher slot="fixed" (ionRefresh)="handleRefresh($event)">
+    <ion-refresher-content></ion-refresher-content>
+  </ion-refresher>
+
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>How It Works?</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <p style="font-size: larger">
+        <a (click)="openPage(twitter)"><strong>#Learn2Earn</strong></a>
+        with LangX
+      </p>
+      <ul style="font-size: larger">
+        <li>
+          A fixed daily amount of 10,000 tokens is available on the testnet.
+        </li>
+        <li>
+          In the future, the Smart Contract will determine the distribution of
+          tokens each day.
+        </li>
+        <li>
+          Tokens are distributed based on your
+          <a (click)="openPage(infoURL)">in-app activity</a>.
+        </li>
+      </ul>
+    </ion-card-content>
+  </ion-card>
 </ion-content>

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.spec.ts
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.spec.ts
@@ -1,0 +1,17 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TokenLeaderboardPage } from './token-leaderboard.page';
+
+describe('TokenLeaderboardPage', () => {
+  let component: TokenLeaderboardPage;
+  let fixture: ComponentFixture<TokenLeaderboardPage>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TokenLeaderboardPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.ts
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.ts
@@ -2,10 +2,15 @@ import { Component, OnInit } from '@angular/core';
 import { Browser } from '@capacitor/browser';
 import { Observable, Subscription } from 'rxjs';
 import { ToastController } from '@ionic/angular';
-import { Store } from '@ngrx/store';
+import { Store, select } from '@ngrx/store';
 
 import { environment } from 'src/environments/environment';
 import { Wallet } from 'src/app/models/Wallet';
+import { listWalletsAction } from 'src/app/store/actions/wallet.action';
+import {
+  isLoadingSelector,
+  leaderboardSelector,
+} from 'src/app/store/selectors/wallet.selector';
 
 @Component({
   selector: 'app-token-leaderboard',
@@ -53,14 +58,13 @@ export class TokenLeaderboardPage implements OnInit {
   }
 
   initValues() {
-    // this.isLoading$ = this.store.pipe(select(isLoadingSelector));
-    // this.streaks$ = this.store.pipe(select(streaksSelector));
-    // this.total$ = this.store.pipe(select(totalSelector));
+    this.isLoading$ = this.store.pipe(select(isLoadingSelector));
+    this.wallets$ = this.store.pipe(select(leaderboardSelector));
   }
 
   listWallets() {
     // Dispatch action to get all visits
-    // this.store.dispatch(getStreaksAction());
+    this.store.dispatch(listWalletsAction());
   }
 
   //

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.ts
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.ts
@@ -1,7 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { Browser } from '@capacitor/browser';
+import { Observable, Subscription } from 'rxjs';
+import { ToastController } from '@ionic/angular';
+import { Store } from '@ngrx/store';
 
 import { environment } from 'src/environments/environment';
+import { Wallet } from 'src/app/models/Wallet';
 
 @Component({
   selector: 'app-token-leaderboard',
@@ -13,9 +17,46 @@ export class TokenLeaderboardPage implements OnInit {
     environment.ext.token.LITEPAPER + '/litepaper/token/distibution#formula';
   twitter = environment.ext.token.TWITTER;
 
-  constructor() {}
+  subscription: Subscription;
 
-  ngOnInit() {}
+  isLoading$: Observable<boolean> = null;
+  wallets$: Observable<Wallet[] | null> = null;
+  total$: Observable<number | null> = null;
+
+  constructor(private store: Store, private toastController: ToastController) {}
+
+  ngOnInit() {
+    this.initValues();
+    // Get all Streaks
+    this.listWallets();
+  }
+
+  ionViewWillEnter() {
+    this.subscription = new Subscription();
+
+    // User Errors
+    // this.subscription.add(
+    //   this.store
+    //     .pipe(select(errorSelector))
+    //     .subscribe((error: ErrorInterface) => {
+    //       if (error) {
+    //         this.presentToast(error.message, 'danger');
+    //         this.store.dispatch(clearErrorsAction());
+    //       }
+    //     })
+    // );
+  }
+
+  ionViewWillLeave() {
+    // Unsubscribe from all subscriptions
+    this.subscription.unsubscribe();
+  }
+
+  initValues() {
+    // this.isLoading$ = this.store.pipe(select(isLoadingSelector));
+    // this.streaks$ = this.store.pipe(select(streaksSelector));
+    // this.total$ = this.store.pipe(select(totalSelector));
+  }
 
   listWallets() {
     // Dispatch action to get all visits
@@ -38,5 +79,20 @@ export class TokenLeaderboardPage implements OnInit {
   async openPage(pageURL: any) {
     // console.log(pageURL);
     await Browser.open({ url: pageURL });
+  }
+
+  //
+  // Present Toast
+  //
+
+  async presentToast(msg: string, color?: string) {
+    const toast = await this.toastController.create({
+      message: msg,
+      color: color || 'primary',
+      duration: 1000,
+      position: 'top',
+    });
+
+    await toast.present();
   }
 }

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.ts
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { Browser } from '@capacitor/browser';
+
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-token-leaderboard',
@@ -6,7 +9,34 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./token-leaderboard.page.scss'],
 })
 export class TokenLeaderboardPage implements OnInit {
+  infoURL =
+    environment.ext.token.LITEPAPER + '/litepaper/token/distibution#formula';
+  twitter = environment.ext.token.TWITTER;
+
   constructor() {}
 
   ngOnInit() {}
+
+  listWallets() {
+    // Dispatch action to get all visits
+    // this.store.dispatch(getStreaksAction());
+  }
+
+  //
+  // Pull to refresh
+  //
+
+  handleRefresh(event) {
+    this.listWallets();
+    if (event) event.target.complete();
+  }
+
+  //
+  // Utils
+  //
+
+  async openPage(pageURL: any) {
+    // console.log(pageURL);
+    await Browser.open({ url: pageURL });
+  }
 }

--- a/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.ts
+++ b/src/app/pages/home/profile/settings/token-leaderboard/token-leaderboard.page.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-token-leaderboard',
+  templateUrl: './token-leaderboard.page.html',
+  styleUrls: ['./token-leaderboard.page.scss'],
+})
+export class TokenLeaderboardPage implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/src/app/services/user/wallet.service.ts
+++ b/src/app/services/user/wallet.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Query } from 'appwrite';
 import { Observable, from } from 'rxjs';
+import axios from 'axios';
 
 import { User } from 'src/app/models/User';
 import { listWalletsResponseInterface } from 'src/app/models/types/responses/listWalletsResponse.interface';
@@ -23,9 +24,9 @@ export class WalletService {
 
   listWallets(): Observable<listWalletsResponseInterface> {
     return from(
-      this.api.listDocuments(environment.appwrite.WALLET_COLLECTION, [
-        Query.orderDesc('balance'),
-      ])
+      axios.get(`${environment.api.LEADERBOARD}/token`).then((result) => {
+        return result.data as listWalletsResponseInterface;
+      })
     );
   }
 }

--- a/src/app/services/user/wallet.service.ts
+++ b/src/app/services/user/wallet.service.ts
@@ -3,7 +3,7 @@ import { Query } from 'appwrite';
 import { Observable, from } from 'rxjs';
 
 import { User } from 'src/app/models/User';
-import { listWalletResponseInterface } from 'src/app/models/types/responses/listWalletResponse.interface';
+import { listWalletsResponseInterface } from 'src/app/models/types/responses/listWalletsResponse.interface';
 import { ApiService } from 'src/app/services/api/api.service';
 import { environment } from 'src/environments/environment';
 
@@ -13,10 +13,18 @@ import { environment } from 'src/environments/environment';
 export class WalletService {
   constructor(private api: ApiService) {}
 
-  listWallet(currentUser: User): Observable<listWalletResponseInterface> {
+  getWallet(currentUser: User): Observable<listWalletsResponseInterface> {
     return from(
       this.api.listDocuments(environment.appwrite.WALLET_COLLECTION, [
         Query.equal('$id', currentUser.$id),
+      ])
+    );
+  }
+
+  listWallets(): Observable<listWalletsResponseInterface> {
+    return from(
+      this.api.listDocuments(environment.appwrite.WALLET_COLLECTION, [
+        Query.orderDesc('balance'),
       ])
     );
   }

--- a/src/app/store/actions/types/wallet.actiontypes.ts
+++ b/src/app/store/actions/types/wallet.actiontypes.ts
@@ -2,4 +2,10 @@ export enum ActionTypes {
   GET_WALLET = '[Wallet] Get Wallet',
   GET_WALLET_SUCCESS = '[Wallet] Get Wallet Success',
   GET_WALLET_FAILURE = '[Wallet] Get Wallet Failure',
+
+  LIST_WALLETS = '[Wallet] List Wallets',
+  LIST_WALLETS_SUCCESS = '[Wallet] List Wallets Success',
+  LIST_WALLETS_FAILURE = '[Wallet] List Wallets Failure',
+
+  CLEAR_ERRORS = '[Wallet] Clear Errors',
 }

--- a/src/app/store/actions/wallet.action.ts
+++ b/src/app/store/actions/wallet.action.ts
@@ -1,7 +1,7 @@
 import { createAction, props } from '@ngrx/store';
 
 import { ActionTypes } from 'src/app/store/actions/types/wallet.actiontypes';
-import { listWalletResponseInterface } from 'src/app/models/types/responses/listWalletResponse.interface';
+import { listWalletsResponseInterface } from 'src/app/models/types/responses/listWalletsResponse.interface';
 import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
 
 // Get Wallet Actions
@@ -9,10 +9,26 @@ export const getWalletAction = createAction(ActionTypes.GET_WALLET);
 
 export const getWalletSuccessAction = createAction(
   ActionTypes.GET_WALLET_SUCCESS,
-  props<{ payload: listWalletResponseInterface }>()
+  props<{ payload: listWalletsResponseInterface }>()
 );
 
 export const getWalletFailureAction = createAction(
   ActionTypes.GET_WALLET_FAILURE,
   props<{ error: ErrorInterface }>()
 );
+
+// List Wallets Actions
+export const listWalletsAction = createAction(ActionTypes.LIST_WALLETS);
+
+export const listWalletsSuccessAction = createAction(
+  ActionTypes.LIST_WALLETS_SUCCESS,
+  props<{ payload: listWalletsResponseInterface }>()
+);
+
+export const listWalletsFailureAction = createAction(
+  ActionTypes.LIST_WALLETS_FAILURE,
+  props<{ error: ErrorInterface }>()
+);
+
+// Clear Errors Action
+export const clearErrorsAction = createAction(ActionTypes.CLEAR_ERRORS);

--- a/src/app/store/effects/wallet.effect.ts
+++ b/src/app/store/effects/wallet.effect.ts
@@ -4,7 +4,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Store, select } from '@ngrx/store';
 import { catchError, map, of, switchMap, withLatestFrom } from 'rxjs';
 
-import { listWalletResponseInterface } from 'src/app/models/types/responses/listWalletResponse.interface';
+import { listWalletsResponseInterface } from 'src/app/models/types/responses/listWalletsResponse.interface';
 import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
 import { WalletService } from 'src/app/services/user/wallet.service';
 
@@ -13,6 +13,9 @@ import {
   getWalletAction,
   getWalletSuccessAction,
   getWalletFailureAction,
+  listWalletsFailureAction,
+  listWalletsSuccessAction,
+  listWalletsAction,
 } from 'src/app/store/actions/wallet.action';
 
 @Injectable()
@@ -22,8 +25,8 @@ export class WalletEffects {
       ofType(getWalletAction),
       withLatestFrom(this.store.pipe(select(currentUserSelector))),
       switchMap(([_, currentUser]) => {
-        return this.walletService.listWallet(currentUser).pipe(
-          map((payload: listWalletResponseInterface) => {
+        return this.walletService.getWallet(currentUser).pipe(
+          map((payload: listWalletsResponseInterface) => {
             return getWalletSuccessAction({ payload: payload });
           }),
 
@@ -32,6 +35,26 @@ export class WalletEffects {
               message: errorResponse.message,
             };
             return of(getWalletFailureAction({ error }));
+          })
+        );
+      })
+    )
+  );
+
+  listWallets$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(listWalletsAction),
+      switchMap(() => {
+        return this.walletService.listWallets().pipe(
+          map((payload: listWalletsResponseInterface) => {
+            return listWalletsSuccessAction({ payload: payload });
+          }),
+
+          catchError((errorResponse: HttpErrorResponse) => {
+            const error: ErrorInterface = {
+              message: errorResponse.message,
+            };
+            return of(listWalletsFailureAction({ error }));
           })
         );
       })

--- a/src/app/store/reducers/wallet.reducer.ts
+++ b/src/app/store/reducers/wallet.reducer.ts
@@ -64,7 +64,7 @@ const walletReducer = createReducer(
     listWalletsSuccessAction,
     (state, action): WalletStateInterface => ({
       ...state,
-      isLoading: true,
+      isLoading: false,
       leaderboard: action.payload.documents,
       error: null,
     })

--- a/src/app/store/reducers/wallet.reducer.ts
+++ b/src/app/store/reducers/wallet.reducer.ts
@@ -6,6 +6,9 @@ import {
   getWalletAction,
   getWalletSuccessAction,
   getWalletFailureAction,
+  listWalletsAction,
+  listWalletsSuccessAction,
+  listWalletsFailureAction,
 } from 'src/app/store/actions/wallet.action';
 import {
   deleteAccountSuccessAction,
@@ -15,6 +18,7 @@ import {
 const initialState: WalletStateInterface = {
   isLoading: false,
   wallet: null,
+  leaderboard: null,
   error: null,
 };
 
@@ -40,6 +44,33 @@ const walletReducer = createReducer(
   }),
   on(
     getWalletFailureAction,
+    (state, action): WalletStateInterface => ({
+      ...state,
+      isLoading: false,
+      error: action.error,
+    })
+  ),
+
+  // List Wallets Reducers
+  on(
+    listWalletsAction,
+    (state): WalletStateInterface => ({
+      ...state,
+      isLoading: true,
+      error: null,
+    })
+  ),
+  on(
+    listWalletsSuccessAction,
+    (state, action): WalletStateInterface => ({
+      ...state,
+      isLoading: true,
+      leaderboard: action.payload.documents,
+      error: null,
+    })
+  ),
+  on(
+    listWalletsFailureAction,
     (state, action): WalletStateInterface => ({
       ...state,
       isLoading: false,

--- a/src/app/store/selectors/wallet.selector.ts
+++ b/src/app/store/selectors/wallet.selector.ts
@@ -9,9 +9,15 @@ export const isLoadingSelector = createSelector(
   walletFeatureSelector,
   (walletState: WalletStateInterface) => walletState.isLoading
 );
+
 export const walletSelector = createSelector(
   walletFeatureSelector,
   (walletState: WalletStateInterface) => walletState.wallet
+);
+
+export const leaderboardSelector = createSelector(
+  walletFeatureSelector,
+  (walletState: WalletStateInterface) => walletState.leaderboard
 );
 
 export const errorSelector = createSelector(

--- a/src/environments/environment.prod.ts.sample
+++ b/src/environments/environment.prod.ts.sample
@@ -55,6 +55,7 @@ export const environment = {
     USER: `${API_URL}api/user`,
     LANGUAGE: `${API_URL}api/language`,
     VISIT: `${API_URL}api/visit`,
+    LEADERBOARD: `${API_URL}api/leaderboard`,
   },
   ext: {
     STATUS_PAGE: STATUS_PAGE,

--- a/src/environments/environment.ts.sample
+++ b/src/environments/environment.ts.sample
@@ -55,6 +55,7 @@ export const environment = {
     USER: `${API_URL}api/user`,
     LANGUAGE: `${API_URL}api/language`,
     VISIT: `${API_URL}api/visit`,
+    LEADERBOARD: `${API_URL}api/leaderboard`,
   },
   ext: {
     STATUS_PAGE: STATUS_PAGE,


### PR DESCRIPTION
This pull request adds a leaderboard feature to the Test LangX Token Wallets. It includes the following changes:

- Added a token-leaderboard page and routing

- Updated token-distribution component styles

- Added token leaderboard link to token-distribution component

- Updated leaderboard page title to "Streaks Leaderboard"

- Removed unnecessary code and updated token-details page UI

- Updated token-leaderboard page UI and functionality

- Updated offset condition in leaderboard page

- Removed unused code and updated leaderboard page

- Updated token-leaderboard page UI and functionality

- Added list wallets functionality and error handling

- Updated wallet service to use listWalletsResponseInterface

- Added leaderboard functionality and updated wallet state interface

- Added leaderboard selector to wallet selector file

- Updated token-leaderboard page UI and functionality

- Updated leaderboard API endpoints in environment files

- Updated wallet service to use axios for API calls

- Fixed isLoading flag in walletReducer

- Updated token-leaderboard page UI and functionality

- Added wallet-list component

- Updated wallet-list component with item details and balance

- Added ComponentsModule to TokenLeaderboardPage module

- Updated wallet-list component to display balance with big numbers

Fixes #824