### PR TITLE
Fix: Use Badge.get() instead of totalUnseenMessages

### DIFF
--- a/src/app/store/effects/notification.effect.ts
+++ b/src/app/store/effects/notification.effect.ts
@@ -2,8 +2,7 @@ import { Injectable } from '@angular/core';
 import { createEffect, ofType, Actions } from '@ngrx/effects';
 import { HttpErrorResponse } from '@angular/common/http';
 import { catchError, map, of, switchMap, withLatestFrom } from 'rxjs';
-import { Store, select } from '@ngrx/store';
-import { Badge } from '@capawesome/capacitor-badge';
+import { Store } from '@ngrx/store';
 
 // Interface Imports
 import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
@@ -49,13 +48,6 @@ export class NotificationEffects {
     )
   );
 
-  // TODO: #829 In future, Use Badge.get() instead of totalUnseenMessages
-  // Update to app badge count
-  // if ('setAppBadge' in navigator) {
-  //   Badge.set({ count: totalUnseenMessages });
-  // } else {
-  //   console.log('Badging API is not supported in this browser.');
-  // }
   constructor(
     private store: Store,
     private actions$: Actions,

--- a/src/app/store/reducers/auth.reducer.ts
+++ b/src/app/store/reducers/auth.reducer.ts
@@ -1,3 +1,4 @@
+import { Badge } from '@capawesome/capacitor-badge';
 import { Action, createReducer, on } from '@ngrx/store';
 
 import { AuthStateInterface } from 'src/app/models/types/states/authState.interface';
@@ -104,6 +105,7 @@ import {
   uploadProfilePictureFailureAction,
   uploadProfilePictureSuccessAction,
 } from 'src/app/store/actions/bucket.action';
+import { Capacitor } from '@capacitor/core';
 
 const initialState: AuthStateInterface = {
   isLoading: false,
@@ -373,14 +375,17 @@ const authReducer = createReducer(
       isLoading: true,
     })
   ),
-  on(
-    updateCurrentUserSuccessAction,
-    (state, action): AuthStateInterface => ({
+  on(updateCurrentUserSuccessAction, (state, action): AuthStateInterface => {
+    // Set the badge count in the app icon
+    if (Capacitor.isNativePlatform()) {
+      Badge.set({ count: action.payload.totalUnseen });
+    }
+    return {
       ...state,
       isLoading: false,
       currentUser: action.payload,
-    })
-  ),
+    };
+  }),
   on(
     updateCurrentUserFailureAction,
     (state, action): AuthStateInterface => ({


### PR DESCRIPTION
This pull request fixes issue #829 by replacing the usage of `totalUnseenMessages` with `Badge.get()` in the `notification.effect.ts` file. Additionally, it adds a new feature to set the badge count in the app icon for total unseen messages.