### PR TITLE
Fix Archived Chats Filtering and Update Room Service Functionality

### DIFF
--- a/functions/push-notification-with-fcm/src/main.js
+++ b/functions/push-notification-with-fcm/src/main.js
@@ -85,13 +85,13 @@ export default async ({ req, res, log, error }) => {
   }
   log('-- User is not blocked');
 
-  log(`Archived in Rooms: ${req.body.roomId?.archived} -- roomId: ${roomId}`);
-  if (req.body.roomId?.archived.includes(toUserDoc.$id)) {
+  log(`Archived Rooms: ${toUserDoc.archivedRooms} -- roomId: ${roomId}`);
+  if (toUserDoc?.archivedRooms.includes(roomId)) {
     return res.json({ ok: false, error: 'You are archived by this user' }, 400);
   }
   log('-- User is not archived');
 
-  // Check token exists or not
+  // Check FCM token exists or not
 
   // Initialize flags
   let iosExists = false;

--- a/functions/total-unseen-user/src/main.js
+++ b/functions/total-unseen-user/src/main.js
@@ -85,8 +85,8 @@ export default async ({ req, res, log, error }) => {
     log(`Unseen count for User 2: ${unseenCountUser2}`);
 
     // Include for archived rooms
-    querry1.push(Query.contains('archived', req.body.$id));
-    querry2.push(Query.contains('archived', req.body.$id));
+    querry1.push(Query.contains('archived', user1));
+    querry2.push(Query.contains('archived', user2));
 
     // List archived rooms
     const listArchivedRoomsForUser1 = await db.listDocuments(
@@ -113,7 +113,7 @@ export default async ({ req, res, log, error }) => {
 
     // Count unseen messages for user2 in archived rooms
     let unseenArchivedCountUser2 = 0;
-    listRoomsForUser2.documents.forEach((room) => {
+    listArchivedRoomsForUser2.documents.forEach((room) => {
       if (room.users[0] === user2 && room.unseen[0] !== 0) {
         unseenArchivedCountUser2 += room.unseen[0];
       } else if (room.users[1] === user2 && room.unseen[1] !== 0) {

--- a/functions/total-unseen-user/src/main.js
+++ b/functions/total-unseen-user/src/main.js
@@ -41,6 +41,14 @@ export default async ({ req, res, log, error }) => {
       Query.orderDesc('$updatedAt'),
     ];
 
+    // Push archived rooms to query
+    user1Doc.archivedRooms?.forEach((id) => {
+      querry1.push(Query.notEqual('$id', id));
+    });
+    user2Doc.archivedRooms?.forEach((id) => {
+      querry2.push(Query.notEqual('$id', id));
+    });
+
     const listRoomsForUser1 = await db.listDocuments(
       process.env.APP_DATABASE,
       process.env.ROOMS_COLLECTION,
@@ -56,10 +64,6 @@ export default async ({ req, res, log, error }) => {
     // Count unseen messages for user1
     let unseenCountUser1 = 0;
     listRoomsForUser1.documents.forEach((room) => {
-      // Skip this room if it's archived by the user
-      if (room.archived.includes(user1)) {
-        return;
-      }
       if (room.users[0] === user1 && room.unseen[0] !== 0) {
         unseenCountUser1 += room.unseen[0];
       } else if (room.users[1] === user1 && room.unseen[1] !== 0) {
@@ -70,10 +74,6 @@ export default async ({ req, res, log, error }) => {
     // Count unseen messages for user2
     let unseenCountUser2 = 0;
     listRoomsForUser2.documents.forEach((room) => {
-      // Skip this room if it's archived by the user
-      if (room.archived.includes(user2)) {
-        return;
-      }
       if (room.users[0] === user2 && room.unseen[0] !== 0) {
         unseenCountUser2 += room.unseen[0];
       } else if (room.users[1] === user2 && room.unseen[1] !== 0) {
@@ -84,21 +84,31 @@ export default async ({ req, res, log, error }) => {
     log(`Unseen count for User 1: ${unseenCountUser1}`);
     log(`Unseen count for User 2: ${unseenCountUser2}`);
 
+    // Init queries
+    let querry1archived = [
+      Query.contains('users', user1),
+      Query.orderDesc('$updatedAt'),
+    ];
+    let querry2archived = [
+      Query.contains('users', user2),
+      Query.orderDesc('$updatedAt'),
+    ];
+
     // Include for archived rooms
-    querry1.push(Query.contains('archived', user1));
-    querry2.push(Query.contains('archived', user2));
+    querry1archived.push(Query.contains('$id', user1Doc.archivedRooms));
+    querry2archived.push(Query.contains('$id', user2Doc.archivedRooms));
 
     // List archived rooms
     const listArchivedRoomsForUser1 = await db.listDocuments(
       process.env.APP_DATABASE,
       process.env.ROOMS_COLLECTION,
-      querry1
+      querry1archived
     );
 
     const listArchivedRoomsForUser2 = await db.listDocuments(
       process.env.APP_DATABASE,
       process.env.ROOMS_COLLECTION,
-      querry2
+      querry2archived
     );
 
     // Count unseen messages for user1 in archived rooms
@@ -120,6 +130,9 @@ export default async ({ req, res, log, error }) => {
         unseenArchivedCountUser2 += room.unseen[1];
       }
     });
+
+    log(`Unseen count for User 1 Archived: ${unseenArchivedCountUser1}`);
+    log(`Unseen count for User 2 Archived: ${unseenArchivedCountUser2}`);
 
     // Update user documents with totalUnseen attribute
     await Promise.all([

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -101,7 +101,7 @@ export class AppComponent {
         this.updateService.checkForUpdates();
 
         // Get rooms when App State Becomes Active
-        this.store.dispatch(getRoomsAction({}));
+        this.store.dispatch(getRoomsAction());
       }
     });
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -101,7 +101,7 @@ export class AppComponent {
         this.updateService.checkForUpdates();
 
         // Get rooms when App State Becomes Active
-        this.store.dispatch(getRoomsAction());
+        this.store.dispatch(getRoomsAction({}));
       }
     });
   }

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -21,6 +21,7 @@ export type User = Models.Document & {
   notifications?: string[];
   notificationsArray?: string[];
   blockedUsers?: string[];
+  archivedRooms?: string[];
   privacy?: string[];
   contributors?: string[];
   sponsor?: boolean;

--- a/src/app/models/types/states/authState.interface.ts
+++ b/src/app/models/types/states/authState.interface.ts
@@ -25,6 +25,10 @@ export interface AuthStateInterface {
   updatePasswordError: ErrorInterface | null;
   blockUserSuccess: boolean;
   blockUserError: ErrorInterface | null;
+  archiveRoomSuccess: boolean;
+  archiveRoomError: ErrorInterface | null;
+  unArchiveRoomSuccess: boolean;
+  unArchiveRoomError: ErrorInterface | null;
   unBlockUserSuccess: boolean;
   unBlockUserError: ErrorInterface | null;
   blockedUsersData: User[] | null;

--- a/src/app/models/types/states/roomState.interface.ts
+++ b/src/app/models/types/states/roomState.interface.ts
@@ -3,8 +3,10 @@ import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
 
 export interface RoomStateInterface {
   isLoading: boolean;
-  total: number;
   rooms: RoomExtendedInterface[] | null;
+  total: number;
+  archivedRooms: RoomExtendedInterface[] | null;
+  archivedTotal: number;
   error: ErrorInterface | null;
   createRoomError: ErrorInterface | null;
 }

--- a/src/app/pages/home/messages/archive/archive.page.ts
+++ b/src/app/pages/home/messages/archive/archive.page.ts
@@ -102,7 +102,7 @@ export class ArchivePage implements OnInit {
   }
 
   listRooms() {
-    this.store.dispatch(getRoomsAction({ request: { archived: true } }));
+    // this.store.dispatch(getRoomsAction());
   }
 
   getChat(room) {

--- a/src/app/pages/home/messages/archive/archive.page.ts
+++ b/src/app/pages/home/messages/archive/archive.page.ts
@@ -112,7 +112,6 @@ export class ArchivePage implements OnInit {
   handleRefresh(event) {
     this.listRooms();
     event.target.complete();
-    console.log('Async operation refresh has ended');
   }
 
   //

--- a/src/app/pages/home/messages/archive/archive.page.ts
+++ b/src/app/pages/home/messages/archive/archive.page.ts
@@ -164,7 +164,6 @@ export class ArchivePage implements OnInit {
   }
 
   unArchiveRoom(room: Room) {
-    console.log('unArchiveRoom', room);
     // Dispatch action
     const request = { roomId: room.$id };
     this.store.dispatch(unArchiveRoomAction({ request }));

--- a/src/app/pages/home/messages/archive/archive.page.ts
+++ b/src/app/pages/home/messages/archive/archive.page.ts
@@ -10,12 +10,19 @@ import { updateRoomRequestInterface } from 'src/app/models/types/requests/update
 
 // Import Actions and Selectors
 import { activateRoomAction } from 'src/app/store/actions/message.action';
-import { updateRoomAction } from 'src/app/store/actions/room.action';
+import {
+  unArchiveRoomAction,
+  unArchiveRoomInitialStateAction,
+  updateRoomAction,
+} from 'src/app/store/actions/room.action';
 import {
   getArchivedRoomsAction,
   getArchivedRoomsWithOffsetAction,
 } from 'src/app/store/actions/rooms.action';
-import { currentUserSelector } from 'src/app/store/selectors/auth.selector';
+import {
+  currentUserSelector,
+  unArchiveRoomErrorSelector,
+} from 'src/app/store/selectors/auth.selector';
 import {
   archivedRoomsSelector,
   archivedTotalSelector,
@@ -64,6 +71,14 @@ export class ArchivePage implements OnInit {
             this.presentToast(error.message, 'danger');
           }
         })
+    );
+    this.subscription.add(
+      this.store.pipe(select(unArchiveRoomErrorSelector)).subscribe((error) => {
+        if (error) {
+          this.presentToast(error.message, 'danger');
+          this.store.dispatch(unArchiveRoomInitialStateAction());
+        }
+      })
     );
   }
 
@@ -150,11 +165,9 @@ export class ArchivePage implements OnInit {
 
   unArchiveRoom(room: Room) {
     console.log('unArchiveRoom', room);
-    const request: updateRoomRequestInterface = {
-      roomId: room.$id,
-      data: { archived: false },
-    };
-    this.store.dispatch(updateRoomAction({ request }));
+    // Dispatch action
+    const request = { roomId: room.$id };
+    this.store.dispatch(unArchiveRoomAction({ request }));
   }
 
   //

--- a/src/app/pages/home/messages/archive/archive.page.ts
+++ b/src/app/pages/home/messages/archive/archive.page.ts
@@ -102,7 +102,7 @@ export class ArchivePage implements OnInit {
   }
 
   listRooms() {
-    this.store.dispatch(getRoomsAction({}));
+    this.store.dispatch(getRoomsAction({ request: { archived: true } }));
   }
 
   getChat(room) {

--- a/src/app/pages/home/messages/archive/archive.page.ts
+++ b/src/app/pages/home/messages/archive/archive.page.ts
@@ -104,7 +104,7 @@ export class ArchivePage implements OnInit {
         return archivedRooms.filter(
           (room) =>
             !currentUser.blockedUsers.includes(room?.['userData']?.$id) &&
-            room?.['archived'].includes(currentUser?.$id)
+            currentUser.archivedRooms.includes(room.$id)
         );
       })
     );

--- a/src/app/pages/home/messages/archive/archive.page.ts
+++ b/src/app/pages/home/messages/archive/archive.page.ts
@@ -122,25 +122,25 @@ export class ArchivePage implements OnInit {
     // Offset is the number of users already loaded
     let offset: number = 0;
 
-    this.rooms$
-      .subscribe((users) => {
-        if (!users) return;
-        offset = users.length;
-        this.total$
-          .subscribe((total) => {
-            if (offset < total) {
-              this.store.dispatch(
-                getRoomsWithOffsetAction({
-                  request: { offset },
-                })
-              );
-            } else {
-              console.log('All rooms loaded');
-            }
-          })
-          .unsubscribe();
-      })
-      .unsubscribe();
+    // this.rooms$
+    //   .subscribe((users) => {
+    //     if (!users) return;
+    //     offset = users.length;
+    //     this.total$
+    //       .subscribe((total) => {
+    //         if (offset < total) {
+    //           this.store.dispatch(
+    //             getRoomsWithOffsetAction({
+    //               request: { offset },
+    //             })
+    //           );
+    //         } else {
+    //           console.log('All rooms loaded');
+    //         }
+    //       })
+    //       .unsubscribe();
+    //   })
+    //   .unsubscribe();
 
     event.target.complete();
   }

--- a/src/app/pages/home/messages/archive/archive.page.ts
+++ b/src/app/pages/home/messages/archive/archive.page.ts
@@ -102,7 +102,7 @@ export class ArchivePage implements OnInit {
   }
 
   listRooms() {
-    this.store.dispatch(getRoomsAction());
+    this.store.dispatch(getRoomsAction({}));
   }
 
   getChat(room) {

--- a/src/app/pages/home/messages/archive/archive.page.ts
+++ b/src/app/pages/home/messages/archive/archive.page.ts
@@ -102,9 +102,7 @@ export class ArchivePage implements OnInit {
           return null;
         }
         return archivedRooms.filter(
-          (room) =>
-            !currentUser.blockedUsers.includes(room?.['userData']?.$id) &&
-            currentUser.archivedRooms.includes(room.$id)
+          (room) => !currentUser.blockedUsers.includes(room?.['userData']?.$id)
         );
       })
     );

--- a/src/app/pages/home/messages/archive/archive.page.ts
+++ b/src/app/pages/home/messages/archive/archive.page.ts
@@ -102,7 +102,9 @@ export class ArchivePage implements OnInit {
           return null;
         }
         return archivedRooms.filter(
-          (room) => !currentUser.blockedUsers.includes(room?.['userData']?.$id)
+          (room) =>
+            !currentUser.blockedUsers.includes(room?.['userData']?.$id) &&
+            currentUser.archivedRooms.includes(room.$id)
         );
       })
     );

--- a/src/app/pages/home/messages/messages.page.ts
+++ b/src/app/pages/home/messages/messages.page.ts
@@ -129,9 +129,7 @@ export class MessagesPage implements OnInit {
           return null;
         }
         return rooms.filter(
-          (room) =>
-            !currentUser.blockedUsers.includes(room?.['userData']?.$id) &&
-            !currentUser.archivedRooms.includes(room.$id)
+          (room) => !currentUser.blockedUsers.includes(room?.['userData']?.$id)
         );
       })
     );

--- a/src/app/pages/home/messages/messages.page.ts
+++ b/src/app/pages/home/messages/messages.page.ts
@@ -136,7 +136,7 @@ export class MessagesPage implements OnInit {
   }
 
   listRooms() {
-    this.store.dispatch(getRoomsAction());
+    this.store.dispatch(getRoomsAction({}));
   }
 
   //

--- a/src/app/pages/home/messages/messages.page.ts
+++ b/src/app/pages/home/messages/messages.page.ts
@@ -129,7 +129,9 @@ export class MessagesPage implements OnInit {
           return null;
         }
         return rooms.filter(
-          (room) => !currentUser.blockedUsers.includes(room?.['userData']?.$id)
+          (room) =>
+            !currentUser.blockedUsers.includes(room?.['userData']?.$id) &&
+            !currentUser.archivedRooms.includes(room.$id)
         );
       })
     );

--- a/src/app/pages/home/messages/messages.page.ts
+++ b/src/app/pages/home/messages/messages.page.ts
@@ -9,7 +9,6 @@ import { Observable, Subscription, combineLatest, map } from 'rxjs';
 import { Room } from 'src/app/models/Room';
 import { User } from 'src/app/models/User';
 import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
-import { updateRoomRequestInterface } from 'src/app/models/types/requests/updateRoomRequest.interface';
 import { FcmService } from 'src/app/services/fcm/fcm.service';
 
 // Import Actions and Selectors

--- a/src/app/pages/home/messages/messages.page.ts
+++ b/src/app/pages/home/messages/messages.page.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ToastController } from '@ionic/angular';
 import { Store, select } from '@ngrx/store';
-import { Router } from '@angular/router';
+import { NavigationEnd, Router } from '@angular/router';
 import { Capacitor } from '@capacitor/core';
 import { Observable, Subscription, combineLatest, map } from 'rxjs';
 
@@ -76,6 +76,12 @@ export class MessagesPage implements OnInit {
     } else {
       this.fcmService.registerPush();
     }
+
+    this.router.events.subscribe((event) => {
+      if (event instanceof NavigationEnd && event.url === '/home/messages') {
+        this.listRooms();
+      }
+    });
   }
 
   registerPushForWeb() {
@@ -104,9 +110,6 @@ export class MessagesPage implements OnInit {
         }
       })
     );
-
-    // Get all chat Rooms
-    this.listRooms();
   }
 
   ionViewWillLeave() {
@@ -147,6 +150,7 @@ export class MessagesPage implements OnInit {
   }
 
   listRooms() {
+    // console.log('Listing rooms');
     this.store.dispatch(getRoomsAction());
   }
 

--- a/src/app/pages/home/messages/messages.page.ts
+++ b/src/app/pages/home/messages/messages.page.ts
@@ -131,7 +131,7 @@ export class MessagesPage implements OnInit {
         return rooms.filter(
           (room) =>
             !currentUser.blockedUsers.includes(room?.['userData']?.$id) &&
-            !room?.['archived'].includes(currentUser?.$id)
+            !currentUser.archivedRooms.includes(room.$id)
         );
       })
     );

--- a/src/app/pages/home/messages/messages.page.ts
+++ b/src/app/pages/home/messages/messages.page.ts
@@ -15,6 +15,8 @@ import { FcmService } from 'src/app/services/fcm/fcm.service';
 // Import Actions and Selectors
 import { activateRoomAction } from 'src/app/store/actions/message.action';
 import {
+  archiveRoomAction,
+  archiveRoomInitialStateAction,
   clearErrorsAction,
   updateRoomAction,
 } from 'src/app/store/actions/room.action';
@@ -23,6 +25,7 @@ import {
   getRoomsWithOffsetAction,
 } from 'src/app/store/actions/rooms.action';
 import {
+  archiveRoomErrorSelector,
   currentUserSelector,
   totalUnseenArchivedSelector,
 } from 'src/app/store/selectors/auth.selector';
@@ -92,6 +95,14 @@ export class MessagesPage implements OnInit {
             this.store.dispatch(clearErrorsAction());
           }
         })
+    );
+    this.subscription.add(
+      this.store.pipe(select(archiveRoomErrorSelector)).subscribe((error) => {
+        if (error) {
+          this.presentToast(error.message, 'danger');
+          this.store.dispatch(archiveRoomInitialStateAction());
+        }
+      })
     );
 
     // Get all chat Rooms
@@ -184,12 +195,9 @@ export class MessagesPage implements OnInit {
   }
 
   archiveRoom(room: Room) {
-    console.log('archiveRoom', room);
-    const request: updateRoomRequestInterface = {
-      roomId: room.$id,
-      data: { archived: true },
-    };
-    this.store.dispatch(updateRoomAction({ request }));
+    // Dispatch action
+    const request = { roomId: room.$id };
+    this.store.dispatch(archiveRoomAction({ request }));
   }
 
   //

--- a/src/app/pages/home/messages/messages.page.ts
+++ b/src/app/pages/home/messages/messages.page.ts
@@ -177,7 +177,6 @@ export class MessagesPage implements OnInit {
   handleRefresh(event) {
     this.listRooms();
     event.target.complete();
-    console.log('Async operation refresh has ended');
   }
 
   openArchiveChatPage() {

--- a/src/app/pages/home/messages/messages.page.ts
+++ b/src/app/pages/home/messages/messages.page.ts
@@ -136,7 +136,7 @@ export class MessagesPage implements OnInit {
   }
 
   listRooms() {
-    this.store.dispatch(getRoomsAction({}));
+    this.store.dispatch(getRoomsAction());
   }
 
   //

--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -187,21 +187,17 @@ export class RoomService {
 
   listRooms(
     currentUser: User,
-    options?: { archived?: boolean; offset?: number }
+    options?: { offset?: number; archived?: boolean }
   ): Observable<listRoomsResponseInterface> {
     // Define queries
     const queries: any[] = [];
 
-    // Query for rooms that contain the current user
-    queries.push(Query.contains('users', currentUser.$id));
-
     // Query for archived rooms if needed
     if (options?.archived) {
-      queries.push(Query.contains('archived', currentUser.$id));
+      currentUser.archivedRooms?.forEach((id) => {
+        queries.push(Query.notEqual('$id', id));
+      });
     }
-
-    // Query for rooms descending by $updatedAt
-    queries.push(Query.orderDesc('$updatedAt'));
 
     // TODO: #340 Query for users that are not blocked by the current user
     // if (currentUser?.blockedUsers) {
@@ -209,6 +205,12 @@ export class RoomService {
     //     queries.push(Query.notEqual('users', id));
     //   });
     // }
+
+    // Query for rooms that contain the current user
+    queries.push(Query.contains('users', currentUser.$id));
+
+    // Query for rooms descending by $updatedAt
+    queries.push(Query.orderDesc('$updatedAt'));
 
     // Limit and offset
     queries.push(Query.limit(environment.opts.PAGINATION_LIMIT));

--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -196,6 +196,11 @@ export class RoomService {
     // Query for rooms that contain the current user
     queries.push(Query.contains('users', currentUser.$id));
 
+    // Query for archived rooms if needed
+    if (archived) {
+      queries.push(Query.contains('archived', currentUser.$id));
+    }
+
     // Query for rooms descending by $updatedAt
     queries.push(Query.orderDesc('$updatedAt'));
 

--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -195,13 +195,13 @@ export class RoomService {
     // Query for rooms that contain the current user
     queries.push(Query.contains('users', currentUser.$id));
 
-    // Query for rooms descending by $updatedAt
-    queries.push(Query.orderDesc('$updatedAt'));
-
     // Query for archived rooms if needed
     if (options?.archived) {
       queries.push(Query.contains('archived', currentUser.$id));
     }
+
+    // Query for rooms descending by $updatedAt
+    queries.push(Query.orderDesc('$updatedAt'));
 
     // TODO: #340 Query for users that are not blocked by the current user
     // if (currentUser?.blockedUsers) {

--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -201,11 +201,12 @@ export class RoomService {
       queries.push(Query.contains('$id', currentUser.archivedRooms));
     }
 
-    if (currentUser?.blockedUsers) {
-      currentUser.blockedUsers.forEach((id) => {
-        queries.push(Query.notEqual('users', id));
-      });
-    }
+    // TODO: #340 Query for users that are not blocked by the current user
+    // if (currentUser?.blockedUsers) {
+    //   currentUser.blockedUsers.forEach((id) => {
+    //     queries.push(Query.notEqual('users', id));
+    //   });
+    // }
 
     // Query for rooms that contain the current user
     queries.push(Query.contains('users', currentUser.$id));

--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -199,12 +199,11 @@ export class RoomService {
       });
     }
 
-    // TODO: #340 Query for users that are not blocked by the current user
-    // if (currentUser?.blockedUsers) {
-    //   currentUser.blockedUsers.forEach((id) => {
-    //     queries.push(Query.notEqual('users', id));
-    //   });
-    // }
+    if (currentUser?.blockedUsers) {
+      currentUser.blockedUsers.forEach((id) => {
+        queries.push(Query.notEqual('users', id));
+      });
+    }
 
     // Query for rooms that contain the current user
     queries.push(Query.contains('users', currentUser.$id));

--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -187,6 +187,7 @@ export class RoomService {
 
   listRooms(
     currentUser: User,
+    archived?: boolean,
     offset?: number
   ): Observable<listRoomsResponseInterface> {
     // Define queries

--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -197,6 +197,8 @@ export class RoomService {
       currentUser.archivedRooms?.forEach((id) => {
         queries.push(Query.notEqual('$id', id));
       });
+    } else {
+      queries.push(Query.contains('$id', currentUser.archivedRooms));
     }
 
     if (currentUser?.blockedUsers) {

--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -230,6 +230,32 @@ export class RoomService {
     );
   }
 
+  archiveRoom(currentUser: User, roomId: string): Observable<User> {
+    return from(
+      this.api.updateDocument(
+        environment.appwrite.USERS_COLLECTION,
+        currentUser.$id,
+        {
+          archivedRooms: [...currentUser?.archivedRooms, roomId],
+        }
+      )
+    );
+  }
+
+  unArchiveRoom(currentUser: User, roomId: string): Observable<User> {
+    return from(
+      this.api.updateDocument(
+        environment.appwrite.USERS_COLLECTION,
+        currentUser.$id,
+        {
+          archivedRooms: currentUser?.archivedRooms.filter(
+            (room) => room !== roomId
+          ),
+        }
+      )
+    );
+  }
+
   //
   // Utils
   //

--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -187,8 +187,7 @@ export class RoomService {
 
   listRooms(
     currentUser: User,
-    archived?: boolean,
-    offset?: number
+    options?: { archived?: boolean; offset?: number }
   ): Observable<listRoomsResponseInterface> {
     // Define queries
     const queries: any[] = [];
@@ -197,7 +196,7 @@ export class RoomService {
     queries.push(Query.contains('users', currentUser.$id));
 
     // Query for archived rooms if needed
-    if (archived) {
+    if (options?.archived) {
       queries.push(Query.contains('archived', currentUser.$id));
     }
 
@@ -213,7 +212,7 @@ export class RoomService {
 
     // Limit and offset
     queries.push(Query.limit(environment.opts.PAGINATION_LIMIT));
-    if (offset) queries.push(Query.offset(offset));
+    if (options?.offset) queries.push(Query.offset(options?.offset));
 
     return from(
       this.api.listDocuments(environment.appwrite.ROOMS_COLLECTION, queries)

--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -193,7 +193,7 @@ export class RoomService {
     const queries: any[] = [];
 
     // Query for archived rooms if needed
-    if (options?.archived) {
+    if (!options?.archived) {
       currentUser.archivedRooms?.forEach((id) => {
         queries.push(Query.notEqual('$id', id));
       });

--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -195,13 +195,13 @@ export class RoomService {
     // Query for rooms that contain the current user
     queries.push(Query.contains('users', currentUser.$id));
 
+    // Query for rooms descending by $updatedAt
+    queries.push(Query.orderDesc('$updatedAt'));
+
     // Query for archived rooms if needed
     if (options?.archived) {
       queries.push(Query.contains('archived', currentUser.$id));
     }
-
-    // Query for rooms descending by $updatedAt
-    queries.push(Query.orderDesc('$updatedAt'));
 
     // TODO: #340 Query for users that are not blocked by the current user
     // if (currentUser?.blockedUsers) {

--- a/src/app/store/actions/room.action.ts
+++ b/src/app/store/actions/room.action.ts
@@ -1,5 +1,6 @@
 import { createAction, props } from '@ngrx/store';
 
+import { User } from 'src/app/models/User';
 import { Room } from 'src/app/models/Room';
 import { ActionTypes } from 'src/app/store/actions/types/room.actiontypes';
 import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
@@ -74,6 +75,46 @@ export const updateRoomSuccessAction = createAction(
 export const updateRoomFailureAction = createAction(
   ActionTypes.UPDATE_ROOM_FAILURE,
   props<{ error: ErrorInterface }>()
+);
+
+// Archive Room Actions
+export const archiveRoomAction = createAction(
+  ActionTypes.ARCHIVE_ROOM,
+  props<{ request: { roomId: string } }>()
+);
+
+export const archiveRoomSuccessAction = createAction(
+  ActionTypes.ARCHIVE_ROOM_SUCCESS,
+  props<{ payload: User }>()
+);
+
+export const archiveRoomFailureAction = createAction(
+  ActionTypes.ARCHIVE_ROOM_FAILURE,
+  props<{ error: ErrorInterface }>()
+);
+
+export const archiveRoomInitialStateAction = createAction(
+  ActionTypes.ARCHIVE_ROOM_INITIAL_STATE
+);
+
+// Unarchive Room Actions
+export const unArchiveRoomAction = createAction(
+  ActionTypes.UNARCHIVE_ROOM,
+  props<{ request: { roomId: string } }>()
+);
+
+export const unArchiveRoomSuccessAction = createAction(
+  ActionTypes.UNARCHIVE_ROOM_SUCCESS,
+  props<{ payload: User }>()
+);
+
+export const unArchiveRoomFailureAction = createAction(
+  ActionTypes.UNARCHIVE_ROOM_FAILURE,
+  props<{ error: ErrorInterface }>()
+);
+
+export const unArchiveRoomInitialStateAction = createAction(
+  ActionTypes.UNARCHIVE_ROOM_INITIAL_STATE
 );
 
 // Clear Errors

--- a/src/app/store/actions/rooms.action.ts
+++ b/src/app/store/actions/rooms.action.ts
@@ -7,7 +7,7 @@ import { listRoomsResponseInterface } from 'src/app/models/types/responses/listR
 // Get Rooms Actions
 export const getRoomsAction = createAction(
   ActionTypes.GET_ROOMS,
-  props<{ archived?: boolean }>()
+  props<{ request?: { archived?: boolean } }>()
 );
 
 export const getRoomsSuccessAction = createAction(
@@ -23,7 +23,7 @@ export const getRoomsFailureAction = createAction(
 // Get Rooms With Offset Actions
 export const getRoomsWithOffsetAction = createAction(
   ActionTypes.GET_ROOMS_WITH_OFFSET,
-  props<{ request: { offset: number } }>()
+  props<{ request: { offset: number; archived?: boolean } }>()
 );
 
 export const getRoomsWithOffsetSuccessAction = createAction(

--- a/src/app/store/actions/rooms.action.ts
+++ b/src/app/store/actions/rooms.action.ts
@@ -5,10 +5,7 @@ import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
 import { listRoomsResponseInterface } from 'src/app/models/types/responses/listRoomsResponse.interface';
 
 // Get Rooms Actions
-export const getRoomsAction = createAction(
-  ActionTypes.GET_ROOMS,
-  props<{ request?: { archived?: boolean } }>()
-);
+export const getRoomsAction = createAction(ActionTypes.GET_ROOMS);
 
 export const getRoomsSuccessAction = createAction(
   ActionTypes.GET_ROOMS_SUCCESS,
@@ -23,7 +20,7 @@ export const getRoomsFailureAction = createAction(
 // Get Rooms With Offset Actions
 export const getRoomsWithOffsetAction = createAction(
   ActionTypes.GET_ROOMS_WITH_OFFSET,
-  props<{ request: { offset: number; archived?: boolean } }>()
+  props<{ request: { offset: number } }>()
 );
 
 export const getRoomsWithOffsetSuccessAction = createAction(
@@ -33,5 +30,36 @@ export const getRoomsWithOffsetSuccessAction = createAction(
 
 export const getRoomsWithOffsetFailureAction = createAction(
   ActionTypes.GET_ROOMS_WITH_OFFSET_FAILURE,
+  props<{ error: ErrorInterface }>()
+);
+
+// Get Archived Rooms Actions
+export const getArchivedRoomsAction = createAction(
+  ActionTypes.GET_ARCHIVED_ROOMS
+);
+
+export const getArchivedRoomsSuccessAction = createAction(
+  ActionTypes.GET_ARCHIVED_ROOMS_SUCCESS,
+  props<{ payload: listRoomsResponseInterface }>()
+);
+
+export const getArchivedRoomsFailureAction = createAction(
+  ActionTypes.GET_ARCHIVED_ROOMS_FAILURE,
+  props<{ error: ErrorInterface }>()
+);
+
+// Get Archived Rooms With Offset Actions
+export const getArchivedRoomsWithOffsetAction = createAction(
+  ActionTypes.GET_ARCHIVED_ROOMS_WITH_OFFSET,
+  props<{ request: { offset: number } }>()
+);
+
+export const getArchivedRoomsWithOffsetSuccessAction = createAction(
+  ActionTypes.GET_ARCHIVED_ROOMS_WITH_OFFSET_SUCCESS,
+  props<{ payload: listRoomsResponseInterface }>()
+);
+
+export const getArchivedRoomsWithOffsetFailureAction = createAction(
+  ActionTypes.GET_ARCHIVED_ROOMS_WITH_OFFSET_FAILURE,
   props<{ error: ErrorInterface }>()
 );

--- a/src/app/store/actions/rooms.action.ts
+++ b/src/app/store/actions/rooms.action.ts
@@ -5,7 +5,10 @@ import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
 import { listRoomsResponseInterface } from 'src/app/models/types/responses/listRoomsResponse.interface';
 
 // Get Rooms Actions
-export const getRoomsAction = createAction(ActionTypes.GET_ROOMS);
+export const getRoomsAction = createAction(
+  ActionTypes.GET_ROOMS,
+  props<{ archived?: boolean }>()
+);
 
 export const getRoomsSuccessAction = createAction(
   ActionTypes.GET_ROOMS_SUCCESS,

--- a/src/app/store/actions/types/room.actiontypes.ts
+++ b/src/app/store/actions/types/room.actiontypes.ts
@@ -12,5 +12,13 @@ export enum ActionTypes {
   UPDATE_ROOM = '[Room] Update Room',
   UPDATE_ROOM_SUCCESS = '[Room] Update Room Success',
   UPDATE_ROOM_FAILURE = '[Room] Update Room Failure',
+  ARCHIVE_ROOM = '[Room] Archive Room',
+  ARCHIVE_ROOM_SUCCESS = '[Room] Archive Room Success',
+  ARCHIVE_ROOM_FAILURE = '[Room] Archive Room Failure',
+  ARCHIVE_ROOM_INITIAL_STATE = '[Room] Archive Room Initial State',
+  UNARCHIVE_ROOM = '[Room] Unarchive Room',
+  UNARCHIVE_ROOM_SUCCESS = '[Room] Unarchive Room Success',
+  UNARCHIVE_ROOM_FAILURE = '[Room] Unarchive Room Failure',
+  UNARCHIVE_ROOM_INITIAL_STATE = '[Room] Unarchive Room Initial State',
   CLEAR_ERRORS = '[Room] Clear Errors',
 }

--- a/src/app/store/actions/types/rooms.actiontypes.ts
+++ b/src/app/store/actions/types/rooms.actiontypes.ts
@@ -5,4 +5,11 @@ export enum ActionTypes {
   GET_ROOMS_WITH_OFFSET = '[Rooms] Get Room With Offset',
   GET_ROOMS_WITH_OFFSET_SUCCESS = '[Rooms] Get Room With Offset Success',
   GET_ROOMS_WITH_OFFSET_FAILURE = '[Rooms] Get Room With Offset Failure',
+
+  GET_ARCHIVED_ROOMS = '[Rooms] Get Archived Rooms',
+  GET_ARCHIVED_ROOMS_SUCCESS = '[Rooms] Get Archived Rooms Success',
+  GET_ARCHIVED_ROOMS_FAILURE = '[Rooms] Get Archived Rooms Failure',
+  GET_ARCHIVED_ROOMS_WITH_OFFSET = '[Rooms] Get Archived Room With Offset',
+  GET_ARCHIVED_ROOMS_WITH_OFFSET_SUCCESS = '[Rooms] Get Archived Room With Offset Success',
+  GET_ARCHIVED_ROOMS_WITH_OFFSET_FAILURE = '[Rooms] Get Archived Room With Offset Failure',
 }

--- a/src/app/store/effects/room.effect.ts
+++ b/src/app/store/effects/room.effect.ts
@@ -6,6 +6,7 @@ import { Router } from '@angular/router';
 import { catchError, map, of, switchMap, tap, withLatestFrom } from 'rxjs';
 import { AxiosError } from 'axios';
 
+import { User } from 'src/app/models/User';
 import { Room } from 'src/app/models/Room';
 import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
 import { listRoomsResponseInterface } from 'src/app/models/types/responses/listRoomsResponse.interface';
@@ -25,7 +26,14 @@ import {
   updateRoomAction,
   updateRoomSuccessAction,
   updateRoomFailureAction,
+  archiveRoomAction,
+  archiveRoomSuccessAction,
+  archiveRoomFailureAction,
+  unArchiveRoomAction,
+  unArchiveRoomSuccessAction,
+  unArchiveRoomFailureAction,
 } from 'src/app/store/actions/room.action';
+import { currentUserSelector } from 'src/app/store/selectors/auth.selector';
 
 @Injectable()
 export class RoomEffects {
@@ -167,6 +175,43 @@ export class RoomEffects {
         })
       ),
     { dispatch: false }
+  );
+
+  archiveRoom$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(archiveRoomAction),
+      withLatestFrom(this.store.pipe(select(currentUserSelector))),
+      switchMap(([{ request }, currentUser]) =>
+        this.roomService.archiveRoom(currentUser, request.roomId).pipe(
+          map((payload: User) => archiveRoomSuccessAction({ payload })),
+
+          catchError((errorResponse: HttpErrorResponse) => {
+            const error: ErrorInterface = {
+              message: errorResponse.message,
+            };
+            return of(archiveRoomFailureAction({ error }));
+          })
+        )
+      )
+    )
+  );
+
+  unArchivedRoom$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(unArchiveRoomAction),
+      withLatestFrom(this.store.pipe(select(currentUserSelector))),
+      switchMap(([{ request }, currentUser]) =>
+        this.roomService.unArchiveRoom(currentUser, request.roomId).pipe(
+          map((payload: User) => unArchiveRoomSuccessAction({ payload })),
+          catchError((errorResponse: HttpErrorResponse) => {
+            const error: ErrorInterface = {
+              message: errorResponse.message,
+            };
+            return of(unArchiveRoomFailureAction({ error }));
+          })
+        )
+      )
+    )
   );
 
   constructor(

--- a/src/app/store/effects/rooms.effect.ts
+++ b/src/app/store/effects/rooms.effect.ts
@@ -23,11 +23,8 @@ export class RoomsEffects {
     this.actions$.pipe(
       ofType(getRoomsAction),
       withLatestFrom(this.store.pipe(select(currentUserSelector))),
-      switchMap(([{ request }, currentUser]) => {
-        if (request?.archived) {
-          console.log('Request is archived:', request?.archived);
-        }
-        return this.roomService.listRooms(currentUser, request?.archived).pipe(
+      switchMap(([{ request }, currentUser]) =>
+        this.roomService.listRooms(currentUser, request?.archived).pipe(
           map((payload: listRoomsResponseInterface) =>
             getRoomsSuccessAction({ payload })
           ),
@@ -38,8 +35,8 @@ export class RoomsEffects {
             };
             return of(getRoomsFailureAction({ error }));
           })
-        );
-      })
+        )
+      )
     )
   );
 

--- a/src/app/store/effects/rooms.effect.ts
+++ b/src/app/store/effects/rooms.effect.ts
@@ -9,6 +9,12 @@ import { ErrorInterface } from 'src/app/models/types/errors/error.interface';
 import { listRoomsResponseInterface } from 'src/app/models/types/responses/listRoomsResponse.interface';
 import { currentUserSelector } from 'src/app/store/selectors/auth.selector';
 import {
+  getArchivedRoomsAction,
+  getArchivedRoomsFailureAction,
+  getArchivedRoomsSuccessAction,
+  getArchivedRoomsWithOffsetAction,
+  getArchivedRoomsWithOffsetFailureAction,
+  getArchivedRoomsWithOffsetSuccessAction,
   getRoomsAction,
   getRoomsFailureAction,
   getRoomsSuccessAction,
@@ -60,6 +66,50 @@ export class RoomsEffects {
                 message: errorResponse.message,
               };
               return of(getRoomsWithOffsetFailureAction({ error }));
+            })
+          )
+      )
+    )
+  );
+
+  getArchivedRooms$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(getArchivedRoomsAction),
+      withLatestFrom(this.store.pipe(select(currentUserSelector))),
+      switchMap(([_, currentUser]) =>
+        this.roomService.listRooms(currentUser, { archived: true }).pipe(
+          map((payload: listRoomsResponseInterface) => {
+            return getArchivedRoomsSuccessAction({ payload });
+          }),
+
+          catchError((errorResponse: HttpErrorResponse) => {
+            const error: ErrorInterface = {
+              message: errorResponse.message,
+            };
+            return of(getArchivedRoomsFailureAction({ error }));
+          })
+        )
+      )
+    )
+  );
+
+  getArchivedRoomsWithOffset$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(getArchivedRoomsWithOffsetAction),
+      withLatestFrom(this.store.pipe(select(currentUserSelector))),
+      switchMap(([{ request }, currentUser]) =>
+        this.roomService
+          .listRooms(currentUser, { archived: true, offset: request.offset })
+          .pipe(
+            map((payload: listRoomsResponseInterface) => {
+              return getArchivedRoomsWithOffsetSuccessAction({ payload });
+            }),
+
+            catchError((errorResponse: HttpErrorResponse) => {
+              const error: ErrorInterface = {
+                message: errorResponse.message,
+              };
+              return of(getArchivedRoomsWithOffsetFailureAction({ error }));
             })
           )
       )

--- a/src/app/store/effects/rooms.effect.ts
+++ b/src/app/store/effects/rooms.effect.ts
@@ -23,11 +23,11 @@ export class RoomsEffects {
     this.actions$.pipe(
       ofType(getRoomsAction),
       withLatestFrom(this.store.pipe(select(currentUserSelector))),
-      switchMap(([{ request }, currentUser]) =>
-        this.roomService.listRooms(currentUser, request?.archived).pipe(
-          map((payload: listRoomsResponseInterface) =>
-            getRoomsSuccessAction({ payload })
-          ),
+      switchMap(([_, currentUser]) =>
+        this.roomService.listRooms(currentUser).pipe(
+          map((payload: listRoomsResponseInterface) => {
+            return getRoomsSuccessAction({ payload });
+          }),
 
           catchError((errorResponse: HttpErrorResponse) => {
             const error: ErrorInterface = {
@@ -46,7 +46,7 @@ export class RoomsEffects {
       withLatestFrom(this.store.pipe(select(currentUserSelector))),
       switchMap(([{ request }, currentUser]) =>
         this.roomService
-          .listRooms(currentUser, request?.archived, request.offset)
+          .listRooms(currentUser, { offset: request.offset })
           .pipe(
             map((payload: listRoomsResponseInterface) =>
               // TODO: #248 Before dispatch getRoomsWithOffsetSuccessAction,

--- a/src/app/store/effects/rooms.effect.ts
+++ b/src/app/store/effects/rooms.effect.ts
@@ -23,8 +23,11 @@ export class RoomsEffects {
     this.actions$.pipe(
       ofType(getRoomsAction),
       withLatestFrom(this.store.pipe(select(currentUserSelector))),
-      switchMap(([_, currentUser]) =>
-        this.roomService.listRooms(currentUser).pipe(
+      switchMap(([{ request }, currentUser]) => {
+        if (request?.archived) {
+          console.log('Request is archived:', request?.archived);
+        }
+        return this.roomService.listRooms(currentUser).pipe(
           map((payload: listRoomsResponseInterface) =>
             getRoomsSuccessAction({ payload })
           ),
@@ -35,8 +38,8 @@ export class RoomsEffects {
             };
             return of(getRoomsFailureAction({ error }));
           })
-        )
-      )
+        );
+      })
     )
   );
 

--- a/src/app/store/reducers/auth.reducer.ts
+++ b/src/app/store/reducers/auth.reducer.ts
@@ -1,4 +1,5 @@
 import { Badge } from '@capawesome/capacitor-badge';
+import { Capacitor } from '@capacitor/core';
 import { Action, createReducer, on } from '@ngrx/store';
 
 import { AuthStateInterface } from 'src/app/models/types/states/authState.interface';
@@ -105,7 +106,16 @@ import {
   uploadProfilePictureFailureAction,
   uploadProfilePictureSuccessAction,
 } from 'src/app/store/actions/bucket.action';
-import { Capacitor } from '@capacitor/core';
+import {
+  archiveRoomAction,
+  archiveRoomFailureAction,
+  archiveRoomInitialStateAction,
+  archiveRoomSuccessAction,
+  unArchiveRoomAction,
+  unArchiveRoomFailureAction,
+  unArchiveRoomInitialStateAction,
+  unArchiveRoomSuccessAction,
+} from 'src/app/store/actions/room.action';
 
 const initialState: AuthStateInterface = {
   isLoading: false,
@@ -131,6 +141,10 @@ const initialState: AuthStateInterface = {
   unBlockUserError: null,
   blockedUsersData: null,
   blockedUsersError: null,
+  archiveRoomSuccess: false,
+  archiveRoomError: null,
+  unArchiveRoomSuccess: false,
+  unArchiveRoomError: null,
   registerValidationError: null,
   loginValidationError: null,
   unauthorizedError: null,
@@ -957,6 +971,76 @@ const authReducer = createReducer(
       ...state,
       isLoading: false,
       blockedUsersError: action.error,
+    })
+  ),
+
+  // Archive Room Actions
+  on(
+    archiveRoomAction,
+    (state): AuthStateInterface => ({
+      ...state,
+      isLoading: true,
+      archiveRoomError: null,
+    })
+  ),
+  on(
+    archiveRoomSuccessAction,
+    (state, action): AuthStateInterface => ({
+      ...state,
+      isLoading: false,
+      currentUser: action.payload,
+      archiveRoomSuccess: true,
+    })
+  ),
+  on(
+    archiveRoomFailureAction,
+    (state, action): AuthStateInterface => ({
+      ...state,
+      isLoading: false,
+      archiveRoomError: action.error,
+    })
+  ),
+  on(
+    archiveRoomInitialStateAction,
+    (state): AuthStateInterface => ({
+      ...state,
+      archiveRoomSuccess: false,
+      archiveRoomError: null,
+    })
+  ),
+
+  // UnArchive Room Actions
+  on(
+    unArchiveRoomAction,
+    (state): AuthStateInterface => ({
+      ...state,
+      isLoading: true,
+      unArchiveRoomError: null,
+    })
+  ),
+  on(
+    unArchiveRoomSuccessAction,
+    (state, action): AuthStateInterface => ({
+      ...state,
+      isLoading: false,
+      currentUser: action.payload,
+      unArchiveRoomSuccess: true,
+    })
+  ),
+  on(
+    unArchiveRoomFailureAction,
+    (state, action): AuthStateInterface => ({
+      ...state,
+      isLoading: false,
+      unArchiveRoomError: action.error,
+    })
+  ),
+  on(
+    unArchiveRoomInitialStateAction,
+    (state): AuthStateInterface => ({
+      ...state,
+      unArchiveRoomSuccess: false,
+      unArchiveRoomError: null,
     })
   ),
 

--- a/src/app/store/reducers/room.reducer.ts
+++ b/src/app/store/reducers/room.reducer.ts
@@ -45,6 +45,8 @@ const initialState: RoomStateInterface = {
   isLoading: false,
   total: null,
   rooms: null,
+  archivedRooms: null,
+  archivedTotal: null,
   error: null,
   createRoomError: null,
 };

--- a/src/app/store/reducers/room.reducer.ts
+++ b/src/app/store/reducers/room.reducer.ts
@@ -11,6 +11,12 @@ import {
   logoutSuccessAction,
 } from 'src/app/store/actions/auth.action';
 import {
+  getArchivedRoomsAction,
+  getArchivedRoomsFailureAction,
+  getArchivedRoomsSuccessAction,
+  getArchivedRoomsWithOffsetAction,
+  getArchivedRoomsWithOffsetFailureAction,
+  getArchivedRoomsWithOffsetSuccessAction,
   getRoomsAction,
   getRoomsSuccessAction,
   getRoomsFailureAction,
@@ -100,6 +106,60 @@ const roomReducer = createReducer(
   ),
   on(
     getRoomsWithOffsetFailureAction,
+    (state, action): RoomStateInterface => ({
+      ...state,
+      isLoading: false,
+      error: action.error,
+    })
+  ),
+
+  // Get Archived Rooms Reducers
+  on(
+    getArchivedRoomsAction,
+    (state): RoomStateInterface => ({
+      ...state,
+      isLoading: true,
+      error: null,
+    })
+  ),
+  on(
+    getArchivedRoomsSuccessAction,
+    (state, action): RoomStateInterface => ({
+      ...state,
+      isLoading: false,
+      archivedTotal: action.payload?.total,
+      archivedRooms: action.payload?.documents,
+    })
+  ),
+  on(
+    getArchivedRoomsFailureAction,
+    (state, action): RoomStateInterface => ({
+      ...state,
+      isLoading: false,
+      error: action.error,
+    })
+  ),
+
+  // Get Archived Rooms With Offset Reducers
+  on(
+    getArchivedRoomsWithOffsetAction,
+    (state): RoomStateInterface => ({
+      ...state,
+      isLoading: true,
+      error: null,
+    })
+  ),
+  on(
+    getArchivedRoomsWithOffsetSuccessAction,
+    (state, action): RoomStateInterface => ({
+      ...state,
+      isLoading: false,
+      archivedTotal: action.payload?.total,
+      archivedRooms: [...state.archivedRooms, ...action.payload?.documents],
+    })
+  ),
+  on(
+    getArchivedRoomsWithOffsetFailureAction,
     (state, action): RoomStateInterface => ({
       ...state,
       isLoading: false,

--- a/src/app/store/selectors/auth.selector.ts
+++ b/src/app/store/selectors/auth.selector.ts
@@ -170,6 +170,26 @@ export const unBlockUserErrorSelector = createSelector(
   (authState: AuthStateInterface) => authState.unBlockUserError
 );
 
+export const archiveRoomSuccessSelector = createSelector(
+  authFeatureSelector,
+  (authState: AuthStateInterface) => authState.archiveRoomSuccess
+);
+
+export const archiveRoomErrorSelector = createSelector(
+  authFeatureSelector,
+  (authState: AuthStateInterface) => authState.archiveRoomError
+);
+
+export const unArchiveRoomSuccessSelector = createSelector(
+  authFeatureSelector,
+  (authState: AuthStateInterface) => authState.unArchiveRoomSuccess
+);
+
+export const unArchiveRoomErrorSelector = createSelector(
+  authFeatureSelector,
+  (authState: AuthStateInterface) => authState.unArchiveRoomError
+);
+
 export const isLoadingDeleteAccountSelector = createSelector(
   authFeatureSelector,
   (authState: AuthStateInterface) => authState.isLoadingDeleteAccount

--- a/src/app/store/selectors/room.selector.ts
+++ b/src/app/store/selectors/room.selector.ts
@@ -20,6 +20,16 @@ export const totalSelector = createSelector(
   (roomState: RoomStateInterface) => roomState.total
 );
 
+export const archivedRoomsSelector = createSelector(
+  roomFeatureSelector,
+  (roomState: RoomStateInterface) => roomState.archivedRooms
+);
+
+export const archivedTotalSelector = createSelector(
+  roomFeatureSelector,
+  (roomState: RoomStateInterface) => roomState.archivedTotal
+);
+
 export const errorSelector = createSelector(
   roomFeatureSelector,
   (roomState: RoomStateInterface) => roomState.error


### PR DESCRIPTION
**Description:**

This pull request fixes the bug where archived chats were not using a separate query for filtering. Instead of filtering on the frontend, the filtering of archived chats is now done through a separate query on the backend. This improves performance and aligns with best practices.

In addition, this pull request includes several refactorings and updates to the RoomService functionality. The getRoomsAction and getRoomsWithOffsetAction now include an optional "archived" property for filtering archived rooms. The listRooms method in the RoomService class has been updated to support filtering archived rooms and to exclude blocked users. The room selectors have also been updated to include support for retrieving archived rooms and their total count.

These changes enhance the functionality of retrieving and managing rooms in the application, providing users with the ability to filter and manage archived rooms, as well as excluding blocked users from the list of rooms.

Fixes #594