### PR TITLE
Fix room order bug and update room query

### DIFF
--- a/functions/total-unseen-user/src/main.js
+++ b/functions/total-unseen-user/src/main.js
@@ -34,11 +34,11 @@ export default async ({ req, res, log, error }) => {
     // Init queries
     let querry1 = [
       Query.contains('users', user1),
-      Query.orderDesc('$updatedAt'),
+      Query.orderDesc('lastMessageUpdatedAt'),
     ];
     let querry2 = [
       Query.contains('users', user2),
-      Query.orderDesc('$updatedAt'),
+      Query.orderDesc('lastMessageUpdatedAt'),
     ];
 
     // Push archived rooms to query
@@ -96,11 +96,11 @@ export default async ({ req, res, log, error }) => {
     // Init queries
     let querry1archived = [
       Query.contains('users', user1),
-      Query.orderDesc('$updatedAt'),
+      Query.orderDesc('lastMessageUpdatedAt'),
     ];
     let querry2archived = [
       Query.contains('users', user2),
-      Query.orderDesc('$updatedAt'),
+      Query.orderDesc('lastMessageUpdatedAt'),
     ];
 
     let unseenArchivedCountUser1 = 0;

--- a/functions/total-unseen-user/src/main.js
+++ b/functions/total-unseen-user/src/main.js
@@ -68,7 +68,10 @@ export default async ({ req, res, log, error }) => {
       if (room.users.some((user) => user1Doc.blockedUsers.includes(user))) {
         return;
       }
-
+      if (room.$permissions.length === 0) {
+        log(`there is no permissions`);
+        return;
+      }
       if (room.users[0] === user1 && room.unseen[0] !== 0) {
         unseenCountUser1 += room.unseen[0];
       } else if (room.users[1] === user1 && room.unseen[1] !== 0) {
@@ -81,6 +84,10 @@ export default async ({ req, res, log, error }) => {
     listRoomsForUser2.documents.forEach((room) => {
       // Check if any user in room.users is blocked by user1
       if (room.users.some((user) => user2Doc.blockedUsers.includes(user))) {
+        return;
+      }
+      if (room.$permissions.length === 0) {
+        log(`there is no permissions`);
         return;
       }
       if (room.users[0] === user2 && room.unseen[0] !== 0) {
@@ -123,6 +130,10 @@ export default async ({ req, res, log, error }) => {
         if (room.users.some((user) => user1Doc.blockedUsers.includes(user))) {
           return;
         }
+        if (room.$permissions.length === 0) {
+          log(`there is no permissions`);
+          return;
+        }
         if (room.users[0] === user1 && room.unseen[0] !== 0) {
           unseenArchivedCountUser1 += room.unseen[0];
         } else if (room.users[1] === user1 && room.unseen[1] !== 0) {
@@ -144,6 +155,10 @@ export default async ({ req, res, log, error }) => {
       listArchivedRoomsForUser2.documents.forEach((room) => {
         // Check if any user in room.users is blocked by user1
         if (room.users.some((user) => user2Doc.blockedUsers.includes(user))) {
+          return;
+        }
+        if (room.$permissions.length === 0) {
+          log(`there is no permissions`);
           return;
         }
         if (room.users[0] === user2 && room.unseen[0] !== 0) {

--- a/src/app/models/Room.ts
+++ b/src/app/models/Room.ts
@@ -6,4 +6,5 @@ export type Room = Models.Document & {
   typing: Date[];
   unseen: number[];
   archived: string[];
+  lastMessageUpdatedAt: Date;
 };

--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -212,7 +212,7 @@ export class RoomService {
     queries.push(Query.contains('users', currentUser.$id));
 
     // Query for rooms descending by $updatedAt
-    queries.push(Query.orderDesc('$updatedAt'));
+    queries.push(Query.orderDesc('lastMessageUpdatedAt'));
 
     // Limit and offset
     queries.push(Query.limit(environment.opts.PAGINATION_LIMIT));

--- a/src/app/store/reducers/room.reducer.ts
+++ b/src/app/store/reducers/room.reducer.ts
@@ -297,7 +297,8 @@ const roomReducer = createReducer(
     // Sort rooms by $updatedAt in descending order
     const sortedRooms = updatedRooms?.sort(
       (a, b) =>
-        new Date(b.$updatedAt).getTime() - new Date(a.$updatedAt).getTime()
+        new Date(b?.lastMessageUpdatedAt).getTime() -
+        new Date(a?.lastMessageUpdatedAt).getTime()
     );
     // Return the new state
     return { ...state, rooms: sortedRooms };
@@ -344,7 +345,8 @@ const roomReducer = createReducer(
     // Sort rooms by $updatedAt in descending order
     const sortedRooms = updatedRooms?.sort(
       (a, b) =>
-        new Date(b.$updatedAt).getTime() - new Date(a.$updatedAt).getTime()
+        new Date(b?.lastMessageUpdatedAt).getTime() -
+        new Date(a?.lastMessageUpdatedAt).getTime()
     );
 
     // Return the new state
@@ -385,7 +387,8 @@ const roomReducer = createReducer(
     // Sort rooms by $updatedAt in descending order
     const sortedRooms = updatedRooms.sort(
       (a, b) =>
-        new Date(b.$updatedAt).getTime() - new Date(a.$updatedAt).getTime()
+        new Date(b?.lastMessageUpdatedAt).getTime() -
+        new Date(a?.lastMessageUpdatedAt).getTime()
     );
 
     // Return the new state
@@ -411,7 +414,8 @@ const roomReducer = createReducer(
     // Sort rooms by $updatedAt in descending order
     const sortedRooms = updatedRooms?.sort(
       (a, b) =>
-        new Date(b.$updatedAt).getTime() - new Date(a.$updatedAt).getTime()
+        new Date(b?.lastMessageUpdatedAt).getTime() -
+        new Date(a?.lastMessageUpdatedAt).getTime()
     );
     // Return the new state
     return { ...state, rooms: sortedRooms };
@@ -441,7 +445,8 @@ const roomReducer = createReducer(
     // Sort rooms by $updatedAt in descending order
     const sortedRooms = updatedRooms.sort(
       (a, b) =>
-        new Date(b.$updatedAt).getTime() - new Date(a.$updatedAt).getTime()
+        new Date(b?.lastMessageUpdatedAt).getTime() -
+        new Date(a?.lastMessageUpdatedAt).getTime()
     );
 
     // If the room doesn't exist, add the room to the state


### PR DESCRIPTION
Fixes issue #861

This pull request fixes the room order bug where the room orders were updating incorrectly. The bug was caused by the incorrect ordering of rooms based on the `$updatedAt` field. This pull request updates the room query to order the rooms by the `lastMessageUpdatedAt` field instead.

Please review and merge this pull request to resolve the room order bug.