### PR TITLE
Give the app dialogs that exist on the web

### DIFF
--- a/apps/mobile/app/(app)/blocked.tsx
+++ b/apps/mobile/app/(app)/blocked.tsx
@@ -1,10 +1,11 @@
 import { router } from 'expo-router'
-import { ActivityIndicator, Alert, FlatList, Pressable, StyleSheet, Text, View } from 'react-native'
+import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from 'react-native'
 import { useBlocks, useUnblockUser } from '../../src/api/queries'
 import { Avatar } from '../../src/components/ui/Avatar'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
 import { useProfileCache } from '../../src/hooks/useProfileCache'
+import { confirmAlert } from '../../src/lib/alert'
 import { colors, font, spacing } from '../../src/lib/theme'
 
 /**
@@ -59,10 +60,13 @@ export default function BlockedScreen() {
                   hitSlop={8}
                   disabled={unblock.isPending}
                   onPress={() =>
-                    Alert.alert('Unblock', `Unblock ${name}? You will both be visible again.`, [
-                      { text: 'Cancel', style: 'cancel' },
-                      { text: 'Unblock', onPress: () => unblock.mutate(item.blockedId) },
-                    ])
+                    void confirmAlert({
+                      title: 'Unblock',
+                      message: `Unblock ${name}? You will both be visible again.`,
+                      confirmLabel: 'Unblock',
+                    }).then((yes) => {
+                      if (yes) unblock.mutate(item.blockedId)
+                    })
                   }
                 >
                   <Text style={styles.unblock}>Unblock</Text>

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -3,7 +3,6 @@ import { router, useLocalSearchParams } from 'expo-router'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   ActivityIndicator,
-  Alert,
   FlatList,
   KeyboardAvoidingView,
   Platform,
@@ -29,6 +28,7 @@ import * as ImagePicker from 'expo-image-picker'
 import { AudioBubble, ImageBubble } from '../../../src/components/MediaBubble'
 import { MessageMeta } from '../../../src/components/MessageMeta'
 import { useVoiceRecorder } from '../../../src/hooks/useVoiceRecorder'
+import { showAlert } from '../../../src/lib/alert'
 import { emitWithAck, getSocket } from '../../../src/lib/socket'
 import { colors, font, radius, spacing } from '../../../src/lib/theme'
 
@@ -120,7 +120,7 @@ export default function ChatScreen() {
       const socket = await getSocket()
       await emitWithAck(socket, 'message:media', { conversationId, kind, media })
     } catch (error) {
-      Alert.alert(
+      void showAlert(
         'Could not send',
         error instanceof ApiRequestError && error.code === 'QUOTA_EXCEEDED'
           ? "You've reached today's limit for photos and voice messages."
@@ -134,7 +134,7 @@ export default function ChatScreen() {
   async function pickImage(): Promise<void> {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync()
     if (!permission.granted) {
-      Alert.alert('Photos', 'LangX needs permission to open your photo library.')
+      void showAlert('Photos', 'LangX needs permission to open your photo library.')
       return
     }
     const result = await ImagePicker.launchImageLibraryAsync({
@@ -155,7 +155,7 @@ export default function ChatScreen() {
   async function toggleRecording(): Promise<void> {
     if (!recorder.isRecording) {
       const started = await recorder.start()
-      if (!started && recorder.error) Alert.alert('Microphone', recorder.error)
+      if (!started && recorder.error) void showAlert('Microphone', recorder.error)
       return
     }
     const recording = await recorder.stop()
@@ -202,7 +202,7 @@ export default function ChatScreen() {
       const result = await translateApi.mutateAsync({ text: message.body, targetLang: target })
       setTranslations((current) => ({ ...current, [message._id]: result.translatedText }))
     } catch (error) {
-      Alert.alert(
+      await showAlert(
         'Translation unavailable',
         error instanceof ApiRequestError && error.code === 'QUOTA_EXCEEDED'
           ? "You've used today's free translations. Pro removes the limit."

--- a/apps/mobile/app/(app)/discover.tsx
+++ b/apps/mobile/app/(app)/discover.tsx
@@ -9,7 +9,6 @@ import { router, useLocalSearchParams } from 'expo-router'
 import { useMemo, useState } from 'react'
 import {
   ActivityIndicator,
-  Alert,
   FlatList,
   Pressable,
   RefreshControl,
@@ -37,6 +36,7 @@ import {
   toQuery,
   withoutProFilters,
 } from '../../src/lib/discoveryFilters'
+import { showAlert } from '../../src/lib/alert'
 import { captureLocation, LOCATION_FAILURE_MESSAGE } from '../../src/lib/location'
 import { openPaywall } from '../../src/lib/paywall'
 import { colors, font, radius, spacing } from '../../src/lib/theme'
@@ -93,7 +93,7 @@ export default function DiscoverScreen() {
   async function enableSharing(): Promise<boolean> {
     const fix = await captureLocation()
     if (!fix.ok) {
-      Alert.alert('Location needed', LOCATION_FAILURE_MESSAGE[fix.reason])
+      void showAlert('Location needed', LOCATION_FAILURE_MESSAGE[fix.reason])
       return false
     }
     shareLocation.mutate({ lat: fix.lat, lng: fix.lng })

--- a/apps/mobile/app/(app)/edit-profile.tsx
+++ b/apps/mobile/app/(app)/edit-profile.tsx
@@ -16,7 +16,6 @@ import { router } from 'expo-router'
 import { useState } from 'react'
 import {
   ActivityIndicator,
-  Alert,
   Image,
   Pressable,
   ScrollView,
@@ -40,6 +39,7 @@ import { Chip } from '../../src/components/ui/Chip'
 import { FormField } from '../../src/components/ui/FormField'
 import { CountryPicker } from '../../src/components/CountryPicker'
 import { Screen } from '../../src/components/ui/Screen'
+import { confirmAlert, showAlert } from '../../src/lib/alert'
 import { colors, font, layout, radius, spacing } from '../../src/lib/theme'
 
 const GENDER_LABELS: Record<Gender, string> = {
@@ -105,7 +105,7 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
   async function pick(then: (uri: string, contentType: string) => void): Promise<void> {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync()
     if (!permission.granted) {
-      Alert.alert('Photos', 'LangX needs permission to open your photo library.')
+      void showAlert('Photos', 'LangX needs permission to open your photo library.')
       return
     }
     const result = await ImagePicker.launchImageLibraryAsync({
@@ -121,7 +121,7 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
   function onUploadError(caught: unknown): void {
     // Storage may simply not be configured yet on this instance; say so rather
     // than showing a generic failure the user cannot act on.
-    Alert.alert(
+    void showAlert(
       'Upload failed',
       caught instanceof ApiRequestError && caught.code === 'INTERNAL'
         ? 'Photo storage is not configured on this server yet.'
@@ -329,14 +329,14 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
           <Pressable
             key={photo.url}
             onLongPress={() =>
-              Alert.alert('Remove photo', 'Remove this photo from your profile?', [
-                { text: 'Cancel', style: 'cancel' },
-                {
-                  text: 'Remove',
-                  style: 'destructive',
-                  onPress: () => removePhoto.mutate(photo.url),
-                },
-              ])
+              void confirmAlert({
+                title: 'Remove photo',
+                message: 'Remove this photo from your profile?',
+                confirmLabel: 'Remove',
+                destructive: true,
+              }).then((yes) => {
+                if (yes) removePhoto.mutate(photo.url)
+              })
             }
           >
             <Image source={{ uri: photo.url }} style={styles.photo} />

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -1,15 +1,7 @@
 import { countryFlag, getCountry, getLanguage } from '@langx/shared'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useState } from 'react'
-import {
-  ActivityIndicator,
-  Alert,
-  Pressable,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from 'react-native'
+import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from 'react-native'
 import { ApiRequestError } from '../../../src/api/client'
 import {
   useBlockUser,
@@ -23,6 +15,7 @@ import { PhotoGallery } from '../../../src/components/PhotoGallery'
 import { TierBadge } from '../../../src/components/TierBadge'
 import { Chip } from '../../../src/components/ui/Chip'
 import { Screen } from '../../../src/components/ui/Screen'
+import { chooseAlert, confirmAlert } from '../../../src/lib/alert'
 import { days } from '../../../src/lib/format'
 import { colors, font, layout, radius, spacing } from '../../../src/lib/theme'
 
@@ -88,36 +81,23 @@ export default function ProfileScreen() {
     }
   }
 
-  function confirmBlock(): void {
-    Alert.alert(
-      'Block',
-      `Block ${user.displayName}? Neither of you will appear in the other's lists.`,
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Block',
-          style: 'destructive',
-          onPress: () => {
-            block.mutate(user._id, { onSuccess: () => router.replace('/(app)/discover') })
-          },
-        },
-      ],
-    )
+  async function confirmBlock(): Promise<void> {
+    const yes = await confirmAlert({
+      title: 'Block',
+      message: `Block ${user.displayName}? Neither of you will appear in the other's lists.`,
+      confirmLabel: 'Block',
+      destructive: true,
+    })
+    if (yes) block.mutate(user._id, { onSuccess: () => router.replace('/(app)/discover') })
   }
 
-  function confirmReport(): void {
-    Alert.alert('Report', 'Why are you reporting this profile?', [
-      { text: 'Cancel', style: 'cancel' },
-      { text: 'Spam', onPress: () => report.mutate({ userId: user._id, reason: 'spam' }) },
-      {
-        text: 'Harassment',
-        onPress: () => report.mutate({ userId: user._id, reason: 'harassment' }),
-      },
-      {
-        text: 'Inappropriate content',
-        onPress: () => report.mutate({ userId: user._id, reason: 'inappropriate_content' }),
-      },
+  async function confirmReport(): Promise<void> {
+    const reason = await chooseAlert('Report', 'Why are you reporting this profile?', [
+      { label: 'Spam', value: 'spam' },
+      { label: 'Harassment', value: 'harassment' },
+      { label: 'Inappropriate content', value: 'inappropriate_content' },
     ])
+    if (reason) report.mutate({ userId: user._id, reason })
   }
 
   return (
@@ -197,10 +177,10 @@ export default function ProfileScreen() {
       />
 
       <View style={styles.danger}>
-        <Pressable onPress={confirmReport} hitSlop={8}>
+        <Pressable onPress={() => void confirmReport()} hitSlop={8}>
           <Text style={styles.dangerText}>Report</Text>
         </Pressable>
-        <Pressable onPress={confirmBlock} hitSlop={8}>
+        <Pressable onPress={() => void confirmBlock()} hitSlop={8}>
           <Text style={styles.dangerText}>Block</Text>
         </Pressable>
       </View>

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -1,7 +1,7 @@
 import { ACCOUNT_DELETION_GRACE_DAYS } from '@langx/shared'
 import { router } from 'expo-router'
 import { useState } from 'react'
-import { Alert, Linking, Platform, Pressable, StyleSheet, Switch, Text, View } from 'react-native'
+import { Linking, Platform, Pressable, StyleSheet, Switch, Text, View } from 'react-native'
 import { api, ApiRequestError } from '../../src/api/client'
 import {
   useIsPro,
@@ -13,6 +13,7 @@ import {
 import { Button } from '../../src/components/ui/Button'
 import { Screen } from '../../src/components/ui/Screen'
 import { appVersion } from '../../src/hooks/useAppConfig'
+import { confirmAlert, showAlert } from '../../src/lib/alert'
 import { API_URL } from '../../src/lib/apiUrl'
 import { authClient } from '../../src/lib/auth-client'
 import { authLandingHref } from '../../src/lib/authLanding'
@@ -69,7 +70,7 @@ export default function SettingsScreen() {
     }
     const fix = await captureLocation()
     if (!fix.ok) {
-      Alert.alert('Location unavailable', LOCATION_FAILURE_MESSAGE[fix.reason])
+      void showAlert('Location unavailable', LOCATION_FAILURE_MESSAGE[fix.reason])
       return
     }
     shareLocation.mutate({ lat: fix.lat, lng: fix.lng })
@@ -89,35 +90,28 @@ export default function SettingsScreen() {
     await Linking.openURL(url)
   }
 
-  function confirmDelete(): void {
-    Alert.alert(
-      'Delete your account',
-      `Your account disappears immediately. Your data is kept for ${ACCOUNT_DELETION_GRACE_DAYS} days — signing back in within that window cancels the deletion. After that it is permanently removed.`,
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Delete',
-          style: 'destructive',
-          onPress: () => {
-            void (async () => {
-              setBusy(true)
-              try {
-                await api.post('/me/delete', { confirm: 'DELETE' })
-                await authClient.signOut()
-                router.replace(authLandingHref(await readBoolFlag(FLAG_KEYS.introSeen)))
-              } catch (error) {
-                Alert.alert(
-                  'Could not delete',
-                  error instanceof ApiRequestError ? error.message : 'Try again.',
-                )
-              } finally {
-                setBusy(false)
-              }
-            })()
-          },
-        },
-      ],
-    )
+  async function confirmDelete(): Promise<void> {
+    const yes = await confirmAlert({
+      title: 'Delete your account',
+      message: `Your account disappears immediately. Your data is kept for ${ACCOUNT_DELETION_GRACE_DAYS} days — signing back in within that window cancels the deletion. After that it is permanently removed.`,
+      confirmLabel: 'Delete',
+      destructive: true,
+    })
+    if (!yes) return
+
+    setBusy(true)
+    try {
+      await api.post('/me/delete', { confirm: 'DELETE' })
+      await authClient.signOut()
+      router.replace(authLandingHref(await readBoolFlag(FLAG_KEYS.introSeen)))
+    } catch (error) {
+      await showAlert(
+        'Could not delete',
+        error instanceof ApiRequestError ? error.message : 'Try again.',
+      )
+    } finally {
+      setBusy(false)
+    }
   }
 
   /**
@@ -206,7 +200,7 @@ export default function SettingsScreen() {
       />
 
       <Text style={styles.section}>Account</Text>
-      <Pressable onPress={confirmDelete} disabled={busy} style={styles.delete}>
+      <Pressable onPress={() => void confirmDelete()} disabled={busy} style={styles.delete}>
         <Text style={styles.deleteText}>Delete my account</Text>
       </Pressable>
       <Text style={styles.deleteHint}>

--- a/apps/mobile/app/(onboarding)/photo.tsx
+++ b/apps/mobile/app/(onboarding)/photo.tsx
@@ -2,7 +2,7 @@ import { INTEREST_SUGGESTIONS, MAX_INTERESTS } from '@langx/shared'
 import * as ImagePicker from 'expo-image-picker'
 import { router } from 'expo-router'
 import { useState } from 'react'
-import { Alert, Pressable, StyleSheet, Text, View } from 'react-native'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
 import { Image } from 'expo-image'
 import { uploadAvatarBytes } from '../../src/api/queries'
 import { CountryPicker } from '../../src/components/CountryPicker'
@@ -10,6 +10,7 @@ import { Button } from '../../src/components/ui/Button'
 import { Chip } from '../../src/components/ui/Chip'
 import { Screen } from '../../src/components/ui/Screen'
 import { updateDraft, useOnboardingDraft } from '../../src/hooks/useOnboardingDraft'
+import { showAlert } from '../../src/lib/alert'
 import { colors, font, radius, spacing } from '../../src/lib/theme'
 
 /**
@@ -33,7 +34,7 @@ export default function PhotoStep() {
   async function pickPhoto(): Promise<void> {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync()
     if (!permission.granted) {
-      Alert.alert('Photos unavailable', 'LangX needs access to your photos to set a picture.')
+      void showAlert('Photos unavailable', 'LangX needs access to your photos to set a picture.')
       return
     }
 
@@ -51,7 +52,7 @@ export default function PhotoStep() {
       const url = await uploadAvatarBytes(asset.uri, asset.mimeType ?? 'image/jpeg')
       updateDraft({ avatarUrl: url })
     } catch {
-      Alert.alert('Upload failed', 'That picture did not upload. You can try again or skip.')
+      void showAlert('Upload failed', 'That picture did not upload. You can try again or skip.')
     } finally {
       setUploading(false)
     }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react'
 import { ActivityIndicator, View } from 'react-native'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { ApiRequestError } from '../src/api/client'
+import { AlertHost } from '../src/components/AlertHost'
 import { AppGate } from '../src/components/AppGate'
 import { authClient } from '../src/lib/auth-client'
 import { forgetPurchasesIdentity, identifyForPurchases } from '../src/lib/purchases'
@@ -74,6 +75,12 @@ export default function RootLayout() {
           </View>
         ) : (
           <AppGate>
+            {/*
+              Above the navigator, not inside a screen: the delete-account flow
+              signs out while its own confirmation is still open, and a dialog
+              owned by a screen dies with it.
+            */}
+            <AlertHost />
             <Stack screenOptions={{ headerShown: false }}>
               <Stack.Protected guard={!!session}>
                 <Stack.Screen name="index" />

--- a/apps/mobile/src/components/AlertHost.tsx
+++ b/apps/mobile/src/components/AlertHost.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react'
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native'
+import { dismissValue, resolveAlert, subscribeToAlerts, type AlertRequest } from '../lib/alert'
+import { colors, font, radius, spacing } from '../lib/theme'
+
+/**
+ * Draws whatever `src/lib/alert.ts` has queued.
+ *
+ * Mounted once at the root, above the navigator, so a dialog raised from any
+ * screen survives that screen navigating away — the delete-account flow signs
+ * out underneath its own confirmation.
+ *
+ * `Modal` rather than a positioned `View` because react-native-web renders it
+ * into its own layer: an absolutely positioned overlay inside the tab navigator
+ * sits under the tab bar on web, which is exactly where the buttons are.
+ */
+export function AlertHost() {
+  const [request, setRequest] = useState<AlertRequest<unknown> | null>(null)
+
+  useEffect(() => subscribeToAlerts(setRequest), [])
+
+  if (!request) return null
+  const dismiss = (): void => resolveAlert(request.id, dismissValue(request.buttons))
+
+  return (
+    <Modal transparent animationType="fade" visible onRequestClose={dismiss}>
+      {/* Tapping outside is the same as cancelling, and the same as the back button. */}
+      <Pressable style={styles.backdrop} onPress={dismiss}>
+        {/* Swallows the press so tapping the dialog itself does not close it. */}
+        <Pressable style={styles.card} onPress={() => {}}>
+          <Text style={styles.title}>{request.title}</Text>
+          {request.message ? <Text style={styles.message}>{request.message}</Text> : null}
+          <View style={styles.buttons}>
+            {request.buttons.map((button) => (
+              <Pressable
+                key={button.label}
+                onPress={() => resolveAlert(request.id, button.value)}
+                style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+              >
+                <Text
+                  style={[
+                    styles.buttonText,
+                    button.style === 'destructive' && styles.destructive,
+                    button.style === 'cancel' && styles.cancel,
+                  ]}
+                >
+                  {button.label}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    flex: 1,
+    justifyContent: 'center',
+    padding: spacing.lg,
+  },
+  card: {
+    backgroundColor: colors.bg,
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    maxWidth: 420,
+    padding: spacing.lg,
+    width: '100%',
+  },
+  title: { ...font.title, color: colors.text, fontSize: 20 },
+  message: { ...font.body, color: colors.textMuted, lineHeight: 22, marginTop: spacing.sm },
+  // A column, not a row: these labels are sentences ("Inappropriate content"),
+  // and three of them side by side wrap into unreadable stacks on a phone.
+  buttons: { gap: spacing.xs, marginTop: spacing.lg },
+  button: { borderRadius: radius.md, paddingHorizontal: spacing.md, paddingVertical: spacing.sm },
+  buttonPressed: { backgroundColor: colors.border },
+  buttonText: { ...font.body, color: colors.text, fontWeight: '600', textAlign: 'center' },
+  destructive: { color: colors.danger },
+  cancel: { color: colors.textMuted, fontWeight: '400' },
+})

--- a/apps/mobile/src/lib/alert.test.ts
+++ b/apps/mobile/src/lib/alert.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  askAlert,
+  chooseAlert,
+  confirmAlert,
+  dismissValue,
+  resetAlertsForTest,
+  resolveAlert,
+  showAlert,
+  subscribeToAlerts,
+  type AlertRequest,
+} from './alert'
+
+beforeEach(() => resetAlertsForTest())
+
+/** Stands in for `AlertHost`: records what it is asked to draw. */
+function mountHost(): { shown: () => AlertRequest<unknown> | null } {
+  let current: AlertRequest<unknown> | null = null
+  subscribeToAlerts((request) => {
+    current = request
+  })
+  return { shown: () => current }
+}
+
+describe('askAlert', () => {
+  it('resolves with the pressed button’s value', async () => {
+    const host = mountHost()
+    const answer = askAlert('Title', 'Body', [
+      { label: 'No', value: 'no' },
+      { label: 'Yes', value: 'yes' },
+    ])
+    resolveAlert(host.shown()!.id, 'yes')
+    await expect(answer).resolves.toBe('yes')
+  })
+
+  it('shows nothing once every request is answered', async () => {
+    const host = mountHost()
+    const answer = showAlert('Done')
+    resolveAlert(host.shown()!.id, undefined)
+    await answer
+    expect(host.shown()).toBeNull()
+  })
+
+  /**
+   * The reason this queues instead of replacing: an upload failing while a
+   * quota warning is still up must not swallow one of the two messages.
+   */
+  it('queues a second request behind the first', async () => {
+    const host = mountHost()
+    const first = askAlert('First', undefined, [{ label: 'OK', value: 1 }])
+    const second = askAlert('Second', undefined, [{ label: 'OK', value: 2 }])
+    expect(host.shown()?.title).toBe('First')
+
+    resolveAlert(host.shown()!.id, 1)
+    await expect(first).resolves.toBe(1)
+    expect(host.shown()?.title).toBe('Second')
+
+    resolveAlert(host.shown()!.id, 2)
+    await expect(second).resolves.toBe(2)
+  })
+
+  it('ignores an id it has already resolved', async () => {
+    const host = mountHost()
+    const answer = showAlert('Once')
+    const { id } = host.shown()!
+    resolveAlert(id, undefined)
+    await answer
+    expect(() => resolveAlert(id, undefined)).not.toThrow()
+  })
+})
+
+describe('confirmAlert', () => {
+  it('is false until the confirm button is pressed', async () => {
+    const host = mountHost()
+    const answer = confirmAlert({ title: 'Delete', confirmLabel: 'Delete', destructive: true })
+    const request = host.shown()!
+    expect(request.buttons.map((b) => b.label)).toEqual(['Cancel', 'Delete'])
+    expect(request.buttons[1]?.style).toBe('destructive')
+    resolveAlert(request.id, true)
+    await expect(answer).resolves.toBe(true)
+  })
+
+  /**
+   * Dismissing has to mean "no". This is the guard on the account-deletion
+   * dialog: tapping the backdrop must never be read as consent.
+   */
+  it('treats a dismissal as a refusal', async () => {
+    const host = mountHost()
+    const answer = confirmAlert({ title: 'Delete', confirmLabel: 'Delete' })
+    const request = host.shown()!
+    resolveAlert(request.id, dismissValue(request.buttons))
+    await expect(answer).resolves.toBe(false)
+  })
+})
+
+describe('chooseAlert', () => {
+  it('resolves with the chosen value', async () => {
+    const host = mountHost()
+    const answer = chooseAlert('Report', 'Why?', [
+      { label: 'Spam', value: 'spam' },
+      { label: 'Harassment', value: 'harassment' },
+    ])
+    expect(host.shown()?.buttons.map((b) => b.label)).toEqual(['Spam', 'Harassment', 'Cancel'])
+    resolveAlert(host.shown()!.id, 'harassment')
+    await expect(answer).resolves.toBe('harassment')
+  })
+
+  it('resolves with null when dismissed, so nothing is reported by accident', async () => {
+    const host = mountHost()
+    const answer = chooseAlert('Report', undefined, [{ label: 'Spam', value: 'spam' }])
+    const request = host.shown()!
+    resolveAlert(request.id, dismissValue(request.buttons))
+    await expect(answer).resolves.toBeNull()
+  })
+})
+
+describe('dismissValue', () => {
+  it('is the cancel button’s value', () => {
+    expect(dismissValue([{ label: 'Cancel', value: false, style: 'cancel' }])).toBe(false)
+  })
+
+  it('is undefined when there is nothing to cancel', () => {
+    expect(dismissValue([{ label: 'OK', value: undefined }])).toBeUndefined()
+  })
+})
+
+describe('subscribeToAlerts', () => {
+  it('hands a pending request to a host that mounts late', () => {
+    void showAlert('Already waiting')
+    const host = mountHost()
+    expect(host.shown()?.title).toBe('Already waiting')
+  })
+
+  it('stops publishing after unsubscribe', () => {
+    const seen = vi.fn()
+    const unsubscribe = subscribeToAlerts(seen)
+    unsubscribe()
+    seen.mockClear()
+    void showAlert('Nobody is listening')
+    expect(seen).not.toHaveBeenCalled()
+  })
+})

--- a/apps/mobile/src/lib/alert.ts
+++ b/apps/mobile/src/lib/alert.ts
@@ -1,0 +1,132 @@
+/**
+ * Dialogs that exist on every platform.
+ *
+ * `Alert` from react-native is `class Alert { static alert() {} }` on
+ * react-native-web — an empty function. Every confirmation in this app was
+ * therefore a no-op in the browser, and the ones carrying an `onPress` were
+ * worse than silent: "Delete my account" raised a dialog that never appeared,
+ * so the callback behind it never ran and the button did nothing at all.
+ *
+ * The fix is one dialog of our own rather than a platform switch. `window.confirm`
+ * would cover the two-button cases and not the report picker, which offers three
+ * reasons, and a UI that diverges by platform is a UI that gets tested on one of
+ * them. `AlertHost` renders these requests with `Modal`, which react-native-web
+ * does implement.
+ *
+ * This module is the state, deliberately separate from the component that draws
+ * it: everything decided here is a pure function of a queue, and `src/lib` is the
+ * only place the test setup can reach.
+ */
+
+export interface AlertButton<T = void> {
+  label: string
+  /** Resolves the request with this when pressed. */
+  value: T
+  /** `cancel` is also what dismissing resolves to. `destructive` reads red. */
+  style?: 'default' | 'cancel' | 'destructive'
+}
+
+export interface AlertRequest<T = unknown> {
+  id: number
+  title: string
+  message?: string
+  buttons: AlertButton<T>[]
+}
+
+type Listener = (request: AlertRequest<unknown> | null) => void
+
+let nextId = 1
+let queue: { request: AlertRequest<unknown>; resolve: (value: never) => void }[] = []
+let listener: Listener | null = null
+
+function publish(): void {
+  listener?.(queue[0]?.request ?? null)
+}
+
+/** `AlertHost` subscribes; the returned function unsubscribes. */
+export function subscribeToAlerts(next: Listener): () => void {
+  listener = next
+  publish()
+  return () => {
+    if (listener === next) listener = null
+  }
+}
+
+/**
+ * Shows a dialog and resolves with the pressed button's value.
+ *
+ * Requests queue rather than replace each other. Two failures arriving together
+ * — an upload that fails while a quota warning is still up — must not leave the
+ * user having seen only one of them.
+ */
+export function askAlert<T>(
+  title: string,
+  message: string | undefined,
+  buttons: AlertButton<T>[],
+): Promise<T> {
+  return new Promise<T>((resolve) => {
+    queue = [
+      ...queue,
+      {
+        request: { id: nextId++, title, message, buttons } as AlertRequest<unknown>,
+        resolve,
+      },
+    ]
+    publish()
+  })
+}
+
+/** Called by `AlertHost` when a button is pressed or the dialog is dismissed. */
+export function resolveAlert(id: number, value: unknown): void {
+  const entry = queue.find((each) => each.request.id === id)
+  if (!entry) return
+  queue = queue.filter((each) => each.request.id !== id)
+  entry.resolve(value as never)
+  publish()
+}
+
+/** What dismissing a dialog means: the cancel button, or nothing. */
+export function dismissValue<T>(buttons: AlertButton<T>[]): T | undefined {
+  return buttons.find((b) => b.style === 'cancel')?.value
+}
+
+/** A message with nothing to decide. */
+export function showAlert(title: string, message?: string): Promise<void> {
+  return askAlert<void>(title, message, [{ label: 'OK', value: undefined }])
+}
+
+/** A yes/no question. Dismissing counts as no. */
+export function confirmAlert(options: {
+  title: string
+  message?: string
+  confirmLabel: string
+  destructive?: boolean
+}): Promise<boolean> {
+  return askAlert<boolean>(options.title, options.message, [
+    { label: 'Cancel', value: false, style: 'cancel' },
+    {
+      label: options.confirmLabel,
+      value: true,
+      style: options.destructive ? 'destructive' : 'default',
+    },
+  ])
+}
+
+/** One of several choices, or `null` when cancelled. */
+export function chooseAlert<T extends string>(
+  title: string,
+  message: string | undefined,
+  choices: { label: string; value: T }[],
+): Promise<T | null> {
+  return askAlert<T | null>(title, message, [
+    ...choices.map((c) => ({ label: c.label, value: c.value })),
+    { label: 'Cancel', value: null, style: 'cancel' as const },
+  ])
+}
+
+/** Test seam: drops any queued request without resolving it. */
+export function resetAlertsForTest(): void {
+  queue = []
+  listener = null
+  nextId = 1
+}

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -109,6 +109,42 @@ Without the webhook the app still sells subscriptions — the paywall calls
 every renewal and cancellation that happens outside the app, which is most of
 them after the first month.
 
+### Which database production actually uses
+
+dev and prod are **not two clusters — they are two database names inside one
+cluster**, and the cluster is the one called `dev`. Checked 28 August 2026:
+
+| Where              | `MONGODB_DB`   | Against                                 |
+| ------------------ | -------------- | --------------------------------------- |
+| Local `.env`       | `langx_dev`    | `dev.3xuhkbz.mongodb.net` (Atlas)       |
+| `fly.toml` `[env]` | `langx`        | whatever the `MONGODB_URI` secret holds |
+| Tests              | `langx_*_test` | `mongodb-memory-server`, never Atlas    |
+
+So **production is `langx`, and it is serving**: `langx-api.fly.dev/health`
+answers `{"status":"ok","db":"up"}`. `client.db(dbName)` in
+`apps/api/src/db/client.ts` is the entire separation — one connection string,
+one Atlas user, two names.
+
+Two consequences, neither of which is visible from the app:
+
+- The credentials in `.env` and `atlas-credentials.env` are a **single Atlas
+  user reaching both databases**. Anything that can read the dev database can
+  read and drop the production one, and a script run with the wrong
+  `MONGODB_DB` writes to real users. `scripts/seed-test-users.ts` takes a
+  `--db` flag for exactly this reason — it is a guard, not a convenience.
+- Both share one cluster's storage and connection limit, so a migration ETL
+  run from a laptop competes with production traffic.
+
+- [ ] Verify against the deploy rather than against this file, with
+      `fly secrets list` and `fly config env` on `langx-api`. A secret named
+      `MONGODB_DB` silently overrides `[env]` in `fly.toml`, and that could not
+      be checked from the droplet — flyctl is not installed there
+- [ ] Decide whether production keeps living in a cluster named `dev`. A
+      separate cluster — or at minimum a second Atlas user restricted to
+      `langx` — is what stops a local mistake reaching real users. It costs one
+      `fly secrets set MONGODB_URI` and a restart, so do it **before** the
+      migration ETLs load 3,479 real profiles in, not after
+
 ## Deep links only work once the domain answers
 
 `app.langx.io` is claimed in two places — `associatedDomains` on iOS,
@@ -214,6 +250,36 @@ A `DeviceNotRegistered` ticket in the reply means the credentials are wrong,
 not the token. The API prunes tokens that come back with it, so a
 misconfigured send also quietly empties the devices collection — fix the
 credentials before running the streak reminder against real users.
+
+## Actions that succeed silently
+
+`src/lib/alert.ts` and `AlertHost` give the app a dialog that works in the
+browser as well as on a device, and the destructive paths already ask before
+they act. The other half is missing: an action that _succeeds_ says nothing.
+
+Sign out is the clearest case. `apps/mobile/app/(app)/me.tsx` unregisters the
+push token, ends the session and replaces the route — three things — and all
+the user sees is the sign-in screen appearing. On web that reads as a page that
+navigated by itself, not as a session that ended.
+
+- [ ] Ask before signing out, so a mis-tap on the profile screen is not an
+      instant session loss
+- [ ] Acknowledge after it: "Signed out — your session has ended." A request
+      queued in `alert.ts` outlives the `router.replace` underneath it, because
+      `AlertHost` is mounted at the root layout rather than inside the
+      navigator — the same reason the delete-account confirmation survives
+      signing itself out
+- [ ] Give the same treatment to the other actions that return to a screen with
+      no word about what happened: profile saved, photo uploaded, report sent,
+      user blocked and unblocked
+- [ ] Decide modal vs. banner first, once, rather than per screen. `AlertHost`
+      draws a `Modal`, which is right for a question and heavy for "Saved" — a
+      success with nothing to decide probably wants a self-dismissing banner on
+      the same queue, not a button the user has to press. Ship the two side by
+      side and the app has two notification languages
+
+Nothing here blocks the build, and all of it is visible in the first minute of
+use. It belongs before the rollout widens, not in the first patch after it.
 
 ## Prerequisites that are business process, not code
 


### PR DESCRIPTION
`Alert` from react-native is never drawn by react-native-web, so every confirmation and every error the app raised through it was invisible in the browser — deleting an account did nothing visible at all. This replaces it with our own `alert.ts` queue and an `AlertHost` mounted in `_layout.tsx`, covering blocked, chat, discover, edit-profile, profile, settings and the onboarding photo screen.

Also adds two open items to the release runbook:

- The modal-vs-banner choice, settled once rather than per screen: **success → toast, failure → alert.**
- dev and prod are two database names inside the one Atlas cluster called `dev`, not two clusters. Production runs `langx`; local development runs `langx_dev` against the same cluster and the same user.

Verified end to end in a browser: the delete dialog, cancel, backdrop dismissal, the three-option report, and block/unblock.

Merge order note: `xuelink/signout-feedback` is branched off this one and its `me.tsx` calls `confirmAlert`, so this must land first.
