### PR TITLE
Say something when signing out

### DIFF
--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -28,11 +28,13 @@ import { Avatar } from '../../src/components/ui/Avatar'
 import { Button } from '../../src/components/ui/Button'
 import { Chip } from '../../src/components/ui/Chip'
 import { Screen } from '../../src/components/ui/Screen'
+import { confirmAlert } from '../../src/lib/alert'
 import { authClient } from '../../src/lib/auth-client'
 import { authLandingHref } from '../../src/lib/authLanding'
 import { FLAG_KEYS, readBoolFlag } from '../../src/lib/localFlags'
 import { openPaywall } from '../../src/lib/paywall'
 import { colors, font, layout, radius, spacing } from '../../src/lib/theme'
+import { showToast } from '../../src/lib/toast'
 
 /** "🇹🇷 Türkiye", not "🇹🇷 TR" — the flag and the code say the same thing twice. */
 function countryLabel(code: string): string {
@@ -84,6 +86,16 @@ export default function MeScreen() {
   const owned = wallet.data?.owned ?? []
 
   async function signOut(): Promise<void> {
+    // Sign out sits under the profile, one mis-tap away from everything on it.
+    // Asking costs a tap; not asking costs a session and, on a device that
+    // never saved the password, whatever it takes to get back in.
+    const yes = await confirmAlert({
+      title: 'Sign out?',
+      message: 'You can sign back in with the same account whenever you like.',
+      confirmLabel: 'Sign out',
+    })
+    if (!yes) return
+
     // Before the session ends, not after: once signed out the request has no
     // credentials and the token would stay attached to the account, still
     // receiving its messages on a device nobody is signed into.
@@ -93,6 +105,10 @@ export default function MeScreen() {
     // `(auth)/index` is the only screen that reads the flag, and this route
     // never went through it.
     router.replace(authLandingHref(await readBoolFlag(FLAG_KEYS.introSeen)))
+    // After the replace, and it still arrives: `ToastHost` lives above the
+    // navigator. Without this the whole thing reads as a screen that navigated
+    // by itself rather than as a session that ended.
+    showToast('Signed out — your session has ended.')
   }
 
   /** Everything on this screen comes from a different query. */

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -7,6 +7,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { ApiRequestError } from '../src/api/client'
 import { AlertHost } from '../src/components/AlertHost'
 import { AppGate } from '../src/components/AppGate'
+import { ToastHost } from '../src/components/ToastHost'
 import { authClient } from '../src/lib/auth-client'
 import { forgetPurchasesIdentity, identifyForPurchases } from '../src/lib/purchases'
 import { colors } from '../src/lib/theme'
@@ -91,6 +92,12 @@ export default function RootLayout() {
                 <Stack.Screen name="(auth)" />
               </Stack.Protected>
             </Stack>
+            {/*
+              After the navigator, not before it: this one is a plain
+              positioned view rather than a Modal, so painting over the screen
+              is a matter of coming later in the tree.
+            */}
+            <ToastHost />
           </AppGate>
         )}
       </QueryClientProvider>

--- a/apps/mobile/src/components/ToastHost.tsx
+++ b/apps/mobile/src/components/ToastHost.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from 'react'
+import { Animated, Pressable, StyleSheet, Text } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { dismissToast, subscribeToToasts, type Toast } from '../lib/toast'
+import { colors, font, radius, spacing } from '../lib/theme'
+
+/**
+ * Draws whatever `src/lib/toast.ts` has queued.
+ *
+ * Mounted once at the root and *after* the navigator, so it paints over every
+ * screen and survives the screen underneath it going away — signing out
+ * replaces the route immediately, and a banner owned by the profile screen
+ * would die with it, which is the one moment it has something to say.
+ *
+ * A plain absolutely positioned view rather than `Modal`, which is what
+ * `AlertHost` uses: a `Modal` takes the touches of the whole screen, and a
+ * message with nothing to decide must not stop anyone from carrying on while
+ * it is up. `pointerEvents="box-none"` keeps that true of the full-width layer
+ * — only the banner itself is tappable, and tapping it dismisses early.
+ */
+export function ToastHost() {
+  const [toast, setToast] = useState<Toast | null>(null)
+  const opacity = useRef(new Animated.Value(0)).current
+  const insets = useSafeAreaInsets()
+
+  useEffect(() => subscribeToToasts(setToast), [])
+
+  useEffect(() => {
+    if (!toast) return
+    opacity.setValue(0)
+    Animated.timing(opacity, { toValue: 1, duration: 160, useNativeDriver: true }).start()
+    // Keyed on the id, so a second toast arriving restarts the clock for
+    // itself rather than inheriting what was left of the first one's.
+    const timer = setTimeout(() => dismissToast(toast.id), toast.durationMs)
+    return () => clearTimeout(timer)
+  }, [toast, opacity])
+
+  if (!toast) return null
+
+  return (
+    <Animated.View
+      pointerEvents="box-none"
+      style={[styles.layer, { opacity, paddingTop: insets.top + spacing.md }]}
+    >
+      <Pressable
+        accessibilityRole="alert"
+        onPress={() => dismissToast(toast.id)}
+        style={styles.banner}
+      >
+        <Text style={styles.text}>{toast.message}</Text>
+      </Pressable>
+    </Animated.View>
+  )
+}
+
+const styles = StyleSheet.create({
+  // Top, not bottom, which is where a toast usually goes. The bottom of this
+  // app is where its buttons are — the tab bar on every signed-in screen, and
+  // the intro's Next — and the banner is tappable, so four seconds of it
+  // sitting there is four seconds of a dead button. At the top it covers a
+  // heading, which nobody was going to press.
+  layer: {
+    alignItems: 'center',
+    left: 0,
+    paddingHorizontal: spacing.lg,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  // Neutral dark rather than `colors.success`: these sentences report what
+  // happened, and green would dress "Signed out" up as a celebration.
+  banner: {
+    backgroundColor: colors.primary,
+    borderRadius: radius.md,
+    maxWidth: 420,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    width: '100%',
+  },
+  text: { ...font.body, color: colors.primaryText, textAlign: 'center' },
+})

--- a/apps/mobile/src/lib/toast.test.ts
+++ b/apps/mobile/src/lib/toast.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  TOAST_DURATION_MS,
+  dismissToast,
+  resetToastsForTest,
+  showToast,
+  subscribeToToasts,
+  type Toast,
+} from './toast'
+
+beforeEach(() => resetToastsForTest())
+
+/** Stands in for `ToastHost`: records what it is asked to draw. */
+function mountHost(): { shown: () => Toast | null } {
+  let current: Toast | null = null
+  subscribeToToasts((toast) => {
+    current = toast
+  })
+  return { shown: () => current }
+}
+
+describe('showToast', () => {
+  it('shows the message it was given', () => {
+    const host = mountHost()
+    showToast('Signed out — your session has ended.')
+    expect(host.shown()?.message).toBe('Signed out — your session has ended.')
+    expect(host.shown()?.durationMs).toBe(TOAST_DURATION_MS)
+  })
+
+  it('shows nothing until something is queued', () => {
+    const host = mountHost()
+    expect(host.shown()).toBeNull()
+  })
+
+  it('shows nothing again once dismissed', () => {
+    const host = mountHost()
+    showToast('Saved')
+    dismissToast(host.shown()!.id)
+    expect(host.shown()).toBeNull()
+  })
+
+  /**
+   * The reason this queues instead of replacing, which is also why `alert.ts`
+   * does: two things finishing at once must not leave one of them unsaid.
+   */
+  it('queues a second message behind the first', () => {
+    const host = mountHost()
+    showToast('First')
+    showToast('Second')
+    expect(host.shown()?.message).toBe('First')
+
+    dismissToast(host.shown()!.id)
+    expect(host.shown()?.message).toBe('Second')
+
+    dismissToast(host.shown()!.id)
+    expect(host.shown()).toBeNull()
+  })
+
+  /**
+   * `ToastHost` sets a timer per toast and clears it on unmount, but a timer
+   * that fires late — after the banner was tapped — must not take the next
+   * message down with it.
+   */
+  it('ignores a dismissal for a toast that is already gone', () => {
+    const host = mountHost()
+    showToast('First')
+    const staleId = host.shown()!.id
+    dismissToast(staleId)
+    showToast('Second')
+
+    dismissToast(staleId)
+    expect(host.shown()?.message).toBe('Second')
+  })
+
+  it('accepts a duration of its own', () => {
+    const host = mountHost()
+    showToast('Briefly', 500)
+    expect(host.shown()?.durationMs).toBe(500)
+  })
+
+  it('stops publishing once unsubscribed', () => {
+    let current: Toast | null = null
+    const unsubscribe = subscribeToToasts((toast) => {
+      current = toast
+    })
+    unsubscribe()
+    showToast('Nobody is listening')
+    expect(current).toBeNull()
+  })
+})

--- a/apps/mobile/src/lib/toast.ts
+++ b/apps/mobile/src/lib/toast.ts
@@ -1,0 +1,74 @@
+/**
+ * Transient confirmations: the app saying that something it just did worked.
+ *
+ * Deliberately not part of `alert.ts`, and this is the whole design decision.
+ * An alert is a question — it blocks, it waits, and the answer changes what
+ * happens next. A confirmation has nothing to decide: it appears, it says what
+ * happened, it leaves. Putting both on one queue would make every "Signed out"
+ * wait behind a dialog nobody has answered yet, and would put an OK button
+ * under a sentence nobody needs to acknowledge.
+ *
+ * The rule that follows, so it is decided once rather than per screen:
+ * **something that worked gets a toast, something that failed gets an alert.**
+ * A failure carries detail and is worth interrupting for; missing it because
+ * you looked away for four seconds is exactly the outcome `alert.ts` exists to
+ * prevent.
+ *
+ * Same shape as `alert.ts` otherwise and for the same reason: the state lives
+ * here, apart from the component that draws it, because `src/lib` is the only
+ * directory the test setup can reach. The timer belongs to `ToastHost` so that
+ * everything decided in this module stays a pure function of a queue.
+ */
+
+export interface Toast {
+  id: number
+  message: string
+  durationMs: number
+}
+
+/** Long enough to read a short sentence without having to stop and read it. */
+export const TOAST_DURATION_MS = 4000
+
+type Listener = (toast: Toast | null) => void
+
+let nextId = 1
+let queue: Toast[] = []
+let listener: Listener | null = null
+
+function publish(): void {
+  listener?.(queue[0] ?? null)
+}
+
+/** `ToastHost` subscribes; the returned function unsubscribes. */
+export function subscribeToToasts(next: Listener): () => void {
+  listener = next
+  publish()
+  return () => {
+    if (listener === next) listener = null
+  }
+}
+
+/**
+ * Says that something worked.
+ *
+ * Queues rather than replaces, for the same reason alerts do: two things
+ * finishing at once must not leave the user having seen only one of them.
+ */
+export function showToast(message: string, durationMs: number = TOAST_DURATION_MS): void {
+  queue = [...queue, { id: nextId++, message, durationMs }]
+  publish()
+}
+
+/** Called by `ToastHost` when the timer runs out, or when the banner is tapped. */
+export function dismissToast(id: number): void {
+  if (!queue.some((toast) => toast.id === id)) return
+  queue = queue.filter((toast) => toast.id !== id)
+  publish()
+}
+
+/** Test seam: drops anything queued. */
+export function resetToastsForTest(): void {
+  queue = []
+  listener = null
+  nextId = 1
+}

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -262,21 +262,24 @@ push token, ends the session and replaces the route — three things — and all
 the user sees is the sign-in screen appearing. On web that reads as a page that
 navigated by itself, not as a session that ended.
 
-- [ ] Ask before signing out, so a mis-tap on the profile screen is not an
+**The decision, made once so it is not remade per screen: something that
+worked gets a toast, something that failed gets an alert.** A failure carries
+detail and is worth interrupting for — missing it because you looked away for
+four seconds is the outcome `alert.ts` exists to prevent. A success has nothing
+to decide, and putting an OK button under it asks for a tap that means nothing.
+`src/lib/toast.ts` is the second queue that follows from it, drawn by
+`ToastHost` as a self-dismissing banner rather than a `Modal`, so it never
+takes the screen's touches while it is up.
+
+- [x] Ask before signing out, so a mis-tap on the profile screen is not an
       instant session loss
-- [ ] Acknowledge after it: "Signed out — your session has ended." A request
-      queued in `alert.ts` outlives the `router.replace` underneath it, because
-      `AlertHost` is mounted at the root layout rather than inside the
-      navigator — the same reason the delete-account confirmation survives
-      signing itself out
+- [x] Acknowledge after it: "Signed out — your session has ended." The banner
+      outlives the `router.replace` underneath it because `ToastHost` is
+      mounted at the root layout rather than inside the navigator — the same
+      reason the delete-account confirmation survives signing itself out
 - [ ] Give the same treatment to the other actions that return to a screen with
       no word about what happened: profile saved, photo uploaded, report sent,
-      user blocked and unblocked
-- [ ] Decide modal vs. banner first, once, rather than per screen. `AlertHost`
-      draws a `Modal`, which is right for a question and heavy for "Saved" — a
-      success with nothing to decide probably wants a self-dismissing banner on
-      the same queue, not a button the user has to press. Ship the two side by
-      side and the app has two notification languages
+      user blocked and unblocked, account deleted
 
 Nothing here blocks the build, and all of it is visible in the first minute of
 use. It belongs before the rollout widens, not in the first patch after it.


### PR DESCRIPTION
Signing out did three things at once — unregistered the push token, ended the session, replaced the route — and showed none of them. All the user saw was the sign-in screen appearing, which on web reads as a screen that navigated by itself rather than as a session that ended. It was also one mis-tap away from everything else on the profile screen, with no way back on a device that never saved the password.

So: a confirmation before, and a banner after.

`toast.ts` is a second queue rather than a mode on `alert.ts`, and that split is the part worth reviewing. An alert is a question — it blocks, it waits, and the answer changes what happens next. A confirmation has nothing to decide. Sharing one queue would have made every "Signed out" wait behind a dialog nobody had answered, and put an OK button under a sentence nobody needs to acknowledge. The rule that follows, recorded in the runbook so it is settled once rather than per screen: **something that worked gets a toast, something that failed gets an alert.**

`ToastHost` sits above the navigator, next to `AlertHost`, so the banner outlives the `router.replace` underneath it — the same reason the delete-account confirmation survives signing itself out. It is a positioned view rather than a `Modal`, so it never takes the screen's touches while it is up, and it sits at the top rather than the bottom: the bottom of this app is where its buttons are (the tab bar, the intro's Next), and a tappable banner down there is four seconds of a dead button.

Verified in a browser against a real API: cancelling leaves the session alone and says nothing, confirming ends it, the banner arrives on the screen the replace landed on, and it leaves on its own.

---

**Based on `xuelink/web-alerts` (#945), not on `main`.** `me.tsx` calls `confirmAlert`, which only exists there. Merge #945 first or this does not compile.