### PR TITLE
feat(chat): sent / delivered / read ticks on your own messages

### DIFF
--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -139,6 +139,18 @@ export const INDEXES: Partial<IndexSpec> = {
      */
     { key: { conversationId: 1, readAt: 1 }, name: 'conversation_unread' },
     /**
+     * The same shape one step earlier in a message's life: `markDelivered`
+     * selects the messages in one conversation that have not reached the
+     * recipient yet. It runs on every send to someone who is online and once
+     * per conversation when someone reconnects, so it is on the hot path twice
+     * over.
+     *
+     * Not sparse, for the same reason as `conversation_unread` above — the
+     * query matches documents *missing* `deliveredAt`, and those are exactly
+     * the ones a sparse index would leave out.
+     */
+    { key: { conversationId: 1, deliveredAt: 1 }, name: 'conversation_undelivered' },
+    /**
      * The whole safety net under the v1 message import. The importer inserts
      * before it marks the room done, so a crash halfway leaves the room
      * unclaimed and the next run replays it — this index is what makes that

--- a/apps/api/src/modules/chat/conversations.ts
+++ b/apps/api/src/modules/chat/conversations.ts
@@ -40,6 +40,14 @@ export interface Message {
    * the same message, which is what lets the importer be replayed safely.
    */
   legacyId?: string
+  /**
+   * When the message reached the recipient's device — the second tick. Set by
+   * `markDelivered` either as the message goes out over an open socket, or on
+   * the sweep that runs when the recipient next connects. Absent on everything
+   * that predates the feature, which is why `deliveryStateOf` treats `readAt`
+   * as proof of delivery rather than requiring both.
+   */
+  deliveredAt?: Date
   readAt?: Date
   createdAt: Date
   /** Set when the sender's account was purged; the body is cleared, the row stays. */

--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -240,6 +240,71 @@ export async function listMessages(
   return { items: items.reverse(), nextCursor, participants: conversation.participants }
 }
 
+/**
+ * The second tick: everything in this conversation that `recipientId` has not
+ * received yet is now on their device. Returns the timestamp if anything
+ * actually changed and `null` otherwise, so a caller does not emit a realtime
+ * event announcing that nothing happened.
+ *
+ * `$exists: false` rather than a blanket `$set`, because delivery is a moment,
+ * not a flag — re-stamping a message that arrived an hour ago would drag its
+ * timestamp forward every time the recipient reconnects.
+ */
+export async function markDelivered(
+  db: Db,
+  conversationId: ObjectId,
+  recipientId: string,
+): Promise<Date | null> {
+  const deliveredAt = new Date()
+  const result = await db.collection<Message>(COLLECTIONS.messages).updateMany(
+    {
+      conversationId,
+      senderId: { $ne: recipientId },
+      deliveredAt: { $exists: false },
+    },
+    { $set: { deliveredAt } },
+  )
+  return result.modifiedCount > 0 ? deliveredAt : null
+}
+
+export interface DeliveredSweep {
+  conversationId: string
+  /** The counterpart — the one waiting to see a second tick appear. */
+  senderId: string
+  deliveredAt: Date
+}
+
+/**
+ * What runs when someone connects: every message that was sent to them while
+ * they were away is delivered now, in every thread at once.
+ *
+ * Without this, a message sent to an offline recipient would sit on one tick
+ * forever — the send-time path can only mark what it can hand to an open
+ * socket, and there may not be one.
+ *
+ * Scoped to conversations with a non-zero unread count rather than all of
+ * them, which is sound because undelivered implies unread: a message cannot be
+ * read before it arrives, so anything missing `deliveredAt` is still counted
+ * in `unread[userId]`. That keeps a reconnect off a scan of the user's entire
+ * history — reconnects are frequent and happen in bursts (a train tunnel, a
+ * phone waking up), which is exactly when a full scan would hurt most.
+ */
+export async function markPendingDelivered(db: Db, userId: string): Promise<DeliveredSweep[]> {
+  const pending = await db
+    .collection<Conversation>(COLLECTIONS.conversations)
+    .find({ participants: userId, [`unread.${userId}`]: { $gt: 0 } })
+    .toArray()
+
+  const swept: DeliveredSweep[] = []
+  for (const conversation of pending) {
+    const deliveredAt = await markDelivered(db, conversation._id, userId)
+    const senderId = conversation.participants.find((id) => id !== userId)
+    if (!deliveredAt || !senderId) continue
+    swept.push({ conversationId: conversation._id.toHexString(), senderId, deliveredAt })
+  }
+  return swept
+}
+
 export async function markConversationRead(
   db: Db,
   userId: string,
@@ -254,6 +319,12 @@ export async function markConversationRead(
       { $set: { [`unread.${userId}`]: 0 } },
       { returnDocument: 'after' },
     )
+  // Reading a thread proves the messages in it arrived, and this is the only
+  // path that catches a reader who never held a socket — opening the app
+  // straight from a push notification marks read over REST. No
+  // `conversation:delivered` event follows, because the `conversation:read`
+  // the caller emits already implies it.
+  await markDelivered(db, conversation._id, userId)
   await db
     .collection<Message>(COLLECTIONS.messages)
     .updateMany(

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -199,6 +199,31 @@ describe('Faz 5 — conversation/message history REST', () => {
     expect(body.unread[b.userId]).toBe(0)
   })
 
+  it('reading over REST marks the thread delivered as well as read', async () => {
+    const a = await newUser('read-implies-a@example.com')
+    const b = await newUser('read-implies-b@example.com')
+    const conversation = await startConversation(a, b.userId, 'opened from a push')
+
+    // No socket anywhere in this test: opening the app straight from a
+    // notification is exactly the path where nothing else can have set the
+    // second tick, and a message cannot be read without having arrived.
+    const read = await app.inject({
+      method: 'POST',
+      url: `/conversations/${conversation._id}/read`,
+      headers: { cookie: b.cookie },
+    })
+    expect(read.statusCode, read.body).toBe(200)
+
+    const history = await app.inject({
+      method: 'GET',
+      url: `/conversations/${conversation._id}/messages`,
+      headers: { cookie: a.cookie },
+    })
+    const message = history.json<{ items: { deliveredAt?: string; readAt?: string }[] }>().items[0]
+    expect(message?.deliveredAt).toBeDefined()
+    expect(message?.readAt).toBeDefined()
+  })
+
   it('refuses history access once the two participants have blocked each other', async () => {
     const a = await newUser('blocked-history-a@example.com')
     const b = await newUser('blocked-history-b@example.com')

--- a/apps/api/src/ws/chat.test.ts
+++ b/apps/api/src/ws/chat.test.ts
@@ -243,6 +243,114 @@ describe('Faz 5 — realtime chat over Socket.io', () => {
     expect(event).toMatchObject({ conversationId: conversation._id, readBy: bob.userId })
   })
 
+  it('a message to a recipient who is connected comes back delivered', async () => {
+    const alice = await newUser('ws-deliv-alice@example.com')
+    const bob = await newUser('ws-deliv-bob@example.com')
+    const conversation = await startConversation(alice, bob.userId, 'hello')
+
+    // Bob first, so his connect-time sweep of that opening message fires
+    // before Alice has a room to receive it in — leaving the send below as
+    // the only thing that can produce the event this test waits for.
+    const bobSocket = await connectSocket(bob.cookie)
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    const aliceSocket = await connectSocket(alice.cookie)
+
+    const delivered = waitForEvent<{ conversationId: string; deliveredTo: string }>(
+      aliceSocket,
+      'conversation:delivered',
+    )
+    aliceSocket.emit('message:send', { conversationId: conversation._id, body: 'you there?' })
+
+    expect(await delivered).toMatchObject({
+      conversationId: conversation._id,
+      deliveredTo: bob.userId,
+    })
+    expect(bobSocket.connected).toBe(true)
+
+    const history = await app.inject({
+      method: 'GET',
+      url: `/conversations/${conversation._id}/messages`,
+      headers: { cookie: alice.cookie },
+    })
+    const sent = history
+      .json<{ items: { body: string; deliveredAt?: string; readAt?: string }[] }>()
+      .items.find((m) => m.body === 'you there?')
+    expect(sent?.deliveredAt).toBeDefined()
+    // Delivered is not read — Bob has a socket, not the thread open.
+    expect(sent?.readAt).toBeUndefined()
+  })
+
+  it('a message sent to someone offline stays on one tick until they connect', async () => {
+    const alice = await newUser('ws-undeliv-alice@example.com')
+    const bob = await newUser('ws-undeliv-bob@example.com')
+    const conversation = await startConversation(alice, bob.userId, 'first hello')
+    const aliceSocket = await connectSocket(alice.cookie)
+
+    await new Promise<void>((resolve) => {
+      aliceSocket.emit(
+        'message:send',
+        { conversationId: conversation._id, body: 'while away' },
+        () => resolve(),
+      )
+    })
+
+    const readHistory = async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/conversations/${conversation._id}/messages`,
+        headers: { cookie: alice.cookie },
+      })
+      return response.json<{ items: { body: string; deliveredAt?: string }[] }>().items
+    }
+
+    // Nobody was there to hand it to, so nothing may claim it arrived.
+    expect((await readHistory()).find((m) => m.body === 'while away')?.deliveredAt).toBeUndefined()
+
+    const delivered = waitForEvent<{ conversationId: string; deliveredTo: string }>(
+      aliceSocket,
+      'conversation:delivered',
+    )
+    await connectSocket(bob.cookie)
+
+    expect(await delivered).toMatchObject({
+      conversationId: conversation._id,
+      deliveredTo: bob.userId,
+    })
+    // Both of Alice's messages, not just the one sent while Bob was away.
+    const after = await readHistory()
+    expect(after.every((m) => m.deliveredAt)).toBe(true)
+  })
+
+  it('reconnecting does not drag an existing delivery timestamp forward', async () => {
+    const alice = await newUser('ws-redeliv-alice@example.com')
+    const bob = await newUser('ws-redeliv-bob@example.com')
+    const conversation = await startConversation(alice, bob.userId, 'stamp me once')
+
+    const firstBobSocket = await connectSocket(bob.cookie)
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    const stampOf = async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/conversations/${conversation._id}/messages`,
+        headers: { cookie: alice.cookie },
+      })
+      return response.json<{ items: { deliveredAt?: string }[] }>().items[0]?.deliveredAt
+    }
+
+    const first = await stampOf()
+    expect(first).toBeDefined()
+
+    firstBobSocket.disconnect()
+    await connectSocket(bob.cookie)
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    // Delivery is the moment it arrived, not a flag that gets re-set — a
+    // second tick that keeps changing its own timestamp is telling a lie
+    // about when the message got there.
+    expect(await stampOf()).toBe(first)
+  })
+
   it('typing relays to the other participant only', async () => {
     const alice = await newUser('ws-typing-alice@example.com')
     const bob = await newUser('ws-typing-bob@example.com')

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -1,5 +1,6 @@
 import { sendCorrectionSchema, sendMediaMessageSchema, sendTextMessageSchema } from '@langx/shared'
 import type { FastifyInstance } from 'fastify'
+import type { ObjectId } from 'mongodb'
 import { Server as SocketIOServer, type Socket } from 'socket.io'
 import { z, ZodError } from 'zod'
 import { ERROR_CODES } from '@langx/shared'
@@ -10,6 +11,8 @@ import { getProfile } from '../modules/profiles/profiles'
 import { assertConversationAccess } from '../modules/chat/access'
 import {
   markConversationRead,
+  markDelivered,
+  markPendingDelivered,
   sendCorrection,
   sendMediaMessage,
   sendTextMessage,
@@ -22,24 +25,47 @@ function userRoom(userId: string): string {
 }
 
 /**
- * Pushes a new message to the recipient — but only if they have no socket in
- * their room. Someone with the thread open on screen does not need their phone
- * to buzz about the message they are watching arrive.
+ * The two things that happen to a message the instant after it is written, and
+ * the reason they are one function: both hinge on the same question — is the
+ * recipient holding a socket right now?
  *
- * Best-effort by design: a failed push must never fail the send. The message is
- * already durably written and already delivered over the socket by this point.
+ * If they are, `message:new` above just reached their device, which is the
+ * second tick; we stamp `deliveredAt` and tell the sender. If they are not,
+ * their phone buzzes instead, and the message stays on one tick until they
+ * connect and {@link markPendingDelivered} sweeps it up. Someone with the
+ * thread open on screen does not need a notification about the message they
+ * are watching arrive, and someone who is away has nothing to deliver to — the
+ * two branches are genuinely exclusive, so asking twice would only create room
+ * for the answer to change in between.
+ *
+ * Best-effort by design: a failed push or a failed stamp must never fail the
+ * send. The message is durably written by the time this runs.
+ *
+ * `pushWhenAway` is false for corrections, which have never notified.
  */
-async function notifyRecipient(
+async function deliverToRecipient(
   app: FastifyInstance,
   io: AppServer,
-  conversation: { participants: readonly string[] },
+  conversation: { _id: ObjectId; participants: readonly string[] },
   message: { senderId: string; body: string; conversationId: { toHexString: () => string } },
+  { pushWhenAway }: { pushWhenAway: boolean },
 ): Promise<void> {
   try {
     const recipientId = conversation.participants.find((id) => id !== message.senderId)
     if (!recipientId) return
     const sockets = await io.in(userRoom(recipientId)).fetchSockets()
-    if (sockets.length > 0) return
+    if (sockets.length > 0) {
+      const deliveredAt = await markDelivered(app.mongo.db, conversation._id, recipientId)
+      if (deliveredAt) {
+        io.to(userRoom(message.senderId)).emit('conversation:delivered', {
+          conversationId: message.conversationId.toHexString(),
+          deliveredTo: recipientId,
+          deliveredAt: deliveredAt.toISOString(),
+        })
+      }
+      return
+    }
+    if (!pushWhenAway) return
 
     const [sender, tokens] = await Promise.all([
       app.mongo.db
@@ -56,7 +82,7 @@ async function notifyRecipient(
       data: { kind: 'message', conversationId: message.conversationId.toHexString() },
     })
   } catch (error) {
-    app.log.warn({ err: error }, 'push notification failed')
+    app.log.warn({ err: error }, 'post-send delivery fan-out failed')
   }
 }
 
@@ -153,6 +179,27 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
     void socket.join(userRoom(userId))
 
     /**
+     * Connecting *is* the delivery receipt for everything sent while this user
+     * was away — this is the only thing that moves those messages off one
+     * tick, since the send-time path had no socket to hand them to.
+     *
+     * Deliberately not awaited and deliberately silent on failure: a second
+     * tick appearing late is a cosmetic loss, whereas a rejection here would
+     * take down a connection that is otherwise perfectly good.
+     */
+    void markPendingDelivered(app.mongo.db, userId)
+      .then((swept) => {
+        for (const { conversationId, senderId, deliveredAt } of swept) {
+          io.to(userRoom(senderId)).emit('conversation:delivered', {
+            conversationId,
+            deliveredTo: userId,
+            deliveredAt: deliveredAt.toISOString(),
+          })
+        }
+      })
+      .catch((error: unknown) => app.log.warn({ err: error }, 'delivery sweep on connect failed'))
+
+    /**
      * Wraps a handler in the connection's rate limit. Refusing through the ack
      * rather than dropping the frame matters: a client that gets no answer
      * retries, which is the opposite of what a limit is for.
@@ -178,7 +225,7 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
           for (const participantId of conversation.participants) {
             io.to(userRoom(participantId)).emit('message:new', message)
           }
-          void notifyRecipient(app, io, conversation, message)
+          void deliverToRecipient(app, io, conversation, message, { pushWhenAway: true })
           ack?.({ ok: true, data: message })
         })
         .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))
@@ -209,7 +256,7 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
           for (const participantId of conversation.participants) {
             io.to(userRoom(participantId)).emit('message:new', message)
           }
-          void notifyRecipient(app, io, conversation, message)
+          void deliverToRecipient(app, io, conversation, message, { pushWhenAway: true })
           ack?.({ ok: true, data: message })
         })
         .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))
@@ -224,6 +271,9 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
           for (const participantId of conversation.participants) {
             io.to(userRoom(participantId)).emit('message:new', message)
           }
+          // Ticks, but no push: a correction is help arriving in a thread the
+          // recipient chose to be in, not something to wake a phone for.
+          void deliverToRecipient(app, io, conversation, message, { pushWhenAway: false })
           ack?.({ ok: true, data: message })
         })
         .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -216,6 +216,7 @@ export interface MessageDto {
   body: string
   media?: MessageMediaDto
   correction?: { original: string; corrected: string; note?: string }
+  deliveredAt?: string
   readAt?: string
   createdAt: string
 }

--- a/apps/mobile/src/components/MessageMeta.tsx
+++ b/apps/mobile/src/components/MessageMeta.tsx
@@ -1,3 +1,4 @@
+import { deliveryStateOf, type DeliveryState } from '@langx/shared'
 import { StyleSheet, Text, View } from 'react-native'
 import type { MessageDto } from '../api/queries'
 import { colors, font, spacing } from '../lib/theme'
@@ -9,27 +10,39 @@ function clockTime(iso: string): string {
 }
 
 /**
- * The time under a message, and — on your own — whether it has been read.
+ * A tick means nothing to a screen reader, and the whole point of the glyph is
+ * that it carries information the text does not.
+ */
+const LABELS: Record<DeliveryState, string> = {
+  sent: 'Sent',
+  delivered: 'Delivered',
+  read: 'Read',
+}
+
+/**
+ * The time under a message, and — on your own — how far it has got.
  *
- * Everything behind this was already built and none of it was drawn:
- * `Message.readAt` is written by `markConversationRead`, the `conversation:read`
- * socket event travels in both directions, and `MessageDto.readAt` reached the
- * client and was never once read. A chat with no timestamps and no read state
- * is the kind of gap people notice immediately and cannot name.
- *
- * Two states, not three. v1 showed sending / sent / read and v2 has no
- * `deliveredAt` field and no acknowledgement event to build one from — in a
- * one-to-one chat the socket connection is already the delivery receipt. A
- * third tick would be decoration standing in for information we do not have.
+ * One tick sent, two ticks delivered, two tinted ticks read: the convention
+ * WhatsApp and Telegram taught everyone, so it needs no explanation in the UI.
+ * Each state is backed by something real — `deliveredAt` is written when the
+ * message goes out over a socket the recipient is holding, or when they next
+ * connect; `readAt` when they open the thread. Neither is inferred from the
+ * other.
  */
 export function MessageMeta({ message, mine }: { message: MessageDto; mine: boolean }) {
   const tint = mine ? colors.primaryText : colors.textMuted
+  const state = deliveryStateOf(message)
 
   return (
     <View style={styles.row}>
       <Text style={[styles.time, { color: tint }]}>{clockTime(message.createdAt)}</Text>
       {mine ? (
-        <Text style={[styles.status, { color: tint }]}>{message.readAt ? '◉' : '○'}</Text>
+        <Text
+          accessibilityLabel={LABELS[state]}
+          style={[styles.status, { color: state === 'read' ? colors.read : tint }]}
+        >
+          {state === 'sent' ? '✓' : '✓✓'}
+        </Text>
       ) : null}
     </View>
   )
@@ -44,5 +57,13 @@ const styles = StyleSheet.create({
     marginTop: 2,
   },
   time: { ...font.caption, fontSize: 11, opacity: 0.7 },
-  status: { fontSize: 11, opacity: 0.85 },
+  status: {
+    fontSize: 11,
+    // Pulls the second tick under the first, the way the single glyph these
+    // imitate is drawn. Without it the pair reads as two separate marks.
+    letterSpacing: -3,
+    opacity: 0.9,
+    // The negative tracking above also eats the space after the last tick.
+    paddingRight: 3,
+  },
 })

--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -42,6 +42,46 @@ export function useSocket(): void {
         void queryClient.invalidateQueries({ queryKey: keys.tokens })
       })
 
+      /**
+       * Patched into the cache rather than invalidated, unlike the read event
+       * below. Delivery fires on *every* message sent to someone who is
+       * online, so refetching the thread each time would put a request behind
+       * every keystroke-turned-message in an active conversation — and the
+       * event already carries everything the change needs. Reads are the
+       * rarer event and clear an unread count the client cannot recompute,
+       * which is why that one still goes back to the server.
+       */
+      socket.on(
+        'conversation:delivered',
+        ({
+          conversationId,
+          deliveredTo,
+          deliveredAt,
+        }: {
+          conversationId: string
+          deliveredTo: string
+          deliveredAt: string
+        }) => {
+          queryClient.setQueryData<{ items: MessageDto[]; nextCursor: string | null }>(
+            keys.messages(conversationId),
+            (old) => {
+              if (!old) return old
+              // The server stamped every message in the thread the recipient
+              // had not received yet, so this mirrors that filter exactly:
+              // theirs are not mine to mark, and an existing timestamp is the
+              // moment it actually arrived.
+              let changed = false
+              const items = old.items.map((message) => {
+                if (message.senderId === deliveredTo || message.deliveredAt) return message
+                changed = true
+                return { ...message, deliveredAt }
+              })
+              return changed ? { ...old, items } : old
+            },
+          )
+        },
+      )
+
       socket.on('conversation:read', ({ conversationId }: { conversationId: string }) => {
         void queryClient.invalidateQueries({ queryKey: keys.messages(conversationId) })
         // The chat list too: reading a conversation clears its unread count,

--- a/apps/mobile/src/lib/theme.ts
+++ b/apps/mobile/src/lib/theme.ts
@@ -20,6 +20,13 @@ export const colors = {
   danger: '#d92d20',
   success: '#12864b',
   streak: '#f79009',
+  /**
+   * The read ticks, and the only colour that has to work against `primary`
+   * rather than `bg` — status ticks appear on your own bubble and nowhere
+   * else. `accent` is the app's blue but clears barely 3:1 on that near-black
+   * at 11px; this is the same blue lifted until the glyph is unambiguous.
+   */
+  read: '#59a8ff',
   pro: '#7a5af8',
   /**
    * Deliberately the same hue family as `pro`, only deeper. Pro+ is a superset

--- a/packages/shared/src/chat.test.ts
+++ b/packages/shared/src/chat.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { DELIVERY_STATES, deliveryStateOf } from './chat'
+
+describe('deliveryStateOf', () => {
+  it('is sent when the server has it and nothing more is known', () => {
+    expect(deliveryStateOf({})).toBe('sent')
+  })
+
+  it('is delivered once it has reached the recipient device', () => {
+    expect(deliveryStateOf({ deliveredAt: new Date() })).toBe('delivered')
+  })
+
+  it('is read once they have opened the thread', () => {
+    expect(deliveryStateOf({ deliveredAt: new Date(), readAt: new Date() })).toBe('read')
+  })
+
+  /**
+   * The reason `readAt` is checked first. Every message that predates
+   * `deliveredAt` — the v1 import, and everything sent before the second tick
+   * shipped — has a `readAt` and no `deliveredAt`, and showing those as one
+   * tick would be a visible regression across the whole of history.
+   */
+  it('reads a message with no delivery stamp as read, not as sent', () => {
+    expect(deliveryStateOf({ readAt: new Date() })).toBe('read')
+  })
+
+  it('ignores explicit nulls the way it ignores absent fields', () => {
+    expect(deliveryStateOf({ deliveredAt: null, readAt: null })).toBe('sent')
+  })
+
+  it('accepts the ISO strings the API actually sends', () => {
+    expect(deliveryStateOf({ deliveredAt: '2026-08-28T10:00:00.000Z' })).toBe('delivered')
+    expect(deliveryStateOf({ readAt: '2026-08-28T10:00:00.000Z' })).toBe('read')
+  })
+
+  it('lists the states in the order a message passes through them', () => {
+    expect(DELIVERY_STATES).toEqual(['sent', 'delivered', 'read'])
+  })
+})

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -151,3 +151,34 @@ export function isImageContentType(value: string): boolean {
 export function isAudioContentType(value: string): boolean {
   return (AUDIO_CONTENT_TYPES as readonly string[]).includes(value)
 }
+
+/**
+ * What the ticks under your own message mean, in the order they happen:
+ *
+ * - `sent` — one tick. The server has it. Nothing more is claimed: the other
+ *   person may be asleep with their phone off.
+ * - `delivered` — two ticks. It reached their device, which for us means it
+ *   went out over a socket they had open (or they connected and we handed it
+ *   over then). Still unread.
+ * - `read` — two ticks, tinted. They opened the thread.
+ *
+ * The same three states WhatsApp and Telegram use, and people read them
+ * without being taught. A message never moves backwards through this.
+ */
+export const DELIVERY_STATES = ['sent', 'delivered', 'read'] as const
+export type DeliveryState = (typeof DELIVERY_STATES)[number]
+
+/**
+ * `readAt` wins over `deliveredAt` rather than requiring both, so that history
+ * predating `deliveredAt` — every v1 message imported as seen, and everything
+ * sent before this shipped — reads as `read` instead of falling back to one
+ * tick. Being read is proof of delivery; there is nothing to backfill.
+ */
+export function deliveryStateOf(message: {
+  deliveredAt?: string | Date | null
+  readAt?: string | Date | null
+}): DeliveryState {
+  if (message.readAt) return 'read'
+  if (message.deliveredAt) return 'delivered'
+  return 'sent'
+}


### PR DESCRIPTION
Adds the three-state receipt people already know from WhatsApp and Telegram: one tick when the server has the message, two when it reaches the recipient's device, two tinted when they open the thread.

Only the third state existed before. `Message.readAt` was already written and `MessageDto.readAt` already reached the client, where it was drawn as a two-state circle — the component said outright that a third tick would be decoration, because there was no `deliveredAt` to back it. So this adds the missing state rather than the missing glyph.

- `Message.deliveredAt`, stamped by `markDelivered`, never re-stamped: delivery is a moment, not a flag, and a timestamp that moves forward on every reconnect lies about when the message arrived.
- Two paths set it. The send itself, when the recipient is holding a socket, and a sweep when they next connect. Without the second, anything sent to someone offline would sit on one tick forever.
- Reading a thread stamps it too. Opening the app from a push notification marks read over REST with no socket in play, and a message cannot be read before it arrives.
- New `conversation:delivered` event to the sender. The client patches its cache instead of invalidating, unlike the read event: delivery fires on every message to an online recipient, and the payload already carries the whole change.
- `deliveryStateOf` in `packages/shared` checks `readAt` first, so the v1 import and everything sent before this shipped read as `read` rather than dropping to one tick. Nothing to backfill.
- New `conversation_undelivered` index, non-sparse for the same reason as `conversation_unread` — the query matches documents *missing* the field, which is exactly what a sparse index leaves out.

**Known gap, deliberately left out of scope:** `POST /conversations` does no socket fan-out at all — no `message:new`, no push — which predates this change. So the first message of a thread does not go to two ticks the moment an online recipient receives it; it catches up on their next connect or when they open the thread. Truthful, just skips the intermediate state. Fixing it means adding realtime to that route, which is a separate behaviour change.

Rebased onto `main` after tonight's four merges. No conflicts: `theme.ts` was the only shared file and the new `read` token sits alongside the alert/toast work, not on top of it.
