### PR TITLE
Make a purchase testable without a store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,12 @@ REVENUECAT_SECRET_API_KEY=
 # shared secret you pick yourself, not a value RevenueCat generates. Left
 # unset, POST /webhooks/revenuecat refuses every request (fails closed).
 REVENUECAT_WEBHOOK_AUTH_HEADER=
+# `true` swaps RevenueCat for an in-process fake and exposes
+# POST /billing/test-event, so a purchase can be driven end to end with no
+# store product and no network — see docs/billing-testing.md. Takes precedence
+# over REVENUECAT_SECRET_API_KEY above, and the API refuses to boot with it set
+# under NODE_ENV=production. Leave blank unless you are testing billing.
+REVENUECAT_FAKE_STORE=
 # Not read by this backend at all — RevenueCat Web's Stripe connection is a
 # one-time dashboard configuration on RevenueCat's side, not a runtime API
 # call from here. Kept as a placeholder for that account's own bookkeeping.
@@ -123,4 +129,9 @@ GOOGLE_SERVICES_JSON=
 EXPO_PUBLIC_REVENUECAT_IOS_KEY=
 EXPO_PUBLIC_REVENUECAT_ANDROID_KEY=
 EXPO_PUBLIC_REVENUECAT_TEST_STORE_KEY=
+# `1` is the client half of REVENUECAT_FAKE_STORE: the paywall lists every
+# package at obviously fake prices and buying one calls the API's fake store.
+# Ignored unless the bundle is a development one, so it cannot follow a web
+# export into production. Both halves have to be set for a purchase to land.
+EXPO_PUBLIC_REVENUECAT_FAKE_STORE=
 EXPO_PUBLIC_SENTRY_DSN=

--- a/apps/api/scripts/revenuecat-webhook.ts
+++ b/apps/api/scripts/revenuecat-webhook.ts
@@ -1,0 +1,106 @@
+/**
+ * Post a RevenueCat-shaped webhook at a running API.
+ *
+ * The companion to the in-app fake store (`docs/billing-testing.md`). That one
+ * proves the purchase flow; this one proves the *endpoint* — it goes over HTTP
+ * through `POST /webhooks/revenuecat`, so it is the only local way to exercise
+ * the `Authorization` shared secret, the body schema and the idempotency guard
+ * exactly as RevenueCat will. It is also what to reach for when a real event
+ * needs replaying against a deployed API.
+ *
+ * Reads `REVENUECAT_WEBHOOK_AUTH_HEADER` (and optionally `API_URL`) from the
+ * environment rather than through `loadEnv`: this talks to an API over the
+ * network and has no business demanding a database URI to do it.
+ *
+ *   REVENUECAT_WEBHOOK_AUTH_HEADER=dev-secret \
+ *     pnpm --filter @langx/api exec tsx scripts/revenuecat-webhook.ts \
+ *     --user <userId> --type INITIAL_PURCHASE --package pro_plus_monthly
+ *
+ *   ... --type CANCELLATION --package $rc_monthly
+ *   ... --type EXPIRATION --package $rc_monthly --expires-in-days -1
+ *
+ * `--user` is the Better Auth user id, because that is what the app sets as
+ * RevenueCat's `app_user_id`; anything else produces an event the webhook
+ * records for audit and cannot apply to anybody.
+ */
+import {
+  TIER_ENTITLEMENTS,
+  packageDefinition,
+  type BillingPeriod,
+  type RevenueCatEvent,
+} from '@langx/shared'
+import { randomUUID } from 'node:crypto'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** Unused for `lifetime`, which has no expiry at all — see `expiration_at_ms` below. */
+const DEFAULT_DAYS: Record<BillingPeriod, number> = { monthly: 30, yearly: 365, lifetime: 0 }
+
+function flag(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`)
+  return index === -1 ? undefined : process.argv[index + 1]
+}
+
+function required(name: string): string {
+  const value = flag(name)
+  if (!value) throw new Error(`--${name} is required`)
+  return value
+}
+
+async function main(): Promise<void> {
+  const url = flag('url') ?? process.env.API_URL ?? 'http://localhost:4000'
+  const secret = flag('secret') ?? process.env.REVENUECAT_WEBHOOK_AUTH_HEADER
+  if (!secret) {
+    throw new Error(
+      'REVENUECAT_WEBHOOK_AUTH_HEADER is not set (or pass --secret). It must match the API exactly — the route refuses every request otherwise.',
+    )
+  }
+
+  const userId = required('user')
+  const type = required('type')
+  const packageId = required('package')
+  const definition = packageDefinition(packageId)
+  if (definition === null || definition.tier === 'free') {
+    throw new Error(`No such package: ${packageId}`)
+  }
+
+  // Defaulted from the package rather than to a fixed 30, so an annual
+  // subscription does not arrive dated a month out — reading that back and
+  // believing it is what the yearly plan does is an easy mistake to make once.
+  // Negative values are the point of the flag being there at all: an
+  // EXPIRATION carries a timestamp in the past, and sending one is how the
+  // expiry branch gets exercised without waiting a year.
+  const expiresInDays = Number(flag('expires-in-days') ?? DEFAULT_DAYS[definition.period])
+  if (!Number.isFinite(expiresInDays)) throw new Error('--expires-in-days must be a number')
+
+  const event: RevenueCatEvent = {
+    // Fresh every run: `subscriptions.eventId` is unique, so re-sending one id
+    // is answered with `processed: false` — which is the correct behaviour and
+    // a confusing thing to hit by accident.
+    id: `script_${randomUUID()}`,
+    type,
+    app_user_id: userId,
+    product_id: `script.${definition.tier}.${definition.period}`,
+    store: 'fake_store',
+    environment: 'SANDBOX',
+    expiration_at_ms: definition.period === 'lifetime' ? null : Date.now() + expiresInDays * DAY_MS,
+    entitlement_ids: [...TIER_ENTITLEMENTS[definition.tier]],
+  }
+
+  console.log(`${event.type} → ${userId} (${definition.tier}, ${definition.period})`)
+
+  const response = await fetch(`${url}/webhooks/revenuecat`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: secret },
+    body: JSON.stringify({ api_version: '1.0', event }),
+  })
+
+  console.log(`${response.status} ${response.statusText}`)
+  console.log(await response.text())
+  if (!response.ok) process.exitCode = 1
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -100,6 +100,21 @@ const envSchema = z.object({
   REVENUECAT_SECRET_API_KEY: emptyToUndefined(z.string().optional()),
   REVENUECAT_WEBHOOK_AUTH_HEADER: emptyToUndefined(z.string().optional()),
 
+  /**
+   * Replaces RevenueCat with an in-process stand-in, so a purchase can be
+   * driven end to end without an App Store or Play product existing — see
+   * `docs/billing-testing.md`. It takes precedence over
+   * `REVENUECAT_SECRET_API_KEY`: a machine that has both is a machine where a
+   * leftover real key would otherwise silently win, and the surprise there
+   * runs the wrong way round.
+   *
+   * `loadEnv` refuses to return with this set under `NODE_ENV=production`.
+   * That check is the whole safety story — everything else about this flag is
+   * a convenience, but a production API that hands out Pro to anyone who asks
+   * is not a bug you find in review.
+   */
+  REVENUECAT_FAKE_STORE: z.preprocess((v) => v === 'true' || v === '1', z.boolean()).default(false),
+
   // Faz 2: username claim. Must match what the ETL used to hash legacy
   // emails into handleReservations.legacyEmailHash, or nothing ever matches.
   LEGACY_EMAIL_HASH_SALT: emptyToUndefined(z.string().optional()),
@@ -138,5 +153,16 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): Env {
       .join('\n')
     throw new Error(`Invalid environment:\n${issues}`)
   }
+
+  // Refusing to boot, rather than ignoring the flag, because the two failures
+  // look identical from outside and only one of them is safe: an API that
+  // quietly dropped the flag would keep serving real billing while whoever set
+  // it believes they are on the fake store.
+  if (parsed.data.NODE_ENV === 'production' && parsed.data.REVENUECAT_FAKE_STORE) {
+    throw new Error(
+      'Invalid environment:\n  REVENUECAT_FAKE_STORE: refused under NODE_ENV=production — it grants entitlement with no purchase behind it',
+    )
+  }
+
   return parsed.data
 }

--- a/apps/api/src/modules/billing/createRevenueCatClient.ts
+++ b/apps/api/src/modules/billing/createRevenueCatClient.ts
@@ -1,9 +1,15 @@
 import type { Env } from '../../env'
+import { createFakeRevenueCat } from './fakeRevenueCat'
 import { createNotConfiguredRevenueCatClient, createRevenueCatClient } from './revenueCatClient'
 import type { RevenueCatClient } from './revenueCatClient'
 
 /** Mirrors `createStorageProvider`/`createTranslationProvider` — the app boots either way, only `/billing/refresh` depends on this being real. */
 export function createRevenueCatClientFromEnv(env: Env): RevenueCatClient {
+  // Checked before the secret key on purpose. A developer who sets the flag on
+  // a machine that still has a real key in its `.env` means the fake; the
+  // reverse reading would send simulated purchases at the live dashboard.
+  // `loadEnv` has already refused this combination under NODE_ENV=production.
+  if (env.REVENUECAT_FAKE_STORE) return createFakeRevenueCat()
   if (env.REVENUECAT_SECRET_API_KEY) return createRevenueCatClient(env.REVENUECAT_SECRET_API_KEY)
   return createNotConfiguredRevenueCatClient()
 }

--- a/apps/api/src/modules/billing/fakeRevenueCat.test.ts
+++ b/apps/api/src/modules/billing/fakeRevenueCat.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { FAKE_STORE, asFakeRevenueCat, createFakeRevenueCat } from './fakeRevenueCat'
+import { createNotConfiguredRevenueCatClient } from './revenueCatClient'
+
+const USER = 'user-1'
+
+describe('createFakeRevenueCat', () => {
+  it('grants nothing until something is bought', async () => {
+    const store = createFakeRevenueCat()
+    expect(await store.getEntitlement(USER)).toBeNull()
+  })
+
+  it('grants the tier the package sells', async () => {
+    const store = createFakeRevenueCat()
+    store.purchase(USER, '$rc_monthly')
+
+    expect(await store.getEntitlement(USER)).toMatchObject({ tier: 'pro', store: FAKE_STORE })
+  })
+
+  /**
+   * The overlap `ENTITLEMENT_PRECEDENCE` exists for. A fake that granted only
+   * `pro_plus` would resolve correctly by accident and never exercise it.
+   */
+  it('gives a Pro+ buyer both entitlement ids, and resolves them to pro_plus', async () => {
+    const store = createFakeRevenueCat()
+    const event = store.purchase(USER, 'pro_plus_monthly')
+
+    expect(event?.entitlement_ids).toEqual(['pro_plus', 'pro'])
+    expect(await store.getEntitlement(USER)).toMatchObject({ tier: 'pro_plus' })
+  })
+
+  it('refuses a package identifier nothing sells', async () => {
+    const store = createFakeRevenueCat()
+    expect(store.purchase(USER, 'not_a_package')).toBeNull()
+    expect(await store.getEntitlement(USER)).toBeNull()
+  })
+
+  it('gives a lifetime purchase no expiry and nothing to renew', async () => {
+    const store = createFakeRevenueCat()
+    const event = store.purchase(USER, '$rc_lifetime')
+
+    expect(event?.expiration_at_ms).toBeNull()
+    expect(await store.getEntitlement(USER)).toMatchObject({ tier: 'pro', expiresAt: null })
+  })
+
+  it('dates a subscription in the future, and a yearly one further out', () => {
+    const store = createFakeRevenueCat()
+    const monthly = store.purchase('monthly-user', '$rc_monthly')
+    const yearly = store.purchase('yearly-user', '$rc_annual')
+
+    expect(monthly?.expiration_at_ms).toBeGreaterThan(Date.now())
+    expect(yearly?.expiration_at_ms).toBeGreaterThan(monthly?.expiration_at_ms ?? 0)
+  })
+
+  it('emits ids no two events share, because the webhook dedupes on them', () => {
+    const store = createFakeRevenueCat()
+    const first = store.purchase(USER, '$rc_monthly')
+    const second = store.purchase(USER, '$rc_monthly')
+
+    expect(first?.id).not.toEqual(second?.id)
+  })
+
+  describe('cancel', () => {
+    it('keeps access — a cancellation stops the next charge, not this period', async () => {
+      const store = createFakeRevenueCat()
+      store.purchase(USER, '$rc_monthly')
+
+      expect(store.cancel(USER)?.type).toBe('CANCELLATION')
+      expect(await store.getEntitlement(USER)).toMatchObject({ tier: 'pro' })
+    })
+
+    it('has nothing to cancel for an account that never bought', () => {
+      expect(createFakeRevenueCat().cancel(USER)).toBeNull()
+    })
+  })
+
+  describe('expire', () => {
+    it('ends access', async () => {
+      const store = createFakeRevenueCat()
+      store.purchase(USER, '$rc_monthly')
+
+      expect(store.expire(USER)?.type).toBe('EXPIRATION')
+      expect(await store.getEntitlement(USER)).toBeNull()
+    })
+
+    /**
+     * The EXPIRATION event has to describe what ended, so the webhook can
+     * record which product it was — asking the store afterwards only reports
+     * what is left.
+     */
+    it('names the subscription that just ended', () => {
+      const store = createFakeRevenueCat()
+      store.purchase(USER, 'pro_plus_yearly')
+
+      expect(store.expire(USER)?.entitlement_ids).toEqual(['pro_plus', 'pro'])
+    })
+  })
+
+  it('grants a promotional lifetime entitlement, as the v1 loyalty gift does', async () => {
+    const store = createFakeRevenueCat()
+    await store.grantLifetimeEntitlement(USER, 'pro_plus')
+
+    expect(await store.getEntitlement(USER)).toMatchObject({ tier: 'pro_plus', expiresAt: null })
+  })
+})
+
+describe('asFakeRevenueCat', () => {
+  it('recognises the fake', () => {
+    expect(asFakeRevenueCat(createFakeRevenueCat())).not.toBeNull()
+  })
+
+  // The guard the route's boot-time check depends on: anything that is not
+  // this fake must come back null rather than be widened into one.
+  it('does not recognise a real client', () => {
+    expect(asFakeRevenueCat(createNotConfiguredRevenueCatClient())).toBeNull()
+  })
+})

--- a/apps/api/src/modules/billing/fakeRevenueCat.ts
+++ b/apps/api/src/modules/billing/fakeRevenueCat.ts
@@ -1,0 +1,213 @@
+import {
+  TIER_ENTITLEMENTS,
+  packageDefinition,
+  tierFromEntitlementIds,
+  type BillingPeriod,
+  type EntitlementId,
+  type PaidPlanTier,
+  type RevenueCatEvent,
+} from '@langx/shared'
+import { randomUUID } from 'node:crypto'
+import type { RevenueCatClient, SubscriberEntitlement } from './revenueCatClient'
+
+/**
+ * RevenueCat, replaced by a Map — so that a purchase can be driven from end to
+ * end on a laptop, with no App Store product, no Play product and no network.
+ *
+ * This exists because of a real gap rather than for convenience: none of
+ * Faz 7's billing code could be exercised outside its unit tests until store
+ * products existed (`docs/release-runbook.md` → "cannot be tested end to
+ * end"), which is a long time to leave a paywall, a webhook handler and an
+ * entitlement writer unverified against each other.
+ *
+ * **What this fakes and what it does not.** It stands in for RevenueCat's
+ * *state* — what a subscriber holds — and it produces the events RevenueCat
+ * would have sent. Everything downstream of that is the real thing: the
+ * harness feeds those events to `processRevenueCatWebhook` and reads the
+ * result back through `refreshEntitlement`, both untouched. So it proves our
+ * half of the integration works, and says nothing about whether the store
+ * receipt, the RevenueCat dashboard configuration or the webhook delivery do.
+ * Those still need a Test Store purchase on a device.
+ *
+ * Guarded twice over: `loadEnv` refuses `REVENUECAT_FAKE_STORE` under
+ * `NODE_ENV=production`, and the routes that drive it are only registered when
+ * the flag is on.
+ */
+export interface FakeRevenueCat extends RevenueCatClient {
+  /** Distinguishes this from the real client at runtime — see `asFakeRevenueCat`. */
+  readonly isFake: true
+  /**
+   * Records a purchase and returns the `INITIAL_PURCHASE` RevenueCat would
+   * have sent for it. Returns `null` for a package identifier `PACKAGES` does
+   * not sell, so the caller can answer "no such package" rather than invent a
+   * subscription nobody could have bought.
+   */
+  purchase(appUserId: string, packageId: string): RevenueCatEvent | null
+  /** Stops the renewal, keeping access until it runs out — a `CANCELLATION`. */
+  cancel(appUserId: string): RevenueCatEvent | null
+  /** Ends access now — an `EXPIRATION`, the event the webhook reconciles on. */
+  expire(appUserId: string): RevenueCatEvent | null
+}
+
+/**
+ * Never one of RevenueCat's real store values (`app_store`, `play_store`,
+ * `stripe`, …). It is written into `subscriptions.store` and
+ * `profiles.entitlement.store` like any other purchase, and the one question
+ * that must stay answerable afterwards is which rows the harness put there.
+ */
+export const FAKE_STORE = 'fake_store'
+
+/**
+ * How long each period lasts here.
+ *
+ * Deliberately not read from `PLAN_LIMITS` or anywhere else in config: these
+ * are not product rules, they are how long a *simulated* subscription runs
+ * before `getEntitlement` starts calling it expired. A real one is timed by
+ * Apple or Google and we never compute it. `Record<BillingPeriod, …>` is what
+ * makes a new period a compile error here instead of a subscription that
+ * expires the moment it is bought.
+ */
+const PERIOD_MS: Record<BillingPeriod, number | null> = {
+  monthly: 30 * 24 * 60 * 60 * 1000,
+  yearly: 365 * 24 * 60 * 60 * 1000,
+  /** Not "very long" — a lifetime has no expiry at all, and `null` is how the rest of the code spells that. */
+  lifetime: null,
+}
+
+interface FakeSubscription {
+  entitlementIds: EntitlementId[]
+  productId: string
+  expiresAt: Date | null
+  willRenew: boolean
+}
+
+/**
+ * A product identifier that could not be mistaken for one in App Store Connect
+ * or Play Console, for the same reason `FAKE_STORE` is not `app_store`.
+ */
+function fakeProductId(tier: PaidPlanTier, period: BillingPeriod): string {
+  return `fake.${tier}.${period}`
+}
+
+function isActive(subscription: FakeSubscription, now: Date): boolean {
+  return subscription.expiresAt === null || subscription.expiresAt.getTime() > now.getTime()
+}
+
+export function createFakeRevenueCat(): FakeRevenueCat {
+  // In memory, and so lost on every restart. Persisting it would mean a
+  // schema, an index and a collection that exist only for a harness; a
+  // developer re-buying after `pnpm dev` restarts is the cheaper trade, and
+  // `docs/billing-testing.md` says so.
+  const subscribers = new Map<string, FakeSubscription>()
+
+  function event(type: string, appUserId: string, subscription: FakeSubscription): RevenueCatEvent {
+    return {
+      // The unique index on `subscriptions.eventId` is the webhook's
+      // idempotency guard, so every simulated event needs an id no other one
+      // will ever repeat — including across restarts, which a counter would
+      // not survive.
+      id: `fake_${randomUUID()}`,
+      type,
+      app_user_id: appUserId,
+      product_id: subscription.productId,
+      store: FAKE_STORE,
+      // RevenueCat's own value for a non-production purchase. The webhook
+      // records it verbatim, so a row written here is identifiable as a test
+      // one from two independent fields.
+      environment: 'SANDBOX',
+      expiration_at_ms: subscription.expiresAt ? subscription.expiresAt.getTime() : null,
+      entitlement_ids: [...subscription.entitlementIds],
+    }
+  }
+
+  return {
+    isFake: true,
+
+    purchase(appUserId: string, packageId: string): RevenueCatEvent | null {
+      const definition = packageDefinition(packageId)
+      // `free` is unreachable through `PACKAGES` today, but `PackageDefinition`
+      // permits it, and a "purchase" of the free tier is not a thing to invent
+      // a subscription for.
+      if (definition === null || definition.tier === 'free') return null
+
+      const tier: PaidPlanTier = definition.tier
+      const lifetimeMs = PERIOD_MS[definition.period]
+      const subscription: FakeSubscription = {
+        entitlementIds: [...TIER_ENTITLEMENTS[tier]],
+        productId: fakeProductId(tier, definition.period),
+        expiresAt: lifetimeMs === null ? null : new Date(Date.now() + lifetimeMs),
+        // A lifetime purchase is not a subscription and has nothing to renew.
+        willRenew: definition.period !== 'lifetime',
+      }
+      subscribers.set(appUserId, subscription)
+      return event('INITIAL_PURCHASE', appUserId, subscription)
+    },
+
+    cancel(appUserId: string): RevenueCatEvent | null {
+      const subscription = subscribers.get(appUserId)
+      if (!subscription) return null
+      subscription.willRenew = false
+      // Access deliberately survives: cancelling stops the next charge, and the
+      // webhook's CANCELLATION branch only flips `willRenew` for that reason.
+      return event('CANCELLATION', appUserId, subscription)
+    },
+
+    expire(appUserId: string): RevenueCatEvent | null {
+      const subscription = subscribers.get(appUserId)
+      if (!subscription) return null
+      subscribers.delete(appUserId)
+      // The event is built from the subscription that just ended — an
+      // EXPIRATION names what stopped, not what is left, which is exactly the
+      // ambiguity the webhook reconciles against `getEntitlement` below.
+      return event('EXPIRATION', appUserId, subscription)
+    },
+
+    getEntitlement(appUserId: string): Promise<SubscriberEntitlement | null> {
+      const subscription = subscribers.get(appUserId)
+      if (!subscription || !isActive(subscription, new Date())) return Promise.resolve(null)
+
+      // Resolved through the shared precedence rule rather than from a tier
+      // stored alongside: a Pro+ subscriber holds both ids here exactly as they
+      // do at RevenueCat, so the harness exercises that resolution instead of
+      // trusting a field only it writes.
+      const tier = tierFromEntitlementIds(subscription.entitlementIds)
+      if (tier === null) return Promise.resolve(null)
+
+      return Promise.resolve({
+        tier,
+        expiresAt: subscription.expiresAt,
+        productId: subscription.productId,
+        store: FAKE_STORE,
+      })
+    },
+
+    grantLifetimeEntitlement(appUserId: string, entitlementId: string): Promise<void> {
+      const existing = subscribers.get(appUserId)
+      const entitlementIds = existing ? [...existing.entitlementIds] : []
+      if (!entitlementIds.includes(entitlementId as EntitlementId)) {
+        entitlementIds.push(entitlementId as EntitlementId)
+      }
+      // A promotional grant has no product and no expiry — which is why the v1
+      // loyalty gift is expressed as one, and why it lands here as a lifetime
+      // subscription with nothing to renew.
+      subscribers.set(appUserId, {
+        entitlementIds,
+        productId: existing?.productId ?? 'fake.promotional',
+        expiresAt: null,
+        willRenew: false,
+      })
+      return Promise.resolve()
+    },
+  }
+}
+
+/**
+ * The fake behind a `RevenueCatClient`, or `null` for the real one.
+ *
+ * The routes that drive the harness need capabilities the interface does not
+ * have, and this is the only widening point — a caller that forgets to check
+ * gets `null`, not a client that throws at the first simulated purchase.
+ */
+export function asFakeRevenueCat(client: RevenueCatClient): FakeRevenueCat | null {
+  return 'isFake' in client && client.isFake === true ? (client as FakeRevenueCat) : null
+}

--- a/apps/api/src/routes/billing.test.ts
+++ b/apps/api/src/routes/billing.test.ts
@@ -457,4 +457,21 @@ describe('Faz 7 — billing', () => {
       expect(response.json()).toMatchObject({ tier: 'free' })
     })
   })
+
+  describe('POST /billing/test-event', () => {
+    // The route that hands out entitlement with no purchase behind it should
+    // not exist unless somebody asked for it. This app is built without
+    // REVENUECAT_FAKE_STORE, which is every deployment that is not a
+    // developer's laptop — see billingTestStore.test.ts for the other half.
+    it('does not exist without REVENUECAT_FAKE_STORE', async () => {
+      const user = await newUser('no-test-store@example.com')
+      const response = await app.inject({
+        method: 'POST',
+        url: '/billing/test-event',
+        headers: { cookie: user.cookie },
+        payload: { action: 'purchase', packageId: '$rc_monthly' },
+      })
+      expect(response.statusCode).toBe(404)
+    })
+  })
 })

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -1,9 +1,30 @@
 import { ERROR_CODES, revenueCatWebhookBodySchema } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { z } from 'zod'
 import { ApiError } from '../lib/ApiError'
 import { requireAuth } from '../middleware/requireAuth'
+import { asFakeRevenueCat } from '../modules/billing/fakeRevenueCat'
 import { refreshEntitlement } from '../modules/billing/refresh'
 import { processRevenueCatWebhook } from '../modules/billing/webhook'
+import { getProfile } from '../modules/profiles/profiles'
+
+/**
+ * What the local harness can make the fake store do. Not "every RevenueCat
+ * event type": each of these is one a user can actually cause from the app or
+ * their store account, and the point of the harness is to reproduce the flow a
+ * person goes through. Replaying arbitrary event types is what
+ * `scripts/revenuecat-webhook.ts` is for.
+ */
+const testEventBodySchema = z
+  .object({
+    action: z.enum(['purchase', 'cancel', 'expire']),
+    /** A `PACKAGES` identifier. Required by `purchase`, meaningless to the rest. */
+    packageId: z.string().min(1).optional(),
+  })
+  .refine((body) => body.action !== 'purchase' || body.packageId !== undefined, {
+    message: 'packageId is required for a purchase',
+    path: ['packageId'],
+  })
 
 // eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
 export const billingRoutes: FastifyPluginAsyncZod = async (app) => {
@@ -35,4 +56,67 @@ export const billingRoutes: FastifyPluginAsyncZod = async (app) => {
     const entitlement = await refreshEntitlement(app.mongo.db, app.revenueCat, request.userId)
     return reply.send(entitlement)
   })
+
+  if (app.env.REVENUECAT_FAKE_STORE) registerTestStoreRoute(app)
+}
+
+/**
+ * `POST /billing/test-event` — buy, cancel or expire against the fake store.
+ *
+ * Registered only when `REVENUECAT_FAKE_STORE` is on, which `loadEnv` refuses
+ * under `NODE_ENV=production`. See `docs/billing-testing.md`.
+ *
+ * It deliberately does **not** shortcut to writing `profiles.entitlement`. The
+ * fake store produces the event RevenueCat would have sent and this handler
+ * puts it through `processRevenueCatWebhook`, the same function the real
+ * webhook route calls with the same arguments — so what the harness exercises
+ * is the production path, and a bug in it fails here too. What is skipped is
+ * only the HTTP hop and its shared-secret check, which have their own tests
+ * and their own script.
+ */
+function registerTestStoreRoute(app: Parameters<FastifyPluginAsyncZod>[0]): void {
+  const store = asFakeRevenueCat(app.revenueCat)
+  if (!store) {
+    // Refusing to boot rather than skipping the route: the flag is set, so
+    // somebody is expecting to be able to buy, and a 404 at the paywall is a
+    // much harder thing to explain than a message at startup.
+    throw new Error(
+      'REVENUECAT_FAKE_STORE is set but the RevenueCat client is not the fake one — check createRevenueCatClientFromEnv',
+    )
+  }
+
+  app.post(
+    '/billing/test-event',
+    { schema: { body: testEventBodySchema }, preHandler: requireAuth },
+    async (request, reply) => {
+      const { action, packageId } = request.body
+      const userId = request.userId
+
+      // Always the caller's own id, never one from the body. The harness is a
+      // development tool, but "grant Pro to any user id you can name" is not a
+      // shape worth having anywhere.
+      const event =
+        action === 'purchase'
+          ? store.purchase(userId, packageId ?? '')
+          : action === 'cancel'
+            ? store.cancel(userId)
+            : store.expire(userId)
+
+      if (!event) {
+        throw new ApiError(
+          ERROR_CODES.VALIDATION_FAILED,
+          action === 'purchase'
+            ? `No such package: ${packageId ?? ''}`
+            : 'Nothing to change — this account has no purchase in the fake store',
+        )
+      }
+
+      await processRevenueCatWebhook(app.mongo.db, event, store)
+      const profile = await getProfile(app.mongo.db, userId)
+      return reply.send({
+        event: { id: event.id, type: event.type },
+        entitlement: profile?.entitlement,
+      })
+    },
+  )
 }

--- a/apps/api/src/routes/billingTestStore.test.ts
+++ b/apps/api/src/routes/billingTestStore.test.ts
@@ -1,0 +1,235 @@
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import type { FastifyInstance } from 'fastify'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { buildApp } from '../app'
+import { createAuth } from '../auth'
+import { connectToDatabase, type DbHandle } from '../db/client'
+import { ensureIndexes } from '../db/indexes'
+import { loadEnv } from '../env'
+import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
+import { createStorageProvider } from '../storage/createStorageProvider'
+import { CapturingEmailSender, signUpAndSignIn, type SignedUpUser } from '../testSupport/authFlow'
+import { createTranslationProvider } from '../translation/createTranslationProvider'
+
+const PASSWORD = 'correct horse battery staple'
+
+/**
+ * The local purchase harness, from the outside.
+ *
+ * `fakeRevenueCat.test.ts` covers the fake store on its own; this covers the
+ * thing it was built for — that a purchase made through the API arrives in
+ * `profiles.entitlement` by way of the real webhook handler, and that
+ * `/billing/refresh` afterwards agrees with it. Nothing here is stubbed: the
+ * client comes from `createRevenueCatClientFromEnv` exactly as it does at boot,
+ * chosen only by the environment flag.
+ */
+function onboardingBody(overrides: Record<string, unknown> = {}) {
+  return {
+    handle: `user${Math.random().toString(36).slice(2, 10)}`,
+    displayName: 'Test User',
+    birthYear: 1995,
+    gender: 'undisclosed',
+    nativeLanguages: [{ code: 'tr' }],
+    learning: [{ code: 'en', level: 'intermediate', priority: 1 }],
+    ...overrides,
+  }
+}
+
+describe('POST /billing/test-event (REVENUECAT_FAKE_STORE)', () => {
+  let replSet: MongoMemoryReplSet
+  let handle: DbHandle
+  let app: FastifyInstance
+  let emailSender: CapturingEmailSender
+
+  async function newUser(email: string): Promise<SignedUpUser> {
+    const user = await signUpAndSignIn(app, emailSender, {
+      email,
+      password: PASSWORD,
+      name: 'Test',
+    })
+    const response = await app.inject({
+      method: 'POST',
+      url: '/profiles',
+      headers: { cookie: user.cookie },
+      payload: onboardingBody(),
+    })
+    if (response.statusCode !== 201) {
+      throw new Error(`onboarding failed (${response.statusCode}): ${response.body}`)
+    }
+    return user
+  }
+
+  /** Only the half the assertions read — the event id is echoed back too, and never checked here. */
+  interface TestEventResponse {
+    entitlement?: { tier: string; willRenew?: boolean; store?: string }
+  }
+
+  function testEvent(user: SignedUpUser, payload: Record<string, unknown>) {
+    return app.inject({
+      method: 'POST',
+      url: '/billing/test-event',
+      headers: { cookie: user.cookie },
+      payload,
+    })
+  }
+
+  function refresh(user: SignedUpUser) {
+    return app.inject({
+      method: 'POST',
+      url: '/billing/refresh',
+      headers: { cookie: user.cookie },
+    })
+  }
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+    handle = await connectToDatabase(replSet.getUri(), 'langx_test_store')
+
+    const env = loadEnv({
+      NODE_ENV: 'test',
+      MONGODB_URI: replSet.getUri(),
+      MONGODB_DB: 'langx_test_store',
+      LOG_LEVEL: 'silent',
+      BETTER_AUTH_SECRET: 'a'.repeat(32),
+      BETTER_AUTH_URL: 'http://localhost:4000',
+      REVENUECAT_FAKE_STORE: 'true',
+      // Set on purpose: the flag has to win over a real key, or a developer
+      // with one left in their .env would fire simulated purchases at the live
+      // dashboard. If precedence ever flips, every case below fails at once.
+      REVENUECAT_SECRET_API_KEY: 'sk_would_be_a_real_key',
+    })
+
+    await ensureIndexes(handle.db)
+
+    emailSender = new CapturingEmailSender()
+    const auth = await createAuth({ env, db: handle.db, client: handle.client, emailSender })
+    app = await buildApp({
+      env,
+      client: handle.client,
+      db: handle.db,
+      auth,
+      storage: createStorageProvider(env),
+      translation: createTranslationProvider(env),
+      revenueCat: createRevenueCatClientFromEnv(env),
+    })
+    await app.ready()
+
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      const warmUp = await app.inject({
+        method: 'POST',
+        url: '/api/auth/sign-up/email',
+        payload: { email: `warmup-${attempt}@example.com`, password: PASSWORD, name: 'Warm Up' },
+      })
+      if (warmUp.statusCode === 200) break
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+    emailSender.messages.length = 0
+  }, 120_000)
+
+  afterAll(async () => {
+    await app?.close()
+    await handle?.close()
+    await replSet?.stop()
+  })
+
+  it('requires a session', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/billing/test-event',
+      payload: { action: 'purchase', packageId: '$rc_monthly' },
+    })
+    expect(response.statusCode).toBe(401)
+  })
+
+  it('rejects a purchase with no package named', async () => {
+    const user = await newUser('no-package@example.com')
+    const response = await testEvent(user, { action: 'purchase' })
+    expect(response.statusCode).toBe(400)
+  })
+
+  it('rejects a package identifier nothing sells', async () => {
+    const user = await newUser('bad-package@example.com')
+    const response = await testEvent(user, { action: 'purchase', packageId: 'not_a_package' })
+    expect(response.statusCode).toBe(400)
+  })
+
+  it('writes the bought tier onto the profile', async () => {
+    const user = await newUser('buys-pro@example.com')
+    const response = await testEvent(user, { action: 'purchase', packageId: '$rc_monthly' })
+
+    expect(response.statusCode, response.body).toBe(200)
+    expect(response.json<TestEventResponse>().entitlement).toMatchObject({
+      tier: 'pro',
+      willRenew: true,
+      store: 'fake_store',
+    })
+  })
+
+  it('writes pro_plus for a Pro+ package, not the tier a bare grant would default to', async () => {
+    const user = await newUser('buys-plus@example.com')
+    const response = await testEvent(user, { action: 'purchase', packageId: 'pro_plus_yearly' })
+
+    expect(response.json<TestEventResponse>().entitlement).toMatchObject({ tier: 'pro_plus' })
+  })
+
+  /**
+   * The point of the harness. `/billing/refresh` reconciles from RevenueCat
+   * rather than from what the client claims, so a purchase that did not reach
+   * the fake store's own records would be erased here — the same way a
+   * database-only grant is erased in production.
+   */
+  it('survives the reconcile the paywall runs after a purchase', async () => {
+    const user = await newUser('refresh-after-buy@example.com')
+    await testEvent(user, { action: 'purchase', packageId: 'pro_plus_monthly' })
+
+    const response = await refresh(user)
+    expect(response.statusCode, response.body).toBe(200)
+    expect(response.json()).toMatchObject({ tier: 'pro_plus' })
+  })
+
+  it('keeps access after a cancellation and only stops the renewal', async () => {
+    const user = await newUser('cancels@example.com')
+    await testEvent(user, { action: 'purchase', packageId: '$rc_monthly' })
+
+    const response = await testEvent(user, { action: 'cancel' })
+    expect(response.statusCode, response.body).toBe(200)
+    expect(response.json<TestEventResponse>().entitlement).toMatchObject({
+      tier: 'pro',
+      willRenew: false,
+    })
+  })
+
+  it('drops to free on expiry', async () => {
+    const user = await newUser('expires@example.com')
+    await testEvent(user, { action: 'purchase', packageId: '$rc_monthly' })
+
+    const response = await testEvent(user, { action: 'expire' })
+    expect(response.statusCode, response.body).toBe(200)
+    expect(response.json<TestEventResponse>().entitlement).toMatchObject({ tier: 'free' })
+    expect((await refresh(user)).json()).toMatchObject({ tier: 'free' })
+  })
+
+  it('refuses to cancel something that was never bought', async () => {
+    const user = await newUser('nothing-to-cancel@example.com')
+    const response = await testEvent(user, { action: 'cancel' })
+    expect(response.statusCode).toBe(400)
+  })
+
+  /**
+   * A purchase is one person's. The route reads the buyer from the session and
+   * never from the body, so a user id smuggled in cannot move entitlement onto
+   * somebody else's profile.
+   */
+  it('ignores an app_user_id in the body', async () => {
+    const buyer = await newUser('smuggler@example.com')
+    const victim = await newUser('bystander@example.com')
+
+    await testEvent(buyer, {
+      action: 'purchase',
+      packageId: '$rc_monthly',
+      app_user_id: victim.userId,
+    })
+
+    expect((await refresh(victim)).json()).toMatchObject({ tier: 'free' })
+  })
+})

--- a/apps/mobile/env.d.ts
+++ b/apps/mobile/env.d.ts
@@ -25,6 +25,14 @@ declare global {
       readonly EXPO_PUBLIC_REVENUECAT_IOS_KEY?: string
       readonly EXPO_PUBLIC_REVENUECAT_ANDROID_KEY?: string
       readonly EXPO_PUBLIC_REVENUECAT_TEST_STORE_KEY?: string
+      /**
+       * `'1'` replaces RevenueCat entirely with the local development harness
+       * in `lib/fakePurchases.ts`, so the paywall can be bought from on web
+       * and without store products. Only ever read together with `__DEV__`,
+       * and the API needs its own `REVENUECAT_FAKE_STORE` for the purchase to
+       * land anywhere — see `docs/billing-testing.md`.
+       */
+      readonly EXPO_PUBLIC_REVENUECAT_FAKE_STORE?: string
     }
   }
 }

--- a/apps/mobile/src/lib/fakePurchases.test.ts
+++ b/apps/mobile/src/lib/fakePurchases.test.ts
@@ -1,0 +1,38 @@
+import { PACKAGES } from '@langx/shared'
+import { describe, expect, it } from 'vitest'
+import { fakeOffers } from './fakePurchases'
+
+describe('fakeOffers', () => {
+  it('offers every package the app sells', () => {
+    expect(
+      fakeOffers()
+        .map((offer) => offer.id)
+        .sort(),
+    ).toEqual(Object.keys(PACKAGES).sort())
+  })
+
+  it('sells each package as the tier and period the shared table says', () => {
+    for (const offer of fakeOffers()) {
+      expect(offer).toMatchObject(PACKAGES[offer.id as keyof typeof PACKAGES])
+    }
+  })
+
+  /**
+   * The paywall groups its columns by tier, so a harness that produced only
+   * one tier's packages would leave half the screen untested.
+   */
+  it('covers both paid tiers', () => {
+    expect(new Set(fakeOffers().map((offer) => offer.tier))).toEqual(new Set(['pro', 'pro_plus']))
+  })
+
+  /**
+   * The one thing about these prices that is load-bearing. A paywall showing
+   * plausible prices while no money moves is a screenshot that gets mistaken
+   * for the real one; every price has to say what it is on its face.
+   */
+  it('labels every price as a test price', () => {
+    for (const offer of fakeOffers()) {
+      expect(offer.priceString).toMatch(/^TEST /)
+    }
+  })
+})

--- a/apps/mobile/src/lib/fakePurchases.ts
+++ b/apps/mobile/src/lib/fakePurchases.ts
@@ -1,0 +1,100 @@
+import { PACKAGES } from '@langx/shared'
+import type { PurchaseOffer, PurchaseOutcome } from './purchases'
+
+/**
+ * A store that is not a store, so the paywall can be bought from on a laptop.
+ *
+ * `react-native-purchases` is native-only and every real package needs an App
+ * Store or Play product behind it, which together meant the purchase flow
+ * could not be run at all outside a device build with store configuration —
+ * see `docs/billing-testing.md`. With this on, the paywall lists real packages
+ * at obviously fake prices and buying one calls the API's fake-store route,
+ * which puts a RevenueCat-shaped event through the real webhook handler.
+ *
+ * **Off unless two independent things are true**: the explicit environment
+ * flag, and `__DEV__`. The second is the one that matters — Expo inlines
+ * `EXPO_PUBLIC_*` at build time, so a flag left set in a shell could otherwise
+ * follow a `pnpm build:web` all the way into a published bundle, and this is
+ * not a mistake that announces itself. Nothing here is reachable from a
+ * production build regardless of how the environment is set.
+ *
+ * The server half is guarded separately and refuses to boot with the flag on
+ * under `NODE_ENV=production`, so neither side can be talked into this alone.
+ */
+export function isFakePurchasesEnabled(): boolean {
+  return __DEV__ && process.env.EXPO_PUBLIC_REVENUECAT_FAKE_STORE === '1'
+}
+
+/**
+ * Prices for packages nobody is charged for.
+ *
+ * They read `TEST` first and are checked by nothing, because that is the whole
+ * job: a paywall showing plausible prices in a state where no money moves is a
+ * screenshot waiting to be mistaken for the real one. Real prices are never
+ * built here — they come from the store, formatted and in the user's currency,
+ * which is a store-compliance requirement and not a preference.
+ *
+ * `Record<keyof typeof PACKAGES, string>` means a package added to the shared
+ * table without a price here stops this file compiling, matching how the
+ * paywall's own copy tables are enforced.
+ */
+const TEST_PRICES: Record<keyof typeof PACKAGES, string> = {
+  $rc_monthly: 'TEST $4.99',
+  $rc_annual: 'TEST $39.99',
+  $rc_lifetime: 'TEST $99.99',
+  pro_plus_monthly: 'TEST $9.99',
+  pro_plus_yearly: 'TEST $79.99',
+}
+
+/**
+ * Every package the app sells, in `PACKAGES` order.
+ *
+ * Read off the shared table rather than a list of its own, so the harness
+ * offers exactly what a correctly configured RevenueCat offering would — a
+ * package missing from `PACKAGES` is missing here too, which is the failure
+ * `getOffers` is written to make visible.
+ */
+export function fakeOffers(): PurchaseOffer[] {
+  // `Object.keys` is typed `string[]` however narrow the object is, and this
+  // one is a const table whose keys are exactly `PACKAGES`'s — the assertion
+  // recovers what the compiler already knows, and `TEST_PRICES` above is what
+  // keeps the two key sets from drifting apart.
+  const ids = Object.keys(PACKAGES) as (keyof typeof PACKAGES)[]
+  return ids.map((id) => ({
+    id,
+    tier: PACKAGES[id].tier,
+    priceString: TEST_PRICES[id],
+    period: PACKAGES[id].period,
+  }))
+}
+
+/**
+ * "Buys" a package by asking the API to run one through its fake store.
+ *
+ * There is no local success to report: entitlement lives on the server, and a
+ * client that said `purchased` off its own bat would be testing nothing. The
+ * paywall's existing `POST /billing/refresh` afterwards is what makes the new
+ * tier appear, exactly as it does after a real purchase.
+ *
+ * `unavailable` rather than `failed` when the route is not there, because that
+ * is what it means: the API is running without `REVENUECAT_FAKE_STORE`, so
+ * this device cannot buy — the same state the paywall already has copy for.
+ */
+export async function fakePurchase(offerId: string): Promise<PurchaseOutcome> {
+  // Imported here rather than at module scope, for the same shape of reason
+  // `purchases.ts` loads the RevenueCat SDK lazily: `../api/client` reaches
+  // `react-native` through `apiFetch`, and vitest runs in Node, where that
+  // module cannot be parsed. At module scope it would take the offer table
+  // below down with it and leave the harness itself untestable.
+  const { api } = await import('../api/client')
+  try {
+    await api.post('/billing/test-event', { action: 'purchase', packageId: offerId })
+    return 'purchased'
+  } catch (error) {
+    return isNotFound(error) ? 'unavailable' : 'failed'
+  }
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'status' in error && error.status === 404
+}

--- a/apps/mobile/src/lib/purchases.ts
+++ b/apps/mobile/src/lib/purchases.ts
@@ -1,5 +1,6 @@
 import { packageDefinition, type BillingPeriod, type PaidPlanTier } from '@langx/shared'
 import { Platform } from 'react-native'
+import { fakeOffers, fakePurchase, isFakePurchasesEnabled } from './fakePurchases'
 // `import type` is erased at compile time, so naming the module here costs
 // nothing at runtime — the actual native module is still only pulled in by the
 // dynamic import in `loadSdk()`, on the platforms that have it.
@@ -24,6 +25,13 @@ import type * as PurchasesSdk from 'react-native-purchases'
  * shapes below, and the RevenueCat `PurchasesPackage` objects stay in
  * `packagesById` — passing an opaque SDK object through React props is how a
  * UI ends up unable to be tested without the native module present.
+ *
+ * Each function below opens with the same `isFakePurchasesEnabled()` check,
+ * which is the local development harness (`./fakePurchases`) taking the whole
+ * module over. Branching here rather than at the call sites is what keeps the
+ * promise the paragraph above makes: the paywall still has exactly one surface
+ * onto billing and cannot tell which store it is talking to, so what the
+ * harness exercises is the screen that ships.
  */
 
 /** `react-native-purchases` is native-only; the browser build needs RevenueCat's separate JS SDK, which this app does not ship. */
@@ -44,6 +52,7 @@ function apiKey(): string | null {
 }
 
 export function isPurchasesAvailable(): boolean {
+  if (isFakePurchasesEnabled()) return true
   return apiKey() !== null
 }
 
@@ -88,6 +97,11 @@ async function loadSdk(): Promise<PurchasesModule | null> {
  * Safe to call repeatedly; it no-ops once the current user is already bound.
  */
 export async function identifyForPurchases(userId: string): Promise<void> {
+  // Nothing to bind under the harness: its purchases are made by an
+  // authenticated API call, so the app user id *is* the session's user id and
+  // cannot drift from it — which is the failure this function exists to
+  // prevent, made structurally impossible rather than handled.
+  if (isFakePurchasesEnabled()) return
   if (configuredFor === userId) return
   const sdk = await loadSdk()
   if (!sdk) return
@@ -110,6 +124,7 @@ export async function identifyForPurchases(userId: string): Promise<void> {
 
 /** Clears the binding on sign-out so the next account does not inherit it. */
 export async function forgetPurchasesIdentity(): Promise<void> {
+  if (isFakePurchasesEnabled()) return
   if (configuredFor === null) return
   const sdk = await loadSdk()
   configuredFor = null
@@ -128,6 +143,7 @@ export async function forgetPurchasesIdentity(): Promise<void> {
  * the paywall renders the same honest empty state for all of them.
  */
 export async function getOffers(): Promise<PurchaseOffer[]> {
+  if (isFakePurchasesEnabled()) return fakeOffers()
   const sdk = await loadSdk()
   if (!sdk) return []
 
@@ -166,6 +182,7 @@ export async function getOffers(): Promise<PurchaseOffer[]> {
  * teaches people it is broken.
  */
 export async function purchaseOffer(offerId: string): Promise<PurchaseOutcome> {
+  if (isFakePurchasesEnabled()) return fakePurchase(offerId)
   const sdk = await loadSdk()
   const pkg = packagesById.get(offerId)
   if (!sdk || !pkg) return 'unavailable'
@@ -186,6 +203,10 @@ export async function purchaseOffer(offerId: string): Promise<PurchaseOutcome> {
  * runs afterwards.
  */
 export async function restorePurchases(): Promise<boolean> {
+  // There is no device receipt to restore *from* here, and reporting failure
+  // would be misleading: the caller reconciles with the server straight
+  // afterwards, and under the harness the server is the only record there was.
+  if (isFakePurchasesEnabled()) return true
   const sdk = await loadSdk()
   if (!sdk) return false
   try {

--- a/docs/billing-testing.md
+++ b/docs/billing-testing.md
@@ -1,0 +1,113 @@
+# Testing a purchase without a store
+
+Faz 7's billing code — paywall, webhook handler, entitlement writer,
+reconciliation — could not be run against itself outside its unit tests. A real
+purchase needs an App Store or Play product, a RevenueCat offering configured
+against it, and a device build to make it from; none of that exists yet
+(`release-runbook.md` → "Before the stores"). That left the one flow the whole
+tier system rests on unexercised.
+
+The harness below replaces RevenueCat with a stand-in on both sides, so the
+flow can be run end to end from a laptop, on the web build, with no network.
+
+## What it proves, and what it does not
+
+It fakes RevenueCat's **state** — what a subscriber holds — and produces the
+events RevenueCat would have sent. Everything after that point is the shipping
+code: the events go through `processRevenueCatWebhook`, entitlement lands in
+`profiles.entitlement`, and the paywall reads it back through
+`POST /billing/refresh` exactly as it does in production. The mobile client
+branches inside `lib/purchases.ts`, which is the app's only surface onto
+billing, so the screen under test is the screen that ships.
+
+What it says nothing about:
+
+- whether the RevenueCat dashboard's packages, entitlements and offerings match
+  `PACKAGES` and `ENTITLEMENT_TIERS`
+- whether a store receipt validates
+- whether RevenueCat can reach `POST /webhooks/revenuecat` — that needs a
+  public URL, and the shared secret is only exercised by the script below
+
+Those still need a **Test Store purchase on a device**, which is the runbook's
+existing checklist item and is not replaced by any of this.
+
+## Turning it on
+
+Two flags, one per side. Both are needed: with only the client flag the paywall
+lists packages and buying one fails; with only the server flag nothing calls
+the route.
+
+```bash
+# .env
+REVENUECAT_FAKE_STORE=true
+EXPO_PUBLIC_REVENUECAT_FAKE_STORE=1
+```
+
+Then `pnpm dev` and open the paywall — on the web build, or a device, or both.
+
+The guards are deliberate and worth knowing about, because they are what makes
+a flag like this safe to have in a public repo:
+
+- `loadEnv` **refuses to boot** with `REVENUECAT_FAKE_STORE` set under
+  `NODE_ENV=production`. It does not ignore the flag: the two look identical
+  from outside, and only one of them is safe.
+- The client half is also gated on `__DEV__`. Expo inlines `EXPO_PUBLIC_*` at
+  build time, so a flag left set in a shell could otherwise ride a
+  `pnpm build:web` into a published bundle.
+- `POST /billing/test-event` is not registered at all unless the server flag is
+  on, so it does not exist to be found on any deployment.
+
+## Buying
+
+The paywall works normally. Every package is listed at a price beginning with
+`TEST`, and buying one calls `POST /billing/test-event`, which runs an
+`INITIAL_PURCHASE` through the webhook handler and returns the resulting
+entitlement. The paywall's usual `POST /billing/refresh` follows and the tier
+appears.
+
+The same route covers the rest of a subscription's life, which is most of what
+goes wrong in billing:
+
+```bash
+# cookies from a signed-in session; --user is never taken from the body
+curl -X POST localhost:4000/billing/test-event -H 'content-type: application/json' \
+  -b "$COOKIE" -d '{"action":"purchase","packageId":"pro_plus_monthly"}'
+curl ... -d '{"action":"cancel"}'   # access continues, willRenew flips
+curl ... -d '{"action":"expire"}'   # access ends, tier drops to free
+```
+
+Purchases live in memory and are lost when the API restarts. Persisting them
+would mean a collection and an index that exist only for a harness; re-buying
+after a restart is the cheaper trade.
+
+## Replaying a webhook
+
+`POST /billing/test-event` skips the HTTP hop, so it never checks the shared
+secret. The script does, against a running API — local or deployed — and is
+also how a real event gets replayed:
+
+```bash
+REVENUECAT_WEBHOOK_AUTH_HEADER=dev-secret \
+  pnpm --filter @langx/api exec tsx scripts/revenuecat-webhook.ts \
+  --user <userId> --type INITIAL_PURCHASE --package pro_plus_monthly
+```
+
+`--user` is the Better Auth user id, because that is what the app sets as
+RevenueCat's `app_user_id`. Anything else produces an event the webhook records
+for audit and cannot apply to anybody — which is itself worth seeing once.
+
+Useful variations: `--type CANCELLATION`, `--type EXPIRATION`,
+`--expires-in-days -1` for a subscription that has already lapsed, and
+`--url https://<host>` to aim at a deployment. Re-sending is safe: a repeated
+event id comes back `processed: false`, which is the idempotency guard doing
+its job.
+
+## Where the pieces are
+
+| Path                                             | What                                        |
+| ------------------------------------------------ | ------------------------------------------- |
+| `apps/api/src/modules/billing/fakeRevenueCat.ts` | The stand-in: subscriber state and events   |
+| `apps/api/src/routes/billing.ts`                 | `POST /billing/test-event`, flag-gated      |
+| `apps/api/scripts/revenuecat-webhook.ts`         | Posts an event at the real webhook route    |
+| `apps/mobile/src/lib/fakePurchases.ts`           | The client half, behind `purchases.ts`      |
+| `apps/api/src/routes/billingTestStore.test.ts`   | The whole flow, in CI, with no flags to set |

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -218,7 +218,11 @@ credentials before running the streak reminder against real users.
 ## Prerequisites that are business process, not code
 
 None of these can be done from this repo, and Faz 7's subscription work cannot
-be tested end to end until they are:
+be tested against a real store until they are. What _can_ be tested without
+them — the paywall, the webhook handler, entitlement and reconciliation, as one
+flow — is in [`billing-testing.md`](billing-testing.md); it does not replace the
+Test Store purchase below, it only stops that purchase being the first time any
+of it runs together.
 
 - [ ] Paid apps agreement accepted (Apple + Google)
 - [ ] Bank and tax details submitted

--- a/packages/shared/src/billing.ts
+++ b/packages/shared/src/billing.ts
@@ -63,6 +63,23 @@ export const ENTITLEMENT_TIERS = {
 
 export type EntitlementId = keyof typeof ENTITLEMENT_TIERS
 
+/**
+ * The entitlement ids a paid tier hands out — the mirror image of
+ * `tierFromEntitlementIds`.
+ *
+ * Pro+ lists `pro` as well because that is how the Pro+ *products* are
+ * configured in the dashboard: a Pro+ subscriber genuinely holds both ids, and
+ * `ENTITLEMENT_PRECEDENCE` exists to resolve exactly that overlap. Written
+ * down once here so that everything which has to reproduce a purchase — the
+ * loyalty gift below, the fake store the local harness buys from — says it the
+ * same way. Two independent spellings of "Pro+ also grants Pro" is how one of
+ * them quietly stops being true.
+ */
+export const TIER_ENTITLEMENTS = {
+  pro: ['pro'],
+  pro_plus: ['pro_plus', 'pro'],
+} as const satisfies Record<PaidPlanTier, readonly EntitlementId[]>
+
 /** How often a package bills. Not a duration — only what the paywall labels it. */
 export type BillingPeriod = 'monthly' | 'yearly' | 'lifetime'
 
@@ -169,8 +186,12 @@ export interface LifetimeGrantRung {
  * `/billing/refresh` the app makes.
  */
 export const LOYALTY_LIFETIME_GRANTS = [
-  { minLegacyTokenBalance: 37_821, tier: 'pro_plus', entitlements: ['pro_plus', 'pro'] },
-  { minLegacyTokenBalance: 9_136, tier: 'pro', entitlements: ['pro'] },
+  {
+    minLegacyTokenBalance: 37_821,
+    tier: 'pro_plus',
+    entitlements: TIER_ENTITLEMENTS.pro_plus,
+  },
+  { minLegacyTokenBalance: 9_136, tier: 'pro', entitlements: TIER_ENTITLEMENTS.pro },
 ] as const satisfies readonly LifetimeGrantRung[]
 
 /**


### PR DESCRIPTION
Faz 7's billing code could not be run against itself outside its unit tests. A real purchase needs an App Store or Play product, a RevenueCat offering configured against it, and a device build to make it from, so the paywall, the webhook handler, the entitlement writer and the reconciliation path had never run together — see `docs/release-runbook.md` → "cannot be tested end to end".

This replaces RevenueCat with a stand-in on both sides, behind two flags that are off by default.

## What it does

- `apps/api/src/modules/billing/fakeRevenueCat.ts` fakes RevenueCat's *state* — what a subscriber holds — and produces the events RevenueCat would have sent. Everything after that is the shipping code.
- `POST /billing/test-event` (purchase / cancel / expire) puts those events through the real `processRevenueCatWebhook`, with the same arguments the webhook route uses. No shortcut to writing `profiles.entitlement`, so a bug in the production path fails here too.
- The client branches inside `apps/mobile/src/lib/purchases.ts`, which is the app's only surface onto billing, so the screen under test is the screen that ships. Packages are listed at prices that read `TEST` first.
- `apps/api/scripts/revenuecat-webhook.ts` posts a real-shaped event over HTTP at `POST /webhooks/revenuecat`, which is the only local way to exercise the shared secret and the body schema — and is also how a real event gets replayed against a deployment.
- `TIER_ENTITLEMENTS` moves the "Pro+ grants `pro` too" rule into the shared table the loyalty gift already relied on, so the fake store reproduces a purchase from the same source rather than a second spelling of it.

## What it does not do

It says nothing about whether the RevenueCat dashboard matches `PACKAGES` / `ENTITLEMENT_TIERS`, whether a store receipt validates, or whether RevenueCat can reach the webhook. Those still need a Test Store purchase on a device; the runbook item stands and is now cross-linked rather than replaced.

## Guards

- `loadEnv` **refuses to boot** with `REVENUECAT_FAKE_STORE` under `NODE_ENV=production` rather than ignoring the flag — the two look identical from outside and only one is safe.
- The route is not registered at all without the flag, so it does not exist to be found on any deployment.
- The client half also requires `__DEV__`, so a stale `EXPO_PUBLIC_*` in a shell cannot ride a `pnpm build:web` into a published bundle.
- The flag takes precedence over `REVENUECAT_SECRET_API_KEY`, and a test asserts that: a developer with a real key in their `.env` means the fake, not the live dashboard.

## Verification

`pnpm test` (448), `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` all clean. Also run live, outside the test suite: on a real dev server over HTTP (purchase → `pro_plus`, `/billing/refresh` agreeing, cancel → `willRenew: false`, expire → `free`, unknown package → 400); the script (wrong secret 401, correct 200, `EXPIRATION` replay dropping to free); and the paywall in a browser on the Expo web build, where clicking Pro+ Monthly moves the account from free to `pro_plus` and the app's own "You're on Pro+" banner appears.

That live run is also what caught the one bug in here: `--expires-in-days` defaulted to a flat 30, so `$rc_annual` was dated a month out instead of a year.

**Docs:** `docs/billing-testing.md`.
