### PR TITLE
fix(chat): announce the first message of a thread

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -9,7 +9,6 @@ import {
   validatorCompiler,
 } from 'fastify-type-provider-zod'
 import type { Db, MongoClient } from 'mongodb'
-import type { Server as SocketIOServer } from 'socket.io'
 import type { Auth } from './auth'
 import type { Env } from './env'
 import { ApiError } from './lib/ApiError'
@@ -36,6 +35,7 @@ import { DisabledLegacyVerifier, type LegacyVerifier } from './modules/handles/l
 import type { StorageProvider } from './storage/StorageProvider'
 import type { TranslationProvider } from './translation/TranslationProvider'
 import { attachSocketServer } from './ws'
+import type { AppServer } from './ws/types'
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -48,7 +48,13 @@ declare module 'fastify' {
     push: PushSender
     legacyVerifier: LegacyVerifier
     appVersion: string
-    io: SocketIOServer
+    /**
+     * The pinned server type, not socket.io's default. Its generics default
+     * `data` to `any`, which makes every `app.io` handed to a typed helper an
+     * unsafe argument — caught by lint the first time a route outside `ws/`
+     * needed to fan a message out.
+     */
+    io: AppServer
   }
 }
 

--- a/apps/api/src/modules/chat/conversations.ts
+++ b/apps/api/src/modules/chat/conversations.ts
@@ -54,6 +54,11 @@ export interface Message {
   deletedWithAccount?: boolean
 }
 
+export interface StartResult {
+  conversation: Conversation
+  message: Message
+}
+
 /** `<minId>_<maxId>` — the same two people can never open a second conversation. */
 export function pairKeyFor(a: string, b: string): string {
   return [a, b].sort().join('_')
@@ -77,7 +82,7 @@ export async function startConversation(
   db: Db,
   viewerId: string,
   input: StartConversationInput,
-): Promise<Conversation> {
+): Promise<StartResult> {
   if (input.toUserId === viewerId) {
     throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Cannot start a conversation with yourself')
   }
@@ -167,5 +172,9 @@ export async function startConversation(
   // false here by construction — only one side has spoken.
   await awardForSend(db, { conversation, message, becameMutual: false })
 
-  return conversation
+  // The message comes back as well as the conversation because the caller has
+  // to fan it out, and it is the only thing that holds it: this path does not
+  // go through `recordMessage`, so nothing else ever sees the first message of
+  // a thread. Returning just the conversation is what let it go unannounced.
+  return { conversation, message }
 }

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -6,6 +6,7 @@ import { requireAuth, requireVerifiedEmail } from '../middleware/requireAuth'
 import { startConversation } from '../modules/chat/conversations'
 import { effectiveTier } from '../modules/profiles/entitlement'
 import { getProfile } from '../modules/profiles/profiles'
+import { fanOutMessage } from '../ws/fanOut'
 
 // eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
 export const conversationRoutes: FastifyPluginAsyncZod = async (app) => {
@@ -13,7 +14,18 @@ export const conversationRoutes: FastifyPluginAsyncZod = async (app) => {
     '/conversations',
     { preHandler: requireVerifiedEmail, schema: { body: startConversationSchema } },
     async (request, reply) => {
-      const conversation = await startConversation(app.mongo.db, request.userId, request.body)
+      const { conversation, message } = await startConversation(
+        app.mongo.db,
+        request.userId,
+        request.body,
+      )
+      // Starting a conversation *is* sending its first message, so it gets the
+      // same treatment as every other send: it reaches the recipient live, it
+      // advances the sender's ticks, and it notifies if they are away. This
+      // was the one message path with no realtime at all — a first message sat
+      // unannounced until something happened to refetch, which for the person
+      // being contacted is the message that matters most.
+      void fanOutMessage(app, app.io, conversation, message, { pushWhenAway: true })
       return reply.code(201).send(conversation)
     },
   )

--- a/apps/api/src/ws/chat.test.ts
+++ b/apps/api/src/ws/chat.test.ts
@@ -351,6 +351,70 @@ describe('Faz 5 — realtime chat over Socket.io', () => {
     expect(await stampOf()).toBe(first)
   })
 
+  it('the first message of a thread reaches the recipient live, not on the next refetch', async () => {
+    const alice = await newUser('ws-firstmsg-alice@example.com')
+    const bob = await newUser('ws-firstmsg-bob@example.com')
+
+    // Both connected *before* the conversation exists — the case the socket
+    // send path always handled and `POST /conversations` did not, because it
+    // wrote the message and told nobody.
+    await connectSocket(alice.cookie)
+    const bobSocket = await connectSocket(bob.cookie)
+
+    const received = waitForEvent<{ body: string; senderId: string }>(bobSocket, 'message:new')
+    await startConversation(alice, bob.userId, 'first contact')
+
+    expect(await received).toMatchObject({ body: 'first contact', senderId: alice.userId })
+  })
+
+  it('the first message goes to two ticks while the recipient is connected', async () => {
+    const alice = await newUser('ws-firstdeliv-alice@example.com')
+    const bob = await newUser('ws-firstdeliv-bob@example.com')
+
+    await connectSocket(bob.cookie)
+    const aliceSocket = await connectSocket(alice.cookie)
+
+    const delivered = waitForEvent<{ deliveredTo: string }>(aliceSocket, 'conversation:delivered')
+    const conversation = await startConversation(alice, bob.userId, 'tick me')
+
+    expect(await delivered).toMatchObject({
+      conversationId: conversation._id,
+      deliveredTo: bob.userId,
+    })
+
+    const history = await app.inject({
+      method: 'GET',
+      url: `/conversations/${conversation._id}/messages`,
+      headers: { cookie: alice.cookie },
+    })
+    const first = history.json<{ items: { deliveredAt?: string; readAt?: string }[] }>().items[0]
+    expect(first?.deliveredAt).toBeDefined()
+    // Bob holds a socket; he has not opened the thread.
+    expect(first?.readAt).toBeUndefined()
+  })
+
+  it('a first message to someone offline still waits for them to connect', async () => {
+    const alice = await newUser('ws-firstoff-alice@example.com')
+    const bob = await newUser('ws-firstoff-bob@example.com')
+    const aliceSocket = await connectSocket(alice.cookie)
+
+    // Nobody to hand it to, so the second tick may not appear yet — the point
+    // of stamping on real delivery rather than on the write succeeding.
+    const conversation = await startConversation(alice, bob.userId, 'are you there')
+    const before = await app.inject({
+      method: 'GET',
+      url: `/conversations/${conversation._id}/messages`,
+      headers: { cookie: alice.cookie },
+    })
+    expect(
+      before.json<{ items: { deliveredAt?: string }[] }>().items[0]?.deliveredAt,
+    ).toBeUndefined()
+
+    const delivered = waitForEvent<{ deliveredTo: string }>(aliceSocket, 'conversation:delivered')
+    await connectSocket(bob.cookie)
+    expect(await delivered).toMatchObject({ deliveredTo: bob.userId })
+  })
+
   it('typing relays to the other participant only', async () => {
     const alice = await newUser('ws-typing-alice@example.com')
     const bob = await newUser('ws-typing-bob@example.com')

--- a/apps/api/src/ws/fanOut.ts
+++ b/apps/api/src/ws/fanOut.ts
@@ -1,0 +1,86 @@
+import type { FastifyInstance } from 'fastify'
+import type { ObjectId } from 'mongodb'
+import { markDelivered } from '../modules/chat/messages'
+import { sendPush, tokensFor } from '../modules/push/devices'
+import { userRoom, type AppServer } from './types'
+
+/** The parts of a conversation this needs; `Conversation` itself carries far more. */
+interface FannedConversation {
+  _id: ObjectId
+  participants: readonly string[]
+}
+
+interface FannedMessage {
+  senderId: string
+  body: string
+  conversationId: { toHexString: () => string }
+}
+
+/**
+ * Everything that happens to a message once it is durably written: both
+ * participants see it arrive, the sender's ticks advance, and the recipient's
+ * phone buzzes if they were not there to receive it.
+ *
+ * One function because these three are a single sequence, not three
+ * independent effects — the same reason `recordMessage` exists on the write
+ * side. When they were separate, `POST /conversations` did none of them: the
+ * first message of a thread was written and then simply sat there, invisible
+ * until something else happened to refetch. Anything that creates a message
+ * calls this, so a new message path cannot quietly ship without realtime again.
+ *
+ * Best-effort throughout: a failed emit, stamp or push must never fail a send
+ * that has already been committed.
+ *
+ * `pushWhenAway` is false for corrections, which have never notified.
+ */
+export async function fanOutMessage(
+  app: FastifyInstance,
+  io: AppServer,
+  conversation: FannedConversation,
+  message: FannedMessage,
+  { pushWhenAway }: { pushWhenAway: boolean },
+): Promise<void> {
+  try {
+    for (const participantId of conversation.participants) {
+      io.to(userRoom(participantId)).emit('message:new', message)
+    }
+
+    const recipientId = conversation.participants.find((id) => id !== message.senderId)
+    if (!recipientId) return
+
+    // Asked once and branched on, rather than asked again per effect: someone
+    // holding a socket has just received the emit above and needs no
+    // notification, someone away has nothing to deliver to. Two lookups would
+    // only create room for the answer to change in between.
+    const sockets = await io.in(userRoom(recipientId)).fetchSockets()
+    if (sockets.length > 0) {
+      const deliveredAt = await markDelivered(app.mongo.db, conversation._id, recipientId)
+      if (deliveredAt) {
+        io.to(userRoom(message.senderId)).emit('conversation:delivered', {
+          conversationId: message.conversationId.toHexString(),
+          deliveredTo: recipientId,
+          deliveredAt: deliveredAt.toISOString(),
+        })
+      }
+      return
+    }
+    if (!pushWhenAway) return
+
+    const [sender, tokens] = await Promise.all([
+      app.mongo.db
+        .collection<{ displayName?: string; handle: string }>('profiles')
+        .findOne({ _id: message.senderId as unknown as never }),
+      tokensFor(app.mongo.db, recipientId),
+    ])
+    if (tokens.length === 0) return
+
+    await sendPush(app.mongo.db, app.push, {
+      to: tokens,
+      title: sender?.displayName ?? sender?.handle ?? 'LangX',
+      body: message.body.slice(0, 120),
+      data: { kind: 'message', conversationId: message.conversationId.toHexString() },
+    })
+  } catch (error) {
+    app.log.warn({ err: error }, 'post-send fan-out failed')
+  }
+}

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -1,7 +1,6 @@
 import { sendCorrectionSchema, sendMediaMessageSchema, sendTextMessageSchema } from '@langx/shared'
 import type { FastifyInstance } from 'fastify'
-import type { ObjectId } from 'mongodb'
-import { Server as SocketIOServer, type Socket } from 'socket.io'
+import { Server as SocketIOServer } from 'socket.io'
 import { z, ZodError } from 'zod'
 import { ERROR_CODES } from '@langx/shared'
 import { ApiError } from '../lib/ApiError'
@@ -11,100 +10,14 @@ import { getProfile } from '../modules/profiles/profiles'
 import { assertConversationAccess } from '../modules/chat/access'
 import {
   markConversationRead,
-  markDelivered,
   markPendingDelivered,
   sendCorrection,
   sendMediaMessage,
   sendTextMessage,
 } from '../modules/chat/messages'
-import { sendPush, tokensFor } from '../modules/push/devices'
+import { fanOutMessage } from './fanOut'
 import { SocketRateLimiter } from './rateLimit'
-
-function userRoom(userId: string): string {
-  return `user:${userId}`
-}
-
-/**
- * The two things that happen to a message the instant after it is written, and
- * the reason they are one function: both hinge on the same question — is the
- * recipient holding a socket right now?
- *
- * If they are, `message:new` above just reached their device, which is the
- * second tick; we stamp `deliveredAt` and tell the sender. If they are not,
- * their phone buzzes instead, and the message stays on one tick until they
- * connect and {@link markPendingDelivered} sweeps it up. Someone with the
- * thread open on screen does not need a notification about the message they
- * are watching arrive, and someone who is away has nothing to deliver to — the
- * two branches are genuinely exclusive, so asking twice would only create room
- * for the answer to change in between.
- *
- * Best-effort by design: a failed push or a failed stamp must never fail the
- * send. The message is durably written by the time this runs.
- *
- * `pushWhenAway` is false for corrections, which have never notified.
- */
-async function deliverToRecipient(
-  app: FastifyInstance,
-  io: AppServer,
-  conversation: { _id: ObjectId; participants: readonly string[] },
-  message: { senderId: string; body: string; conversationId: { toHexString: () => string } },
-  { pushWhenAway }: { pushWhenAway: boolean },
-): Promise<void> {
-  try {
-    const recipientId = conversation.participants.find((id) => id !== message.senderId)
-    if (!recipientId) return
-    const sockets = await io.in(userRoom(recipientId)).fetchSockets()
-    if (sockets.length > 0) {
-      const deliveredAt = await markDelivered(app.mongo.db, conversation._id, recipientId)
-      if (deliveredAt) {
-        io.to(userRoom(message.senderId)).emit('conversation:delivered', {
-          conversationId: message.conversationId.toHexString(),
-          deliveredTo: recipientId,
-          deliveredAt: deliveredAt.toISOString(),
-        })
-      }
-      return
-    }
-    if (!pushWhenAway) return
-
-    const [sender, tokens] = await Promise.all([
-      app.mongo.db
-        .collection<{ displayName?: string; handle: string }>('profiles')
-        .findOne({ _id: message.senderId as unknown as never }),
-      tokensFor(app.mongo.db, recipientId),
-    ])
-    if (tokens.length === 0) return
-
-    await sendPush(app.mongo.db, app.push, {
-      to: tokens,
-      title: sender?.displayName ?? sender?.handle ?? 'LangX',
-      body: message.body.slice(0, 120),
-      data: { kind: 'message', conversationId: message.conversationId.toHexString() },
-    })
-  } catch (error) {
-    app.log.warn({ err: error }, 'post-send delivery fan-out failed')
-  }
-}
-
-interface SocketData {
-  userId: string
-  /** Per-connection token buckets; see ws/rateLimit.ts. */
-  limiter: SocketRateLimiter
-}
-
-/** Socket.io's four generics default `data` to `any` — this pins it down so `.data.userId` typechecks. */
-type AppSocket = Socket<
-  Record<string, never>,
-  Record<string, never>,
-  Record<string, never>,
-  SocketData
->
-type AppServer = SocketIOServer<
-  Record<string, never>,
-  Record<string, never>,
-  Record<string, never>,
-  SocketData
->
+import { userRoom, type AppServer, type AppSocket } from './types'
 
 type AckResponse =
   { ok: true; data?: unknown } | { ok: false; error: { code: string; message: string } }
@@ -222,10 +135,7 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
         .parseAsync(payload)
         .then((input) => sendTextMessage(app.mongo.db, userId, input))
         .then(({ message, conversation }) => {
-          for (const participantId of conversation.participants) {
-            io.to(userRoom(participantId)).emit('message:new', message)
-          }
-          void deliverToRecipient(app, io, conversation, message, { pushWhenAway: true })
+          void fanOutMessage(app, io, conversation, message, { pushWhenAway: true })
           ack?.({ ok: true, data: message })
         })
         .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))
@@ -253,10 +163,7 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
           return sendMediaMessage(app.mongo.db, userId, input, app.env.STORAGE_PUBLIC_BASE_URL)
         })
         .then(({ message, conversation }) => {
-          for (const participantId of conversation.participants) {
-            io.to(userRoom(participantId)).emit('message:new', message)
-          }
-          void deliverToRecipient(app, io, conversation, message, { pushWhenAway: true })
+          void fanOutMessage(app, io, conversation, message, { pushWhenAway: true })
           ack?.({ ok: true, data: message })
         })
         .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))
@@ -268,12 +175,9 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
         .parseAsync(payload)
         .then((input) => sendCorrection(app.mongo.db, userId, input))
         .then(({ message, conversation }) => {
-          for (const participantId of conversation.participants) {
-            io.to(userRoom(participantId)).emit('message:new', message)
-          }
           // Ticks, but no push: a correction is help arriving in a thread the
           // recipient chose to be in, not something to wake a phone for.
-          void deliverToRecipient(app, io, conversation, message, { pushWhenAway: false })
+          void fanOutMessage(app, io, conversation, message, { pushWhenAway: false })
           ack?.({ ok: true, data: message })
         })
         .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))

--- a/apps/api/src/ws/types.ts
+++ b/apps/api/src/ws/types.ts
@@ -1,0 +1,26 @@
+import type { Server as SocketIOServer, Socket } from 'socket.io'
+import type { SocketRateLimiter } from './rateLimit'
+
+export interface SocketData {
+  userId: string
+  /** Per-connection token buckets; see ws/rateLimit.ts. */
+  limiter: SocketRateLimiter
+}
+
+/** Socket.io's four generics default `data` to `any` — this pins it down so `.data.userId` typechecks. */
+export type AppSocket = Socket<
+  Record<string, never>,
+  Record<string, never>,
+  Record<string, never>,
+  SocketData
+>
+export type AppServer = SocketIOServer<
+  Record<string, never>,
+  Record<string, never>,
+  Record<string, never>,
+  SocketData
+>
+
+export function userRoom(userId: string): string {
+  return `user:${userId}`
+}


### PR DESCRIPTION
`POST /conversations` wrote a message and told nobody. No `message:new`, no ticks, no push — the one message path in the app with no realtime at all. The person being contacted saw nothing until something else happened to refetch, and the sender's message sat on one tick until the recipient reconnected or opened the thread.

That gap was visible in #947 and called out in its description; this closes it rather than leaving it documented.

The fix is not another copy of the fan-out. All three socket handlers were already repeating "emit to both participants, then deliver or push", and the REST path was the one that never got the paragraph — so the sequence moves into `ws/fanOut.ts` and every message path calls it. A new message path cannot ship without realtime by forgetting to paste it in. `ws/index.ts` loses 108 lines.

- `startConversation` returns the message it wrote alongside the conversation. Nothing else held it: this path does not go through `recordMessage`, which is why the message had nowhere to go.
- `app.io` is now typed `AppServer` rather than socket.io's default, whose generics leave `data` as `any`. Lint caught this the moment a route outside `ws/` passed `app.io` to a typed helper.

## Behaviour change worth reviewing

**Starting a conversation now sends a push when the recipient is away, which it never did.** A first message is the most notification-worthy event in the app, and the `initiations` quota already bounds how many a person can send in a day — but this is the one user-visible change here, and it reaches people who have never had a notification from this path before.

## Verification

Typecheck, eslint and `prettier --check` clean; the full API package at 31 files / 334 tests. Three new tests: the first message arriving live, going to two ticks for an online recipient, and waiting for connect when they are offline.
