### PR TITLE
ci: stop the mongod binary race that fails runs at random

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,23 @@ jobs:
       - name: Format
         run: pnpm format:check
 
+      # `apps/api`'s tests each start their own MongoMemoryServer, and vitest
+      # runs the files in parallel workers. On a cold cache they all reach for
+      # the same mongod binary at once and race on its download and lockfile —
+      # which surfaces as `Cannot unlock file ... .lock`, an ENOENT renaming
+      # `.tgz.downloading`, or a 120s hook timeout in whichever file lost. It
+      # reads exactly like a real test failure and is not one. Caching the
+      # directory removes the download on all but the first run; fetching the
+      # binary once here removes the race on that first run.
+      - name: Cache the mongodb-memory-server binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-binaries-${{ runner.os }}
+
+      - name: Fetch the mongodb-memory-server binary
+        working-directory: apps/api
+        run: node -e "const {MongoMemoryServer}=require('mongodb-memory-server');MongoMemoryServer.create().then(s=>s.stop())"
+
       - name: Test
         run: pnpm test


### PR DESCRIPTION
Three runs failed on this tonight, none of them for the reason they appeared to:

- **#945** lost `discovery.test.ts` to `Cannot unlock file ... 8.2.6.lock` — on a branch that touches no API file at all.
- **The push of #949 to `main`** failed with `ENOENT` renaming `mongodb-linux-x86_64-ubuntu2404-8.2.6.tgz.downloading`, taking `moderation.test.ts` and `profiles.test.ts` down with 120s hook timeouts.
- **The re-run of that same job** failed again, back on the lockfile.

Every one of them named a test file that had nothing to do with the change under test.

`apps/api`'s test files each start their own `MongoMemoryServer`, and vitest runs the files in parallel workers. On a cold cache they all reach for the same mongod binary at once and race on its download and its lockfile. Whichever worker loses reports a failure that looks exactly like a real one — which is the expensive part, because the only way to tell them apart is to read the trace and check that the failing file was untouched by the branch.

- Caching `~/.cache/mongodb-binaries` removes the download on every run after the first, which also gives back the ~20s it costs.
- Fetching the binary once before `pnpm test` removes the race on the first run, and on any run where the cache is cold or the key rotates.

The test code is untouched; this is a CI-only change. `main` is red on this right now, so this is what makes it green again rather than another re-run and another minute of the budget.
