### PR TITLE
Say something when the other four things work

### DIFF
--- a/apps/mobile/app/(app)/blocked.tsx
+++ b/apps/mobile/app/(app)/blocked.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
 import { useProfileCache } from '../../src/hooks/useProfileCache'
 import { confirmAlert } from '../../src/lib/alert'
+import { showToast } from '../../src/lib/toast'
 import { colors, font, spacing } from '../../src/lib/theme'
 
 /**
@@ -65,7 +66,10 @@ export default function BlockedScreen() {
                       message: `Unblock ${name}? You will both be visible again.`,
                       confirmLabel: 'Unblock',
                     }).then((yes) => {
-                      if (yes) unblock.mutate(item.blockedId)
+                      if (yes)
+                        unblock.mutate(item.blockedId, {
+                          onSuccess: () => showToast(`${name} is unblocked.`),
+                        })
                     })
                   }
                 >

--- a/apps/mobile/app/(app)/edit-profile.tsx
+++ b/apps/mobile/app/(app)/edit-profile.tsx
@@ -40,6 +40,7 @@ import { FormField } from '../../src/components/ui/FormField'
 import { CountryPicker } from '../../src/components/CountryPicker'
 import { Screen } from '../../src/components/ui/Screen'
 import { confirmAlert, showAlert } from '../../src/lib/alert'
+import { showToast } from '../../src/lib/toast'
 import { colors, font, layout, radius, spacing } from '../../src/lib/theme'
 
 const GENDER_LABELS: Record<Gender, string> = {
@@ -151,6 +152,7 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
         learning: learning.map((l, index) => ({ ...l, priority: index + 1 })),
       })
       router.back()
+      showToast('Profile saved.')
     } catch (caught) {
       setError(caught instanceof ApiRequestError ? caught.message : 'Could not save your profile.')
     }
@@ -172,7 +174,10 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
             disabled={uploadAvatar.isPending}
             onPress={() =>
               void pick((uri, contentType) =>
-                uploadAvatar.mutate({ uri, contentType }, { onError: onUploadError }),
+                uploadAvatar.mutate(
+                  { uri, contentType },
+                  { onError: onUploadError, onSuccess: () => showToast('Photo updated.') },
+                ),
               )
             }
           />
@@ -348,7 +353,10 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
             disabled={addPhoto.isPending}
             onPress={() =>
               void pick((uri, contentType) =>
-                addPhoto.mutate({ uri, contentType }, { onError: onUploadError }),
+                addPhoto.mutate(
+                  { uri, contentType },
+                  { onError: onUploadError, onSuccess: () => showToast('Photo added.') },
+                ),
               )
             }
           >

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -16,6 +16,7 @@ import { TierBadge } from '../../../src/components/TierBadge'
 import { Chip } from '../../../src/components/ui/Chip'
 import { Screen } from '../../../src/components/ui/Screen'
 import { chooseAlert, confirmAlert } from '../../../src/lib/alert'
+import { showToast } from '../../../src/lib/toast'
 import { days } from '../../../src/lib/format'
 import { colors, font, layout, radius, spacing } from '../../../src/lib/theme'
 
@@ -88,7 +89,13 @@ export default function ProfileScreen() {
       confirmLabel: 'Block',
       destructive: true,
     })
-    if (yes) block.mutate(user._id, { onSuccess: () => router.replace('/(app)/discover') })
+    if (yes)
+      block.mutate(user._id, {
+        onSuccess: () => {
+          router.replace('/(app)/discover')
+          showToast(`${user.displayName} is blocked.`)
+        },
+      })
   }
 
   async function confirmReport(): Promise<void> {
@@ -97,7 +104,11 @@ export default function ProfileScreen() {
       { label: 'Harassment', value: 'harassment' },
       { label: 'Inappropriate content', value: 'inappropriate_content' },
     ])
-    if (reason) report.mutate({ userId: user._id, reason })
+    if (reason)
+      report.mutate(
+        { userId: user._id, reason },
+        { onSuccess: () => showToast('Report sent. We will look into it.') },
+      )
   }
 
   return (

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -14,6 +14,7 @@ import { Button } from '../../src/components/ui/Button'
 import { Screen } from '../../src/components/ui/Screen'
 import { appVersion } from '../../src/hooks/useAppConfig'
 import { confirmAlert, showAlert } from '../../src/lib/alert'
+import { showToast } from '../../src/lib/toast'
 import { API_URL } from '../../src/lib/apiUrl'
 import { authClient } from '../../src/lib/auth-client'
 import { authLandingHref } from '../../src/lib/authLanding'
@@ -104,6 +105,12 @@ export default function SettingsScreen() {
       await api.post('/me/delete', { confirm: 'DELETE' })
       await authClient.signOut()
       router.replace(authLandingHref(await readBoolFlag(FLAG_KEYS.introSeen)))
+      // The grace period is the one thing worth repeating here: the dialog said
+      // it before the account existed in this state, and this is the first
+      // moment it is true.
+      showToast(
+        `Account deleted. Signing back in within ${ACCOUNT_DELETION_GRACE_DAYS} days cancels it.`,
+      )
     } catch (error) {
       await showAlert(
         'Could not delete',

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -135,10 +135,12 @@ Two consequences, neither of which is visible from the app:
 - Both share one cluster's storage and connection limit, so a migration ETL
   run from a laptop competes with production traffic.
 
-- [ ] Verify against the deploy rather than against this file, with
-      `fly secrets list` and `fly config env` on `langx-api`. A secret named
-      `MONGODB_DB` silently overrides `[env]` in `fly.toml`, and that could not
-      be checked from the droplet — flyctl is not installed there
+- [x] Verified against the deploy rather than against this file, on
+      28 August 2026: `fly config env -a langx-api` reports `MONGODB_DB=langx`,
+      and `fly secrets list` holds only `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`,
+      `MONGODB_URI`, `RESEND_API_KEY`, `EMAIL_FROM` and `TRUSTED_ORIGINS` — no
+      `MONGODB_DB` secret, so nothing overrides `[env]` in `fly.toml`.
+      Production is `langx`, confirmed from the deploy and not from this file
 - [ ] Decide whether production keeps living in a cluster named `dev`. A
       separate cluster — or at minimum a second Atlas user restricted to
       `langx` — is what stops a local mistake reaching real users. It costs one
@@ -277,9 +279,11 @@ takes the screen's touches while it is up.
       outlives the `router.replace` underneath it because `ToastHost` is
       mounted at the root layout rather than inside the navigator — the same
       reason the delete-account confirmation survives signing itself out
-- [ ] Give the same treatment to the other actions that return to a screen with
+- [x] Give the same treatment to the other actions that return to a screen with
       no word about what happened: profile saved, photo uploaded, report sent,
-      user blocked and unblocked, account deleted
+      user blocked and unblocked, account deleted. Reporting was the worst of
+      them — the picker closed onto an identical screen, so nothing
+      distinguished a sent report from a cancelled one
 
 Nothing here blocks the build, and all of it is visible in the first minute of
 use. It belongs before the rollout widens, not in the first patch after it.


### PR DESCRIPTION
Sign out got a banner; these did not, and they are the same failure. Each one finishes, returns you to a screen identical to the one you left, and says nothing — so "it worked" and "the tap missed" look the same.

Reporting was the worst of them. The reason picker closed onto a profile that had not changed in any way, which meant a sent report and a cancelled one were indistinguishable. Someone reporting harassment had no way of knowing whether anyone had been told.

The rest follow the rule the last change settled — **something that worked gets a toast, something that failed gets an alert** — so each is an `onSuccess` on the mutation that already existed, not new plumbing:

- Profile saved, which navigates back before the save is visible anywhere
- Photo updated and photo added
- Blocked, alongside the replace to Discover it already did
- Unblocked
- Account deleted, repeating the grace period at the first moment it is true rather than only in the dialog that preceded it

The runbook's two remaining boxes are closed here: this one, and the database check — `fly config env -a langx-api` reports `MONGODB_DB=langx` and no `MONGODB_DB` secret exists, so production runs the `langx` database and nothing overrides `fly.toml`.

## Verification

In a browser against a real API: report, save, block and unblock each raise their banner and it leaves on its own. Account deletion is the same one-line pattern and was **not** run live — it would delete an account the other sessions on this box are using.

Checks: `tsc --noEmit`, eslint, prettier, 8 test files / 49 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)