### PR TITLE
Take the unread key off the record, not the request

### DIFF
--- a/apps/api/src/modules/chat/conversations.ts
+++ b/apps/api/src/modules/chat/conversations.ts
@@ -131,9 +131,20 @@ export async function startConversation(
   const conversation: Conversation = {
     _id: new ObjectId(),
     pairKey,
-    participants: [viewerId, input.toUserId],
+    participants: [viewerId, recipient._id],
     lastMessage: { body: input.body, senderId: viewerId, createdAt: now },
-    unread: { [viewerId]: 0, [input.toUserId]: 1 },
+    /**
+     * The recipient's id is read off the profile that was just loaded, not off
+     * the request that named it — even though the two are equal by the time
+     * execution reaches here, since `findOne` above threw NOT_FOUND otherwise.
+     *
+     * It matters because this one is used as a *property name*, and a property
+     * name whose provenance is a request body is a shape worth not having:
+     * proving it safe means re-reading forty lines up every time, and it is
+     * what CodeQL's `js/remote-property-injection` flags (alert 12). Taking it
+     * from the record removes the question rather than answering it.
+     */
+    unread: { [viewerId]: 0, [recipient._id]: 1 },
     firstMessageBy: viewerId,
     firstMessageAt: now,
     bothSpoke: false,


### PR DESCRIPTION
Closes CodeQL alert 12 (`js/remote-property-injection`, high) in `apps/api/src/modules/chat/conversations.ts`.

## What the alert says

`unread: { [viewerId]: 0, [input.toUserId]: 1 }` writes a property whose *name* comes from the request body.

## Why it is a false positive today

- `profiles.findOne({ _id: input.toUserId })` forty lines up throws `NOT_FOUND` unless the value is an existing profile `_id`, which is a server-generated Better Auth id — not attacker-chosen text.
- A computed key in an object literal (`{ ['__proto__']: 1 }`) creates an own property; only the literal `__proto__:` form touches the prototype. So prototype pollution is not reachable through this sink even in principle.

## Why change it anyway

Both of those are facts a reader has to reconstruct from two places every time the line is read. The recipient's record is already loaded and its `_id` is equal to the request's value by construction, so taking the key from the record removes the question rather than answering it — and closes the alert at the source instead of dismissing it.

**No behaviour change**: the two values are identical whenever this line runs. `participants` follows for consistency, so the pair is not left half-derived from each source.

## Checked

`apps/api` typecheck clean; `conversations`, `messages` and `moderation` route suites pass (51 tests). Also swept for the same shape elsewhere — `messages.ts` and `legacyConversations.ts` build `unread.*` keys from ids that came out of the database or the session, and `dailyActivity.ts` / `media.ts` index fixed lookup tables, so this was the only site taking a property name straight from a request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)