### PR TITLE
Show account age and email verification on profile screens

### DIFF
--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -15,6 +15,7 @@ import {
 import { MongoServerError, type Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import { ApiError } from '../../lib/ApiError'
+import { authId } from '../../lib/authId'
 import { assertOwnBucket } from '../../lib/assertOwnBucket'
 import { resolveHandleClaim } from '../handles/handleReservations'
 import type { RevenueCatClient } from '../billing/revenueCatClient'
@@ -365,6 +366,13 @@ export interface PublicProfile {
   cosmetics: string[]
   isOnline: boolean
   lastActiveAt: Date
+  /** Account creation, shown as an age — `formatAccountAge` does the wording. */
+  createdAt: Date
+  /**
+   * Better Auth's flag, not one of ours: it lives on `user`, so it reaches
+   * here through {@link isEmailVerified} rather than off the profile document.
+   */
+  emailVerified: boolean
 }
 
 const ONLINE_WINDOW_MS = 5 * 60 * 1000
@@ -382,7 +390,11 @@ const ONLINE_WINDOW_MS = 5 * 60 * 1000
  * never reach another user in any form. What nearby discovery returns is a
  * bucketed distance computed on the server, never a point.
  */
-export function toPublicProfile(profile: Profile, now: Date = new Date()): PublicProfile {
+export function toPublicProfile(
+  profile: Profile,
+  emailVerified: boolean,
+  now: Date = new Date(),
+): PublicProfile {
   const lastActiveAt = profile.stats?.lastActiveAt ?? profile.createdAt
   const result: PublicProfile = {
     _id: profile._id,
@@ -402,12 +414,30 @@ export function toPublicProfile(profile: Profile, now: Date = new Date()): Publi
     cosmetics: profile.cosmetics ?? [],
     isOnline: now.getTime() - new Date(lastActiveAt).getTime() < ONLINE_WINDOW_MS,
     lastActiveAt: new Date(lastActiveAt),
+    createdAt: profile.createdAt,
+    emailVerified,
   }
   if (profile.avatarUrl !== undefined) result.avatarUrl = profile.avatarUrl
   if (profile.bio !== undefined) result.bio = profile.bio
   if (profile.country !== undefined) result.country = profile.country
   if (profile.city !== undefined) result.city = profile.city
   return result
+}
+
+/**
+ * Whether Better Auth considers this account's email verified.
+ *
+ * Its own routes carry the flag on the session, but that is the *viewer's*
+ * session — a profile being looked at has none here, so the only way to the
+ * value is the `user` document, through `authId` like every other crossing of
+ * the two id worlds. A string `_id` matches nothing and would report every
+ * profile unverified without erroring.
+ */
+export async function isEmailVerified(db: Db, userId: string): Promise<boolean> {
+  const user = await db
+    .collection(COLLECTIONS.user)
+    .findOne({ _id: authId(userId) }, { projection: { emailVerified: 1 } })
+  return user?.emailVerified === true
 }
 
 /** Looks up by `@handle` or by user id — the two things a deep link can carry. */

--- a/apps/api/src/routes/login.test.ts
+++ b/apps/api/src/routes/login.test.ts
@@ -254,7 +254,7 @@ describe('sign-in, and the bridge to v1 behind it', () => {
       .collection<Profile>(COLLECTIONS.profiles)
       .findOne({ handle: 'returninguser' })
     expect(profile?.restoredFromV1).toBeTruthy()
-    expect(toPublicProfile(profile!)).not.toHaveProperty('restoredFromV1')
+    expect(toPublicProfile(profile!, true)).not.toHaveProperty('restoredFromV1')
   })
 
   it('credits the v1 economy exactly once, however many times sign-in is retried', async () => {

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -8,6 +8,7 @@ import { connectToDatabase, type DbHandle } from '../db/client'
 import { COLLECTIONS } from '../db/collections'
 import { ensureIndexes } from '../db/indexes'
 import { loadEnv } from '../env'
+import { authId } from '../lib/authId'
 import { hashLegacyEmail } from '../modules/handles/legacyEmailHash'
 import { createStorageProvider } from '../storage/createStorageProvider'
 import { createTranslationProvider } from '../translation/createTranslationProvider'
@@ -650,6 +651,66 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
       expect(response.statusCode).toBe(200)
       expect(response.json()).not.toHaveProperty('location')
       expect(response.body).not.toContain('28.98')
+    })
+  })
+
+  describe('account age and email verification on a public profile', () => {
+    async function onboarded(email: string, handle: string): Promise<SignedUpUser> {
+      const user = await newUser(email)
+      const response = await app.inject({
+        method: 'POST',
+        url: '/profiles',
+        headers: { cookie: user.cookie },
+        payload: onboardingBody({ handle }),
+      })
+      if (response.statusCode !== 201) {
+        throw new Error(`onboarding failed (${response.statusCode}): ${response.body}`)
+      }
+      return user
+    }
+
+    it('carries createdAt and emailVerified, and no raw birthYear or email', async () => {
+      await onboarded('public-age-viewed@example.com', 'ageviewed')
+      const viewer = await onboarded('public-age-viewer@example.com', 'ageviewer')
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/profiles/ageviewed',
+        headers: { cookie: viewer.cookie },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ createdAt: string; emailVerified: boolean }>()
+      expect(new Date(body.createdAt).getTime()).toBeGreaterThan(0)
+      // The account got here through onboarding, which requires a verified
+      // email — so `true` here also proves the ObjectId lookup found the
+      // Better Auth user at all. A string `_id` would find nothing and
+      // report every profile unverified without failing.
+      expect(body.emailVerified).toBe(true)
+      expect(body).not.toHaveProperty('birthYear')
+      expect(response.body).not.toContain('public-age-viewed@example.com')
+    })
+
+    it('reports an unverified account as unverified rather than assuming', async () => {
+      const viewer = await onboarded('public-unverified-viewer@example.com', 'unverifviewer')
+      const target = await onboarded('public-unverified@example.com', 'unverifviewed')
+
+      // Reaching past Better Auth on purpose: nothing in the app can produce
+      // this state today, because onboarding is gated on a verified email.
+      // The flag is read from `user` rather than assumed for exactly the day
+      // that stops being true.
+      await handle.db
+        .collection(COLLECTIONS.user)
+        .updateOne({ _id: authId(target.userId) }, { $set: { emailVerified: false } })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/profiles/unverifviewed',
+        headers: { cookie: viewer.cookie },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json<{ emailVerified: boolean }>().emailVerified).toBe(false)
     })
   })
 })

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -10,6 +10,7 @@ import {
   createProfile,
   findProfileByHandleOrId,
   getProfile,
+  isEmailVerified,
   setLocation,
   toPublicProfile,
   updateProfile,
@@ -63,7 +64,11 @@ export const profileRoutes: FastifyPluginAsyncZod = async (app) => {
       }
 
       if (viewer) await recordProfileView(app.mongo.db, viewer, target._id)
-      return reply.send(toPublicProfile(target))
+      // Read after the block check, not with it: an unverified-email lookup
+      // for a profile this viewer is not allowed to see is a query we should
+      // never run.
+      const emailVerified = await isEmailVerified(app.mongo.db, target._id)
+      return reply.send(toPublicProfile(target, emailVerified))
     },
   )
 

--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -4,6 +4,7 @@ import {
   STREAK_RESTORE_SKU,
   TOKEN_RULES,
   countryFlag,
+  formatAccountAge,
   getCountry,
   getLanguage,
   streakRestorePrice,
@@ -122,6 +123,9 @@ export default function MeScreen() {
         <Avatar url={profile.avatarUrl} name={profile.displayName} size={layout.avatarLarge} />
         <Text style={styles.name}>{profile.displayName}</Text>
         <Text style={styles.handle}>@{profile.handle}</Text>
+        <Text style={styles.joined}>
+          Registered {formatAccountAge(new Date(profile.createdAt))}
+        </Text>
         {/*
           The same badges other people already see on your profile. Yours
           showed name and handle only, so the one profile you cannot look at
@@ -278,6 +282,7 @@ const styles = StyleSheet.create({
   badges: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.xs, justifyContent: 'center' },
   name: { ...font.title, color: colors.text, marginTop: spacing.sm },
   handle: { ...font.caption, color: colors.textMuted },
+  joined: { ...font.caption, color: colors.textMuted, marginTop: spacing.xs },
   stats: {
     backgroundColor: colors.surface,
     borderRadius: radius.lg,

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -1,4 +1,4 @@
-import { countryFlag, getCountry, getLanguage } from '@langx/shared'
+import { countryFlag, formatAccountAge, getCountry, getLanguage } from '@langx/shared'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useState } from 'react'
 import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from 'react-native'
@@ -126,12 +126,19 @@ export default function ProfileScreen() {
         />
         <Text style={styles.name}>{user.displayName}</Text>
         <Text style={styles.handle}>@{user.handle}</Text>
+        {/*
+          How long the account has existed, next to who it says it is: the two
+          questions someone asks about a stranger who just messaged them are
+          the same question, and only one of them was answered here before.
+        */}
+        <Text style={styles.joined}>Registered {formatAccountAge(new Date(user.createdAt))}</Text>
         <View style={styles.badges}>
           <Chip label={`${user.age}`} />
           {user.country ? <Chip label={countryLabel(user.country)} /> : null}
           {user.streak.current > 0 ? (
             <Chip label={`🔥 ${days(user.streak.current)}`} tone="streak" />
           ) : null}
+          {user.emailVerified ? <Chip label="✓ Verified email" tone="accent" /> : null}
           <TierBadge tier={user.tier} />
         </View>
       </View>
@@ -212,6 +219,7 @@ const styles = StyleSheet.create({
   hero: { alignItems: 'center', paddingVertical: spacing.lg },
   name: { ...font.title, color: colors.text, marginTop: spacing.md },
   handle: { ...font.caption, color: colors.textMuted },
+  joined: { ...font.caption, color: colors.textMuted, marginTop: spacing.xs },
   badges: {
     flexDirection: 'row',
     flexWrap: 'wrap',

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -83,6 +83,8 @@ export interface MeProfile {
   entitlement: { tier: PlanTier; expiresAt?: string }
   streak: { current: number; longest: number }
   cosmetics?: string[]
+  /** ISO. The one date on this screen the user did not enter themselves. */
+  createdAt: string
   /**
    * Set while a deletion is pending. The profile is still returned to its
    * owner — they are the one person who has to be able to see it, and to take

--- a/apps/mobile/src/api/types.ts
+++ b/apps/mobile/src/api/types.ts
@@ -40,6 +40,9 @@ export interface PublicProfileDto {
   cosmetics: string[]
   isOnline: boolean
   lastActiveAt: string
+  /** ISO; rendered as an age with `formatAccountAge`, never as a date. */
+  createdAt: string
+  emailVerified: boolean
 }
 
 export interface DiscoveryItem {

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -348,12 +348,20 @@ as something bought rather than as the product.
       `app.config.ts`. `branding/` has no vector master — its only SVG is an
       auto-trace — and its `splash.png` is 3601×3600, so none of it can be
       reused unaltered
-- [ ] Profile screens show account age ("Registered 3 months ago", the unit
+- [x] Profile screens show account age ("Registered 3 months ago", the unit
       widening from days to months to years as the account gets older) and a
-      Verified Email badge. Both need adding to the public profile DTO in
-      `packages/shared` and reading through the profile repository;
-      `emailVerified` lives in Better Auth's `user` collection, so it crosses
-      the id boundary and goes through `lib/authId.ts`
+      Verified Email badge. The DTO is `PublicProfile` in
+      `apps/api/src/modules/profiles/profiles.ts`, mirrored by
+      `PublicProfileDto` in `apps/mobile/src/api/types.ts` — **not**
+      `packages/shared`, which holds the schemas and now the wording in
+      `accountAge.ts`. `emailVerified` lives in Better Auth's `user`
+      collection, so it crosses the id boundary and goes through
+      `lib/authId.ts`. One thing to know before reading the badge as a signal:
+      it is true for **every** profile today, because onboarding is gated on
+      `requireVerifiedEmail` and the v1 bridge marks the address verified
+      itself, so nothing can currently produce an unverified profile. It is
+      read from `user` rather than assumed, so that an email-change flow later
+      does not turn it into a badge that lies
 - [ ] Restyle the screens and the pages. `website/src/lib/data/*.ts` is
       hand-synced content and does not move, and neither does the
       toast-and-alert behaviour decided above — only the appearance changes

--- a/packages/shared/src/accountAge.test.ts
+++ b/packages/shared/src/accountAge.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { formatAccountAge } from './accountAge'
+
+const NOW = new Date('2026-08-28T12:00:00Z')
+
+/** `days` before {@link NOW}, to the minute. */
+function ago(days: number, hours = 0): Date {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000 - hours * 60 * 60 * 1000)
+}
+
+describe('formatAccountAge', () => {
+  it('calls anything under a day old "today"', () => {
+    expect(formatAccountAge(NOW, NOW)).toBe('today')
+    expect(formatAccountAge(ago(0, 23), NOW)).toBe('today')
+  })
+
+  it('says "today" for a future date rather than counting backwards', () => {
+    // A device whose clock is ahead sends a createdAt in our future. The
+    // label must degrade to the truthful end of the range, not to "-1 days".
+    expect(formatAccountAge(new Date(NOW.getTime() + 60_000), NOW)).toBe('today')
+  })
+
+  it('counts days, singular at one', () => {
+    expect(formatAccountAge(ago(1), NOW)).toBe('1 day ago')
+    expect(formatAccountAge(ago(5), NOW)).toBe('5 days ago')
+    expect(formatAccountAge(ago(29), NOW)).toBe('29 days ago')
+  })
+
+  it('widens to months at 30 days', () => {
+    expect(formatAccountAge(ago(30), NOW)).toBe('1 month ago')
+    expect(formatAccountAge(ago(95), NOW)).toBe('3 months ago')
+  })
+
+  it('never says "12 months" — the year step owns that boundary', () => {
+    expect(formatAccountAge(ago(360), NOW)).toBe('11 months ago')
+    expect(formatAccountAge(ago(364), NOW)).toBe('11 months ago')
+    expect(formatAccountAge(ago(365), NOW)).toBe('1 year ago')
+  })
+
+  it('widens to years, singular at one', () => {
+    expect(formatAccountAge(ago(365), NOW)).toBe('1 year ago')
+    expect(formatAccountAge(ago(900), NOW)).toBe('2 years ago')
+  })
+})

--- a/packages/shared/src/accountAge.ts
+++ b/packages/shared/src/accountAge.ts
@@ -1,0 +1,55 @@
+/**
+ * How long an account has existed, worded for a profile screen.
+ *
+ * This is a trust signal, not a statistic: an account made this morning and
+ * one made three years ago should not look the same to the person deciding
+ * whether to answer a message. That is also why the unit widens — "1,094 days
+ * ago" is precise and tells a reader nothing.
+ */
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/** Below this many days the label counts days; above it, months. */
+const DAYS_IN_MONTH = 30
+const DAYS_IN_YEAR = 365
+
+function plural(count: number, unit: string): string {
+  return `${count} ${unit}${count === 1 ? '' : 's'} ago`
+}
+
+/**
+ * Whole days elapsed, floored. Negative when the input is in the future —
+ * which happens with nothing more exotic than a phone whose clock is a few
+ * minutes fast, so callers must not assume this is positive.
+ */
+function daysSince(createdAt: Date, now: Date): number {
+  return Math.floor((now.getTime() - createdAt.getTime()) / MS_PER_DAY)
+}
+
+/**
+ * "today", "5 days ago", "3 months ago", "2 years ago" — the phrase only,
+ * without a verb, so each surface supplies its own ("Registered …", "Joined
+ * …") instead of this deciding for all of them.
+ *
+ * The month and year steps divide by fixed 30- and 365-day lengths rather
+ * than doing calendar arithmetic. The unit is already an approximation at
+ * that range, and calendar months would buy an exactness the label discards
+ * while adding leap-year and month-length edges to get wrong.
+ */
+export function formatAccountAge(createdAt: Date, now: Date = new Date()): string {
+  const days = daysSince(createdAt, now)
+
+  // Includes future dates: a clock a few minutes fast must not render
+  // "-1 days ago", and "today" is the honest reading of an account that is
+  // at most hours old.
+  if (days < 1) return 'today'
+  if (days < DAYS_IN_MONTH) return plural(days, 'day')
+
+  if (days < DAYS_IN_YEAR) {
+    // 360 days is 12 whole 30-day months but not yet a year, and "12 months
+    // ago" next to a "1 year ago" that arrives five days later reads as a
+    // bug. Hold at 11 until the year step takes over.
+    return plural(Math.min(Math.floor(days / DAYS_IN_MONTH), 11), 'month')
+  }
+  return plural(Math.floor(days / DAYS_IN_YEAR), 'year')
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './account'
+export * from './accountAge'
 export * from './age'
 export * from './appConfig'
 export * from './appIdentity'


### PR DESCRIPTION
Closes the profile item under **Design pass** in `docs/release-runbook.md`.

## What changed

- `packages/shared/src/accountAge.ts` — `formatAccountAge`, with tests. Days → months → years as the account ages; holds at "11 months" so a "12 months ago" never sits next to a "1 year ago" five days later; a future `createdAt` (a phone clock running fast) reads as "today" instead of "-1 days ago".
- `PublicProfile` now carries `createdAt` and `emailVerified`. `emailVerified` lives in Better Auth's `user` collection, so `isEmailVerified` goes through `lib/authId.ts` — a string `_id` there matches nothing and would report every profile unverified without erroring, which is what the second route test pins down.
- `toPublicProfile` takes `emailVerified` as a required argument rather than defaulting it: a default of `false` would render "unverified" for anyone whose caller forgot.
- Both profile screens show "Registered 3 months ago"; the public one also shows a Verified email chip.

## One thing worth knowing before reading the badge as a signal

**It is true for every profile today.** Onboarding is gated on `requireVerifiedEmail` and the v1 password bridge marks the address verified itself, so nothing in the app can currently produce a profile whose email is unverified. The flag is read from `user` rather than assumed so that an email-change flow later does not turn this into a badge that lies — but as shipped it draws on everyone. Say the word and I will drop the chip and keep the field.

The runbook item also pointed at `packages/shared` for the DTO; it is actually `apps/api/src/modules/profiles/profiles.ts`, mirrored in `apps/mobile/src/api/types.ts`. Corrected in the same commit.

## Checks

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and `pnpm test` (104 + 49 + 336) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)