### PR TITLE
Show profile languages as two cards with a level icon

### DIFF
--- a/apps/mobile/app/(app)/discover.tsx
+++ b/apps/mobile/app/(app)/discover.tsx
@@ -1,6 +1,7 @@
 import {
   formatDistance,
   getLanguage,
+  LEVEL_SHORT_LABELS,
   NEARBY_MAX_KM,
   NEARBY_RADIUS_OPTIONS_KM,
   type DiscoverySort,
@@ -50,7 +51,7 @@ const SORTS: { key: DiscoverySort; label: string }[] = [
 function LanguageLine({ item }: { item: DiscoveryItem }) {
   const speaks = item.nativeLanguages.map((l) => getLanguage(l.code)?.name ?? l.code).join(', ')
   const learns = item.learning
-    .map((l) => `${getLanguage(l.code)?.name ?? l.code} ${l.level}`)
+    .map((l) => `${getLanguage(l.code)?.name ?? l.code} ${LEVEL_SHORT_LABELS[l.level]}`)
     .join(', ')
   return (
     <Text style={styles.languages} numberOfLines={1}>

--- a/apps/mobile/app/(app)/edit-profile.tsx
+++ b/apps/mobile/app/(app)/edit-profile.tsx
@@ -95,7 +95,7 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
   const [gender, setGender] = useState<Gender>(profile?.gender ?? 'undisclosed')
   const [native, setNative] = useState<string[]>(profile?.nativeLanguages.map((l) => l.code) ?? [])
   const [learning, setLearning] = useState<{ code: string; level: LanguageLevel }[]>(
-    profile?.learning.map((l) => ({ code: l.code, level: l.level as LanguageLevel })) ?? [],
+    profile?.learning.map((l) => ({ code: l.code, level: l.level })) ?? [],
   )
   const [editing, setEditing] = useState<'none' | 'native' | 'learning'>('none')
   const [error, setError] = useState<string | undefined>()

--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -6,7 +6,6 @@ import {
   countryFlag,
   formatAccountAge,
   getCountry,
-  getLanguage,
   streakRestorePrice,
   type Gender,
 } from '@langx/shared'
@@ -22,6 +21,7 @@ import {
   useWallet,
   useTokens,
 } from '../../src/api/queries'
+import { LanguageCards } from '../../src/components/LanguageCards'
 import { PhotoGallery } from '../../src/components/PhotoGallery'
 import { unregisterPushToken } from '../../src/hooks/usePushRegistration'
 import { TierBadge } from '../../src/components/TierBadge'
@@ -176,19 +176,7 @@ export default function MeScreen() {
         </Pressable>
       ) : null}
 
-      <Text style={styles.sectionTitle}>My languages</Text>
-      <View style={styles.chips}>
-        {profile.nativeLanguages.map((l) => (
-          <Chip key={l.code} label={getLanguage(l.code)?.name ?? l.code} tone="accent" selected />
-        ))}
-        {profile.learning.map((l) => (
-          <Chip
-            key={l.code}
-            label={`${getLanguage(l.code)?.name ?? l.code} · ${l.level}`}
-            tone="accent"
-          />
-        ))}
-      </View>
+      <LanguageCards native={profile.nativeLanguages} learning={profile.learning} />
 
       <Text style={styles.sectionTitle}>Token store</Text>
       <Text style={styles.storeHint}>
@@ -314,7 +302,6 @@ const styles = StyleSheet.create({
     marginBottom: spacing.sm,
     marginTop: spacing.xl,
   },
-  chips: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.xs },
   storeHint: { ...font.caption, color: colors.textMuted, marginBottom: spacing.md },
   storeRow: {
     alignItems: 'center',

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -1,4 +1,4 @@
-import { countryFlag, formatAccountAge, getCountry, getLanguage } from '@langx/shared'
+import { countryFlag, formatAccountAge, getCountry } from '@langx/shared'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useState } from 'react'
 import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from 'react-native'
@@ -11,6 +11,7 @@ import {
 } from '../../../src/api/queries'
 import { Avatar } from '../../../src/components/ui/Avatar'
 import { Button } from '../../../src/components/ui/Button'
+import { LanguageCards } from '../../../src/components/LanguageCards'
 import { PhotoGallery } from '../../../src/components/PhotoGallery'
 import { TierBadge } from '../../../src/components/TierBadge'
 import { Chip } from '../../../src/components/ui/Chip'
@@ -147,23 +148,7 @@ export default function ProfileScreen() {
 
       {user.bio ? <Text style={styles.bio}>{user.bio}</Text> : null}
 
-      <Text style={styles.sectionTitle}>Speaks</Text>
-      <View style={styles.chips}>
-        {user.nativeLanguages.map((l) => (
-          <Chip key={l.code} label={getLanguage(l.code)?.name ?? l.code} tone="accent" selected />
-        ))}
-      </View>
-
-      <Text style={styles.sectionTitle}>Learning</Text>
-      <View style={styles.chips}>
-        {user.learning.map((l) => (
-          <Chip
-            key={l.code}
-            label={`${getLanguage(l.code)?.name ?? l.code} · ${l.level}`}
-            tone="accent"
-          />
-        ))}
-      </View>
+      <LanguageCards native={user.nativeLanguages} learning={user.learning} />
 
       {user.interests.length > 0 ? (
         <>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "private": true,
   "license": "BSD-3-Clause",
-  "description": "LangX v2 client \u2014 iOS, Android and web from one Expo codebase",
+  "description": "LangX v2 client — iOS, Android and web from one Expo codebase",
   "main": "expo-router/entry",
   "scripts": {
     "dev": "expo start",
@@ -18,6 +18,7 @@
   "dependencies": {
     "@better-auth/expo": "catalog:",
     "@expo/metro-runtime": "~57.0.13",
+    "@expo/vector-icons": "^15.1.1",
     "@langx/shared": "workspace:*",
     "@tanstack/react-query": "catalog:",
     "better-auth": "catalog:",

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -3,6 +3,7 @@ import {
   hasFeature,
   isPaidTier,
   type Gender,
+  type LanguageLevel,
   type PaidPlanTier,
   type PlanFeature,
   type PlanTier,
@@ -65,7 +66,7 @@ export interface MeProfile {
   timezone?: string
   photos?: { url: string }[]
   nativeLanguages: { code: string }[]
-  learning: { code: string; level: string; priority: number }[]
+  learning: { code: string; level: LanguageLevel; priority: number }[]
   interests: string[]
   settings: { discoverable: boolean; notifications: boolean }
   privacy: { incognito: boolean }

--- a/apps/mobile/src/api/types.ts
+++ b/apps/mobile/src/api/types.ts
@@ -19,7 +19,7 @@ export type {
 
 // Re-exported above for consumers; imported here because a `export ... from`
 // does not bind the name locally and the DTOs below need to use it.
-import type { PlanTier } from '@langx/shared'
+import type { LanguageLevel, PlanTier } from '@langx/shared'
 
 export interface PublicProfileDto {
   _id: string
@@ -33,7 +33,7 @@ export interface PublicProfileDto {
   country?: string
   city?: string
   nativeLanguages: { code: string }[]
-  learning: { code: string; level: string; priority: number }[]
+  learning: { code: string; level: LanguageLevel; priority: number }[]
   interests: string[]
   streak: { current: number; longest: number }
   tier: PlanTier
@@ -55,7 +55,7 @@ export interface DiscoveryItem {
   gender: string
   country?: string
   nativeLanguages: { code: string }[]
-  learning: { code: string; level: string }[]
+  learning: { code: string; level: LanguageLevel }[]
   streak: { current: number }
   isOnline: boolean
   score?: number

--- a/apps/mobile/src/components/LanguageCards.tsx
+++ b/apps/mobile/src/components/LanguageCards.tsx
@@ -1,0 +1,120 @@
+import { Ionicons } from '@expo/vector-icons'
+import { LEVEL_LABELS, getLanguage, type LanguageLevel } from '@langx/shared'
+import type { ReactNode } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import { LEVEL_ICON } from '../lib/languageLevel'
+import { colors, font, radius, spacing } from '../lib/theme'
+
+interface LanguageCardsProps {
+  native: { code: string }[]
+  learning: { code: string; level: LanguageLevel; priority: number }[]
+}
+
+const ICON_SIZE = 20
+
+/**
+ * The two language cards from a profile: what someone is learning, and what
+ * they grew up with. Both profile screens render this, so they stop wording
+ * the same two lists differently — `me` called them "My languages" in one
+ * block, `profile/[handle]` split them into "Speaks" and "Learning".
+ *
+ * The level is an icon and nothing else. Spelling it out is what produced
+ * "Spanish · absoluteBeginner" on both screens; the enum was never meant to be
+ * read, and the icon says the same thing without a label to get wrong.
+ */
+export function LanguageCards({ native, learning }: LanguageCardsProps) {
+  // `priority` is the order the user picked them in. The API has always sent
+  // it and no screen has ever used it.
+  const study = [...learning].sort((a, b) => a.priority - b.priority)
+
+  return (
+    <>
+      {study.length > 0 ? (
+        <Card title="Study Language(s)" subtitle="The language(s) that you Practice & Learn">
+          {study.map((language) => (
+            <LanguageRow
+              key={language.code}
+              code={language.code}
+              icon={
+                <Ionicons
+                  name={LEVEL_ICON[language.level]}
+                  size={ICON_SIZE}
+                  color={colors.accent}
+                  // The icon carries the level on its own now, so this is the
+                  // only thing left that can say it out loud.
+                  accessibilityLabel={LEVEL_LABELS[language.level]}
+                />
+              }
+            />
+          ))}
+        </Card>
+      ) : null}
+
+      {native.length > 0 ? (
+        <Card title="Mother Tongue(s)" subtitle="The language(s) you speak at home">
+          {native.map((language) => (
+            <LanguageRow
+              key={language.code}
+              code={language.code}
+              icon={<Text style={styles.emoji}>🗣️</Text>}
+            />
+          ))}
+        </Card>
+      ) : null}
+    </>
+  )
+}
+
+function Card({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string
+  subtitle: string
+  children: ReactNode
+}) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.subtitle}>{subtitle}</Text>
+      <View style={styles.rows}>{children}</View>
+    </View>
+  )
+}
+
+/**
+ * `nativeName` is dropped when it repeats the name — "English English" reads
+ * as a rendering bug rather than as extra information.
+ */
+function LanguageRow({ code, icon }: { code: string; icon: ReactNode }) {
+  const language = getLanguage(code)
+  const nativeName = language && language.nativeName !== language.name ? language.nativeName : null
+
+  return (
+    <View style={styles.row}>
+      <View style={styles.iconSlot}>{icon}</View>
+      <Text style={styles.name}>{language?.name ?? code}</Text>
+      {nativeName ? <Text style={styles.nativeName}>{nativeName}</Text> : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    marginTop: spacing.md,
+    padding: spacing.md,
+  },
+  title: { ...font.heading, color: colors.text },
+  subtitle: { ...font.caption, color: colors.textMuted, marginTop: 2 },
+  rows: { marginTop: spacing.md },
+  row: { alignItems: 'center', flexDirection: 'row', gap: spacing.md, paddingVertical: spacing.sm },
+  /** Fixed, so the names line up whether the row shows an icon or an emoji. */
+  iconSlot: { alignItems: 'center', width: ICON_SIZE },
+  emoji: { fontSize: 16 },
+  name: { ...font.body, color: colors.text, flex: 1 },
+  nativeName: { ...font.caption, color: colors.textMuted },
+})

--- a/apps/mobile/src/lib/languageLevel.test.ts
+++ b/apps/mobile/src/lib/languageLevel.test.ts
@@ -1,0 +1,15 @@
+import { LANGUAGE_LEVELS } from '@langx/shared'
+import { describe, expect, it } from 'vitest'
+import { LEVEL_ICON } from './languageLevel'
+
+describe('LEVEL_ICON', () => {
+  // A fifth level would otherwise render as a blank space where the icon goes,
+  // on a screen that no longer prints the level as text to fall back on.
+  it('covers every level', () => {
+    for (const level of LANGUAGE_LEVELS) expect(LEVEL_ICON[level]).toBeTruthy()
+  })
+
+  it('gives each level its own icon', () => {
+    expect(new Set(Object.values(LEVEL_ICON)).size).toBe(LANGUAGE_LEVELS.length)
+  })
+})

--- a/apps/mobile/src/lib/languageLevel.ts
+++ b/apps/mobile/src/lib/languageLevel.ts
@@ -1,0 +1,21 @@
+import type { LanguageLevel } from '@langx/shared'
+
+/**
+ * The icon that stands in for a level on a profile, so the level is shown
+ * rather than spelled out.
+ *
+ * These are v1's icons, level for level: it drew `battery-dead`, `-half`,
+ * `-full` and `rocket` for its numeric 0–3, and `V1_LEVEL_TO_LANGUAGE_LEVEL`
+ * maps those same four numbers onto these four levels. A returning user sees
+ * the metaphor they already learned.
+ *
+ * Ionicons names, but typed as strings on purpose — this file is under
+ * `src/lib` so that vitest can load it, and vitest cannot resolve
+ * `react-native`, which `@expo/vector-icons` imports.
+ */
+export const LEVEL_ICON = {
+  absoluteBeginner: 'battery-dead-outline',
+  beginner: 'battery-half-outline',
+  intermediate: 'battery-full-outline',
+  fluent: 'rocket-outline',
+} as const satisfies Record<LanguageLevel, string>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       '@expo/metro-runtime':
         specifier: ~57.0.13
         version: 57.0.13(@expo/log-box@57.0.3)(expo@57.0.16)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
+      '@expo/vector-icons':
+        specifier: ^15.1.1
+        version: 15.1.1(expo-font@57.0.1)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       '@langx/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -1305,6 +1308,13 @@ packages:
         optional: true
       react-native-worklets:
         optional: true
+
+  '@expo/vector-icons@15.1.1':
+    resolution: {integrity: sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==}
+    peerDependencies:
+      expo-font: '>=14.0.4'
+      react: '*'
+      react-native: '*'
 
   '@expo/ws-tunnel@2.0.0':
     resolution: {integrity: sha512-j+JfTRdCk820J9dU0sA2SqshQIKFOMo7ED84w9MJFcebfbNQgsLztEY/SABDkGnjatrW4xGqnUhVRxSBVyCkXw==}
@@ -6206,6 +6216,12 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  '@expo/vector-icons@15.1.1(expo-font@57.0.1)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      expo-font: 57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
 
   '@expo/ws-tunnel@2.0.0(ws@8.21.3)':
     dependencies:


### PR DESCRIPTION
## What

Profile languages become v1's two cards — **Study Language(s)** and **Mother Tongue(s)**, each with its subtitle — and the level is shown as an **icon instead of text**.

Before, both profile screens printed the raw enum: a user read `Spanish · absoluteBeginner`. They also worded the same two lists differently (`me` had one "My languages" block; `profile/[handle]` split it into "Speaks" / "Learning"). Both now render the same `LanguageCards` component.

The icons are v1's, level for level — it drew `battery-dead` / `-half` / `-full` / `rocket` for its numeric 0–3, and `V1_LEVEL_TO_LANGUAGE_LEVEL` maps those same four numbers onto our four levels, so a returning user already knows what they mean. `LEVEL_LABELS` goes on `accessibilityLabel`, which is now the only thing that can say the level out loud.

## The dependency

This adds the app's **first icon library**. There was none — the house style is emoji in a `<Text>`, and mother tongues keep that (they have no level to draw). Faking four battery states out of `View`s to avoid a dependency seemed worse than the dependency. `@expo/vector-icons` is font glyphs on top of `expo-font`, which is already here: no native module, so it ships over the air rather than needing a store build.

Icon colour is `colors.accent`, not the amber in v1's screenshot. `colors.streak` means streak everywhere else in v2, and `docs/release-runbook.md` → **Design pass** still has "keep v1's amber or make the black-and-blue drift official" unticked — this change should not quietly settle that. It reads the token, so one edit flips every icon later.

## Along the way

- The DTOs typed `level` as `string`, which lost the `LanguageLevel` union and made indexing `LEVEL_ICON` / `LEVEL_LABELS` impossible. Narrowing it also retires a cast in `edit-profile` that only existed because of it.
- `discover` leaked the same raw enum into its language line; it now uses `LEVEL_SHORT_LABELS`, like `filters` and `edit-profile` always have.
- Study languages are sorted by `priority` — the order the user picked them in, which the API has always sent and nothing had ever used.
- `nativeName` is shown beside the name, and dropped when it repeats it, so "English" does not print twice.

## Testing

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and `pnpm test` all pass locally (new `src/lib/languageLevel.test.ts` covers every level having a distinct icon — that is what catches a fifth level rendering as a blank space).

This is a visual change, so it also wants a look on `/me`, someone else's `/profile/<handle>` and `/discover`. Watch for glyphs rendering as **boxes**, which is the font-loading failure mode for a new icon font.

🤖 Generated with [Claude Code](https://claude.com/claude-code)