### PR TITLE
Put Chats first and move Settings into the profile's top corner

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -45,17 +45,17 @@ export default function AppLayout() {
         }}
       >
         <Tabs.Screen
-          name="discover"
-          options={{
-            title: 'Discover',
-            tabBarIcon: ({ focused }) => <TabIcon emoji="🧭" focused={focused} />,
-          }}
-        />
-        <Tabs.Screen
           name="chats"
           options={{
             title: 'Chats',
             tabBarIcon: ({ focused }) => <TabIcon emoji="💬" focused={focused} />,
+          }}
+        />
+        <Tabs.Screen
+          name="discover"
+          options={{
+            title: 'Discover',
+            tabBarIcon: ({ focused }) => <TabIcon emoji="🧭" focused={focused} />,
           }}
         />
         <Tabs.Screen

--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -9,6 +9,7 @@ import {
   streakRestorePrice,
   type Gender,
 } from '@langx/shared'
+import { Ionicons } from '@expo/vector-icons'
 import { router } from 'expo-router'
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native'
 import {
@@ -119,6 +120,23 @@ export default function MeScreen() {
 
   return (
     <Screen scroll onRefresh={refresh} refreshing={me.isRefetching}>
+      {/*
+        Settings used to be a button below the token store, at the bottom of a
+        screen that scrolls for a while — reachable, but only by someone who
+        already knew it was there. It is the only way into that screen, so it
+        gets the corner instead.
+      */}
+      <View style={styles.topBar}>
+        <Pressable
+          onPress={() => router.push('/(app)/settings')}
+          hitSlop={12}
+          accessibilityRole="button"
+          accessibilityLabel="Settings"
+        >
+          <Ionicons name="settings-outline" size={24} color={colors.textMuted} />
+        </Pressable>
+      </View>
+
       <View style={styles.hero}>
         <Avatar url={profile.avatarUrl} name={profile.displayName} size={layout.avatarLarge} />
         <Text style={styles.name}>{profile.displayName}</Text>
@@ -250,13 +268,7 @@ export default function MeScreen() {
       <Button
         label="Edit profile"
         onPress={() => router.push('/(app)/edit-profile')}
-        style={styles.settings}
-      />
-      <Button
-        label="Settings"
-        variant="secondary"
-        onPress={() => router.push('/(app)/settings')}
-        style={styles.settingsSecondary}
+        style={styles.firstAction}
       />
       <Button label="Sign out" variant="secondary" onPress={signOut} style={styles.signOut} />
     </Screen>
@@ -266,6 +278,7 @@ export default function MeScreen() {
 const styles = StyleSheet.create({
   loading: { marginTop: spacing.xxl },
   flex: { flex: 1 },
+  topBar: { alignItems: 'center', flexDirection: 'row', justifyContent: 'flex-end' },
   hero: { alignItems: 'center', gap: spacing.xs, paddingVertical: spacing.lg },
   badges: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.xs, justifyContent: 'center' },
   name: { ...font.title, color: colors.text, marginTop: spacing.sm },
@@ -320,7 +333,6 @@ const styles = StyleSheet.create({
   storeAction: { flexShrink: 0, width: 'auto' },
   storeName: { ...font.body, color: colors.text, fontWeight: '600' },
   storeMeta: { ...font.caption, color: colors.textMuted },
-  settings: { marginTop: spacing.xl },
-  settingsSecondary: { marginTop: spacing.sm },
+  firstAction: { marginTop: spacing.xl },
   signOut: { marginBottom: spacing.xxl, marginTop: spacing.sm },
 })


### PR DESCRIPTION
Two navigation changes to the signed-in area.

## Tab order

The tab bar now reads **Chats · Discover · Leaderboard · Profile** — the first two entries swapped. Ordering is declaration order in the `Tabs` navigator, so that is the whole change.

It also makes `chats` the navigator's initial route, but where the app lands is unaffected: `app/index.tsx`, `(onboarding)/done.tsx` and `(onboarding)/welcome-back.tsx` all redirect to `/(app)/discover` explicitly. Verified in the running app — after sign-in you still land on Discover.

## Settings

Settings had exactly one entry point in the whole app: a secondary `Button` below the token store, at the bottom of a screen that scrolls for a while. Being the only way in, it now gets the top-right corner of the profile instead, and the bottom button is removed so there is still only one.

The gear sits inside `Screen`'s scroll content rather than in a real header. Every navigator here sets `headerShown: false`, and `(app)/_layout.tsx` already wraps the group in a `SafeAreaView edges={['top']}` that a header would fight over the top inset — so the in-content row matches what the `‹ Back` rows on the other screens already do.

Uses `Ionicons` from `@expo/vector-icons`, which arrived on main in #956.

## Verification

Local: `typecheck`, `lint`, `format:check` and `test` all pass (48 files, 491 tests).

Driven in the browser against `:8081`, signed in as a seeded test user:

- tab order read from the DOM: `Chats | Discover | Leaderboard | Profile`
- gear measured at `x=380` in a 420px viewport, `y=16` — right half, top
- tapping it opens Settings and hides the tab bar; `‹ Back` returns to the profile
- the bottom "Settings" button is gone; "Edit profile" and "Sign out" remain

No automated test covers this — the app has no navigation or screen tests, so the four checks only show there is no regression elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)