### PR TITLE
Report every tracked quota, and show them while developing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,4 +134,9 @@ EXPO_PUBLIC_REVENUECAT_TEST_STORE_KEY=
 # Ignored unless the bundle is a development one, so it cannot follow a web
 # export into production. Both halves have to be set for a purchase to land.
 EXPO_PUBLIC_REVENUECAT_FAKE_STORE=
+
+# `1` draws the on-screen debug panels (today: the profile's daily quota
+# counters). Ignored unless the bundle is a development one, for the same
+# reason as the flag above.
+EXPO_PUBLIC_DEBUG_PANEL=
 EXPO_PUBLIC_SENTRY_DSN=

--- a/apps/api/src/routes/conversations.test.ts
+++ b/apps/api/src/routes/conversations.test.ts
@@ -295,6 +295,33 @@ describe('Faz 4 — starting a conversation', () => {
       // Sending conversations never touches the translation bucket.
       expect(afterBody.translations).toMatchObject({ limit: 20, remaining: 20 })
     })
+
+    /**
+     * `media` is consumed on the socket path but was missing from this
+     * response, which left the chat screen unable to say which limit an
+     * attachment had hit. Every kind `quota.ts` tracks is reported.
+     */
+    it('reports every tracked kind, media included', async () => {
+      const free = await newUser('quota-kinds-free@example.com')
+      const freeBody = await app
+        .inject({ method: 'GET', url: '/me/quota', headers: { cookie: free.cookie } })
+        .then((r) => r.json<Record<string, { limit: number | null }>>())
+
+      expect(Object.keys(freeBody).sort()).toEqual(['initiations', 'media', 'translations'])
+      expect(freeBody.media).toMatchObject({
+        limit: PLAN_LIMITS.free.mediaPer24h,
+        remaining: PLAN_LIMITS.free.mediaPer24h,
+        nextAvailableAt: null,
+      })
+
+      const pro = await newUser('quota-kinds-pro@example.com')
+      await makePro(pro.userId)
+      const proBody = await app
+        .inject({ method: 'GET', url: '/me/quota', headers: { cookie: pro.cookie } })
+        .then((r) => r.json<Record<string, { limit: number | null }>>())
+
+      expect(proBody.media).toMatchObject({ limit: null, remaining: null })
+    })
   })
 
   describe('the 24h window rolls, it does not reset', () => {

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -35,10 +35,15 @@ export const conversationRoutes: FastifyPluginAsyncZod = async (app) => {
     if (!profile) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Profile not found')
 
     const tier = effectiveTier(profile)
-    const [initiations, translations] = await Promise.all([
+    // Every kind `quota.ts` tracks, so a client never has to guess why an
+    // action was refused. `media` was missing here while being consumed on
+    // the socket path, which left the chat screen with no way to say which
+    // limit it had hit.
+    const [initiations, translations, media] = await Promise.all([
       getQuotaStatus(app.mongo.db, request.userId, tier, 'initiations'),
       getQuotaStatus(app.mongo.db, request.userId, tier, 'translations'),
+      getQuotaStatus(app.mongo.db, request.userId, tier, 'media'),
     ])
-    return reply.send({ initiations, translations })
+    return reply.send({ initiations, translations, media })
   })
 }

--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -22,6 +22,7 @@ import {
   useWallet,
   useTokens,
 } from '../../src/api/queries'
+import { DebugQuotaPanel } from '../../src/components/DebugQuotaPanel'
 import { LanguageCards } from '../../src/components/LanguageCards'
 import { PhotoGallery } from '../../src/components/PhotoGallery'
 import { unregisterPushToken } from '../../src/hooks/usePushRegistration'
@@ -264,6 +265,8 @@ export default function MeScreen() {
           </View>
         )
       })}
+
+      <DebugQuotaPanel />
 
       <Button
         label="Edit profile"

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -260,7 +260,11 @@ export function useQuota() {
   return useQuery({
     queryKey: keys.quota,
     queryFn: () =>
-      api.get<{ initiations: QuotaStatusDto; translations: QuotaStatusDto }>('/me/quota'),
+      api.get<{
+        initiations: QuotaStatusDto
+        translations: QuotaStatusDto
+        media: QuotaStatusDto
+      }>('/me/quota'),
   })
 }
 

--- a/apps/mobile/src/components/DebugQuotaPanel.tsx
+++ b/apps/mobile/src/components/DebugQuotaPanel.tsx
@@ -1,0 +1,53 @@
+import { StyleSheet, Text, View } from 'react-native'
+import { useQuota } from '../api/queries'
+import { isDebugPanelEnabled } from '../lib/debugPanel'
+import { formatQuota } from '../lib/quotaFormat'
+import { colors, font, radius, spacing } from '../lib/theme'
+
+/**
+ * The viewer's own daily quotas, for looking at during development.
+ *
+ * Deliberately not a product surface: the numbers are useful while building
+ * anything that spends a quota, and meaningless to someone who has never
+ * heard the word. `isDebugPanelEnabled` keeps it out of every shipped build,
+ * so nothing here needs product copy.
+ */
+export function DebugQuotaPanel() {
+  const quota = useQuota()
+  if (!isDebugPanelEnabled()) return null
+
+  const rows: [string, string][] = quota.data
+    ? [
+        ['New chats left today', formatQuota(quota.data.initiations)],
+        ['Translations left today', formatQuota(quota.data.translations)],
+        ['Attachments left today', formatQuota(quota.data.media)],
+      ]
+    : [['Quota', quota.isError ? 'unavailable' : 'loading…']]
+
+  return (
+    <View style={styles.panel}>
+      <Text style={styles.title}>DEBUG · quota</Text>
+      {rows.map(([label, value]) => (
+        <View key={label} style={styles.row}>
+          <Text style={styles.label}>{label}</Text>
+          <Text style={styles.value}>{value}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  label: { ...font.caption, color: colors.textMuted },
+  panel: {
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    borderStyle: 'dashed',
+    borderWidth: 1,
+    marginTop: spacing.xl,
+    padding: spacing.md,
+  },
+  row: { flexDirection: 'row', justifyContent: 'space-between', marginTop: spacing.xs },
+  title: { ...font.label, color: colors.textMuted },
+  value: { ...font.caption, color: colors.text, fontVariant: ['tabular-nums'] },
+})

--- a/apps/mobile/src/lib/debugPanel.test.ts
+++ b/apps/mobile/src/lib/debugPanel.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isDebugPanelEnabled } from './debugPanel'
+
+function setEnv(dev: boolean, flag: string | undefined) {
+  vi.stubGlobal('__DEV__', dev)
+  if (flag === undefined) delete process.env.EXPO_PUBLIC_DEBUG_PANEL
+  else process.env.EXPO_PUBLIC_DEBUG_PANEL = flag
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  delete process.env.EXPO_PUBLIC_DEBUG_PANEL
+})
+
+describe('isDebugPanelEnabled', () => {
+  it('is on only when both conditions hold', () => {
+    setEnv(true, '1')
+    expect(isDebugPanelEnabled()).toBe(true)
+  })
+
+  /**
+   * The condition that actually protects a shipped bundle: `EXPO_PUBLIC_*` is
+   * inlined at build time, so a flag left set in a shell can otherwise follow
+   * a web export into production.
+   */
+  it('is off in a production bundle however the environment is set', () => {
+    setEnv(false, '1')
+    expect(isDebugPanelEnabled()).toBe(false)
+  })
+
+  it('is off in development without the flag', () => {
+    setEnv(true, undefined)
+    expect(isDebugPanelEnabled()).toBe(false)
+  })
+
+  it('does not treat some other truthy value as the flag', () => {
+    setEnv(true, 'true')
+    expect(isDebugPanelEnabled()).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/debugPanel.ts
+++ b/apps/mobile/src/lib/debugPanel.ts
@@ -1,0 +1,13 @@
+/**
+ * Whether the on-screen debug panels are drawn.
+ *
+ * **Off unless two independent things are true**: the explicit environment
+ * flag, and `__DEV__`. The reasoning is `fakePurchases.ts`'s — Expo inlines
+ * `EXPO_PUBLIC_*` at build time, so a flag left set in a shell can follow a
+ * `pnpm build:web` into a published bundle without saying so. `__DEV__` is
+ * the condition that holds regardless of how the environment is set, and it
+ * is the reason a debug panel can be written without weighing what it leaks.
+ */
+export function isDebugPanelEnabled(): boolean {
+  return __DEV__ && process.env.EXPO_PUBLIC_DEBUG_PANEL === '1'
+}

--- a/apps/mobile/src/lib/quotaFormat.test.ts
+++ b/apps/mobile/src/lib/quotaFormat.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { formatQuota } from './quotaFormat'
+
+describe('formatQuota', () => {
+  it('reads a null limit as unlimited rather than as a missing value', () => {
+    expect(formatQuota({ limit: null, remaining: null, nextAvailableAt: null })).toBe('∞')
+  })
+
+  it('shows what is left out of the limit', () => {
+    expect(formatQuota({ limit: 5, remaining: 3, nextAvailableAt: null })).toBe('3 / 5')
+  })
+
+  /**
+   * The reset time is the expiry of the oldest timestamp in the window, which
+   * is only the answer to "when can I do this again" once nothing is left.
+   */
+  it('stays quiet about the reset time while there is anything left', () => {
+    const at = new Date(Date.now() + 3_600_000).toISOString()
+    expect(formatQuota({ limit: 5, remaining: 1, nextAvailableAt: at })).toBe('1 / 5')
+  })
+
+  it('appends the reset time once the bucket is empty', () => {
+    const at = new Date(2026, 7, 28, 14, 20)
+    expect(formatQuota({ limit: 5, remaining: 0, nextAvailableAt: at.toISOString() })).toBe(
+      '0 / 5 · resets 14:20',
+    )
+  })
+
+  it('falls back to the counts when the server sends no reset time', () => {
+    expect(formatQuota({ limit: 5, remaining: 0, nextAvailableAt: null })).toBe('0 / 5')
+  })
+})

--- a/apps/mobile/src/lib/quotaFormat.ts
+++ b/apps/mobile/src/lib/quotaFormat.ts
@@ -1,0 +1,21 @@
+import type { QuotaStatusDto } from '../api/queries'
+
+/**
+ * One quota bucket as a line of text.
+ *
+ * `limit: null` means unlimited on this tier rather than "unknown", so it
+ * reads as `∞` rather than as a missing value. The reset time is only shown
+ * once the bucket is empty: before that it is the expiry of the oldest of
+ * several timestamps, which is not the question anyone is asking.
+ */
+export function formatQuota(status: QuotaStatusDto): string {
+  if (status.limit === null) return '∞'
+
+  const used = `${status.remaining ?? 0} / ${status.limit}`
+  if (status.remaining !== 0 || !status.nextAvailableAt) return used
+
+  const at = new Date(status.nextAvailableAt)
+  if (Number.isNaN(at.getTime())) return used
+  const time = `${String(at.getHours()).padStart(2, '0')}:${String(at.getMinutes()).padStart(2, '0')}`
+  return `${used} · resets ${time}`
+}


### PR DESCRIPTION
## What

`GET /me/quota` reported `initiations` and `translations` but not `media`, even though `media` is one of the three kinds `apps/api/src/lib/quota.ts` tracks and is consumed on the socket path. The chat screen therefore could not tell a user *which* limit an attachment had hit.

- `GET /me/quota` now returns all three buckets.
- A development-only panel on the profile screen shows new chats / translations / attachments left today.

## Why the panel cannot ship

It is behind the two independent conditions `src/lib/fakePurchases.ts:24-26` established. `EXPO_PUBLIC_*` is inlined at build time, so a flag left set in a shell can follow a `pnpm build:web` into a published bundle without announcing itself; `__DEV__` is the half that holds regardless of how the environment is set. That is why the panel needed no product copy.

## Tests

- `apps/api/src/routes/conversations.test.ts` — the response carries exactly the three tracked kinds; `media.limit` is 50 on free and `null` on Pro.
- `apps/mobile/src/lib/quotaFormat.test.ts` — unlimited, counting down, and the reset time appearing only once the bucket is empty.
- `apps/mobile/src/lib/debugPanel.test.ts` — both conditions are required, including the production-bundle case.

Full suite green: 337 api, 60 mobile, 104 shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)