### PR TITLE
Give the token store its own screen, reached from the balance

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -94,6 +94,7 @@ export default function AppLayout() {
         <Tabs.Screen name="viewers" options={FULL_SCREEN} />
         <Tabs.Screen name="filters" options={FULL_SCREEN} />
         <Tabs.Screen name="intro" options={FULL_SCREEN} />
+        <Tabs.Screen name="store" options={FULL_SCREEN} />
       </Tabs>
     </SafeAreaView>
   )

--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -1,14 +1,4 @@
-import {
-  COSMETICS,
-  STREAK_FREEZE_SKU,
-  STREAK_RESTORE_SKU,
-  TOKEN_RULES,
-  countryFlag,
-  formatAccountAge,
-  getCountry,
-  streakRestorePrice,
-  type Gender,
-} from '@langx/shared'
+import { countryFlag, formatAccountAge, getCountry, type Gender } from '@langx/shared'
 import { Ionicons } from '@expo/vector-icons'
 import { router } from 'expo-router'
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native'
@@ -16,7 +6,6 @@ import {
   useEffectiveTier,
   useIsPro,
   useMe,
-  usePurchase,
   useQuota,
   useViewers,
   useWallet,
@@ -67,7 +56,6 @@ export default function MeScreen() {
   const wallet = useWallet()
   const quota = useQuota()
   const viewers = useViewers()
-  const purchase = usePurchase()
   // Above the early return: hooks cannot be called conditionally, and putting
   // this below it renders nothing at all.
   const isPro = useIsPro()
@@ -83,10 +71,6 @@ export default function MeScreen() {
 
   const profile = me.data
   const balance = wallet.data?.balance ?? 0
-  const restored = profile.restoredFromV1
-  const restorableStreak = restored && !restored.streakRestoredAt ? restored.frozenStreak : 0
-  const restorePrice = streakRestorePrice(restorableStreak)
-  const owned = wallet.data?.owned ?? []
 
   async function signOut(): Promise<void> {
     // Sign out sits under the profile, one mis-tap away from everything on it.
@@ -163,7 +147,17 @@ export default function MeScreen() {
       <View style={styles.stats}>
         <Stat label="Streak" value={`🔥 ${xp.data?.streak.current ?? 0}`} tone={colors.streak} />
         <Stat label="Total tokens" value={String(xp.data?.tokens.all ?? 0)} />
-        <Stat label="Balance" value={String(balance)} tone={colors.accent} />
+        {/* The balance is the way into the store — a number nobody can act on
+            reads as decoration, and the store had nowhere else to be reached
+            from once it left this screen. */}
+        <Pressable
+          onPress={() => router.push('/(app)/store')}
+          accessibilityRole="button"
+          accessibilityLabel="Token store"
+          style={styles.flex}
+        >
+          <Stat label="Balance ›" value={String(balance)} tone={colors.accent} />
+        </Pressable>
       </View>
 
       {/* Free users get the count and a locked list; that contrast is the
@@ -196,75 +190,6 @@ export default function MeScreen() {
       ) : null}
 
       <LanguageCards native={profile.nativeLanguages} learning={profile.learning} />
-
-      <Text style={styles.sectionTitle}>Token store</Text>
-      <Text style={styles.storeHint}>
-        Tokens cannot be bought, traded, withdrawn, or used to unlock any Pro feature — only streak
-        freezes and cosmetics.
-      </Text>
-
-      {/*
-        Only ever offered to someone who came back from v1 and has not bought
-        it yet — `restoredFromV1` carries the number and `streakRestoredAt` is
-        the latch. Before this the welcome-back screen could name the streak
-        and offer nothing to do about it.
-      */}
-      {restorableStreak > 0 ? (
-        <View style={styles.storeRow}>
-          <View style={styles.flex}>
-            <Text style={styles.storeName}>Restore your streak</Text>
-            <Text style={styles.storeMeta}>
-              {`Bring back the ${restorableStreak}-day streak you had in v1`}
-            </Text>
-          </View>
-          <Button
-            label={`${restorePrice} tokens`}
-            variant="secondary"
-            style={styles.storeAction}
-            disabled={balance < restorePrice || purchase.isPending}
-            onPress={() => purchase.mutate(STREAK_RESTORE_SKU)}
-          />
-        </View>
-      ) : null}
-
-      <View style={styles.storeRow}>
-        <View style={styles.flex}>
-          <Text style={styles.storeName}>Streak freeze</Text>
-          <Text style={styles.storeMeta}>
-            {/* One expression, not two on separate lines — JSX eats the
-                newline between them, which rendered "banked /2". */}
-            {`Saves one missed day · ${wallet.data?.streakFreezes ?? 0}/${TOKEN_RULES.sinks.maxBankedStreakFreezes} banked`}
-          </Text>
-        </View>
-        <Button
-          label={`${TOKEN_RULES.sinks.streakFreeze} tokens`}
-          variant="secondary"
-          style={styles.storeAction}
-          disabled={balance < TOKEN_RULES.sinks.streakFreeze || purchase.isPending}
-          onPress={() => purchase.mutate(STREAK_FREEZE_SKU)}
-        />
-      </View>
-
-      {COSMETICS.map((item) => {
-        const isOwned = owned.includes(item.id)
-        return (
-          <View key={item.id} style={styles.storeRow}>
-            <View style={styles.flex}>
-              <Text style={styles.storeName}>{item.label}</Text>
-              <Text style={styles.storeMeta}>
-                {item.kind === 'frame' ? 'Profile frame' : 'Title'}
-              </Text>
-            </View>
-            <Button
-              label={isOwned ? 'Owned' : `${item.price} tokens`}
-              variant="secondary"
-              style={styles.storeAction}
-              disabled={isOwned || balance < item.price || purchase.isPending}
-              onPress={() => purchase.mutate(item.id)}
-            />
-          </View>
-        )
-      })}
 
       <DebugQuotaPanel />
 
@@ -318,24 +243,6 @@ const styles = StyleSheet.create({
     marginBottom: spacing.sm,
     marginTop: spacing.xl,
   },
-  storeHint: { ...font.caption, color: colors.textMuted, marginBottom: spacing.md },
-  storeRow: {
-    alignItems: 'center',
-    borderBottomColor: colors.border,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    flexDirection: 'row',
-    gap: spacing.md,
-    paddingVertical: spacing.md,
-  },
-  /**
-   * Undoes `Button`'s full-width default, which is right in a form column and
-   * wrong here: claiming 100% of a row leaves nothing for the name beside it,
-   * and the name column — being `flex: 1`, so shrinkable — collapses to a
-   * single character per line rather than pushing back.
-   */
-  storeAction: { flexShrink: 0, width: 'auto' },
-  storeName: { ...font.body, color: colors.text, fontWeight: '600' },
-  storeMeta: { ...font.caption, color: colors.textMuted },
   firstAction: { marginTop: spacing.xl },
   signOut: { marginBottom: spacing.xxl, marginTop: spacing.sm },
 })

--- a/apps/mobile/app/(app)/store.tsx
+++ b/apps/mobile/app/(app)/store.tsx
@@ -1,0 +1,95 @@
+import { router } from 'expo-router'
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native'
+import { useMe, usePurchase, useTokens, useWallet } from '../../src/api/queries'
+import { StoreRow } from '../../src/components/store/StoreRow'
+import { Screen } from '../../src/components/ui/Screen'
+import { buildStoreOffers } from '../../src/lib/storeOffers'
+import { colors, font, radius, spacing } from '../../src/lib/theme'
+
+/**
+ * The token store, reached by tapping the balance on the profile.
+ *
+ * A route rather than a sheet: the app has no modal routes and adding one
+ * would mean a gesture-handler dependency that does not resolve from this
+ * package, for a surface that cannot be linked to or backed out of. A route
+ * also has somewhere to put the sections this is going to grow.
+ */
+export default function StoreScreen() {
+  const me = useMe()
+  const xp = useTokens()
+  const wallet = useWallet()
+  const purchase = usePurchase()
+
+  if (me.isPending || !me.data) {
+    return (
+      <Screen>
+        <ActivityIndicator style={styles.loading} />
+      </Screen>
+    )
+  }
+
+  const restored = me.data.restoredFromV1
+  const offers = buildStoreOffers({
+    balance: wallet.data?.balance ?? 0,
+    owned: wallet.data?.owned ?? [],
+    streakFreezes: wallet.data?.streakFreezes ?? 0,
+    restorableStreak: restored && !restored.streakRestoredAt ? restored.frozenStreak : 0,
+  })
+
+  function refresh(): void {
+    void Promise.all([me.refetch(), xp.refetch(), wallet.refetch()])
+  }
+
+  return (
+    <Screen scroll onRefresh={refresh} refreshing={wallet.isFetching}>
+      <Pressable onPress={() => router.back()} hitSlop={12} style={styles.backRow}>
+        <Text style={styles.back}>‹ Back</Text>
+      </Pressable>
+      <Text style={styles.title}>Token store</Text>
+
+      <View style={styles.balance}>
+        <Text style={styles.balanceLabel}>Balance</Text>
+        <Text style={styles.balanceValue}>{wallet.data?.balance ?? 0}</Text>
+      </View>
+
+      <Text style={styles.hint}>
+        Tokens cannot be bought, traded, withdrawn, or used to unlock any Pro feature — only streak
+        freezes and cosmetics.
+      </Text>
+
+      {offers.map((offer) => (
+        <StoreRow
+          key={offer.id}
+          offer={offer}
+          pending={purchase.isPending}
+          onBuy={(id) => purchase.mutate(id)}
+        />
+      ))}
+    </Screen>
+  )
+}
+
+const styles = StyleSheet.create({
+  back: { ...font.body, color: colors.textMuted },
+  backRow: { paddingTop: spacing.md },
+  balance: {
+    alignItems: 'center',
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: spacing.lg,
+    padding: spacing.lg,
+  },
+  balanceLabel: { ...font.label, color: colors.textMuted },
+  balanceValue: { ...font.title, color: colors.accent },
+  hint: {
+    ...font.caption,
+    color: colors.textMuted,
+    marginBottom: spacing.md,
+    marginTop: spacing.xl,
+  },
+  loading: { marginTop: spacing.xxl },
+  title: { ...font.title, color: colors.text, marginTop: spacing.xs },
+})

--- a/apps/mobile/src/components/store/StoreRow.tsx
+++ b/apps/mobile/src/components/store/StoreRow.tsx
@@ -1,0 +1,55 @@
+import { StyleSheet, Text, View } from 'react-native'
+import type { StoreOffer } from '../../lib/storeOffers'
+import { colors, font, spacing } from '../../lib/theme'
+import { Button } from '../ui/Button'
+
+/**
+ * One buyable thing. Owned items keep their row rather than disappearing, so
+ * the catalogue stays the same shape whoever is looking at it.
+ */
+export function StoreRow({
+  offer,
+  pending,
+  onBuy,
+}: {
+  offer: StoreOffer
+  pending: boolean
+  onBuy: (id: string) => void
+}) {
+  return (
+    <View style={styles.row}>
+      <View style={styles.flex}>
+        <Text style={styles.name}>{offer.title}</Text>
+        <Text style={styles.meta}>{offer.subtitle}</Text>
+      </View>
+      <Button
+        label={offer.owned ? 'Owned' : `${offer.price} tokens`}
+        variant="secondary"
+        style={styles.action}
+        disabled={offer.owned || !offer.affordable || pending}
+        onPress={() => onBuy(offer.id)}
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  /**
+   * Undoes `Button`'s full-width default, which is right in a form column and
+   * wrong here: claiming 100% of a row leaves nothing for the name beside it,
+   * and the name column — being `flex: 1`, so shrinkable — collapses to a
+   * single character per line rather than pushing back.
+   */
+  action: { flexShrink: 0, width: 'auto' },
+  flex: { flex: 1 },
+  meta: { ...font.caption, color: colors.textMuted },
+  name: { ...font.body, color: colors.text, fontWeight: '600' },
+  row: {
+    alignItems: 'center',
+    borderBottomColor: colors.border,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: spacing.md,
+    paddingVertical: spacing.md,
+  },
+})

--- a/apps/mobile/src/lib/storeOffers.test.ts
+++ b/apps/mobile/src/lib/storeOffers.test.ts
@@ -1,0 +1,82 @@
+import { COSMETICS, STREAK_FREEZE_SKU, STREAK_RESTORE_SKU, TOKEN_RULES } from '@langx/shared'
+import { describe, expect, it } from 'vitest'
+import { buildStoreOffers, type StoreInput } from './storeOffers'
+
+const base: StoreInput = { balance: 0, owned: [], streakFreezes: 0, restorableStreak: 0 }
+const byId = (input: Partial<StoreInput>, id: string) =>
+  buildStoreOffers({ ...base, ...input }).find((offer) => offer.id === id)
+
+describe('buildStoreOffers', () => {
+  it('always lists the freeze and every cosmetic', () => {
+    const ids = buildStoreOffers(base).map((offer) => offer.id)
+    expect(ids).toEqual([STREAK_FREEZE_SKU, ...COSMETICS.map((c) => c.id)])
+  })
+
+  describe('streak restore', () => {
+    it('is absent for someone who never came from v1', () => {
+      expect(byId({}, STREAK_RESTORE_SKU)).toBeUndefined()
+    })
+
+    /** The caller resolves the `streakRestoredAt` latch into a 0. */
+    it('is priced per day once there is a streak to buy back', () => {
+      const offer = byId({ restorableStreak: 30, balance: 10_000 }, STREAK_RESTORE_SKU)
+      expect(offer).toMatchObject({
+        price: 30 * TOKEN_RULES.sinks.streakRestorePerDay,
+        affordable: true,
+      })
+    })
+
+    it('is capped rather than priced without limit', () => {
+      const offer = byId({ restorableStreak: 10_000, balance: 1_000_000 }, STREAK_RESTORE_SKU)
+      expect(offer?.price).toBe(TOKEN_RULES.sinks.streakRestoreMax)
+    })
+  })
+
+  describe('streak freeze', () => {
+    it('is unaffordable below the price', () => {
+      const offer = byId({ balance: TOKEN_RULES.sinks.streakFreeze - 1 }, STREAK_FREEZE_SKU)
+      expect(offer?.affordable).toBe(false)
+    })
+
+    /**
+     * The server refuses this at `wallet.ts:78`. The button used to be
+     * pressable anyway and the purchase came back as an error.
+     */
+    it('is unaffordable with a full bank, however large the balance', () => {
+      const offer = byId(
+        { balance: 1_000_000, streakFreezes: TOKEN_RULES.sinks.maxBankedStreakFreezes },
+        STREAK_FREEZE_SKU,
+      )
+      expect(offer).toMatchObject({ affordable: false, owned: false })
+    })
+
+    it('is buyable again one below the cap', () => {
+      const offer = byId(
+        { balance: 1_000_000, streakFreezes: TOKEN_RULES.sinks.maxBankedStreakFreezes - 1 },
+        STREAK_FREEZE_SKU,
+      )
+      expect(offer?.affordable).toBe(true)
+    })
+  })
+
+  describe('cosmetics', () => {
+    const gold = COSMETICS.find((c) => c.id === 'frame.gold')!
+
+    it('marks what has been bought', () => {
+      expect(byId({ owned: [gold.id], balance: 1_000_000 }, gold.id)).toMatchObject({
+        owned: true,
+        affordable: false,
+      })
+    })
+
+    it('does not offer to sell an owned item again at any balance', () => {
+      const offers = buildStoreOffers({ ...base, owned: [gold.id], balance: 1_000_000 })
+      expect(offers.filter((o) => o.owned).every((o) => !o.affordable)).toBe(true)
+    })
+
+    it('keeps the catalogue price and the kind as its subtitle', () => {
+      expect(byId({}, gold.id)).toMatchObject({ price: gold.price, subtitle: 'Profile frame' })
+      expect(byId({}, 'title.tutor')?.subtitle).toBe('Title')
+    })
+  })
+})

--- a/apps/mobile/src/lib/storeOffers.ts
+++ b/apps/mobile/src/lib/storeOffers.ts
@@ -1,0 +1,101 @@
+import {
+  COSMETICS,
+  STREAK_FREEZE_SKU,
+  STREAK_RESTORE_SKU,
+  TOKEN_RULES,
+  streakRestorePrice,
+} from '@langx/shared'
+
+export interface StoreOffer {
+  /** The SKU sent to `POST /me/wallet/purchase`. */
+  id: string
+  title: string
+  subtitle: string
+  price: number
+  owned: boolean
+  /** Whether the balance covers the price. Separate from `owned`: an owned
+   *  item is never buyable however much the balance is. */
+  affordable: boolean
+}
+
+export interface StoreInput {
+  balance: number
+  /** Cosmetic ids already bought, from `GET /me/wallet`. */
+  owned: readonly string[]
+  streakFreezes: number
+  /**
+   * The v1 streak still available to buy back, or 0. The caller resolves the
+   * latch (`restoredFromV1 && !streakRestoredAt`) because only it can see the
+   * profile; everything downstream of that decision lives here.
+   */
+  restorableStreak: number
+}
+
+/**
+ * The whole store catalogue, priced and gated.
+ *
+ * Pulled out of the profile screen's JSX, where the streak-restore latch, the
+ * banked-freeze cap, cosmetic ownership and affordability were four rules
+ * expressed as nested ternaries inside `disabled` props — correct, and
+ * untestable, since `vitest.config.ts` only reaches `src/lib`.
+ *
+ * Affordability is advisory. The purchase route re-checks the balance
+ * atomically, which is what actually prevents overspending; this only decides
+ * whether a button looks pressable.
+ */
+export function buildStoreOffers(input: StoreInput): StoreOffer[] {
+  const offers: StoreOffer[] = []
+  const priced = (id: string, title: string, subtitle: string, price: number, owned = false) => ({
+    id,
+    title,
+    subtitle,
+    price,
+    owned,
+    affordable: !owned && input.balance >= price,
+  })
+
+  // Only ever offered to someone who came back from v1 and has not bought it
+  // yet — the caller has already resolved the latch into `restorableStreak`.
+  if (input.restorableStreak > 0) {
+    const price = streakRestorePrice(input.restorableStreak)
+    offers.push(
+      priced(
+        STREAK_RESTORE_SKU,
+        'Restore your streak',
+        `Bring back the ${input.restorableStreak}-day streak you had in v1`,
+        price,
+      ),
+    )
+  }
+
+  const maxFreezes = TOKEN_RULES.sinks.maxBankedStreakFreezes
+  const freezeOffer = priced(
+    STREAK_FREEZE_SKU,
+    'Streak freeze',
+    // One template string, not two lines: JSX ate the newline between them
+    // and rendered "banked /2".
+    `Saves one missed day · ${input.streakFreezes}/${maxFreezes} banked`,
+    TOKEN_RULES.sinks.streakFreeze,
+  )
+  // A full bank is not "owned" — it is temporarily unbuyable, and it becomes
+  // buyable again the next time one is spent, so it must not read as a
+  // permanent state.
+  offers.push({
+    ...freezeOffer,
+    affordable: freezeOffer.affordable && input.streakFreezes < maxFreezes,
+  })
+
+  for (const item of COSMETICS) {
+    offers.push(
+      priced(
+        item.id,
+        item.label,
+        item.kind === 'frame' ? 'Profile frame' : 'Title',
+        item.price,
+        input.owned.includes(item.id),
+      ),
+    )
+  }
+
+  return offers
+}


### PR DESCRIPTION
## What

The store was ~70 lines of JSX in the middle of `me.tsx`, below the languages and above "Edit profile" — a place nothing could be added to without pushing the rest of the profile further down. It now lives at `/(app)/store`, reached by tapping the Balance stat.

## A route, not a sheet

The app has no modal routes anywhere (`presentation` has zero hits). Adding the first one means `@gorhom/bottom-sheet` plus `react-native-gesture-handler` — which, under pnpm's isolated layout, does not resolve from `apps/mobile` at all — for a surface that cannot be deep-linked or backed out of. The route is registered `FULL_SCREEN` in `app/(app)/_layout.tsx`; without that a fifth tab button appears.

The Balance stat is now a `Pressable` with a `›` affordance. A number nobody can act on reads as decoration, and after the extraction the store had nowhere else to be reached from.

## `buildStoreOffers` is the point

The restore latch, the banked-freeze cap, cosmetic ownership and affordability were four rules living inside `disabled` props — correct, and unreachable by `vitest.config.ts`, which only includes `src/lib`.

## One behaviour change

Writing the rules down surfaced one. The streak-freeze button was pressable with a full bank and the purchase came back as an error; the server has always refused it (`apps/api/src/modules/tokens/wallet.ts:78`). It is now disabled. A full bank is modelled as *unaffordable* rather than *owned*, because it becomes buyable again the next time one is spent.

## Tests

`apps/mobile/src/lib/storeOffers.test.ts` — 10 cases: the restore offer absent without a v1 streak, priced per day, capped at `streakRestoreMax`; the freeze unaffordable below price and at the bank cap, buyable one below it; owned cosmetics never buyable at any balance.

Full suite green: 336 api, 61 mobile, 104 shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)