### PR TITLE
Replace the list spinners with placeholders shaped like the rows

### DIFF
--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -2,7 +2,6 @@ import { useQueryClient } from '@tanstack/react-query'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
-  ActivityIndicator,
   FlatList,
   KeyboardAvoidingView,
   Platform,
@@ -21,6 +20,7 @@ import {
   type MessageDto,
 } from '../../../src/api/queries'
 import { api, ApiRequestError } from '../../../src/api/client'
+import { MessageBubbleSkeleton } from '../../../src/components/skeletons/MessageBubbleSkeleton'
 import { Avatar } from '../../../src/components/ui/Avatar'
 import { Screen } from '../../../src/components/ui/Screen'
 import { useProfileCache } from '../../../src/hooks/useProfileCache'
@@ -30,6 +30,7 @@ import { MessageMeta } from '../../../src/components/MessageMeta'
 import { useVoiceRecorder } from '../../../src/hooks/useVoiceRecorder'
 import { showAlert } from '../../../src/lib/alert'
 import { emitWithAck, getSocket } from '../../../src/lib/socket'
+import { listState } from '../../../src/lib/listState'
 import { colors, font, radius, spacing } from '../../../src/lib/theme'
 
 export default function ChatScreen() {
@@ -54,6 +55,11 @@ export default function ChatScreen() {
   const typingTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const items = messages.data?.items ?? []
+  const state = listState({
+    isPending: messages.isPending,
+    isError: messages.isError,
+    itemCount: items.length,
+  })
   // From the participant list, not from the messages: a thread nobody has
   // replied to yet contains only my own sends, and reading the partner off
   // those leaves the header with no name and no avatar.
@@ -231,8 +237,15 @@ export default function ChatScreen() {
         </Pressable>
       </View>
 
-      {messages.isPending ? (
-        <ActivityIndicator style={styles.loading} />
+      {state === 'skeleton' ? (
+        // `flex: 1` because the FlatList it stands in for takes the whole
+        // height; without it the composer rides up under the placeholders and
+        // then drops when the real thread arrives.
+        <View style={[styles.list, styles.skeletonFill]}>
+          {SKELETON_BUBBLES.map((key, index) => (
+            <MessageBubbleSkeleton key={key} index={index} />
+          ))}
+        </View>
       ) : (
         <FlatList
           ref={listRef}
@@ -404,8 +417,8 @@ const styles = StyleSheet.create({
   headerUser: { alignItems: 'center', flexDirection: 'row', gap: spacing.sm },
   headerName: { ...font.body, color: colors.text, fontWeight: '700' },
   typing: { ...font.caption, color: colors.accent },
-  loading: { marginTop: spacing.xxl },
   list: { gap: spacing.xs, paddingHorizontal: spacing.lg, paddingVertical: spacing.md },
+  skeletonFill: { flex: 1 },
   bubble: {
     borderRadius: radius.lg,
     maxWidth: '80%',
@@ -496,3 +509,6 @@ const styles = StyleSheet.create({
   recordingCancel: { ...font.caption, color: colors.textMuted },
   sendLabel: { color: colors.primaryText, fontSize: 20, fontWeight: '700' },
 })
+
+/** A thread's worth; the composer sits below them either way. */
+const SKELETON_BUBBLES = ['a', 'b', 'c', 'd', 'e', 'f']

--- a/apps/mobile/app/(app)/chats.tsx
+++ b/apps/mobile/app/(app)/chats.tsx
@@ -1,11 +1,14 @@
 import { router } from 'expo-router'
-import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from 'react-native'
+import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native'
 import { useConversations, useMe } from '../../src/api/queries'
+import { ConversationRowSkeleton } from '../../src/components/skeletons/ConversationRowSkeleton'
 import { Avatar } from '../../src/components/ui/Avatar'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
+import { Skeleton } from '../../src/components/ui/Skeleton'
 import { useProfileCache } from '../../src/hooks/useProfileCache'
-import { colors, font, radius, spacing } from '../../src/lib/theme'
+import { listState } from '../../src/lib/listState'
+import { colors, font, layout, radius, spacing } from '../../src/lib/theme'
 
 function relativeTime(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime()
@@ -29,13 +32,22 @@ export default function ChatsScreen() {
     .map((c) => c.participants.find((p) => p !== me.data?._id))
     .filter((id): id is string => Boolean(id))
   const partners = useProfileCache(partnerIds)
+  const state = listState({
+    isPending: conversations.isPending,
+    isError: conversations.isError,
+    itemCount: items.length,
+  })
 
   return (
     <Screen fluid>
       <Text style={styles.title}>Chats</Text>
 
-      {conversations.isPending ? (
-        <ActivityIndicator style={styles.loading} />
+      {state === 'skeleton' ? (
+        <View style={styles.list}>
+          {SKELETON_ROWS.map((key) => (
+            <ConversationRowSkeleton key={key} />
+          ))}
+        </View>
       ) : (
         <FlatList
           data={items}
@@ -61,16 +73,31 @@ export default function ChatsScreen() {
                 onPress={() => router.push(`/(app)/chat/${item._id}`)}
                 style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
               >
-                <Avatar
-                  url={partner?.avatarUrl}
-                  name={partner?.displayName ?? '?'}
-                  online={partner?.isOnline ?? false}
-                />
+                {partner ? (
+                  <Avatar
+                    url={partner.avatarUrl}
+                    name={partner.displayName}
+                    online={partner.isOnline}
+                  />
+                ) : (
+                  <Skeleton
+                    width={layout.avatar}
+                    height={layout.avatar}
+                    radius={layout.avatar / 2}
+                  />
+                )}
                 <View style={styles.body}>
                   <View style={styles.top}>
-                    <Text style={styles.name} numberOfLines={1}>
-                      {partner?.displayName ?? 'Loading…'}
-                    </Text>
+                    {partner ? (
+                      <Text style={styles.name} numberOfLines={1}>
+                        {partner.displayName}
+                      </Text>
+                    ) : (
+                      // The row is real, its partner is not resolved yet: the
+                      // names come from a separate batched query. This used to
+                      // read "Loading…", which looked like somebody's name.
+                      <Skeleton width={132} height={15} />
+                    )}
                     <Text style={styles.time}>{relativeTime(item.lastMessage.createdAt)}</Text>
                   </View>
                   <View style={styles.bottom}>
@@ -99,7 +126,6 @@ export default function ChatsScreen() {
 
 const styles = StyleSheet.create({
   title: { ...font.title, color: colors.text, paddingTop: spacing.md },
-  loading: { marginTop: spacing.xxl },
   list: { paddingBottom: spacing.xxl, paddingTop: spacing.md },
   row: {
     alignItems: 'center',
@@ -127,3 +153,6 @@ const styles = StyleSheet.create({
   },
   badgeText: { color: colors.primaryText, fontSize: 11, fontWeight: '700' },
 })
+
+/** Enough to fill a phone; the list scrolls before it needs more. */
+const SKELETON_ROWS = ['a', 'b', 'c', 'd', 'e', 'f', 'g']

--- a/apps/mobile/app/(app)/discover.tsx
+++ b/apps/mobile/app/(app)/discover.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../src/api/queries'
 import { ApiRequestError } from '../../src/api/client'
 import type { DiscoveryItem } from '../../src/api/types'
+import { DiscoveryCardSkeleton } from '../../src/components/skeletons/DiscoveryCardSkeleton'
 import { Avatar } from '../../src/components/ui/Avatar'
 import { Chip } from '../../src/components/ui/Chip'
 import { EmptyState } from '../../src/components/ui/EmptyState'
@@ -40,6 +41,7 @@ import {
 import { showAlert } from '../../src/lib/alert'
 import { captureLocation, LOCATION_FAILURE_MESSAGE } from '../../src/lib/location'
 import { openPaywall } from '../../src/lib/paywall'
+import { listState } from '../../src/lib/listState'
 import { colors, font, radius, spacing } from '../../src/lib/theme'
 
 const SORTS: { key: DiscoverySort; label: string }[] = [
@@ -118,6 +120,11 @@ export default function DiscoverScreen() {
   })
 
   const items = query.data?.pages.flatMap((page) => page.items) ?? []
+  const state = listState({
+    isPending: query.isPending,
+    isError: query.isError,
+    itemCount: items.length,
+  })
   const count = activeCount(effective)
   const locationRevoked =
     query.error instanceof ApiRequestError && query.error.code === 'LOCATION_REQUIRED'
@@ -171,8 +178,12 @@ export default function DiscoverScreen() {
         ) : null}
       </View>
 
-      {query.isPending ? (
-        <ActivityIndicator style={styles.loading} />
+      {state === 'skeleton' ? (
+        <View style={styles.list}>
+          {SKELETON_ROWS.map((key) => (
+            <DiscoveryCardSkeleton key={key} />
+          ))}
+        </View>
       ) : locationRevoked ? (
         /**
          * The client checked before switching, so reaching here means sharing
@@ -263,7 +274,6 @@ const styles = StyleSheet.create({
   header: { paddingTop: spacing.md },
   title: { ...font.title, color: colors.text },
   filters: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.xs, marginTop: spacing.md },
-  loading: { marginTop: spacing.xxl },
   list: { paddingBottom: spacing.xxl, paddingTop: spacing.md },
   footer: { paddingVertical: spacing.lg },
   card: {
@@ -284,3 +294,6 @@ const styles = StyleSheet.create({
   distance: { ...font.caption, color: colors.textMuted, marginTop: 2 },
   bio: { ...font.caption, color: colors.textMuted, marginTop: 2 },
 })
+
+/** Enough to fill a phone; the list scrolls before it needs more. */
+const SKELETON_ROWS = ['a', 'b', 'c', 'd', 'e', 'f', 'g']

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -16,7 +16,13 @@ import type {
   Wallet,
   TokenSummary,
 } from './types'
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
 import { api } from './client'
 
 /**
@@ -182,6 +188,13 @@ export function useDiscovery(params: Record<string, string>) {
       ),
     initialPageParam: '',
     getNextPageParam: (last) => last.nextCursor ?? undefined,
+    /**
+     * The query key is the whole serialised query string, so every filter
+     * chip creates a fresh cache entry and flips `isPending`. Without this,
+     * one tap replaces the entire list with placeholders — which is a worse
+     * answer than the spinner the placeholders were meant to improve on.
+     */
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/apps/mobile/src/components/skeletons/ConversationRowSkeleton.tsx
+++ b/apps/mobile/src/components/skeletons/ConversationRowSkeleton.tsx
@@ -1,0 +1,39 @@
+import { StyleSheet, View } from 'react-native'
+import { colors, layout, spacing } from '../../lib/theme'
+import { Skeleton } from '../ui/Skeleton'
+
+/**
+ * Geometry copied from `chats.tsx`'s row rather than approximated. A
+ * placeholder of a different height makes the real rows jump into place when
+ * they arrive, which reads worse than the spinner it replaced.
+ */
+export function ConversationRowSkeleton() {
+  return (
+    <View style={styles.row}>
+      <Skeleton width={layout.avatar} height={layout.avatar} radius={layout.avatar / 2} />
+      <View style={styles.body}>
+        <View style={styles.top}>
+          <Skeleton width={132} height={15} />
+          <Skeleton width={34} height={11} />
+        </View>
+        <View style={styles.bottom}>
+          <Skeleton width="70%" height={12} />
+        </View>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  body: { flex: 1 },
+  bottom: { alignItems: 'center', flexDirection: 'row', gap: spacing.sm, marginTop: 4 },
+  row: {
+    alignItems: 'center',
+    borderBottomColor: colors.border,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: spacing.md,
+    paddingVertical: spacing.md,
+  },
+  top: { alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between' },
+})

--- a/apps/mobile/src/components/skeletons/DiscoveryCardSkeleton.tsx
+++ b/apps/mobile/src/components/skeletons/DiscoveryCardSkeleton.tsx
@@ -1,0 +1,34 @@
+import { StyleSheet, View } from 'react-native'
+import { colors, layout, spacing } from '../../lib/theme'
+import { Skeleton } from '../ui/Skeleton'
+
+/** Geometry copied from `discover.tsx`'s card — name row, language line, bio. */
+export function DiscoveryCardSkeleton() {
+  return (
+    <View style={styles.card}>
+      <Skeleton width={layout.avatar} height={layout.avatar} radius={layout.avatar / 2} />
+      <View style={styles.body}>
+        <View style={styles.top}>
+          <Skeleton width={118} height={15} />
+          <Skeleton width={22} height={11} />
+        </View>
+        <Skeleton width={160} height={12} style={styles.line} />
+        <Skeleton width="88%" height={12} style={styles.line} />
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  body: { flex: 1 },
+  card: {
+    alignItems: 'center',
+    borderBottomColor: colors.border,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: spacing.md,
+    paddingVertical: spacing.md,
+  },
+  line: { marginTop: 4 },
+  top: { alignItems: 'center', flexDirection: 'row', gap: spacing.sm },
+})

--- a/apps/mobile/src/components/skeletons/MessageBubbleSkeleton.tsx
+++ b/apps/mobile/src/components/skeletons/MessageBubbleSkeleton.tsx
@@ -1,0 +1,33 @@
+import { StyleSheet, View } from 'react-native'
+import { colors, radius, spacing } from '../../lib/theme'
+import { Skeleton } from '../ui/Skeleton'
+
+/**
+ * A thread's worth of placeholder bubbles, alternating sides.
+ *
+ * Widths vary per index on purpose: a column of identical bars reads as a
+ * loading bar, and what is loading here is a conversation.
+ */
+export function MessageBubbleSkeleton({ index }: { index: number }) {
+  const mine = index % 2 === 1
+  const width = WIDTHS[index % WIDTHS.length] ?? WIDTHS[0]
+  return (
+    <View style={[styles.bubble, mine ? styles.mine : styles.theirs]}>
+      <Skeleton width={width} height={14} />
+    </View>
+  )
+}
+
+const WIDTHS: readonly [number, ...number[]] = [168, 96, 210, 132, 76, 190]
+
+const styles = StyleSheet.create({
+  bubble: {
+    borderRadius: radius.lg,
+    marginTop: spacing.sm,
+    maxWidth: '80%',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  mine: { alignSelf: 'flex-end', backgroundColor: colors.primary },
+  theirs: { alignSelf: 'flex-start', backgroundColor: colors.surface },
+})

--- a/apps/mobile/src/components/ui/Skeleton.tsx
+++ b/apps/mobile/src/components/ui/Skeleton.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react'
+import { Animated, StyleSheet, type ViewStyle } from 'react-native'
+import { colors, radius } from '../../lib/theme'
+
+/**
+ * A placeholder block that pulses while its real content loads.
+ *
+ * RN's `Animated` rather than Reanimated, following `ToastHost`. Opacity with
+ * `useNativeDriver` already runs off the JS thread, which is the only thing
+ * Reanimated would have bought — and Reanimated 4 is imported by nothing in
+ * this app, so reaching for it here would put its worklets bundle into the
+ * shipped web build for a nicer easing curve.
+ */
+export function Skeleton({
+  width,
+  height = 14,
+  radius: corner = radius.sm,
+  style,
+}: {
+  width?: number | `${number}%`
+  height?: number
+  radius?: number
+  style?: ViewStyle
+}) {
+  const opacity = useRef(new Animated.Value(MIN_OPACITY)).current
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, { toValue: 1, duration: 700, useNativeDriver: true }),
+        Animated.timing(opacity, { toValue: MIN_OPACITY, duration: 700, useNativeDriver: true }),
+      ]),
+    )
+    loop.start()
+    return () => loop.stop()
+  }, [opacity])
+
+  return (
+    <Animated.View
+      // Not `accessibilityRole="none"`: a screen reader should skip this
+      // entirely rather than announce an empty element per placeholder row.
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={[
+        styles.block,
+        { borderRadius: corner, height, opacity },
+        width ? { width } : null,
+        style,
+      ]}
+    />
+  )
+}
+
+const MIN_OPACITY = 0.35
+
+const styles = StyleSheet.create({
+  block: { backgroundColor: colors.border },
+})

--- a/apps/mobile/src/lib/listState.test.ts
+++ b/apps/mobile/src/lib/listState.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { listState } from './listState'
+
+describe('listState', () => {
+  it('shows a skeleton only while there is nothing for this query key yet', () => {
+    expect(listState({ isPending: true, isError: false, itemCount: 0 })).toBe('skeleton')
+  })
+
+  it('shows content as soon as there are rows', () => {
+    expect(listState({ isPending: false, isError: false, itemCount: 3 })).toBe('content')
+  })
+
+  /**
+   * An infinite query fetching page two is not pending, but even if a caller
+   * conflates the two flags the rows already on screen must not be replaced
+   * by placeholders.
+   */
+  it('keeps showing content while another page loads', () => {
+    expect(listState({ isPending: true, isError: false, itemCount: 20 })).toBe('content')
+  })
+
+  it('leaves an empty successful result to the caller`s empty state', () => {
+    expect(listState({ isPending: false, isError: false, itemCount: 0 })).toBe('empty')
+  })
+
+  /** A failed refetch is pending-with-nothing; a pulse there promises data that is not coming. */
+  it('does not pulse forever over an error', () => {
+    expect(listState({ isPending: true, isError: true, itemCount: 0 })).toBe('empty')
+  })
+})

--- a/apps/mobile/src/lib/listState.ts
+++ b/apps/mobile/src/lib/listState.ts
@@ -1,0 +1,21 @@
+export type ListState = 'skeleton' | 'empty' | 'content'
+
+/**
+ * What a list should draw right now.
+ *
+ * One place rather than a condition per screen, because the interesting case
+ * is not the first load: an infinite query fetching page two is `isFetching`
+ * with items already on screen, and a refetch after an error is `isPending`
+ * with nothing. Only `isPending` — no data for this query key at all — is a
+ * skeleton; anything else with rows is content, and the caller's empty state
+ * gets the rest.
+ */
+export function listState(input: {
+  isPending: boolean
+  isError: boolean
+  itemCount: number
+}): ListState {
+  if (input.itemCount > 0) return 'content'
+  if (input.isPending && !input.isError) return 'skeleton'
+  return 'empty'
+}


### PR DESCRIPTION
## What

Chats, Discover and a chat thread each showed a centred `ActivityIndicator` while their first page loaded. They now draw placeholder rows.

The geometry is copied from each screen's own styles, not approximated — a placeholder of a different height makes the real content jump into place when it arrives, which reads worse than the spinner it replaced. Verified against screenshots of the loaded lists at the same viewport: the row pitch matches.

## RN `Animated`, not Reanimated

`ToastHost.tsx` is the precedent. Opacity with `useNativeDriver: true` already runs off the JS thread, which is the only thing Reanimated would have bought. `react-native-reanimated@4.5.1` is installed but imported by no app code and `babel.config.js` is bare, so reaching for it here would pull its worklets bundle into the shipped web build in exchange for a nicer easing curve.

## `keepPreviousData` is part of this change, not a separable nicety

`keys.discovery(search)` is the entire serialised query string, so every filter chip tap creates a fresh cache entry and flips `isPending`. Without `placeholderData: keepPreviousData`, this PR would turn one centred spinner per tap into *the whole list flashing placeholders* — strictly worse than what is there today. Screenshot check: with the Online chip tapped and `/discovery` delayed 5s, the previous list is still on screen and the chip reads selected.

## Two smaller things it fixes

- `chats.tsx` rendered the literal string `Loading…` where a partner's name goes. Names come from a separate batched query, so a real row can outrun its partner; the text looked like somebody's name. It is a placeholder now, avatar included.
- The chat thread's placeholder container is `flex: 1`, so the composer stays at the bottom instead of riding up and then dropping when the thread arrives.

## Tests

`apps/mobile/src/lib/listState.test.ts` — the one testable piece, and the one easy to get wrong once pagination lands: rows already on screen stay content even while another page is pending, and a failed refetch does not pulse forever.

Components remain out of scope for `apps/mobile/vitest.config.ts`, so the pulse itself is verified by screenshot, not by test.

Full suite green: 337 api, 75 mobile, 104 shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)