### PR TITLE
Page the chat list and the message history, and stop refetching everything

### DIFF
--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -133,6 +133,36 @@ describe('Faz 5 — conversation/message history REST', () => {
     expect(body.items[0]?.participants).toContain(newer.userId) // most recent activity first
   })
 
+  /**
+   * The client only started reading `nextCursor` here once the chat list
+   * became an infinite query. The server side was already right; this pins it
+   * before anything depends on it.
+   */
+  it('pages the conversation list without repeating or skipping a thread', async () => {
+    const viewer = await newUser('page-convos-viewer@example.com')
+    const partners = []
+    for (const name of ['a', 'b', 'c']) {
+      const partner = await newUser(`page-convos-${name}@example.com`)
+      await startConversation(viewer, partner.userId, `thread ${name}`)
+      partners.push(partner.userId)
+    }
+
+    const seen: string[] = []
+    let cursor: string | null = ''
+    do {
+      const url: string = `/conversations?limit=1${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`
+      const page = await app.inject({ method: 'GET', url, headers: { cookie: viewer.cookie } })
+      expect(page.statusCode, page.body).toBe(200)
+      const body = page.json<{ items: { _id: string }[]; nextCursor: string | null }>()
+      expect(body.items.length).toBeLessThanOrEqual(1)
+      seen.push(...body.items.map((c) => c._id))
+      cursor = body.nextCursor
+    } while (cursor)
+
+    expect(seen).toHaveLength(3)
+    expect(new Set(seen).size).toBe(3)
+  })
+
   it('404s the message history of a conversation you are not part of', async () => {
     const a = await newUser('history-a@example.com')
     const b = await newUser('history-b@example.com')

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
+  ActivityIndicator,
   FlatList,
   KeyboardAvoidingView,
   Platform,
@@ -31,6 +32,7 @@ import { useVoiceRecorder } from '../../../src/hooks/useVoiceRecorder'
 import { showAlert } from '../../../src/lib/alert'
 import { emitWithAck, getSocket } from '../../../src/lib/socket'
 import { listState } from '../../../src/lib/listState'
+import { flattenMessagePages } from '../../../src/lib/messageCache'
 import { colors, font, radius, spacing } from '../../../src/lib/theme'
 
 export default function ChatScreen() {
@@ -49,12 +51,14 @@ export default function ChatScreen() {
   const [translations, setTranslations] = useState<Record<string, string>>({})
   const [translating, setTranslating] = useState<string | null>(null)
   const listRef = useRef<FlatList<MessageDto>>(null)
+  // Starts true: a thread opens at its newest message.
+  const atBottom = useRef(true)
   const translateApi = useTranslate()
   const recorder = useVoiceRecorder()
   const [sendingMedia, setSendingMedia] = useState(false)
   const typingTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const items = messages.data?.items ?? []
+  const items = flattenMessagePages(messages.data)
   const state = listState({
     isPending: messages.isPending,
     isError: messages.isError,
@@ -65,7 +69,7 @@ export default function ChatScreen() {
   // those leaves the header with no name and no avatar.
   // Optional on `participants` too: the response is a bare cast, so an API
   // older than this field would throw here rather than fall back.
-  const partnerId = messages.data?.participants?.find((p) => p !== me.data?._id) ?? ''
+  const partnerId = messages.data?.pages[0]?.participants?.find((p) => p !== me.data?._id) ?? ''
   const partners = useProfileCache(partnerId ? [partnerId] : [])
   const partner = partners[partnerId]
 
@@ -252,7 +256,43 @@ export default function ChatScreen() {
           data={items}
           keyExtractor={(item) => String(item._id)}
           contentContainerStyle={styles.list}
-          onContentSizeChange={() => listRef.current?.scrollToEnd({ animated: false })}
+          /**
+           * Keeps the newest message in view while the reader is at the
+           * bottom, and stops the moment they scroll up.
+           *
+           * "Have we done it once" is the obvious gate and the wrong one: the
+           * first size change arrives before the rows have finished laying
+           * out, so a one-shot scroll lands in the middle of the thread and
+           * never corrects. Unconditional is also wrong — it yanks the reader
+           * back down every time a page of older messages arrives, which
+           * makes scrolling up impossible rather than merely jarring.
+           */
+          onContentSizeChange={() => {
+            if (!atBottom.current) return
+            // One frame later. `scrollToEnd` resolves against the content size
+            // as it is *now*, and rows are still settling when this fires —
+            // scrolling synchronously lands a hundred-odd pixels short and
+            // there is no second size change to correct it.
+            requestAnimationFrame(() => listRef.current?.scrollToEnd({ animated: false }))
+          }}
+          onScroll={({ nativeEvent }) => {
+            const { contentOffset, contentSize, layoutMeasurement } = nativeEvent
+            const distanceFromBottom =
+              contentSize.height - contentOffset.y - layoutMeasurement.height
+            atBottom.current = distanceFromBottom <= BOTTOM_ANCHOR_SLACK
+
+            // Older messages load from the top. `onStartReached` does not
+            // exist on react-native-web's FlatList, and this app ships the
+            // same code to the browser.
+            if (contentOffset.y > OLDER_MESSAGES_THRESHOLD) return
+            if (messages.hasNextPage && !messages.isFetchingNextPage) {
+              void messages.fetchNextPage()
+            }
+          }}
+          scrollEventThrottle={16}
+          ListHeaderComponent={
+            messages.isFetchingNextPage ? <ActivityIndicator style={styles.older} /> : null
+          }
           renderItem={({ item }) => {
             const mine = isMine(item)
             if (item.type === 'correction') {
@@ -419,6 +459,7 @@ const styles = StyleSheet.create({
   typing: { ...font.caption, color: colors.accent },
   list: { gap: spacing.xs, paddingHorizontal: spacing.lg, paddingVertical: spacing.md },
   skeletonFill: { flex: 1 },
+  older: { paddingVertical: spacing.md },
   bubble: {
     borderRadius: radius.lg,
     maxWidth: '80%',
@@ -512,3 +553,15 @@ const styles = StyleSheet.create({
 
 /** A thread's worth; the composer sits below them either way. */
 const SKELETON_BUBBLES = ['a', 'b', 'c', 'd', 'e', 'f']
+
+/** Pixels from the top at which the next page of history is requested. */
+const OLDER_MESSAGES_THRESHOLD = 80
+
+/**
+ * How far off the bottom still counts as "following the conversation".
+ *
+ * Wider than the list's own padding so a settled `scrollToEnd` still reads as
+ * "at the bottom", and far narrower than a deliberate scroll back through the
+ * history — which is the gesture this has to stop stealing.
+ */
+const BOTTOM_ANCHOR_SLACK = 120

--- a/apps/mobile/app/(app)/chats.tsx
+++ b/apps/mobile/app/(app)/chats.tsx
@@ -1,5 +1,13 @@
 import { router } from 'expo-router'
-import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
 import { useConversations, useMe } from '../../src/api/queries'
 import { ConversationRowSkeleton } from '../../src/components/skeletons/ConversationRowSkeleton'
 import { Avatar } from '../../src/components/ui/Avatar'
@@ -7,6 +15,7 @@ import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
 import { Skeleton } from '../../src/components/ui/Skeleton'
 import { useProfileCache } from '../../src/hooks/useProfileCache'
+import { dedupeById } from '../../src/lib/dedupeById'
 import { listState } from '../../src/lib/listState'
 import { colors, font, layout, radius, spacing } from '../../src/lib/theme'
 
@@ -25,7 +34,10 @@ function relativeTime(iso: string): string {
 export default function ChatsScreen() {
   const me = useMe()
   const conversations = useConversations()
-  const items = conversations.data?.items ?? []
+  // Deduped on flatten: a keyset cursor over a moving sort key can emit the
+  // same row on two pages, and a duplicate `key` in a FlatList is a warning
+  // plus a row that never updates.
+  const items = dedupeById(conversations.data?.pages.flatMap((page) => page.items) ?? [])
 
   // One batched lookup for every counterpart, instead of a query per row.
   const partnerIds = items
@@ -53,6 +65,21 @@ export default function ChatsScreen() {
           data={items}
           keyExtractor={(item) => item._id}
           contentContainerStyle={styles.list}
+          refreshControl={
+            <RefreshControl
+              refreshing={conversations.isRefetching}
+              onRefresh={() => void conversations.refetch()}
+            />
+          }
+          onEndReachedThreshold={0.6}
+          onEndReached={() => {
+            if (conversations.hasNextPage && !conversations.isFetchingNextPage) {
+              void conversations.fetchNextPage()
+            }
+          }}
+          ListFooterComponent={
+            conversations.isFetchingNextPage ? <ActivityIndicator style={styles.footer} /> : null
+          }
           ListEmptyComponent={
             <EmptyState
               emoji="💬"
@@ -127,6 +154,7 @@ export default function ChatsScreen() {
 const styles = StyleSheet.create({
   title: { ...font.title, color: colors.text, paddingTop: spacing.md },
   list: { paddingBottom: spacing.xxl, paddingTop: spacing.md },
+  footer: { paddingVertical: spacing.lg },
   row: {
     alignItems: 'center',
     borderBottomColor: colors.border,

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -24,6 +24,8 @@ import {
   useQueryClient,
 } from '@tanstack/react-query'
 import { api } from './client'
+import type { ConversationPageDto } from '../lib/conversationCache'
+import type { MessagePageDto } from '../lib/messageCache'
 
 /**
  * Query keys in one place. A typo in an inline key array is invisible — the
@@ -208,10 +210,14 @@ export interface ConversationDto {
 }
 
 export function useConversations() {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: keys.conversations,
-    queryFn: () =>
-      api.get<{ items: ConversationDto[]; nextCursor: string | null }>('/conversations'),
+    queryFn: ({ pageParam }) =>
+      api.get<ConversationPageDto>(
+        `/conversations${pageParam ? `?cursor=${encodeURIComponent(pageParam)}` : ''}`,
+      ),
+    initialPageParam: '',
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
   })
 }
 
@@ -238,12 +244,19 @@ export interface MessageDto {
 }
 
 export function useMessages(conversationId: string) {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: keys.messages(conversationId),
-    queryFn: () =>
-      api.get<{ items: MessageDto[]; nextCursor: string | null; participants: string[] }>(
-        `/conversations/${conversationId}/messages`,
+    queryFn: ({ pageParam }) =>
+      api.get<MessagePageDto>(
+        `/conversations/${conversationId}/messages${
+          pageParam ? `?cursor=${encodeURIComponent(pageParam)}` : ''
+        }`,
       ),
+    initialPageParam: '',
+    // The cursor walks *backwards* into history, so "the next page" is older
+    // messages and `pages[0]` stays the newest. `flattenMessagePages` is the
+    // only sanctioned way to read this — see the note there.
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
     enabled: conversationId.length > 0,
   })
 }

--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -1,7 +1,10 @@
+import type { InfiniteData } from '@tanstack/react-query'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import type { MessageDto } from '../api/queries'
 import { keys } from '../api/queries'
+import { applyIncomingMessage, type ConversationPageDto } from '../lib/conversationCache'
+import { appendIncomingMessage, applyDeliveredAt, type MessagePageDto } from '../lib/messageCache'
 import { closeSocket, getSocket } from '../lib/socket'
 
 /**
@@ -28,17 +31,35 @@ export function useSocket(): void {
             ? message.conversationId
             : String(message.conversationId)
 
-        queryClient.setQueryData<{ items: MessageDto[]; nextCursor: string | null }>(
+        queryClient.setQueryData<InfiniteData<MessagePageDto>>(
           keys.messages(conversationId),
-          (old) => {
-            if (!old) return old
-            // The sender already appended this optimistically; the socket
-            // echoes to *both* participants, so guard against a duplicate.
-            if (old.items.some((m) => String(m._id) === String(message._id))) return old
-            return { ...old, items: [...old.items, message] }
-          },
+          (old) => appendIncomingMessage(old, message) ?? old,
         )
-        void queryClient.invalidateQueries({ queryKey: keys.conversations })
+
+        /**
+         * Patched rather than invalidated. On an infinite query
+         * `invalidateQueries` refetches *every loaded page*, sequentially —
+         * one request while the chat list had one page, ten once someone has
+         * scrolled, on every single incoming message. The fall back to
+         * invalidating is for a conversation that has scrolled out of the
+         * loaded pages, which is the one case this cannot patch.
+         */
+        const meId = queryClient.getQueryData<{ _id: string }>(keys.me)?._id
+        let patched = false
+        queryClient.setQueryData<InfiniteData<ConversationPageDto>>(keys.conversations, (old) => {
+          if (!old || !meId) return old
+          const next = applyIncomingMessage(old, {
+            conversationId,
+            body: message.body,
+            senderId: message.senderId,
+            createdAt: message.createdAt,
+            forUserId: meId,
+          })
+          if (!next) return old
+          patched = true
+          return next
+        })
+        if (!patched) void queryClient.invalidateQueries({ queryKey: keys.conversations })
         void queryClient.invalidateQueries({ queryKey: keys.tokens })
       })
 
@@ -62,31 +83,22 @@ export function useSocket(): void {
           deliveredTo: string
           deliveredAt: string
         }) => {
-          queryClient.setQueryData<{ items: MessageDto[]; nextCursor: string | null }>(
+          queryClient.setQueryData<InfiniteData<MessagePageDto>>(
             keys.messages(conversationId),
-            (old) => {
-              if (!old) return old
-              // The server stamped every message in the thread the recipient
-              // had not received yet, so this mirrors that filter exactly:
-              // theirs are not mine to mark, and an existing timestamp is the
-              // moment it actually arrived.
-              let changed = false
-              const items = old.items.map((message) => {
-                if (message.senderId === deliveredTo || message.deliveredAt) return message
-                changed = true
-                return { ...message, deliveredAt }
-              })
-              return changed ? { ...old, items } : old
-            },
+            (old) => applyDeliveredAt(old, { deliveredTo, deliveredAt }) ?? old,
           )
         },
       )
 
+      /**
+       * Still invalidated, unlike `message:new` above. This fires once when
+       * someone opens a thread, not once per message, so refetching the
+       * loaded pages is cheap here — and the event is delivered only to the
+       * *other* participant, carrying `readBy`, which is not the unread count
+       * this client draws. Patching it would change nothing visible.
+       */
       socket.on('conversation:read', ({ conversationId }: { conversationId: string }) => {
         void queryClient.invalidateQueries({ queryKey: keys.messages(conversationId) })
-        // The chat list too: reading a conversation clears its unread count,
-        // and without this the badge stays up until something else happens to
-        // refetch — including when *you* are the one who read it elsewhere.
         void queryClient.invalidateQueries({ queryKey: keys.conversations })
       })
     })()

--- a/apps/mobile/src/lib/conversationCache.test.ts
+++ b/apps/mobile/src/lib/conversationCache.test.ts
@@ -1,0 +1,86 @@
+import type { InfiniteData } from '@tanstack/react-query'
+import { describe, expect, it } from 'vitest'
+import type { ConversationDto } from '../api/queries'
+import { applyIncomingMessage, type ConversationPageDto } from './conversationCache'
+
+const ME = 'me'
+const THEM = 'them'
+
+function conversation(id: string, unreadForMe = 0): ConversationDto {
+  return {
+    _id: id,
+    participants: [ME, THEM],
+    lastMessage: { body: `old ${id}`, senderId: THEM, createdAt: '2026-08-01T00:00:00.000Z' },
+    unread: { [ME]: unreadForMe, [THEM]: 0 },
+    bothSpoke: true,
+    updatedAt: '2026-08-01T00:00:00.000Z',
+  }
+}
+
+function pages(...groups: ConversationDto[][]): InfiniteData<ConversationPageDto> {
+  return {
+    pages: groups.map((items, i) => ({ items, nextCursor: i === groups.length - 1 ? null : 'c' })),
+    pageParams: groups.map((_, i) => (i === 0 ? '' : 'c')),
+  }
+}
+
+const incoming = {
+  conversationId: 'c3',
+  body: 'hello',
+  senderId: THEM,
+  createdAt: '2026-08-28T12:00:00.000Z',
+  forUserId: ME,
+}
+
+describe('applyIncomingMessage', () => {
+  it('moves the conversation to the head, even from a later page', () => {
+    const data = pages([conversation('c1'), conversation('c2')], [conversation('c3')])
+    const next = applyIncomingMessage(data, incoming)
+
+    expect(next?.pages[0]?.items.map((c) => c._id)).toEqual(['c3', 'c1', 'c2'])
+    expect(next?.pages[1]?.items).toEqual([])
+  })
+
+  it('carries the new last message', () => {
+    const next = applyIncomingMessage(pages([conversation('c3')]), incoming)
+    expect(next?.pages[0]?.items[0]?.lastMessage).toEqual({
+      body: 'hello',
+      senderId: THEM,
+      createdAt: incoming.createdAt,
+    })
+  })
+
+  it('increments my unread count when someone else wrote', () => {
+    const next = applyIncomingMessage(pages([conversation('c3', 2)]), incoming)
+    expect(next?.pages[0]?.items[0]?.unread[ME]).toBe(3)
+  })
+
+  /** The echo reaches the sender too; their own message is not unread. */
+  it('leaves the count alone when the message is mine', () => {
+    const next = applyIncomingMessage(pages([conversation('c3', 2)]), {
+      ...incoming,
+      senderId: ME,
+    })
+    expect(next?.pages[0]?.items[0]?.unread[ME]).toBe(2)
+  })
+
+  /**
+   * `bothSpoke` means "both have sent at least one message ever", which one
+   * event cannot establish. Guessing it would be wrong in a way nothing
+   * refetches away.
+   */
+  it('does not guess bothSpoke', () => {
+    const data = pages([{ ...conversation('c3'), bothSpoke: false }])
+    const next = applyIncomingMessage(data, incoming)
+    expect(next?.pages[0]?.items[0]?.bothSpoke).toBe(false)
+  })
+
+  /** The caller's signal to fall back to invalidating. */
+  it('returns undefined for a conversation outside the loaded pages', () => {
+    expect(applyIncomingMessage(pages([conversation('c1')]), incoming)).toBeUndefined()
+  })
+
+  it('passes an empty cache straight through', () => {
+    expect(applyIncomingMessage(undefined, incoming)).toBeUndefined()
+  })
+})

--- a/apps/mobile/src/lib/conversationCache.ts
+++ b/apps/mobile/src/lib/conversationCache.ts
@@ -1,0 +1,88 @@
+import type { InfiniteData } from '@tanstack/react-query'
+import type { ConversationDto } from '../api/queries'
+
+export interface ConversationPageDto {
+  items: ConversationDto[]
+  nextCursor: string | null
+}
+
+type Pages = InfiniteData<ConversationPageDto> | undefined
+
+/**
+ * Socket events patched into the paged chat list instead of invalidating it.
+ *
+ * On an infinite query `invalidateQueries` refetches **every loaded page**,
+ * sequentially. The chat list used to do that on every `message:new`, which
+ * was one request while there was one page and is ten once someone has
+ * scrolled. These return `undefined` when the conversation is not in any
+ * loaded page, so the caller can fall back to invalidating — a conversation
+ * that has scrolled off is not one this can patch.
+ */
+export function applyIncomingMessage(
+  data: Pages,
+  input: {
+    conversationId: string
+    body: string
+    senderId: string
+    createdAt: string
+    /** Whose unread count to bump — the signed-in user. */
+    forUserId: string
+  },
+): Pages {
+  if (!data) return data
+  const found = findConversation(data, input.conversationId)
+  if (!found) return undefined
+
+  const patched: ConversationDto = {
+    ...found.conversation,
+    lastMessage: {
+      body: input.body,
+      senderId: input.senderId,
+      createdAt: input.createdAt,
+    },
+    unread:
+      input.senderId === input.forUserId
+        ? found.conversation.unread
+        : {
+            ...found.conversation.unread,
+            [input.forUserId]: (found.conversation.unread[input.forUserId] ?? 0) + 1,
+          },
+    // `bothSpoke` is deliberately left alone. It means "both participants
+    // have sent at least one message ever", which one socket event cannot
+    // establish — the sender may well have spoken before. Guessing it here
+    // would be wrong in a way nothing refetches away.
+    updatedAt: input.createdAt,
+  }
+
+  return moveToHead(data, input.conversationId, patched)
+}
+
+function findConversation(
+  data: InfiniteData<ConversationPageDto>,
+  conversationId: string,
+): { conversation: ConversationDto } | null {
+  for (const page of data.pages) {
+    const conversation = page.items.find((c) => c._id === conversationId)
+    if (conversation) return { conversation }
+  }
+  return null
+}
+
+/**
+ * The server sorts by `lastMessage.createdAt` descending, so a conversation
+ * that just received a message belongs at the very top — whichever page it
+ * was sitting on.
+ */
+function moveToHead(
+  data: InfiniteData<ConversationPageDto>,
+  conversationId: string,
+  patched: ConversationDto,
+): InfiniteData<ConversationPageDto> {
+  const pages = data.pages.map((page) => ({
+    ...page,
+    items: page.items.filter((c) => c._id !== conversationId),
+  }))
+  const [first, ...rest] = pages
+  if (!first) return data
+  return { ...data, pages: [{ ...first, items: [patched, ...first.items] }, ...rest] }
+}

--- a/apps/mobile/src/lib/dedupeById.test.ts
+++ b/apps/mobile/src/lib/dedupeById.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { dedupeById } from './dedupeById'
+
+describe('dedupeById', () => {
+  it('keeps the first of a repeated id', () => {
+    const items = [
+      { _id: 'a', v: 1 },
+      { _id: 'b', v: 2 },
+      { _id: 'a', v: 3 },
+    ]
+    expect(dedupeById(items)).toEqual([
+      { _id: 'a', v: 1 },
+      { _id: 'b', v: 2 },
+    ])
+  })
+
+  it('leaves a list without repeats untouched', () => {
+    const items = [{ _id: 'a' }, { _id: 'b' }]
+    expect(dedupeById(items)).toEqual(items)
+  })
+
+  it('handles an empty list', () => {
+    expect(dedupeById([])).toEqual([])
+  })
+})

--- a/apps/mobile/src/lib/dedupeById.ts
+++ b/apps/mobile/src/lib/dedupeById.ts
@@ -1,0 +1,18 @@
+/**
+ * First occurrence wins.
+ *
+ * Keyset cursors are only stable while the sort key is: pagination over
+ * `lastMessage.createdAt` or `stats.lastActiveAt` can hand back a row already
+ * seen on an earlier page, because the row moved between the two requests.
+ * That is not a bug to fix on the server — the alternative is a snapshot —
+ * but a duplicate `key` in a FlatList is a warning plus a row React will
+ * never update.
+ */
+export function dedupeById<T extends { _id: string }>(items: T[]): T[] {
+  const seen = new Set<string>()
+  return items.filter((item) => {
+    if (seen.has(item._id)) return false
+    seen.add(item._id)
+    return true
+  })
+}

--- a/apps/mobile/src/lib/messageCache.test.ts
+++ b/apps/mobile/src/lib/messageCache.test.ts
@@ -1,0 +1,86 @@
+import type { InfiniteData } from '@tanstack/react-query'
+import { describe, expect, it } from 'vitest'
+import type { MessageDto } from '../api/queries'
+import {
+  appendIncomingMessage,
+  applyDeliveredAt,
+  flattenMessagePages,
+  type MessagePageDto,
+} from './messageCache'
+
+const ME = 'me'
+const THEM = 'them'
+
+function message(id: string, senderId = THEM, deliveredAt?: string): MessageDto {
+  return {
+    _id: id,
+    conversationId: 'c1',
+    senderId,
+    type: 'text',
+    body: id,
+    createdAt: '2026-08-28T12:00:00.000Z',
+    ...(deliveredAt ? { deliveredAt } : {}),
+  }
+}
+
+function pages(...groups: MessageDto[][]): InfiniteData<MessagePageDto> {
+  return {
+    pages: groups.map((items) => ({ items, nextCursor: null, participants: [ME, THEM] })),
+    pageParams: groups.map((_, i) => (i === 0 ? '' : 'c')),
+  }
+}
+
+describe('flattenMessagePages', () => {
+  /**
+   * `pages[0]` is the *newest* page: the cursor walks backwards into history.
+   * Getting this wrong shows a thread with its history in blocks of the wrong
+   * order, which reads as corruption rather than as a paging bug.
+   */
+  it('puts the oldest page first and the newest last', () => {
+    const data = pages([message('new1'), message('new2')], [message('old1'), message('old2')])
+    expect(flattenMessagePages(data).map((m) => m._id)).toEqual(['old1', 'old2', 'new1', 'new2'])
+  })
+
+  it('is empty for an empty cache', () => {
+    expect(flattenMessagePages(undefined)).toEqual([])
+  })
+})
+
+describe('appendIncomingMessage', () => {
+  it('appends to the newest page, not the oldest', () => {
+    const data = pages([message('new1')], [message('old1')])
+    const next = appendIncomingMessage(data, message('fresh'))
+    expect(next?.pages[0]?.items.map((m) => m._id)).toEqual(['new1', 'fresh'])
+    expect(next?.pages[1]?.items.map((m) => m._id)).toEqual(['old1'])
+  })
+
+  /** The sender appended optimistically and the socket echoes to both. */
+  it('ignores a message already in any page', () => {
+    const data = pages([message('new1')], [message('old1')])
+    expect(appendIncomingMessage(data, message('old1'))).toBe(data)
+  })
+})
+
+describe('applyDeliveredAt', () => {
+  const at = '2026-08-28T13:00:00.000Z'
+
+  it('stamps my undelivered messages across every page', () => {
+    const data = pages([message('a', ME)], [message('b', ME)])
+    const next = applyDeliveredAt(data, { deliveredTo: THEM, deliveredAt: at })
+    expect(next?.pages[0]?.items[0]?.deliveredAt).toBe(at)
+    expect(next?.pages[1]?.items[0]?.deliveredAt).toBe(at)
+  })
+
+  it('leaves the recipient`s own messages alone', () => {
+    const data = pages([message('a', THEM)])
+    expect(applyDeliveredAt(data, { deliveredTo: THEM, deliveredAt: at })).toBe(data)
+  })
+
+  /** Delivery is a moment, not a flag — re-stamping drags it forward. */
+  it('does not overwrite a timestamp already there', () => {
+    const earlier = '2026-08-28T11:00:00.000Z'
+    const data = pages([message('a', ME, earlier)])
+    const next = applyDeliveredAt(data, { deliveredTo: THEM, deliveredAt: at })
+    expect(next?.pages[0]?.items[0]?.deliveredAt).toBe(earlier)
+  })
+})

--- a/apps/mobile/src/lib/messageCache.ts
+++ b/apps/mobile/src/lib/messageCache.ts
@@ -1,0 +1,66 @@
+import type { InfiniteData } from '@tanstack/react-query'
+import type { MessageDto } from '../api/queries'
+
+export interface MessagePageDto {
+  items: MessageDto[]
+  nextCursor: string | null
+  participants: string[]
+}
+
+type Pages = InfiniteData<MessagePageDto> | undefined
+
+/**
+ * A page's `items` run oldest → newest, but `nextCursor` walks *backwards*
+ * into history (`listMessages` sorts descending, slices, then reverses). So
+ * `pages[0]` is the newest page and `pages[n]` the oldest, and a new message
+ * always belongs at the end of `pages[0]`.
+ */
+export function appendIncomingMessage(data: Pages, message: MessageDto): Pages {
+  if (!data) return data
+  const [first, ...rest] = data.pages
+  if (!first) return data
+  // The sender already appended this optimistically and the socket echoes to
+  // *both* participants, so guard against a duplicate.
+  if (data.pages.some((page) => page.items.some((m) => sameId(m, message)))) return data
+  return { ...data, pages: [{ ...first, items: [...first.items, message] }, ...rest] }
+}
+
+/**
+ * Everything the recipient had not received yet is now on their device.
+ *
+ * Mirrors the server's filter exactly: their own messages are not theirs to
+ * mark, and an existing timestamp is the moment it actually arrived —
+ * re-stamping would drag it forward on every reconnect.
+ */
+export function applyDeliveredAt(
+  data: Pages,
+  input: { deliveredTo: string; deliveredAt: string },
+): Pages {
+  if (!data) return data
+  let changed = false
+  const pages = data.pages.map((page) => ({
+    ...page,
+    items: page.items.map((message) => {
+      if (message.senderId === input.deliveredTo || message.deliveredAt) return message
+      changed = true
+      return { ...message, deliveredAt: input.deliveredAt }
+    }),
+  }))
+  return changed ? { ...data, pages } : data
+}
+
+/**
+ * Newest last, which is the order the thread is drawn in.
+ *
+ * The reverse is the whole reason this is a function: getting it wrong shows
+ * the conversation with its history in blocks of the wrong order, which looks
+ * like data corruption rather than a paging bug.
+ */
+export function flattenMessagePages(data: Pages): MessageDto[] {
+  if (!data) return []
+  return [...data.pages].reverse().flatMap((page) => page.items)
+}
+
+function sameId(a: MessageDto, b: MessageDto): boolean {
+  return String(a._id) === String(b._id)
+}


### PR DESCRIPTION
## What

Chats asked for one page and threw away the `nextCursor` the server had been returning all along (`listConversations` has had a keyset cursor the whole time). A thread loaded its newest 30 messages with no way to reach the rest. Both are `useInfiniteQuery` now, with pull-to-refresh and an end-reached fetch on the list — the shape copied from `discover.tsx` verbatim rather than a second idiom invented next to it.

## The real hazard is `invalidateQueries`, not the shape

On an infinite query it refetches **every loaded page, sequentially**. `useSocket` did exactly that to the chat list on every `message:new` — one request while there was one page, ten once someone had scrolled. Incoming messages are patched into the cache by `applyIncomingMessage`, which returns `undefined` for a conversation outside the loaded pages so the caller can still fall back to invalidating.

Measured in a browser with two pages loaded: **one incoming message now costs zero requests**, and the conversation still jumps to the top with its unread badge going 1 → 2.

`conversation:read` deliberately keeps invalidating: it fires once per thread opened rather than per message, and the server emits it only to the *other* participant carrying `readBy` — not the unread count this client draws. Patching it would change nothing visible.

## Page order is inverted, and that is a trap

The message cursor walks *backwards* into history, so `pages[0]` is the **newest** page. `flattenMessagePages` is the only sanctioned way to read them. Getting the reverse wrong shows a thread with its history in blocks of the wrong order, which reads as data corruption rather than as a paging bug — hence a named function with a test rather than an inline `.reverse()`.

## The auto-scroll took two attempts, both worth recording

`chat/[id].tsx` scrolled to the end on *every* content size change. Left alone, each page of older messages yanks the reader back to the bottom, so scrolling up is impossible. But a one-shot "have we done it once" flag is also wrong — verified in the browser: it fires before the rows have laid out, lands ~140px short, and leaves the thread open in its middle with no second size change to correct it.

It now follows the bottom only while the reader *is* at the bottom, and defers the scroll a frame so `scrollToEnd` resolves against a settled content size. Verified: `scrollTop` 1039 of a 1051 maximum on open.

## Verified in a browser, not only in tests

Against a local API with 25 conversations and a 41-message thread:

| | before | after |
|---|---|---|
| chat list rows after scrolling | 20 | 25, in 2 requests |
| message requests scrolling to the top of a thread | 1 | 2, content 1835 → 2664px |
| requests caused by one incoming message (2 pages loaded) | 2 | 0 |

## Tests

- `conversationCache.test.ts` — moved to the head from a later page; unread incremented for the recipient and not the sender; `bothSpoke` deliberately not guessed (one event cannot establish "both have ever spoken"); `undefined` for a conversation outside the loaded pages.
- `messageCache.test.ts` — the page-order reverse; appends land on the newest page; the duplicate guard; delivery does not overwrite a timestamp already there.
- `dedupeById.test.ts` — a keyset cursor over a moving sort key can emit a row twice, and a duplicate FlatList key is a warning plus a row React never updates.
- `messages.test.ts` — the conversation list pages without repeating or skipping. The server was already right; this pins it before the client depends on it.

Full suite green: 338 api, 92 mobile, 104 shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)