### PR TITLE
Make "online" mean online, and let Pro turn it off

### DIFF
--- a/apps/api/src/modules/handles/legacyRestore.ts
+++ b/apps/api/src/modules/handles/legacyRestore.ts
@@ -262,7 +262,7 @@ function buildProfile(userId: string, legacy: LegacyProfile, now: Date): Profile
     learning: legacy.learning,
     interests: [],
     settings: { discoverable: true, notifications: true },
-    privacy: { incognito: false },
+    privacy: { incognito: false, hideOnlineStatus: false },
     entitlement: { tier: 'free', updatedAt: now },
     quota: { initiations: [], translations: [], media: [] },
     /**

--- a/apps/api/src/modules/presence/presence.test.ts
+++ b/apps/api/src/modules/presence/presence.test.ts
@@ -1,0 +1,47 @@
+import { PRESENCE_WRITE_MIN_GAP_MS } from '@langx/shared'
+import { describe, expect, it } from 'vitest'
+import { PresenceThrottle } from './presence'
+
+describe('PresenceThrottle', () => {
+  it('writes the first time it is asked', () => {
+    expect(new PresenceThrottle(() => 0).shouldWrite()).toBe(true)
+  })
+
+  it('refuses a second write inside the gap', () => {
+    let now = 0
+    const throttle = new PresenceThrottle(() => now)
+    expect(throttle.shouldWrite()).toBe(true)
+    now = PRESENCE_WRITE_MIN_GAP_MS - 1
+    expect(throttle.shouldWrite()).toBe(false)
+  })
+
+  it('writes again once the gap has passed', () => {
+    let now = 0
+    const throttle = new PresenceThrottle(() => now)
+    throttle.shouldWrite()
+    now = PRESENCE_WRITE_MIN_GAP_MS
+    expect(throttle.shouldWrite()).toBe(true)
+  })
+
+  /**
+   * A refused call must not restart the clock, or a client polling faster
+   * than the gap would push the next real write out forever.
+   */
+  it('does not let a refused call postpone the next one', () => {
+    let now = 0
+    const throttle = new PresenceThrottle(() => now)
+    throttle.shouldWrite()
+    for (let t = 1; t < PRESENCE_WRITE_MIN_GAP_MS; t += 1000) {
+      now = t
+      throttle.shouldWrite()
+    }
+    now = PRESENCE_WRITE_MIN_GAP_MS
+    expect(throttle.shouldWrite()).toBe(true)
+  })
+
+  /** The heartbeat must never land inside the gap by construction. */
+  it('is looser than the heartbeat it throttles', async () => {
+    const { PRESENCE_HEARTBEAT_MS } = await import('@langx/shared')
+    expect(PRESENCE_WRITE_MIN_GAP_MS).toBeLessThan(PRESENCE_HEARTBEAT_MS)
+  })
+})

--- a/apps/api/src/modules/presence/presence.ts
+++ b/apps/api/src/modules/presence/presence.ts
@@ -1,0 +1,47 @@
+import { PRESENCE_WRITE_MIN_GAP_MS } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import type { Profile } from '../profiles/profiles'
+
+/**
+ * Records that someone is here, now.
+ *
+ * `stats.lastActiveAt` and nothing else. Until this existed the field was
+ * written only when a message was sent (`tokens/awards.ts`), so "online" meant
+ * "sent a message in the last five minutes" — someone who opened the app and
+ * browsed for an hour was never online, and the person who closed the app
+ * stayed online for five minutes after their last message rather than after
+ * they left.
+ */
+export async function touchPresence(db: Db, userId: string, at: Date): Promise<void> {
+  await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .updateOne({ _id: userId }, { $set: { 'stats.lastActiveAt': at } })
+}
+
+/**
+ * Per-socket floor on how often presence is written.
+ *
+ * A heartbeat is cheap to send and not cheap to store: without this every
+ * connected client is a write per interval per tab. Lives on the socket, so it
+ * dies with the connection — same shape and same lifetime as
+ * `SocketRateLimiter`, and injectable clock for the same reason.
+ */
+export class PresenceThrottle {
+  readonly #now: () => number
+  #lastWriteMs: number | null = null
+
+  constructor(now: () => number = Date.now) {
+    this.#now = now
+  }
+
+  /** True when enough time has passed to write again. */
+  shouldWrite(): boolean {
+    const now = this.#now()
+    if (this.#lastWriteMs !== null && now - this.#lastWriteMs < PRESENCE_WRITE_MIN_GAP_MS) {
+      return false
+    }
+    this.#lastWriteMs = now
+    return true
+  }
+}

--- a/apps/api/src/modules/profiles/presenceVisibility.ts
+++ b/apps/api/src/modules/profiles/presenceVisibility.ts
@@ -1,0 +1,15 @@
+import type { Profile } from './profiles'
+
+/**
+ * Whether this profile's online status is hidden from everyone.
+ *
+ * Deliberately unlike `incognito`, which re-checks the tier at read time
+ * (`profileViews.ts`). Doing that here would mean a lapsed subscription
+ * silently makes someone visible as online again — a privacy setting revoked
+ * by a billing event, without telling them. This is gated on *write* instead:
+ * only a paid tier can turn it on, and turning it off is always allowed, so
+ * nobody is ever stuck hidden either.
+ */
+export function hidesOnlineStatus(profile: Pick<Profile, 'privacy'>): boolean {
+  return profile.privacy.hideOnlineStatus === true
+}

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -3,6 +3,7 @@ import {
   PLAN_LIMITS,
   TIMEZONE_UPDATE_COOLDOWN_MS,
   effectivePlanTier,
+  isOnlineAt,
   meetsMinimumAge,
   toGeoPoint,
   type GeoPoint,
@@ -16,6 +17,7 @@ import { MongoServerError, type Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import { ApiError } from '../../lib/ApiError'
 import { authId } from '../../lib/authId'
+import { hidesOnlineStatus } from './presenceVisibility'
 import { assertOwnBucket } from '../../lib/assertOwnBucket'
 import { resolveHandleClaim } from '../handles/handleReservations'
 import type { RevenueCatClient } from '../billing/revenueCatClient'
@@ -57,7 +59,7 @@ export interface Profile {
     discoverable: boolean
     notifications: boolean
   }
-  privacy: { incognito: boolean }
+  privacy: { incognito: boolean; hideOnlineStatus?: boolean }
   entitlement: {
     tier: PlanTier
     expiresAt?: Date
@@ -159,7 +161,7 @@ export async function createProfile(
       discoverable: true,
       notifications: true,
     },
-    privacy: { incognito: false },
+    privacy: { incognito: false, hideOnlineStatus: false },
     entitlement: { tier: 'free', updatedAt: now },
     quota: { initiations: [], translations: [], media: [] },
     streak: { current: 0, longest: 0, lastQualifiedDay: null },
@@ -250,6 +252,21 @@ export async function updateProfile(
     Object.entries(input).filter(([, value]) => value !== undefined),
   )
 
+  /**
+   * `privacy` is written key by key, not as a sub-document.
+   *
+   * `$set: { privacy: {...} }` replaces the whole thing, so a request naming
+   * one flag silently clears the other. That was latent while `privacy` had a
+   * single field and is a live bug the moment it has two: a client toggling
+   * incognito would turn the caller's online status back on without asking.
+   * `settings` above is safe only because both its keys are always sent
+   * together; this one is not.
+   */
+  const { privacy, ...rest } = definedUpdates as { privacy?: Record<string, boolean> }
+  const privacyPaths = Object.fromEntries(
+    Object.entries(privacy ?? {}).map(([key, value]) => [`privacy.${key}`, value]),
+  )
+
   const now = new Date()
   let timezoneUpdatedAt: Date | null = null
 
@@ -275,7 +292,8 @@ export async function updateProfile(
     { _id: userId },
     {
       $set: {
-        ...definedUpdates,
+        ...rest,
+        ...privacyPaths,
         ...(timezoneUpdatedAt ? { timezoneUpdatedAt } : {}),
         updatedAt: now,
       },
@@ -365,7 +383,12 @@ export interface PublicProfile {
   tier: PlanTier
   cosmetics: string[]
   isOnline: boolean
-  lastActiveAt: Date
+  /**
+   * Absent when the profile hides its online status. Sending a fresh
+   * timestamp alongside `isOnline: false` would let any client recompute the
+   * truth in one subtraction, which makes the setting theatre.
+   */
+  lastActiveAt?: Date
   /** Account creation, shown as an age — `formatAccountAge` does the wording. */
   createdAt: Date
   /**
@@ -374,8 +397,6 @@ export interface PublicProfile {
    */
   emailVerified: boolean
 }
-
-const ONLINE_WINDOW_MS = 5 * 60 * 1000
 
 /**
  * What one user is allowed to see of another. Built by naming fields rather
@@ -396,6 +417,7 @@ export function toPublicProfile(
   now: Date = new Date(),
 ): PublicProfile {
   const lastActiveAt = profile.stats?.lastActiveAt ?? profile.createdAt
+  const hidden = hidesOnlineStatus(profile)
   const result: PublicProfile = {
     _id: profile._id,
     handle: profile.handle,
@@ -412,11 +434,11 @@ export function toPublicProfile(
     // everyone else a PRO badge the server already refuses to honour.
     tier: effectivePlanTier(profile.entitlement?.tier ?? 'free', profile.entitlement?.expiresAt),
     cosmetics: profile.cosmetics ?? [],
-    isOnline: now.getTime() - new Date(lastActiveAt).getTime() < ONLINE_WINDOW_MS,
-    lastActiveAt: new Date(lastActiveAt),
+    isOnline: hidden ? false : isOnlineAt(lastActiveAt, now),
     createdAt: profile.createdAt,
     emailVerified,
   }
+  if (!hidden) result.lastActiveAt = new Date(lastActiveAt)
   if (profile.avatarUrl !== undefined) result.avatarUrl = profile.avatarUrl
   if (profile.bio !== undefined) result.bio = profile.bio
   if (profile.country !== undefined) result.country = profile.country

--- a/apps/api/src/modules/tokens/awards.ts
+++ b/apps/api/src/modules/tokens/awards.ts
@@ -43,9 +43,10 @@ export async function awardForSend(
 
   const profiles = db.collection<Profile>(COLLECTIONS.profiles)
 
-  // One unconditional write for liveness: `stats.lastActiveAt` is what
-  // discovery's "online now" filter and its `active` sort read, and until now
-  // nothing had ever updated it after onboarding.
+  // `modules/presence` is the primary writer of `stats.lastActiveAt` now —
+  // connect, heartbeat and disconnect. This one stays because it is inside
+  // the award funnel's single write, and pulling it out would widen this diff
+  // into the token economy for no behavioural gain.
   const sender = await profiles.findOneAndUpdate(
     { _id: senderId },
     { $set: { 'stats.lastActiveAt': at }, $inc: { 'stats.messagesSent': 1 } },

--- a/apps/api/src/routes/moderation.test.ts
+++ b/apps/api/src/routes/moderation.test.ts
@@ -320,6 +320,32 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
   })
 
   describe('profile views and incognito', () => {
+    /**
+     * The question Behic asked of the existing toggle: it works, and it only
+     * ever did this. Hiding your online status is `privacy.hideOnlineStatus`
+     * and has no effect here — pinned so neither flag quietly grows into the
+     * other's job.
+     */
+    it('records a profile view even when the viewer hides their online status', async () => {
+      const viewer = await newUser()
+      const viewed = await newUser()
+      await handle.db.collection<Profile>(COLLECTIONS.profiles).updateOne(
+        { _id: viewer.userId },
+        {
+          $set: {
+            entitlement: { tier: 'pro', updatedAt: new Date() },
+            'privacy.hideOnlineStatus': true,
+          },
+        },
+      )
+
+      await get(viewer, `/profiles/${viewed.userId}`)
+      const views = await handle.db
+        .collection(COLLECTIONS.profileViews)
+        .countDocuments({ viewedId: viewed.userId })
+      expect(views).toBe(1)
+    })
+
     it('records one row per viewer however many times they look', async () => {
       const viewer = await newUser()
       const viewed = await newUser()

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -6,6 +6,7 @@ import { buildApp } from '../app'
 import { createAuth } from '../auth'
 import { connectToDatabase, type DbHandle } from '../db/client'
 import { COLLECTIONS } from '../db/collections'
+import type { Profile } from '../modules/profiles/profiles'
 import { ensureIndexes } from '../db/indexes'
 import { loadEnv } from '../env'
 import { authId } from '../lib/authId'
@@ -711,6 +712,122 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
 
       expect(response.statusCode).toBe(200)
       expect(response.json<{ emailVerified: boolean }>().emailVerified).toBe(false)
+    })
+  })
+
+  describe('hiding your online status', () => {
+    async function onboarded(email: string, userHandle: string): Promise<SignedUpUser> {
+      const user = await newUser(email)
+      const created = await app.inject({
+        method: 'POST',
+        url: '/profiles',
+        headers: { cookie: user.cookie },
+        payload: onboardingBody({ handle: userHandle }),
+      })
+      if (created.statusCode !== 201) throw new Error(`onboarding failed: ${created.body}`)
+      return user
+    }
+
+    const makePro = (userId: string) =>
+      handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .updateOne(
+          { _id: userId },
+          { $set: { entitlement: { tier: 'pro', updatedAt: new Date() } } },
+        )
+
+    const patchPrivacy = (user: SignedUpUser, privacy: Record<string, boolean>) =>
+      app.inject({
+        method: 'PATCH',
+        url: '/profiles/me',
+        headers: { cookie: user.cookie },
+        payload: { privacy },
+      })
+
+    it('refuses to turn it on without a paid tier, naming the feature', async () => {
+      const free = await onboarded('hide-free@example.com', 'hidefree')
+      const response = await patchPrivacy(free, { hideOnlineStatus: true })
+
+      expect(response.statusCode).toBe(403)
+      expect(response.json<{ code: string; feature: string }>()).toMatchObject({
+        code: 'UPGRADE_REQUIRED',
+        feature: 'hideOnlineStatus',
+      })
+    })
+
+    /**
+     * Gated on write, not on read — unlike incognito. Re-checking at read time
+     * would make a lapsed subscription silently expose someone as online, so
+     * turning it *off* has to work on any tier or people get stuck hidden.
+     */
+    it('always allows turning it off, on any tier', async () => {
+      const user = await onboarded('hide-off@example.com', 'hideoff')
+      const response = await patchPrivacy(user, { hideOnlineStatus: false })
+      expect(response.statusCode, response.body).toBe(200)
+    })
+
+    it('reports a hidden Pro user as offline, and sends no lastActiveAt at all', async () => {
+      const hider = await onboarded('hide-pro@example.com', 'hidepro')
+      const viewer = await onboarded('hide-viewer@example.com', 'hideviewer')
+      await makePro(hider.userId)
+      expect((await patchPrivacy(hider, { hideOnlineStatus: true })).statusCode).toBe(200)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/profiles/hidepro',
+        headers: { cookie: viewer.cookie },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+      const body = response.json<{ isOnline: boolean; lastActiveAt?: string }>()
+      expect(body.isOnline).toBe(false)
+      // Omitted, not stale: a fresh timestamp beside `isOnline: false` lets
+      // any client recompute the truth in one subtraction.
+      expect(body).not.toHaveProperty('lastActiveAt')
+
+      // Still recorded server-side; only the answer to other people changes.
+      const stored = await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .findOne({ _id: hider.userId })
+      expect(stored?.stats.lastActiveAt).toBeInstanceOf(Date)
+    })
+
+    /**
+     * `$set: { privacy: {...} }` replaces the sub-document, so a request
+     * naming one flag used to clear the other. Latent while `privacy` had one
+     * field; a live bug the moment it has two.
+     */
+    it('does not clear the other privacy flag when one is updated', async () => {
+      const user = await onboarded('hide-partial@example.com', 'hidepartial')
+      await makePro(user.userId)
+
+      expect((await patchPrivacy(user, { hideOnlineStatus: true })).statusCode).toBe(200)
+      expect((await patchPrivacy(user, { incognito: true })).statusCode).toBe(200)
+
+      const after = await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .findOne({ _id: user.userId })
+      expect(after?.privacy).toMatchObject({ incognito: true, hideOnlineStatus: true })
+
+      expect((await patchPrivacy(user, { incognito: false })).statusCode).toBe(200)
+      const later = await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .findOne({ _id: user.userId })
+      expect(later?.privacy).toMatchObject({ incognito: false, hideOnlineStatus: true })
+    })
+
+    /** The two flags are independent; incognito never touched presence. */
+    it('leaves online status alone when only incognito is on', async () => {
+      const hider = await onboarded('incog-only@example.com', 'incogonly')
+      const viewer = await onboarded('incog-viewer@example.com', 'incogviewer')
+      await makePro(hider.userId)
+      await patchPrivacy(hider, { incognito: true })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/profiles/incogonly',
+        headers: { cookie: viewer.cookie },
+      })
+      expect(response.json<{ lastActiveAt?: string }>().lastActiveAt).toBeDefined()
     })
   })
 })

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -1,10 +1,16 @@
-import { locationInputSchema, onboardingProfileSchema, updateProfileSchema } from '@langx/shared'
+import {
+  hasFeature,
+  locationInputSchema,
+  onboardingProfileSchema,
+  updateProfileSchema,
+} from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { ApiError } from '../lib/ApiError'
 import { requireAuth, requireVerifiedEmail } from '../middleware/requireAuth'
 import { hashLegacyEmail } from '../modules/handles/legacyEmailHash'
 import { blockedUserIds } from '../modules/moderation/blocks'
 import { recordProfileView } from '../modules/moderation/profileViews'
+import { effectiveTier } from '../modules/profiles/entitlement'
 import {
   clearLocation,
   createProfile,
@@ -76,6 +82,26 @@ export const profileRoutes: FastifyPluginAsyncZod = async (app) => {
     '/profiles/me',
     { preHandler: requireAuth, schema: { body: updateProfileSchema } },
     async (request, reply) => {
+      /**
+       * The one field gated on *write* rather than at read time.
+       *
+       * `incognito` re-checks the tier every time it is honoured, which is
+       * right for it: nothing is lost if a lapsed subscriber starts leaving
+       * profile-view rows again. Doing that here would silently make someone
+       * visible as online because a payment failed — a privacy setting
+       * revoked by a billing event, without telling them. Turning it *off* is
+       * always allowed, so nobody is ever stuck hidden either.
+       */
+      if (request.body.privacy?.hideOnlineStatus === true) {
+        const current = await getProfile(app.mongo.db, request.userId)
+        if (!current) throw new ApiError('NOT_FOUND', 'Profile not found')
+        if (!hasFeature(effectiveTier(current), 'hideOnlineStatus')) {
+          throw new ApiError('UPGRADE_REQUIRED', 'Hiding your online status is a Pro feature', {
+            feature: 'hideOnlineStatus',
+          })
+        }
+      }
+
       const profile = await updateProfile(app.mongo.db, request.userId, request.body)
       return reply.send(profile)
     },

--- a/apps/api/src/ws/chat.test.ts
+++ b/apps/api/src/ws/chat.test.ts
@@ -2,13 +2,14 @@ import { MongoMemoryReplSet } from 'mongodb-memory-server'
 import type { FastifyInstance } from 'fastify'
 import { type AddressInfo } from 'node:net'
 import { io as ioClient, type Socket as ClientSocket } from 'socket.io-client'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { buildApp } from '../app'
 import { createAuth } from '../auth'
 import { connectToDatabase, type DbHandle } from '../db/client'
 import { COLLECTIONS } from '../db/collections'
 import { ensureIndexes } from '../db/indexes'
 import { loadEnv } from '../env'
+import type { Profile } from '../modules/profiles/profiles'
 import { createStorageProvider } from '../storage/createStorageProvider'
 import { createTranslationProvider } from '../translation/createTranslationProvider'
 import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
@@ -501,5 +502,72 @@ describe('Faz 5 — realtime chat over Socket.io', () => {
     })
     expect(ack.ok).toBe(false)
     expect(ack.error?.code).toBe('BLOCKED')
+  })
+
+  describe('presence', () => {
+    async function lastActiveAt(userId: string): Promise<Date> {
+      const profile = await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .findOne({ _id: userId })
+      return new Date(profile!.stats.lastActiveAt)
+    }
+
+    /** Backdate so any write at all is visible as a jump forward. */
+    async function backdate(userId: string): Promise<Date> {
+      const stale = new Date(Date.now() - 60 * 60 * 1000)
+      await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .updateOne({ _id: userId }, { $set: { 'stats.lastActiveAt': stale } })
+      return stale
+    }
+
+    /**
+     * Before this, `lastActiveAt` moved only when a message was sent, so
+     * someone who opened the app and browsed was never "online".
+     */
+    it('marks a user active as soon as they connect', async () => {
+      const user = await newUser('presence-connect@example.com')
+      const stale = await backdate(user.userId)
+
+      await connectSocket(user.cookie)
+      await vi.waitFor(async () => {
+        expect((await lastActiveAt(user.userId)).getTime()).toBeGreaterThan(stale.getTime())
+      })
+    })
+
+    /**
+     * `now`, not an offline flag: it starts the five-minute decay from the
+     * moment they left, and a decaying timestamp cannot get stuck the way a
+     * boolean left `true` by a crashed process can.
+     */
+    it('stamps the moment they leave on disconnect', async () => {
+      const user = await newUser('presence-disconnect@example.com')
+      const socket = await connectSocket(user.cookie)
+      await vi.waitFor(async () => {
+        expect((await lastActiveAt(user.userId)).getTime()).toBeGreaterThan(0)
+      })
+
+      const stale = await backdate(user.userId)
+      socket.disconnect()
+      await vi.waitFor(async () => {
+        expect((await lastActiveAt(user.userId)).getTime()).toBeGreaterThan(stale.getTime())
+      })
+    })
+
+    it('refuses a client looping on the heartbeat, through the ack', async () => {
+      const user = await newUser('presence-flood@example.com')
+      const socket = await connectSocket(user.cookie)
+
+      const codes: (string | undefined)[] = []
+      for (let i = 0; i < 8; i++) {
+        const ack = await new Promise<{ ok: boolean; error?: { code: string } }>((resolve) => {
+          socket.emit('presence:ping', {}, (response: { ok: boolean; error?: { code: string } }) =>
+            resolve(response),
+          )
+        })
+        codes.push(ack.ok ? undefined : ack.error?.code)
+      }
+      expect(codes).toContain('RATE_LIMITED')
+    })
   })
 })

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -16,6 +16,7 @@ import {
   sendTextMessage,
 } from '../modules/chat/messages'
 import { fanOutMessage } from './fanOut'
+import { PresenceThrottle, touchPresence } from '../modules/presence/presence'
 import { SocketRateLimiter } from './rateLimit'
 import { userRoom, type AppServer, type AppSocket } from './types'
 
@@ -89,7 +90,19 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
   io.on('connection', (socket) => {
     const userId = socket.data.userId
     socket.data.limiter = new SocketRateLimiter()
+    socket.data.presence = new PresenceThrottle()
     void socket.join(userRoom(userId))
+
+    /**
+     * Opening the app makes you online, immediately and unthrottled. People
+     * expect the dot the moment they arrive, and this is once per connection.
+     * Fire-and-forget for the same reason as the delivery sweep below: a
+     * missed presence write decays away by itself, a rejection here would
+     * take down a working connection.
+     */
+    void touchPresence(app.mongo.db, userId, new Date()).catch((error: unknown) =>
+      app.log.warn({ err: error }, 'presence write on connect failed'),
+    )
 
     /**
      * Connecting *is* the delivery receipt for everything sent while this user
@@ -218,6 +231,33 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
           }),
         )
         .catch(() => undefined)
+    })
+
+    socket.on('presence:ping', (_payload: unknown, ack: Ack) => {
+      if (!limited('presence:ping', ack)) return
+      // Throttled: a heartbeat is cheap to send and not cheap to store, and
+      // without a floor every connected tab is a write per interval.
+      if (socket.data.presence.shouldWrite()) {
+        void touchPresence(app.mongo.db, userId, new Date()).catch((error: unknown) =>
+          app.log.warn({ err: error }, 'presence heartbeat write failed'),
+        )
+      }
+      ack?.({ ok: true })
+    })
+
+    /**
+     * Leaving stamps `now`, not an offline flag and not a backdated time.
+     *
+     * It is true ("last seen just now"), it starts the five-minute decay from
+     * the moment they actually left rather than from their last message, and
+     * it leaves the `active` sort ordered by something real. The reason that
+     * matters most is failure: a decaying timestamp cannot get stuck, while a
+     * boolean left `true` by a crashed process marks everyone online forever.
+     */
+    socket.on('disconnect', () => {
+      void touchPresence(app.mongo.db, userId, new Date()).catch((error: unknown) =>
+        app.log.warn({ err: error }, 'presence write on disconnect failed'),
+      )
     })
   })
 

--- a/apps/api/src/ws/rateLimit.ts
+++ b/apps/api/src/ws/rateLimit.ts
@@ -34,6 +34,10 @@ export const EVENT_LIMITS: Record<string, BucketConfig> = {
   'message:media': { capacity: 10, refillPerSecond: 0.5 },
   'conversation:read': { capacity: 30, refillPerSecond: 2 },
   typing: { capacity: 40, refillPerSecond: 10 },
+  // One per 20s sustained, burst of 4. A 60s heartbeat passes with room; a
+  // client looping on it is refused. `DEFAULT_LIMIT` would cover it, but the
+  // note below is explicit that a new event gets a named entry.
+  'presence:ping': { capacity: 4, refillPerSecond: 0.05 },
 }
 
 /** Applied to any event not named above, so a new one is never accidentally unlimited. */

--- a/apps/api/src/ws/types.ts
+++ b/apps/api/src/ws/types.ts
@@ -1,10 +1,13 @@
 import type { Server as SocketIOServer, Socket } from 'socket.io'
+import type { PresenceThrottle } from '../modules/presence/presence'
 import type { SocketRateLimiter } from './rateLimit'
 
 export interface SocketData {
   userId: string
   /** Per-connection token buckets; see ws/rateLimit.ts. */
   limiter: SocketRateLimiter
+  /** Per-connection floor on presence writes; see modules/presence. */
+  presence: PresenceThrottle
 }
 
 /** Socket.io's four generics default `data` to `any` — this pins it down so `.data.userId` typechecks. */

--- a/apps/mobile/app/(app)/paywall.tsx
+++ b/apps/mobile/app/(app)/paywall.tsx
@@ -86,6 +86,11 @@ const BENEFIT_COPY: Record<ProBenefit, { emoji: string; title: string; body: str
     title: 'Incognito browsing',
     body: 'Look at profiles without leaving a trace.',
   },
+  hideOnlineStatus: {
+    emoji: '🌙',
+    title: 'Hide when you are online',
+    body: 'Nobody sees your green dot. You still see theirs.',
+  },
 }
 
 /**
@@ -130,6 +135,7 @@ const FEATURE_TITLE: Record<PlanFeature, string> = {
   advancedFilters: BENEFIT_COPY.advancedFilters.title,
   profileViewerIdentities: BENEFIT_COPY.profileViewerIdentities.title,
   incognito: BENEFIT_COPY.incognito.title,
+  hideOnlineStatus: BENEFIT_COPY.hideOnlineStatus.title,
   nearby: PRO_PLUS_BENEFIT_COPY.nearby.title,
   copilot: PRO_PLUS_BENEFIT_COPY.copilot.title,
 }

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -157,6 +157,17 @@ export default function SettingsScreen() {
         onValueChange={(incognito) => update.mutate({ privacy: { incognito } })}
       />
       <Row
+        title="Hide when I'm online"
+        subtitle={
+          isPro
+            ? 'People will not see the green dot on your profile. You can still see theirs.'
+            : 'Pro feature.'
+        }
+        value={profile?.privacy.hideOnlineStatus ?? false}
+        disabled={!isPro}
+        onValueChange={(hideOnlineStatus) => update.mutate({ privacy: { hideOnlineStatus } })}
+      />
+      <Row
         title="Share my approximate location"
         subtitle="Lets people nearby find you. Rounded to about a kilometre before it is stored — nobody is ever shown where you are, only roughly how far away."
         value={sharingLocation}

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -77,7 +77,7 @@ export interface MeProfile {
   learning: { code: string; level: LanguageLevel; priority: number }[]
   interests: string[]
   settings: { discoverable: boolean; notifications: boolean }
-  privacy: { incognito: boolean }
+  privacy: { incognito: boolean; hideOnlineStatus: boolean }
   /**
    * Present only while the user is sharing one, which is exactly what the
    * Settings toggle reads: there is no separate "sharing is on" flag on the

--- a/apps/mobile/src/api/types.ts
+++ b/apps/mobile/src/api/types.ts
@@ -39,7 +39,8 @@ export interface PublicProfileDto {
   tier: PlanTier
   cosmetics: string[]
   isOnline: boolean
-  lastActiveAt: string
+  /** Absent when the profile hides its online status. */
+  lastActiveAt?: string
   /** ISO; rendered as an age with `formatAccountAge`, never as a date. */
   createdAt: string
   emailVerified: boolean

--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -1,3 +1,4 @@
+import { PRESENCE_HEARTBEAT_MS } from '@langx/shared'
 import type { InfiniteData } from '@tanstack/react-query'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
@@ -20,10 +21,21 @@ export function useSocket(): void {
 
   useEffect(() => {
     let cancelled = false
+    let heartbeat: ReturnType<typeof setInterval> | null = null
 
     void (async () => {
       const socket = await getSocket()
       if (cancelled) return
+
+      /**
+       * Says "still here" while the app is open. Without it `lastActiveAt`
+       * only moved when a message was sent, so browsing for an hour left you
+       * offline. Lives with the socket rather than in a screen for the reason
+       * `_layout.tsx` gives for owning the socket once.
+       */
+      heartbeat = setInterval(() => {
+        socket.emit('presence:ping', {})
+      }, PRESENCE_HEARTBEAT_MS)
 
       socket.on('message:new', (message: MessageDto) => {
         const conversationId =
@@ -105,6 +117,7 @@ export function useSocket(): void {
 
     return () => {
       cancelled = true
+      if (heartbeat) clearInterval(heartbeat)
       closeSocket()
     }
   }, [queryClient])

--- a/packages/shared/src/discovery.ts
+++ b/packages/shared/src/discovery.ts
@@ -27,6 +27,29 @@ export const DISCOVERY_PAGE_SIZE_MAX = 50
 /** A profile counts as "online now" for the free `online` filter within this window. */
 export const ONLINE_WINDOW_MS = 5 * 60 * 1000
 
+/** How often a connected client tells the server it is still there. */
+export const PRESENCE_HEARTBEAT_MS = 60_000
+
+/**
+ * Server-side floor between two presence writes for one socket.
+ *
+ * Below the heartbeat rather than equal to it: at equal values a heartbeat
+ * arriving a millisecond early is silently dropped, and the next one is a
+ * whole interval away, so a connected user flickers offline for no reason.
+ */
+export const PRESENCE_WRITE_MIN_GAP_MS = 50_000
+
+/**
+ * The one definition of "online".
+ *
+ * It used to be written out three times — twice in the API and once as a
+ * local constant in `profiles.ts` that did not import the shared window at
+ * all, so changing it here would have moved two of the three.
+ */
+export function isOnlineAt(lastActiveAt: Date | string, now: Date = new Date()): boolean {
+  return now.getTime() - new Date(lastActiveAt).getTime() < ONLINE_WINDOW_MS
+}
+
 /**
  * Keys that require Pro (`PLAN_LIMITS.advancedFilters`). A free account
  * sending any of these gets `403 UPGRADE_REQUIRED`, not a silently-ignored

--- a/packages/shared/src/limits.ts
+++ b/packages/shared/src/limits.ts
@@ -65,6 +65,14 @@ export interface PlanLimits {
   /** Browse without leaving a profileViews record. */
   incognito: boolean
   /**
+   * Turn off the green dot: nobody sees you as online, and you still see them.
+   *
+   * Separate from `incognito`, which is about *who viewed my profile* and has
+   * never touched presence. One flag doing both would make the store's
+   * privacy description and the paywall copy wrong about each other.
+   */
+  hideOnlineStatus: boolean
+  /**
    * Distance-sorted discovery (`sort=nearby`).
    *
    * Pro+ only, and gates the *sort* alone. Sharing a location is free and
@@ -107,6 +115,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     advancedFilters: false,
     profileViewerIdentities: false,
     incognito: false,
+    hideOnlineStatus: false,
     nearby: false,
     copilot: false,
     maxPhotos: 6,
@@ -119,6 +128,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     advancedFilters: true,
     profileViewerIdentities: true,
     incognito: true,
+    hideOnlineStatus: true,
     nearby: false,
     copilot: false,
     maxPhotos: 6,
@@ -137,6 +147,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     advancedFilters: true,
     profileViewerIdentities: true,
     incognito: true,
+    hideOnlineStatus: true,
     nearby: true,
     copilot: true,
     maxPhotos: 6,
@@ -163,7 +174,12 @@ export function quotaLimit(tier: PlanTier, kind: QuotaKind): Limit {
  * `403 UPGRADE_REQUIRED` payload. `hasFeature` reads these directly off
  * `PLAN_LIMITS`, so this list cannot drift from what the server enforces.
  */
-export const PRO_FEATURES = ['advancedFilters', 'profileViewerIdentities', 'incognito'] as const
+export const PRO_FEATURES = [
+  'advancedFilters',
+  'profileViewerIdentities',
+  'incognito',
+  'hideOnlineStatus',
+] as const
 export type ProFeature = (typeof PRO_FEATURES)[number]
 
 /**
@@ -199,6 +215,7 @@ export const PRO_BENEFITS = [
   'unlimitedTranslation',
   'profileViewerIdentities',
   'incognito',
+  'hideOnlineStatus',
 ] as const
 export type ProBenefit = (typeof PRO_BENEFITS)[number]
 

--- a/packages/shared/src/profile.ts
+++ b/packages/shared/src/profile.ts
@@ -131,7 +131,14 @@ export const updateProfileSchema = z
       discoverable: z.boolean(),
       notifications: z.boolean(),
     }),
-    privacy: z.object({ incognito: z.boolean() }),
+    /**
+     * `.partial()` on the inner object as well as the outer one. With two
+     * keys and both required, every existing client sending
+     * `{ privacy: { incognito } }` would start failing validation the moment
+     * the second key landed. See `updateProfile` — a partial `privacy` also
+     * has to be written as dotted paths, or the `$set` drops the other flag.
+     */
+    privacy: z.object({ incognito: z.boolean(), hideOnlineStatus: z.boolean() }).partial(),
   })
   .partial()
   .refine(


### PR DESCRIPTION
## Two findings first, because they change what this PR is

**1. "Incognito browsing" works — but it has never had anything to do with being online.** Traced end to end: `settings.tsx` → `updateProfileSchema` → `updateProfile` → enforced at `profileViews.ts:49` with a live tier re-check, covered by `moderation.test.ts`. All it does is skip the `profileViews` row when a Pro user looks at someone. `toPublicProfile` never read `privacy` at all. So the setting is not broken; it simply is not this feature. This PR adds a regression test pinning the two as independent, so neither quietly grows into the other's job.

**2. `isOnline` was wrong.** `stats.lastActiveAt` was written in exactly one place — sending a message (`tokens/awards.ts`). "Online now" therefore meant *"sent a message in the last five minutes"*: someone who opened the app and browsed for an hour was never online, and someone who closed the app stayed online for five minutes after their last **message** rather than after they left. `ws/index.ts` had no `disconnect` handler at all.

## Presence

Written on connect (unthrottled — people expect the dot the moment they arrive), on a 60s heartbeat, and on disconnect. Throttled per socket at 50s, so a connected client costs about one write a minute rather than one per event; the floor is deliberately *below* the heartbeat, or a beat arriving a millisecond early is dropped and the user flickers offline for a whole interval.

**Disconnect stamps `now`, not an offline flag.** It is true ("last seen just now"), it starts the five-minute decay from the moment they left, it leaves the `active` sort ordered by something real — and a decaying timestamp cannot get stuck, while a boolean left `true` by a crashed process marks everyone online forever.

`presence:ping` gets a named `EVENT_LIMITS` entry (4 burst, one per 20s sustained) rather than falling through to `DEFAULT_LIMIT`, per the note in that file.

## `privacy.hideOnlineStatus`

New Pro setting, default off. A hidden profile reports `isOnline: false` **and omits `lastActiveAt` entirely** — sending a fresh timestamp beside `isOnline: false` would let any client recompute the truth in one subtraction, which makes the setting theatre.

**Gated on write, not at read time — the one place this deliberately differs from incognito.** Re-checking the tier when it is honoured would silently expose someone as online because a payment failed: a privacy setting revoked by a billing event, without telling them. Turning it *off* is allowed on any tier, so nobody is ever stuck hidden. Happy to flip this if you'd rather the tiers behave identically; it is a product call and a one-line change.

## Two bugs fixed on the way

- **`ONLINE_WINDOW_MS` was defined twice** — `profiles.ts:394` had a local copy that did not import the shared one, so changing the window would have moved two of its three uses. `isOnlineAt` is now the only definition.
- **`updateProfile` `$set` the whole `privacy` sub-document**, so a request naming one flag cleared the other. Latent while `privacy` had a single field; a live bug the moment it has two — toggling incognito would have turned someone's online status back on without asking. Written as dotted paths now, with a test.

## Verified against a running server

| | result |
|---|---|
| backdate `lastActiveAt` an hour, connect a socket | moved to now ✓ |
| three `presence:ping` in a row | one write, not three ✓ |
| disconnect | moved to now ✓ |
| free user `PATCH {privacy:{hideOnlineStatus:true}}` | `403 UPGRADE_REQUIRED`, `feature: hideOnlineStatus` ✓ |
| same user on Pro | 200 ✓ |
| hidden Pro profile with a *fresh* `lastActiveAt` | `isOnline: false`, no `lastActiveAt` key ✓ |
| control profile, not hidden | `isOnline: true`, `lastActiveAt` present ✓ |

## Tests

`presence.test.ts` (throttle, injected clock — including that a refused call does not postpone the next one, and that the floor is looser than the heartbeat by construction); `ws/chat.test.ts` (connect and disconnect both move it; a client looping on the heartbeat is refused through the ack); `profiles.test.ts` (the write gate both ways, the omitted timestamp, and the partial-`privacy` regression); `moderation.test.ts` (the two flags are independent).

`paywall.tsx`'s two `Record<…>` copy tables made the missing strings a compile error, which is what they are for.

Full suite green: 354 api, 109 mobile, 104 shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)