### PR TITLE
Page the three lists that were still fetched whole

### DIFF
--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -164,6 +164,9 @@ export const INDEXES: Partial<IndexSpec> = {
   [COLLECTIONS.blocks]: [
     { key: { blockerId: 1, blockedId: 1 }, name: 'blocker_blocked_unique', unique: true },
     { key: { blockedId: 1 }, name: 'blocked' },
+    // The blocked list pages newest-first; the unique index above covers the
+    // filter but leaves the sort in memory.
+    { key: { blockerId: 1, createdAt: -1 }, name: 'blocker_recent' },
   ],
 
   [COLLECTIONS.reports]: [{ key: { status: 1, createdAt: -1 }, name: 'status_created' }],

--- a/apps/api/src/modules/moderation/blocks.ts
+++ b/apps/api/src/modules/moderation/blocks.ts
@@ -1,7 +1,14 @@
-import { ERROR_CODES, REPORTS_TO_FREEZE_XP, type ReportInput } from '@langx/shared'
-import { MongoServerError, ObjectId, type Db } from 'mongodb'
+import {
+  ERROR_CODES,
+  MODERATION_PAGE_SIZE_DEFAULT,
+  REPORTS_TO_FREEZE_XP,
+  type ModerationListQuery,
+  type ReportInput,
+} from '@langx/shared'
+import { MongoServerError, ObjectId, type Db, type Filter } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import { ApiError } from '../../lib/ApiError'
+import { decodeDateIdCursor, encodeDateIdCursor } from '../../lib/dateIdCursor'
 
 export interface Block {
   _id: ObjectId
@@ -75,12 +82,41 @@ export async function unblockUser(db: Db, blockerId: string, blockedId: string):
   await db.collection<Block>(COLLECTIONS.blocks).deleteOne({ blockerId, blockedId })
 }
 
-export async function listBlocked(db: Db, blockerId: string): Promise<Block[]> {
-  return db
+export interface BlockedPage {
+  items: Block[]
+  nextCursor: string | null
+}
+
+/**
+ * Paged. This used to have no limit at all — one query and one response body
+ * sized by however many people someone had blocked.
+ */
+export async function listBlocked(
+  db: Db,
+  blockerId: string,
+  query: ModerationListQuery = { limit: MODERATION_PAGE_SIZE_DEFAULT },
+): Promise<BlockedPage> {
+  const filter: Filter<Block> = { blockerId }
+  if (query.cursor) {
+    const { date, id } = decodeDateIdCursor(query.cursor)
+    filter.$or = [{ createdAt: { $lt: date } }, { createdAt: date, _id: { $lt: id } }]
+  }
+
+  // One extra to know whether a next page exists without a second round trip.
+  const page = await db
     .collection<Block>(COLLECTIONS.blocks)
-    .find({ blockerId })
-    .sort({ createdAt: -1 })
+    .find(filter)
+    .sort({ createdAt: -1, _id: -1 })
+    .limit(query.limit + 1)
     .toArray()
+
+  const hasMore = page.length > query.limit
+  const items = hasMore ? page.slice(0, query.limit) : page
+  const last = items.at(-1)
+  return {
+    items,
+    nextCursor: hasMore && last ? encodeDateIdCursor(last.createdAt, last._id) : null,
+  }
 }
 
 export interface ReportResult {

--- a/apps/api/src/modules/moderation/profileViews.ts
+++ b/apps/api/src/modules/moderation/profileViews.ts
@@ -1,7 +1,13 @@
-import { ERROR_CODES, hasFeature } from '@langx/shared'
-import { type ObjectId, type Db } from 'mongodb'
+import {
+  ERROR_CODES,
+  MODERATION_PAGE_SIZE_DEFAULT,
+  hasFeature,
+  type ModerationListQuery,
+} from '@langx/shared'
+import { type Db, type Filter, type ObjectId } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import { ApiError } from '../../lib/ApiError'
+import { decodeDateIdCursor, encodeDateIdCursor } from '../../lib/dateIdCursor'
 import { effectiveTier } from '../profiles/entitlement'
 import type { Profile } from '../profiles/profiles'
 import { blockedUserIds } from './blocks'
@@ -26,6 +32,8 @@ export interface ViewerSummary {
     lastViewedAt: string
   }[]
   locked: boolean
+  /** `null` on the last page, and always `null` while `locked`. */
+  nextCursor: string | null
 }
 
 /**
@@ -70,26 +78,45 @@ export async function recordProfileView(
  * the paywall is only persuasive if the user can see there is something behind
  * it.
  */
-export async function getViewers(db: Db, userId: string): Promise<ViewerSummary> {
+export async function getViewers(
+  db: Db,
+  userId: string,
+  query: ModerationListQuery = { limit: MODERATION_PAGE_SIZE_DEFAULT },
+): Promise<ViewerSummary> {
   const profiles = db.collection<Profile>(COLLECTIONS.profiles)
   const me = await profiles.findOne({ _id: userId })
   if (!me) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Complete onboarding first')
 
   const hidden = await blockedUserIds(db, userId)
-  const filter = { viewedId: userId, viewerId: { $nin: hidden } }
+  const filter: Filter<ProfileView> = { viewedId: userId, viewerId: { $nin: hidden } }
 
+  // The count is over everyone, not over the page — it is the number the free
+  // tier is shown, and the thing the paywall is arguing about.
   const total = await db.collection<ProfileView>(COLLECTIONS.profileViews).countDocuments(filter)
 
   if (!hasFeature(effectiveTier(me), 'profileViewerIdentities')) {
-    return { total, viewers: [], locked: true }
+    return { total, viewers: [], locked: true, nextCursor: null }
   }
 
-  const views = await db
+  const paged: Filter<ProfileView> = { ...filter }
+  if (query.cursor) {
+    const { date, id } = decodeDateIdCursor(query.cursor)
+    paged.$or = [{ lastViewedAt: { $lt: date } }, { lastViewedAt: date, _id: { $lt: id } }]
+  }
+
+  // Was a hard `.limit(100)` with no way past it: someone with 150 viewers saw
+  // 100 of them beside a `total` saying 150, which reads as the feature being
+  // broken rather than paged.
+  const page = await db
     .collection<ProfileView>(COLLECTIONS.profileViews)
-    .find(filter)
-    .sort({ lastViewedAt: -1 })
-    .limit(100)
+    .find(paged)
+    .sort({ lastViewedAt: -1, _id: -1 })
+    .limit(query.limit + 1)
     .toArray()
+
+  const hasMore = page.length > query.limit
+  const views = hasMore ? page.slice(0, query.limit) : page
+  const lastView = views.at(-1)
 
   const viewerProfiles = await profiles
     .find(
@@ -113,5 +140,14 @@ export async function getViewers(db: Db, userId: string): Promise<ViewerSummary>
     viewers.push(entry)
   }
 
-  return { total, viewers, locked: false }
+  return {
+    total,
+    viewers,
+    locked: false,
+    // Off the raw page, not off `viewers`: a view whose profile was deleted is
+    // dropped from the output but still consumed a place in the page, and
+    // cursoring from the last *rendered* row would replay it.
+    nextCursor:
+      hasMore && lastView ? encodeDateIdCursor(lastView.lastViewedAt, lastView._id) : null,
+  }
 }

--- a/apps/api/src/modules/tokens/leaderboard.ts
+++ b/apps/api/src/modules/tokens/leaderboard.ts
@@ -103,18 +103,24 @@ export async function getLeaderboard(
    * page — and deriving both from one formula keeps it true by construction.
    */
   const first = top[0]
-  const [startIndex, firstRank] = first
-    ? await Promise.all([
-        aggregates.countDocuments({
-          periodType,
-          periodKey,
-          $or: [{ tokens: { $gt: first.tokens } }, { tokens: first.tokens, _id: { $lt: first._id } }],
-        }),
-        aggregates
-          .countDocuments({ periodType, periodKey, tokens: { $gt: first.tokens } })
-          .then((above) => above + 1),
-      ])
-    : [0, 1]
+  // Annotated, and counted separately rather than destructured out of one
+  // `Promise.all`: a tuple built by a ternary infers as `number[]`, which
+  // under `noUncheckedIndexedAccess` makes both `number | undefined` and
+  // takes `rank` below with it.
+  let startIndex = 0
+  let firstRank = 1
+  if (first) {
+    const [before, above] = await Promise.all([
+      aggregates.countDocuments({
+        periodType,
+        periodKey,
+        $or: [{ tokens: { $gt: first.tokens } }, { tokens: first.tokens, _id: { $lt: first._id } }],
+      }),
+      aggregates.countDocuments({ periodType, periodKey, tokens: { $gt: first.tokens } }),
+    ])
+    startIndex = before
+    firstRank = above + 1
+  }
 
   // Blocked either way, and the person drops out of the table — same rule as
   // discovery and the conversation list. Their rank position stays occupied,
@@ -140,7 +146,7 @@ export async function getLeaderboard(
     const profile = byId.get(row.userId)
     // The page's first row takes its competition rank directly; it may be
     // mid-tie, and `previous` is empty at a page boundary.
-    const rank = index === 0 ? firstRank : rankOf(absoluteIndex, row.tokens, previous)
+    const rank: number = index === 0 ? firstRank : rankOf(absoluteIndex, row.tokens, previous)
     previous = { rank, tokens: row.tokens }
     if (!profile || hidden.has(row.userId)) continue
 

--- a/apps/api/src/modules/tokens/leaderboard.ts
+++ b/apps/api/src/modules/tokens/leaderboard.ts
@@ -1,12 +1,14 @@
 import {
+  ERROR_CODES,
   aggregateId,
   periodKeys,
   type Leaderboard,
   type LeaderboardEntry,
   type PeriodType,
 } from '@langx/shared'
-import type { Db } from 'mongodb'
+import type { Db, Filter } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
+import { ApiError } from '../../lib/ApiError'
 import type { Profile } from '../profiles/profiles'
 import { blockedUserIds } from '../moderation/blocks'
 import type { TokenAggregate } from './ledger'
@@ -29,10 +31,36 @@ function rankOf(
   return index + 1
 }
 
+/**
+ * Cursor over `{tokens: -1, _id: 1}` — `<tokens>|<aggregateId>`.
+ *
+ * Not `dateIdCursor`: a `tokenAggregates` `_id` is the string
+ * `<userId>:<periodType>:<periodKey>`, not an ObjectId. The `_id` tiebreak is
+ * what the sort was already written for ("so paging and repeat calls agree").
+ */
+function encodeBoardCursor(tokens: number, id: string): string {
+  return `${tokens}|${id}`
+}
+
+function decodeBoardCursor(cursor: string): { tokens: number; id: string } {
+  const separator = cursor.indexOf('|')
+  const tokens = Number.parseInt(cursor.slice(0, separator), 10)
+  const id = cursor.slice(separator + 1)
+  if (separator < 0 || !Number.isInteger(tokens) || !id) {
+    throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Malformed cursor')
+  }
+  return { tokens, id }
+}
+
 export async function getLeaderboard(
   db: Db,
   viewerId: string,
-  query: { period: PeriodType; periodKey?: string | undefined; limit: number },
+  query: {
+    period: PeriodType
+    periodKey?: string | undefined
+    limit: number
+    cursor?: string | undefined
+  },
   at: Date = new Date(),
 ): Promise<Leaderboard> {
   const periodType = query.period
@@ -40,12 +68,53 @@ export async function getLeaderboard(
 
   const aggregates = db.collection<TokenAggregate>(COLLECTIONS.tokenAggregates)
 
-  const top = await aggregates
-    .find({ periodType, periodKey })
+  const filter: Filter<TokenAggregate> = { periodType, periodKey }
+  if (query.cursor) {
+    const { tokens, id } = decodeBoardCursor(query.cursor)
+    filter.$or = [{ tokens: { $lt: tokens } }, { tokens, _id: { $gt: id } }]
+  }
+
+  const fetched = await aggregates
+    .find(filter)
     // `_id` breaks ties deterministically, so paging and repeat calls agree.
     .sort({ tokens: -1, _id: 1 })
-    .limit(query.limit)
+    // One extra to detect a next page without a second round trip.
+    .limit(query.limit + 1)
     .toArray()
+
+  const hasMore = fetched.length > query.limit
+  const top = hasMore ? fetched.slice(0, query.limit) : fetched
+
+  /**
+   * Two different numbers about this page's first row, and conflating them is
+   * the whole trap.
+   *
+   * `startIndex` is how many rows sort *before* it — the keyset itself, so
+   * rows tied with it on the previous page are counted. `firstRank` is its
+   * competition rank, which by definition ignores those ties. They coincide
+   * only when the page begins at a new score, which is exactly why using one
+   * for both passes in isolation and fails the moment a tie straddles a page
+   * boundary: the row after the tie gets its positional index instead of
+   * skipping past both halves.
+   *
+   * `firstRank` is the same expression the out-of-page viewer rank uses
+   * below. That is the invariant this file exists to protect — two people on
+   * the same score are told the same position whether or not they made the
+   * page — and deriving both from one formula keeps it true by construction.
+   */
+  const first = top[0]
+  const [startIndex, firstRank] = first
+    ? await Promise.all([
+        aggregates.countDocuments({
+          periodType,
+          periodKey,
+          $or: [{ tokens: { $gt: first.tokens } }, { tokens: first.tokens, _id: { $lt: first._id } }],
+        }),
+        aggregates
+          .countDocuments({ periodType, periodKey, tokens: { $gt: first.tokens } })
+          .then((above) => above + 1),
+      ])
+    : [0, 1]
 
   // Blocked either way, and the person drops out of the table — same rule as
   // discovery and the conversation list. Their rank position stays occupied,
@@ -64,11 +133,14 @@ export async function getLeaderboard(
   const entries: LeaderboardEntry[] = []
   let previous: { rank: number; tokens: number } | null = null
   for (const [index, row] of top.entries()) {
+    const absoluteIndex = startIndex + index
     // A soft-deleted account keeps its aggregate row (the ledger is
     // append-only) but must not appear. It still occupies its rank position,
     // so the ranks of everyone below don't shift when someone deletes.
     const profile = byId.get(row.userId)
-    const rank = rankOf(index, row.tokens, previous)
+    // The page's first row takes its competition rank directly; it may be
+    // mid-tie, and `previous` is empty at a page boundary.
+    const rank = index === 0 ? firstRank : rankOf(absoluteIndex, row.tokens, previous)
     previous = { rank, tokens: row.tokens }
     if (!profile || hidden.has(row.userId)) continue
 
@@ -98,5 +170,15 @@ export async function getLeaderboard(
       ? (await aggregates.countDocuments({ periodType, periodKey, tokens: { $gt: viewerXp } })) + 1
       : null
 
-  return { period: periodType, periodKey, entries, viewer: { rank, tokens: viewerXp, inPage } }
+  const lastRow = top.at(-1)
+  return {
+    period: periodType,
+    periodKey,
+    entries,
+    // Off the raw page: a soft-deleted account is dropped from `entries` but
+    // still occupied a place, so cursoring from the last rendered row would
+    // replay it.
+    nextCursor: hasMore && lastRow ? encodeBoardCursor(lastRow.tokens, lastRow._id) : null,
+    viewer: { rank, tokens: viewerXp, inPage },
+  }
 }

--- a/apps/api/src/routes/leaderboard.test.ts
+++ b/apps/api/src/routes/leaderboard.test.ts
@@ -361,6 +361,77 @@ describe('Faz 9 — daily pool, leaderboards and token sinks', () => {
       expect(result.viewer.rank).toBe(rankA)
     })
 
+    /**
+     * `rankOf` counts from the page's own index, so page two would restart at
+     * 1 — and a tie spanning the boundary would be told two different
+     * positions depending on which page it landed on. The page's starting
+     * rank is asked for with the same count the viewer rank uses, so this
+     * holds by construction.
+     */
+    it('keeps ranks continuous across pages, including a tie on the boundary', async () => {
+      const users = []
+      for (let i = 0; i < 4; i++) users.push(await newUser())
+      // 900, 900, 800, 700 — the tie sits across a limit=2 boundary.
+      const amounts = [900, 900, 800, 700]
+      for (const [i, user] of users.entries()) {
+        await awardTokens(handle.db, {
+          userId: user.userId,
+          kind: 'adjustment',
+          amount: amounts[i]!,
+          refId: `page-tie-${i}`,
+        })
+      }
+
+      const viewer = users[0]!
+      const ourIds = new Set(users.map((u) => u.userId))
+
+      async function walk(limit: number) {
+        const found = new Map<string, { rank: number; tokens: number }>()
+        let cursor: string | null = null
+        do {
+          const suffix: string = cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''
+          const page = await board(viewer, `?period=all&limit=${limit}${suffix}`)
+          for (const entry of page.entries) {
+            if (ourIds.has(entry.userId)) {
+              found.set(entry.userId, { rank: entry.rank, tokens: entry.tokens })
+            }
+          }
+          cursor = page.nextCursor
+        } while (cursor)
+        return found
+      }
+
+      // Two different page sizes put the boundaries in different places. With
+      // the page's start index conflated with its first row's rank, a tie
+      // straddling a boundary makes these disagree — which is the bug.
+      const small = await walk(2)
+      const large = await walk(7)
+
+      expect(small.size).toBe(4)
+      expect(large.size).toBe(4)
+      for (const [userId, entry] of small) {
+        expect(large.get(userId)?.rank, `rank for ${userId}`).toBe(entry.rank)
+      }
+
+      // The two equal scores share a rank wherever the boundaries fall.
+      const byScore = [...small.values()].sort((x, y) => y.tokens - x.tokens)
+      const tied = byScore.filter((e) => e.tokens === byScore[0]!.tokens)
+      expect(tied).toHaveLength(2)
+      expect(tied[0]!.rank).toBe(tied[1]!.rank)
+
+      // And the count-based rank the viewer gets from outside any page still
+      // agrees with the one they got inside one.
+      const own = small.get(viewer.userId)!
+      const board2 = await board(viewer, '?period=all&limit=1')
+      expect(board2.viewer.rank).toBe(own.rank)
+    })
+
+    it('stops handing out cursors on the last page', async () => {
+      const user = await newUser()
+      const result = await board(user, '?period=all&limit=100')
+      expect(result.nextCursor).toBeNull()
+    })
+
     it('reports a rank for someone outside the requested page', async () => {
       const loner = await newUser()
       await awardTokens(handle.db, {

--- a/apps/api/src/routes/moderation.test.ts
+++ b/apps/api/src/routes/moderation.test.ts
@@ -207,6 +207,33 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
       expect((await get(a, '/blocks')).json<{ items: unknown[] }>().items).toHaveLength(0)
     })
 
+    /** Had no limit at all: one query and one response body sized by the list. */
+    it('pages the blocked list without repeating or skipping', async () => {
+      const blocker = await newUser()
+      const blocked = []
+      for (let i = 0; i < 5; i++) {
+        const target = await newUser()
+        expect((await post(blocker, '/blocks', { userId: target.userId })).statusCode).toBe(201)
+        blocked.push(target.userId)
+      }
+
+      const seen: string[] = []
+      let cursor: string | null = null
+      let pages = 0
+      do {
+        const suffix: string = cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''
+        const page = await get(blocker, `/blocks?limit=2${suffix}`)
+        expect(page.statusCode, page.body).toBe(200)
+        const body = page.json<{ items: { blockedId: string }[]; nextCursor: string | null }>()
+        seen.push(...body.items.map((b) => b.blockedId))
+        cursor = body.nextCursor
+        pages++
+      } while (cursor && pages < 10)
+
+      expect(seen).toHaveLength(5)
+      expect(new Set(seen)).toEqual(new Set(blocked))
+    })
+
     it('refuses a self-block', async () => {
       const a = await newUser()
       expect((await post(a, '/blocks', { userId: a.userId })).statusCode).toBe(400)
@@ -410,6 +437,64 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
 
       await get(ghost, `/profiles/${viewed.userId}`)
       expect((await get(viewed, '/me/viewers')).json<{ total: number }>().total).toBe(0)
+    })
+
+    /**
+     * Was a hard `.limit(100)` with no way past it, beside a `total` counting
+     * everyone — so a Pro user with 150 viewers saw a list that contradicted
+     * the number printed above it.
+     */
+    it('pages the viewer list without repeating or skipping, and counts everyone', async () => {
+      const viewed = await newUser()
+      await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .updateOne(
+          { _id: viewed.userId },
+          { $set: { entitlement: { tier: 'pro', updatedAt: new Date() } } },
+        )
+
+      const lookers = []
+      for (let i = 0; i < 5; i++) {
+        const looker = await newUser()
+        await get(looker, `/profiles/${viewed.userId}`)
+        lookers.push(looker.userId)
+      }
+
+      const seen: string[] = []
+      let cursor: string | null = null
+      let pages = 0
+      do {
+        const suffix: string = cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''
+        const page = await get(viewed, `/me/viewers?limit=2${suffix}`)
+        expect(page.statusCode, page.body).toBe(200)
+        const body = page.json<{
+          total: number
+          viewers: { userId: string }[]
+          nextCursor: string | null
+        }>()
+        // The count is over everyone, not over the page — it is what the free
+        // tier is shown and what the paywall argues about.
+        expect(body.total).toBe(5)
+        seen.push(...body.viewers.map((v) => v.userId))
+        cursor = body.nextCursor
+        pages++
+      } while (cursor && pages < 10)
+
+      expect(seen).toHaveLength(5)
+      expect(new Set(seen)).toEqual(new Set(lookers))
+    })
+
+    it('never hands a free user a cursor to page with', async () => {
+      const viewed = await newUser()
+      const looker = await newUser()
+      await get(looker, `/profiles/${viewed.userId}`)
+
+      const body = (await get(viewed, '/me/viewers')).json<{
+        locked: boolean
+        nextCursor: string | null
+      }>()
+      expect(body.locked).toBe(true)
+      expect(body.nextCursor).toBeNull()
     })
 
     it('does not honour incognito for a free user — it is a Pro capability', async () => {

--- a/apps/api/src/routes/moderation.ts
+++ b/apps/api/src/routes/moderation.ts
@@ -1,4 +1,4 @@
-import { blockSchema, reportSchema } from '@langx/shared'
+import { blockSchema, moderationListQuerySchema, reportSchema } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { requireAuth } from '../middleware/requireAuth'
 import { blockUser, listBlocked, reportUser, unblockUser } from '../modules/moderation/blocks'
@@ -15,9 +15,13 @@ export const moderationRoutes: FastifyPluginAsyncZod = async (app) => {
     },
   )
 
-  app.get('/blocks', { preHandler: requireAuth }, async (request, reply) => {
-    return reply.send({ items: await listBlocked(app.mongo.db, request.userId) })
-  })
+  app.get(
+    '/blocks',
+    { preHandler: requireAuth, schema: { querystring: moderationListQuerySchema } },
+    async (request, reply) => {
+      return reply.send(await listBlocked(app.mongo.db, request.userId, request.query))
+    },
+  )
 
   app.delete('/blocks/:userId', { preHandler: requireAuth }, async (request, reply) => {
     const { userId } = request.params as { userId: string }
@@ -37,7 +41,11 @@ export const moderationRoutes: FastifyPluginAsyncZod = async (app) => {
     },
   )
 
-  app.get('/me/viewers', { preHandler: requireAuth }, async (request, reply) => {
-    return reply.send(await getViewers(app.mongo.db, request.userId))
-  })
+  app.get(
+    '/me/viewers',
+    { preHandler: requireAuth, schema: { querystring: moderationListQuerySchema } },
+    async (request, reply) => {
+      return reply.send(await getViewers(app.mongo.db, request.userId, request.query))
+    },
+  )
 }

--- a/apps/mobile/app/(app)/blocked.tsx
+++ b/apps/mobile/app/(app)/blocked.tsx
@@ -1,11 +1,20 @@
 import { router } from 'expo-router'
-import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from 'react-native'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
 import { useBlocks, useUnblockUser } from '../../src/api/queries'
 import { Avatar } from '../../src/components/ui/Avatar'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
 import { useProfileCache } from '../../src/hooks/useProfileCache'
 import { confirmAlert } from '../../src/lib/alert'
+import { dedupeById } from '../../src/lib/dedupeById'
 import { showToast } from '../../src/lib/toast'
 import { colors, font, spacing } from '../../src/lib/theme'
 
@@ -18,7 +27,7 @@ export default function BlockedScreen() {
   const blocks = useBlocks()
   const unblock = useUnblockUser()
 
-  const items = blocks.data?.items ?? []
+  const items = dedupeById(blocks.data?.pages.flatMap((page) => page.items) ?? [])
   // The block row stores ids only; these are the names to show against them.
   const profiles = useProfileCache(items.map((b) => b.blockedId))
 
@@ -36,6 +45,19 @@ export default function BlockedScreen() {
           data={items}
           keyExtractor={(item) => item._id}
           contentContainerStyle={styles.list}
+          refreshControl={
+            <RefreshControl
+              refreshing={blocks.isRefetching}
+              onRefresh={() => void blocks.refetch()}
+            />
+          }
+          onEndReachedThreshold={0.6}
+          onEndReached={() => {
+            if (blocks.hasNextPage && !blocks.isFetchingNextPage) void blocks.fetchNextPage()
+          }}
+          ListFooterComponent={
+            blocks.isFetchingNextPage ? <ActivityIndicator style={styles.footer} /> : null
+          }
           ListEmptyComponent={
             <EmptyState
               emoji="🚫"
@@ -89,6 +111,7 @@ const styles = StyleSheet.create({
   back: { ...font.body, color: colors.textMuted },
   title: { ...font.title, color: colors.text, marginTop: spacing.xs },
   loading: { marginTop: spacing.xxl },
+  footer: { paddingVertical: spacing.lg },
   list: { paddingTop: spacing.md },
   row: {
     alignItems: 'center',

--- a/apps/mobile/app/(app)/leaderboard.tsx
+++ b/apps/mobile/app/(app)/leaderboard.tsx
@@ -1,13 +1,22 @@
 import type { PeriodType } from '@langx/shared'
 import { router } from 'expo-router'
 import { useState } from 'react'
-import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from 'react-native'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
 import { useLeaderboard, useTokens } from '../../src/api/queries'
 import { Avatar } from '../../src/components/ui/Avatar'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
 import { days } from '../../src/lib/format'
 import { colors, font, radius, spacing } from '../../src/lib/theme'
+import { dedupeById } from '../../src/lib/dedupeById'
 
 const TABS: { key: PeriodType; label: string }[] = [
   { key: 'week', label: 'Week' },
@@ -24,8 +33,11 @@ export default function LeaderboardScreen() {
   const xp = useTokens()
 
   const streak = xp.data?.streak
-  const entries = board.data?.entries ?? []
-  const viewer = board.data?.viewer
+  const entries = dedupeById(
+    (board.data?.pages.flatMap((page) => page.entries) ?? []).map((e) => ({ ...e, _id: e.userId })),
+  )
+  // The viewer's own standing is about the whole table, not this page.
+  const viewer = board.data?.pages[0]?.viewer
 
   return (
     <Screen fluid>
@@ -68,6 +80,16 @@ export default function LeaderboardScreen() {
           data={entries}
           keyExtractor={(item) => item.userId}
           contentContainerStyle={styles.list}
+          refreshControl={
+            <RefreshControl
+              refreshing={board.isRefetching}
+              onRefresh={() => void board.refetch()}
+            />
+          }
+          onEndReachedThreshold={0.6}
+          onEndReached={() => {
+            if (board.hasNextPage && !board.isFetchingNextPage) void board.fetchNextPage()
+          }}
           ListEmptyComponent={
             <EmptyState
               emoji="🏆"
@@ -76,13 +98,18 @@ export default function LeaderboardScreen() {
             />
           }
           ListFooterComponent={
-            viewer && !viewer.inPage && viewer.rank ? (
-              <View style={styles.viewerRow}>
-                <Text style={styles.rank}>#{viewer.rank}</Text>
-                <Text style={styles.viewerLabel}>You</Text>
-                <Text style={styles.tokens}>{viewer.tokens}</Text>
-              </View>
-            ) : null
+            <>
+              {board.isFetchingNextPage ? <ActivityIndicator style={styles.footer} /> : null}
+              {/* Your own row, pinned below the page you can see — the whole
+                  point of `viewer.rank` is that it works from outside it. */}
+              {viewer && !viewer.inPage && viewer.rank ? (
+                <View style={styles.viewerRow}>
+                  <Text style={styles.rank}>#{viewer.rank}</Text>
+                  <Text style={styles.viewerLabel}>You</Text>
+                  <Text style={styles.tokens}>{viewer.tokens}</Text>
+                </View>
+              ) : null}
+            </>
           }
           renderItem={({ item }) => (
             <Pressable
@@ -133,6 +160,7 @@ const styles = StyleSheet.create({
   tabLabel: { ...font.caption, color: colors.textMuted, fontWeight: '600' },
   tabLabelActive: { color: colors.primaryText },
   loading: { marginTop: spacing.xxl },
+  footer: { paddingVertical: spacing.lg },
   list: { paddingBottom: spacing.xxl, paddingTop: spacing.md },
   row: {
     alignItems: 'center',

--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -166,9 +166,11 @@ export default function MeScreen() {
         <View>
           <Text style={styles.cardTitle}>Who viewed your profile</Text>
           <Text style={styles.cardBody}>
-            {viewers.data?.locked
-              ? `${viewers.data.total} people looked — see who with Pro`
-              : `${viewers.data?.total ?? 0} people`}
+            {/* `total` and `locked` describe the whole list, so page one is
+                the authority on both. */}
+            {viewers.data?.pages[0]?.locked
+              ? `${viewers.data.pages[0].total} people looked — see who with Pro`
+              : `${viewers.data?.pages[0]?.total ?? 0} people`}
           </Text>
         </View>
         <Text style={styles.chevron}>›</Text>

--- a/apps/mobile/app/(app)/viewers.tsx
+++ b/apps/mobile/app/(app)/viewers.tsx
@@ -1,15 +1,33 @@
 import { router } from 'expo-router'
-import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from 'react-native'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
 import { useViewers } from '../../src/api/queries'
 import { Avatar } from '../../src/components/ui/Avatar'
 import { Button } from '../../src/components/ui/Button'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
+import { dedupeById } from '../../src/lib/dedupeById'
 import { openPaywall } from '../../src/lib/paywall'
 import { colors, font, spacing } from '../../src/lib/theme'
 
 export default function ViewersScreen() {
   const viewers = useViewers()
+  // `total` and `locked` describe the whole list, so the first page is the
+  // authority on both; only `viewers` accumulates.
+  const summary = viewers.data?.pages[0]
+  const items = dedupeById(
+    (viewers.data?.pages.flatMap((page) => page.viewers) ?? []).map((v) => ({
+      ...v,
+      _id: v.userId,
+    })),
+  )
 
   return (
     <Screen fluid>
@@ -20,15 +38,15 @@ export default function ViewersScreen() {
 
       {viewers.isPending ? (
         <ActivityIndicator style={styles.loading} />
-      ) : viewers.data?.locked ? (
+      ) : summary?.locked ? (
         <View style={styles.locked}>
-          <Text style={styles.lockedCount}>{viewers.data.total}</Text>
+          <Text style={styles.lockedCount}>{summary.total}</Text>
           <Text style={styles.lockedLabel}>
-            {viewers.data.total === 0
+            {summary.total === 0
               ? 'Nobody has viewed your profile yet.'
               : 'people viewed your profile'}
           </Text>
-          {viewers.data.total > 0 ? (
+          {summary.total > 0 ? (
             <Button
               label="See who they are"
               onPress={() => openPaywall('profileViewerIdentities')}
@@ -38,9 +56,22 @@ export default function ViewersScreen() {
         </View>
       ) : (
         <FlatList
-          data={viewers.data?.viewers ?? []}
+          data={items}
           keyExtractor={(item) => item.userId}
           contentContainerStyle={styles.list}
+          refreshControl={
+            <RefreshControl
+              refreshing={viewers.isRefetching}
+              onRefresh={() => void viewers.refetch()}
+            />
+          }
+          onEndReachedThreshold={0.6}
+          onEndReached={() => {
+            if (viewers.hasNextPage && !viewers.isFetchingNextPage) void viewers.fetchNextPage()
+          }}
+          ListFooterComponent={
+            viewers.isFetchingNextPage ? <ActivityIndicator style={styles.footer} /> : null
+          }
           ListEmptyComponent={
             <EmptyState emoji="👀" title="No visitors yet" body="Filling in your profile helps." />
           }
@@ -71,6 +102,7 @@ const styles = StyleSheet.create({
   lockedCount: { color: colors.text, fontSize: 56, fontWeight: '700' },
   lockedLabel: { ...font.body, color: colors.textMuted },
   cta: { marginTop: spacing.xl, minWidth: 220 },
+  footer: { paddingVertical: spacing.lg },
   list: { paddingTop: spacing.md },
   row: { alignItems: 'center', flexDirection: 'row', gap: spacing.md, paddingVertical: spacing.md },
   body: { flex: 1 },

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -270,9 +270,14 @@ export function useWallet() {
 }
 
 export function useLeaderboard(period: PeriodType) {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: keys.leaderboard(period),
-    queryFn: () => api.get<Leaderboard>(`/leaderboard?period=${period}`),
+    queryFn: ({ pageParam }) =>
+      api.get<Leaderboard>(
+        `/leaderboard?period=${period}${pageParam ? `&cursor=${encodeURIComponent(pageParam)}` : ''}`,
+      ),
+    initialPageParam: '',
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
   })
 }
 
@@ -294,21 +299,28 @@ export function useQuota() {
   })
 }
 
+export interface ViewerPageDto {
+  total: number
+  locked: boolean
+  viewers: {
+    userId: string
+    handle: string
+    displayName: string
+    avatarUrl?: string
+    lastViewedAt: string
+  }[]
+  nextCursor: string | null
+}
+
 export function useViewers() {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: keys.viewers,
-    queryFn: () =>
-      api.get<{
-        total: number
-        locked: boolean
-        viewers: {
-          userId: string
-          handle: string
-          displayName: string
-          avatarUrl?: string
-          lastViewedAt: string
-        }[]
-      }>('/me/viewers'),
+    queryFn: ({ pageParam }) =>
+      api.get<ViewerPageDto>(
+        `/me/viewers${pageParam ? `?cursor=${encodeURIComponent(pageParam)}` : ''}`,
+      ),
+    initialPageParam: '',
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
   })
 }
 
@@ -517,10 +529,20 @@ export interface BlockDto {
   createdAt: string
 }
 
+export interface BlockPageDto {
+  items: BlockDto[]
+  nextCursor: string | null
+}
+
 export function useBlocks() {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: keys.blocks,
-    queryFn: () => api.get<{ items: BlockDto[] }>('/blocks'),
+    queryFn: ({ pageParam }) =>
+      api.get<BlockPageDto>(
+        `/blocks${pageParam ? `?cursor=${encodeURIComponent(pageParam)}` : ''}`,
+      ),
+    initialPageParam: '',
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
   })
 }
 

--- a/packages/shared/src/leaderboard.ts
+++ b/packages/shared/src/leaderboard.ts
@@ -11,6 +11,12 @@ export const leaderboardQuerySchema = z.object({
    * an explicit key is what lets a client show last week's final table.
    */
   periodKey: z.string().trim().min(1).optional(),
+  /**
+   * Keyset over `{tokens: -1, _id: 1}`, the order the table is already built
+   * in. Without it the board stopped at `LEADERBOARD_PAGE_SIZE` and rank 101
+   * was unreachable.
+   */
+  cursor: z.string().trim().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(LEADERBOARD_PAGE_SIZE).default(LEADERBOARD_PAGE_SIZE),
 })
 export type LeaderboardQuery = z.infer<typeof leaderboardQuerySchema>
@@ -37,6 +43,8 @@ export const leaderboardSchema = z.object({
   period: z.enum(PERIOD_TYPES),
   periodKey: z.string(),
   entries: z.array(leaderboardEntrySchema),
+  /** `null` on the last page. */
+  nextCursor: z.string().nullable(),
   /** The caller's own standing, always present even when outside the page. */
   viewer: z.object({
     rank: z.number().int().nullable(),

--- a/packages/shared/src/moderation.ts
+++ b/packages/shared/src/moderation.ts
@@ -50,3 +50,24 @@ export const REPORTS_TO_FREEZE_XP = 3
 
 export const REPORT_STATUSES = ['open', 'reviewing', 'actioned', 'dismissed'] as const
 export type ReportStatus = (typeof REPORT_STATUSES)[number]
+
+/**
+ * Paging for the two moderation lists.
+ *
+ * `GET /me/viewers` used to take the newest 100 and stop, which a Pro user
+ * paying to see the list would experience as the list being wrong — the
+ * `total` beside it counted everyone. `GET /blocks` had no limit at all.
+ */
+export const MODERATION_PAGE_SIZE_DEFAULT = 30
+export const MODERATION_PAGE_SIZE_MAX = 100
+
+export const moderationListQuerySchema = z.object({
+  cursor: z.string().trim().min(1).optional(),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(MODERATION_PAGE_SIZE_MAX)
+    .default(MODERATION_PAGE_SIZE_DEFAULT),
+})
+export type ModerationListQuery = z.infer<typeof moderationListQuerySchema>


### PR DESCRIPTION
## What

#961 paged chats and the message history. Three lists were left, each wrong in its own way:

| Endpoint | Before | Consequence |
|---|---|---|
| `GET /me/viewers` | `.limit(100)`, no cursor | A Pro user with 150 viewers saw 100 of them **beside a `total` saying 150** — the feature contradicting itself |
| `GET /blocks` | no limit at all | One query and one response body sized by the list |
| `GET /leaderboard` | `limit` defaulted to *and* capped at `LEADERBOARD_PAGE_SIZE` | Rank 101 unreachable |

All three now return `nextCursor` and the screens are infinite queries with pull-to-refresh, a guarded `onEndReached` and a footer spinner — the shape copied from `discover.tsx`.

Viewers and blocks reuse `lib/dateIdCursor` directly. Both take `nextCursor` from the **raw page**, not the rendered rows: a view whose profile was deleted is dropped from the output but still occupied a place, so cursoring from the last visible row would replay it.

`total` and `locked` describe the whole list, so the client reads both off page one and only accumulates `viewers`.

## The leaderboard needed more care, and the test earned its keep

Its `_id` is the string `<userId>:<periodType>:<periodKey>`, not an ObjectId, so it gets its own `<tokens>|<id>` cursor over the `{tokens: -1, _id: 1}` sort the file was already written for ("`_id` breaks ties deterministically, so paging and repeat calls agree").

`rankOf` counts from the page's own index, so page two restarted at rank 1. Fixing that needs **two different numbers** about a page's first row:

- how many rows sort *before* it — the keyset, which **includes** rows tied with it on the previous page;
- its **competition rank**, which by definition excludes them.

Conflating the two passes in isolation and breaks the moment a tie straddles a page boundary: the row after the tie takes its positional index instead of skipping past both halves. I shipped the conflated version first and the full-suite run caught it — in isolation my four test users were the only rows, so both formulas coincided.

The regression test now walks the same table at **two different page sizes** and requires every rank to agree, plus the tie to share a rank and the out-of-page `viewer.rank` to match. Verified it fails against the conflated version: one user comes back rank 2 at `limit=7` and rank 4 at `limit=2`.

## Index

One added, in `db/indexes.ts` as required: `{ blockerId: 1, createdAt: -1 }`. The existing unique index covered the blocked list's filter but left its sort in memory.

`profileViews` already had `{ viewedId: 1, lastViewedAt: -1 }` and `tokenAggregates` already had `{ periodType: 1, periodKey: 1, tokens: -1 }`, so neither needed one.

## Tests

`moderation.test.ts` — viewers and blocks each page without repeating or skipping; `total` stays over everyone rather than over the page; a free user never gets a cursor to page with. `leaderboard.test.ts` — the two-page-size rank agreement above, and the last page stops handing out cursors.

Full suite green: 365 api, 109 mobile, 104 shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)