### PR TITLE
Send every back button to the screen that opened it

### DIFF
--- a/apps/mobile/app/(app)/blocked.tsx
+++ b/apps/mobile/app/(app)/blocked.tsx
@@ -1,4 +1,3 @@
-import { router } from 'expo-router'
 import {
   ActivityIndicator,
   FlatList,

--- a/apps/mobile/app/(app)/blocked.tsx
+++ b/apps/mobile/app/(app)/blocked.tsx
@@ -12,6 +12,7 @@ import { useBlocks, useUnblockUser } from '../../src/api/queries'
 import { Avatar } from '../../src/components/ui/Avatar'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
+import { goBackTo } from '../../src/lib/navigation'
 import { useProfileCache } from '../../src/hooks/useProfileCache'
 import { confirmAlert } from '../../src/lib/alert'
 import { dedupeById } from '../../src/lib/dedupeById'
@@ -33,7 +34,7 @@ export default function BlockedScreen() {
 
   return (
     <Screen fluid>
-      <Pressable onPress={() => router.back()} hitSlop={12} style={styles.backRow}>
+      <Pressable onPress={() => goBackTo('/(app)/settings')} hitSlop={12} style={styles.backRow}>
         <Text style={styles.back}>‹ Back</Text>
       </Pressable>
       <Text style={styles.title}>Blocked people</Text>

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -37,6 +37,7 @@ import { errorCodeOf } from '../../../src/lib/errors'
 import { listState } from '../../../src/lib/listState'
 import { messageActionsFor } from '../../../src/lib/messageActions'
 import { openMessageMenu } from '../../../src/lib/messageMenu'
+import { goBackTo } from '../../../src/lib/navigation'
 import { openPaywall } from '../../../src/lib/paywall'
 import { showToast } from '../../../src/lib/toast'
 import { flattenMessagePages } from '../../../src/lib/messageCache'
@@ -146,7 +147,7 @@ export default function ChatScreen() {
           'Could not send',
           "You've reached today's limit for photos and voice messages.",
         )
-        openPaywall()
+        openPaywall(undefined, `/(app)/chat/${conversationId}`)
       } else {
         void showAlert('Could not send', 'That attachment could not be sent. Try again.')
       }
@@ -235,7 +236,7 @@ export default function ChatScreen() {
         // not a `PlanFeature` — it is a quota that stops applying rather than
         // a capability flag — so there is no key to pass. The paywall's Pro
         // column already lists it.
-        openPaywall()
+        openPaywall(undefined, `/(app)/chat/${conversationId}`)
       } else {
         await showAlert('Translation unavailable', 'Could not translate that message right now.')
       }
@@ -293,12 +294,17 @@ export default function ChatScreen() {
   return (
     <Screen fluid style={styles.screen}>
       <View style={styles.header}>
-        <Pressable onPress={() => router.back()} hitSlop={12}>
+        <Pressable onPress={() => goBackTo('/(app)/chats')} hitSlop={12}>
           <Text style={styles.back}>‹</Text>
         </Pressable>
         <Pressable
           style={styles.headerUser}
-          onPress={() => partner && router.push(`/(app)/profile/${partner.handle}`)}
+          onPress={() =>
+            partner &&
+            router.push(
+              `/(app)/profile/${partner.handle}?from=${encodeURIComponent(`/(app)/chat/${conversationId}`)}`,
+            )
+          }
         >
           <Avatar url={partner?.avatarUrl} name={partner?.displayName ?? '?'} size={32} />
           <View>

--- a/apps/mobile/app/(app)/discover.tsx
+++ b/apps/mobile/app/(app)/discover.tsx
@@ -86,7 +86,7 @@ export default function DiscoverScreen() {
    */
   async function chooseNearby(): Promise<void> {
     if (!canUseNearby) {
-      openPaywall('nearby')
+      openPaywall('nearby', '/(app)/discover')
       return
     }
     if (!sharingLocation && !(await enableSharing())) return
@@ -242,7 +242,11 @@ export default function DiscoverScreen() {
           }
           renderItem={({ item }) => (
             <Pressable
-              onPress={() => router.push(`/(app)/profile/${item.handle}`)}
+              onPress={() =>
+                router.push(
+                  `/(app)/profile/${item.handle}?from=${encodeURIComponent('/(app)/discover')}`,
+                )
+              }
               style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
             >
               <Avatar url={item.avatarUrl} name={item.displayName} online={item.isOnline} />

--- a/apps/mobile/app/(app)/edit-profile.tsx
+++ b/apps/mobile/app/(app)/edit-profile.tsx
@@ -39,6 +39,7 @@ import { Chip } from '../../src/components/ui/Chip'
 import { FormField } from '../../src/components/ui/FormField'
 import { CountryPicker } from '../../src/components/CountryPicker'
 import { Screen } from '../../src/components/ui/Screen'
+import { goBackTo } from '../../src/lib/navigation'
 import { confirmAlert, showAlert } from '../../src/lib/alert'
 import { showToast } from '../../src/lib/toast'
 import { colors, font, layout, radius, spacing } from '../../src/lib/theme'
@@ -151,7 +152,7 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
         nativeLanguages: native.map((code) => ({ code })),
         learning: learning.map((l, index) => ({ ...l, priority: index + 1 })),
       })
-      router.back()
+      goBackTo('/(app)/me')
       showToast('Profile saved.')
     } catch (caught) {
       setError(caught instanceof ApiRequestError ? caught.message : 'Could not save your profile.')
@@ -160,7 +161,7 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
 
   return (
     <Screen scroll>
-      <Pressable onPress={() => router.back()} hitSlop={12} style={styles.backRow}>
+      <Pressable onPress={() => goBackTo('/(app)/me')} hitSlop={12} style={styles.backRow}>
         <Text style={styles.back}>‹ Back</Text>
       </Pressable>
       <Text style={styles.title}>Edit profile</Text>

--- a/apps/mobile/app/(app)/edit-profile.tsx
+++ b/apps/mobile/app/(app)/edit-profile.tsx
@@ -12,7 +12,6 @@ import {
   type Gender,
 } from '@langx/shared'
 import * as ImagePicker from 'expo-image-picker'
-import { router } from 'expo-router'
 import { useState } from 'react'
 import {
   ActivityIndicator,

--- a/apps/mobile/app/(app)/filters.tsx
+++ b/apps/mobile/app/(app)/filters.tsx
@@ -14,6 +14,7 @@ import { CountryPicker } from '../../src/components/CountryPicker'
 import { Button } from '../../src/components/ui/Button'
 import { Chip } from '../../src/components/ui/Chip'
 import { Screen } from '../../src/components/ui/Screen'
+import { goBackTo } from '../../src/lib/navigation'
 import { openPaywall } from '../../src/lib/paywall'
 import {
   AGE_BRACKETS,
@@ -70,7 +71,7 @@ export default function FiltersScreen() {
    */
   function set(patch: FilterPatch, pro = false): void {
     if (pro && !isPro) {
-      openPaywall('advancedFilters')
+      openPaywall('advancedFilters', '/(app)/filters')
       return
     }
     setFilters((current) => {
@@ -93,7 +94,7 @@ export default function FiltersScreen() {
   return (
     <Screen fluid>
       <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
-        <Pressable onPress={() => router.back()} hitSlop={8}>
+        <Pressable onPress={() => goBackTo('/(app)/discover')} hitSlop={8}>
           <Text style={styles.back}>‹ Back</Text>
         </Pressable>
         <Text style={styles.title}>Filters</Text>
@@ -227,7 +228,7 @@ export default function FiltersScreen() {
         <CountryPicker
           value={filters.country ?? ''}
           onChange={(country) => set({ country: country || undefined }, true)}
-          {...(isPro ? {} : { onLocked: () => openPaywall('advancedFilters') })}
+          {...(isPro ? {} : { onLocked: () => openPaywall('advancedFilters', '/(app)/filters') })}
         />
 
         <View style={styles.actions}>

--- a/apps/mobile/app/(app)/leaderboard.tsx
+++ b/apps/mobile/app/(app)/leaderboard.tsx
@@ -113,7 +113,11 @@ export default function LeaderboardScreen() {
           }
           renderItem={({ item }) => (
             <Pressable
-              onPress={() => router.push(`/(app)/profile/${item.handle}`)}
+              onPress={() =>
+                router.push(
+                  `/(app)/profile/${item.handle}?from=${encodeURIComponent('/(app)/leaderboard')}`,
+                )
+              }
               style={[styles.row, item.isViewer && styles.rowViewer]}
             >
               <Text style={styles.rank}>{MEDALS[item.rank - 1] ?? `#${item.rank}`}</Text>

--- a/apps/mobile/app/(app)/paywall.tsx
+++ b/apps/mobile/app/(app)/paywall.tsx
@@ -17,6 +17,7 @@ import { ActivityIndicator, Linking, Pressable, StyleSheet, Text, View } from 'r
 import { useEffectiveTier, useQuota, useRefreshEntitlement } from '../../src/api/queries'
 import { Button } from '../../src/components/ui/Button'
 import { Screen } from '../../src/components/ui/Screen'
+import { goBackTo } from '../../src/lib/navigation'
 import {
   getOffers,
   isPurchasesAvailable,
@@ -147,7 +148,12 @@ function parseFeature(raw: string | undefined): PlanFeature | null {
 }
 
 export default function PaywallScreen() {
-  const { feature: featureParam } = useLocalSearchParams<{ feature?: string }>()
+  // Reached from the profile, the viewer list, filters, Discover and a chat
+  // thread, so the caller says where back leads.
+  const { feature: featureParam, from } = useLocalSearchParams<{
+    feature?: string
+    from?: string
+  }>()
   const feature = parseFeature(featureParam)
   // Which column to point at, read off `PLAN_LIMITS` rather than assumed:
   // move a capability between tiers and the sentence follows it.
@@ -286,7 +292,12 @@ export default function PaywallScreen() {
         </Pressable>
       </View>
 
-      <Button label="Back" variant="secondary" onPress={() => router.back()} style={styles.back} />
+      <Button
+        label="Back"
+        variant="secondary"
+        onPress={() => goBackTo('/(app)/me', from)}
+        style={styles.back}
+      />
     </Screen>
   )
 }

--- a/apps/mobile/app/(app)/paywall.tsx
+++ b/apps/mobile/app/(app)/paywall.tsx
@@ -11,7 +11,7 @@ import {
   type ProBenefit,
   type ProPlusBenefit,
 } from '@langx/shared'
-import { router, useLocalSearchParams } from 'expo-router'
+import { useLocalSearchParams } from 'expo-router'
 import { useEffect, useState } from 'react'
 import { ActivityIndicator, Linking, Pressable, StyleSheet, Text, View } from 'react-native'
 import { useEffectiveTier, useQuota, useRefreshEntitlement } from '../../src/api/queries'

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -17,6 +17,7 @@ import { TierBadge } from '../../../src/components/TierBadge'
 import { Chip } from '../../../src/components/ui/Chip'
 import { Screen } from '../../../src/components/ui/Screen'
 import { chooseAlert, confirmAlert } from '../../../src/lib/alert'
+import { goBackTo } from '../../../src/lib/navigation'
 import { openPaywall } from '../../../src/lib/paywall'
 import { showToast } from '../../../src/lib/toast'
 import { days } from '../../../src/lib/format'
@@ -29,7 +30,10 @@ function countryLabel(code: string): string {
 }
 
 export default function ProfileScreen() {
-  const { handle } = useLocalSearchParams<{ handle: string }>()
+  // `from` is set by whoever pushed here — this screen is reachable from
+  // Discover, Chats, the viewer list, the leaderboard and a chat header, so a
+  // single named parent would be wrong for four of the five.
+  const { handle, from } = useLocalSearchParams<{ handle: string; from?: string }>()
   const profile = useProfile(handle ?? '')
   const startConversation = useStartConversation()
   const block = useBlockUser()
@@ -49,7 +53,11 @@ export default function ProfileScreen() {
     return (
       <Screen>
         <Text style={styles.missing}>Profile not found.</Text>
-        <Button label="Back" variant="secondary" onPress={() => router.back()} />
+        <Button
+          label="Back"
+          variant="secondary"
+          onPress={() => goBackTo('/(app)/discover', from)}
+        />
       </Screen>
     )
   }
@@ -73,7 +81,7 @@ export default function ProfileScreen() {
           // `openPaywall` rather than the raw route: it is the one place that
           // knows how the paywall is reached, and pushing the path directly
           // meant this call site quietly missed whatever it does.
-          openPaywall()
+          openPaywall(undefined, `/(app)/profile/${handle}`)
           return
         }
         if (caught.code === 'CONVERSATION_EXISTS') {
@@ -118,7 +126,11 @@ export default function ProfileScreen() {
 
   return (
     <Screen scroll>
-      <Pressable onPress={() => router.back()} hitSlop={12} style={styles.backRow}>
+      <Pressable
+        onPress={() => goBackTo('/(app)/discover', from)}
+        hitSlop={12}
+        style={styles.backRow}
+      >
         <Text style={styles.back}>‹ Back</Text>
       </Pressable>
 

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../src/api/queries'
 import { Button } from '../../src/components/ui/Button'
 import { Screen } from '../../src/components/ui/Screen'
+import { goBackTo } from '../../src/lib/navigation'
 import { appVersion } from '../../src/hooks/useAppConfig'
 import { confirmAlert, showAlert } from '../../src/lib/alert'
 import { showToast } from '../../src/lib/toast'
@@ -135,7 +136,7 @@ export default function SettingsScreen() {
   }
   return (
     <Screen scroll>
-      <Pressable onPress={() => router.back()} hitSlop={12} style={styles.backRow}>
+      <Pressable onPress={() => goBackTo('/(app)/me')} hitSlop={12} style={styles.backRow}>
         <Text style={styles.back}>‹ Back</Text>
       </Pressable>
       <Text style={styles.title}>Settings</Text>

--- a/apps/mobile/app/(app)/store.tsx
+++ b/apps/mobile/app/(app)/store.tsx
@@ -3,6 +3,7 @@ import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-nati
 import { useMe, usePurchase, useTokens, useWallet } from '../../src/api/queries'
 import { StoreRow } from '../../src/components/store/StoreRow'
 import { Screen } from '../../src/components/ui/Screen'
+import { goBackTo } from '../../src/lib/navigation'
 import { buildStoreOffers } from '../../src/lib/storeOffers'
 import { colors, font, radius, spacing } from '../../src/lib/theme'
 
@@ -42,7 +43,7 @@ export default function StoreScreen() {
 
   return (
     <Screen scroll onRefresh={refresh} refreshing={wallet.isFetching}>
-      <Pressable onPress={() => router.back()} hitSlop={12} style={styles.backRow}>
+      <Pressable onPress={() => goBackTo('/(app)/me')} hitSlop={12} style={styles.backRow}>
         <Text style={styles.back}>‹ Back</Text>
       </Pressable>
       <Text style={styles.title}>Token store</Text>

--- a/apps/mobile/app/(app)/store.tsx
+++ b/apps/mobile/app/(app)/store.tsx
@@ -1,4 +1,3 @@
-import { router } from 'expo-router'
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native'
 import { useMe, usePurchase, useTokens, useWallet } from '../../src/api/queries'
 import { StoreRow } from '../../src/components/store/StoreRow'

--- a/apps/mobile/app/(app)/viewers.tsx
+++ b/apps/mobile/app/(app)/viewers.tsx
@@ -13,6 +13,7 @@ import { Avatar } from '../../src/components/ui/Avatar'
 import { Button } from '../../src/components/ui/Button'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
+import { goBackTo } from '../../src/lib/navigation'
 import { dedupeById } from '../../src/lib/dedupeById'
 import { openPaywall } from '../../src/lib/paywall'
 import { colors, font, spacing } from '../../src/lib/theme'
@@ -31,7 +32,7 @@ export default function ViewersScreen() {
 
   return (
     <Screen fluid>
-      <Pressable onPress={() => router.back()} hitSlop={12} style={styles.backRow}>
+      <Pressable onPress={() => goBackTo('/(app)/me')} hitSlop={12} style={styles.backRow}>
         <Text style={styles.back}>‹ Back</Text>
       </Pressable>
       <Text style={styles.title}>Who viewed your profile</Text>
@@ -49,7 +50,7 @@ export default function ViewersScreen() {
           {summary.total > 0 ? (
             <Button
               label="See who they are"
-              onPress={() => openPaywall('profileViewerIdentities')}
+              onPress={() => openPaywall('profileViewerIdentities', '/(app)/viewers')}
               style={styles.cta}
             />
           ) : null}
@@ -77,7 +78,11 @@ export default function ViewersScreen() {
           }
           renderItem={({ item }) => (
             <Pressable
-              onPress={() => router.push(`/(app)/profile/${item.handle}`)}
+              onPress={() =>
+                router.push(
+                  `/(app)/profile/${item.handle}?from=${encodeURIComponent('/(app)/viewers')}`,
+                )
+              }
               style={styles.row}
             >
               <Avatar url={item.avatarUrl} name={item.displayName} />

--- a/apps/mobile/src/lib/backHref.test.ts
+++ b/apps/mobile/src/lib/backHref.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { backHref } from './backHref'
+
+describe('backHref', () => {
+  it('falls back when no origin was carried', () => {
+    expect(backHref(undefined, '/(app)/me')).toBe('/(app)/me')
+  })
+
+  it('honours an origin inside the signed-in area', () => {
+    expect(backHref('/(app)/chats', '/(app)/discover')).toBe('/(app)/chats')
+  })
+
+  /** `from` is a string off a URL; a back button is not a redirector. */
+  it('refuses anything that is not an in-app route', () => {
+    for (const hostile of [
+      'https://example.com',
+      '//example.com',
+      '/(auth)/sign-in',
+      '/(app)/../../etc',
+      '',
+    ]) {
+      expect(backHref(hostile, '/(app)/me')).toBe('/(app)/me')
+    }
+  })
+})

--- a/apps/mobile/src/lib/backHref.ts
+++ b/apps/mobile/src/lib/backHref.ts
@@ -1,0 +1,32 @@
+import type { Href } from 'expo-router'
+
+/**
+ * Where a full-screen route's back control should go.
+ *
+ * **Not `router.back()`.** Every screen under `(app)` is registered as a
+ * `Tabs.Screen` with `href: null` — see that layout's comment on why it has to
+ * be — which makes them tabs rather than stack entries. Moving between tabs
+ * replaces instead of stacking, so there is nothing to pop and `back()` resets
+ * to the first tab. It reset to Discover until Chats was moved first, at which
+ * point every back button in the app started opening Chats.
+ *
+ * `router.canGoBack()` is no help: measured in a browser it returns `true`
+ * from these screens and `back()` still lands on the first tab. Guarding on it
+ * would look correct and change nothing.
+ *
+ * Separate file from `navigation.ts` so this stays testable — importing
+ * `expo-router` for a value pulls in react-native, which the mobile test setup
+ * cannot parse.
+ */
+export function backHref(from: string | undefined, fallback: Href): Href {
+  return isAppRoute(from) ? (from as Href) : fallback
+}
+
+/**
+ * `from` arrives as a string off a URL, which anyone can write. Only routes
+ * inside the signed-in area are honoured — a back button is not a place to
+ * accept an arbitrary destination.
+ */
+function isAppRoute(value: string | undefined): value is string {
+  return typeof value === 'string' && value.startsWith('/(app)/') && !value.includes('..')
+}

--- a/apps/mobile/src/lib/backHref.ts
+++ b/apps/mobile/src/lib/backHref.ts
@@ -19,14 +19,22 @@ import type { Href } from 'expo-router'
  * cannot parse.
  */
 export function backHref(from: string | undefined, fallback: Href): Href {
-  return isAppRoute(from) ? (from as Href) : fallback
+  return isAppRoute(from) ? from : fallback
 }
 
 /**
  * `from` arrives as a string off a URL, which anyone can write. Only routes
  * inside the signed-in area are honoured — a back button is not a place to
  * accept an arbitrary destination.
+ *
+ * A type predicate rather than a cast at the call site, and not for style.
+ * `Href` is whatever expo-router's generated route types say it is: a union of
+ * the app's route literals once `expo start` has written them, and a loose
+ * string when it has not. So a cast is *required* locally and *redundant* in
+ * CI, and either way one of the two lints fails. Asserting the narrowing here
+ * is the honest description anyway — this is the trust boundary where a
+ * checked string becomes a route.
  */
-function isAppRoute(value: string | undefined): value is string {
+function isAppRoute(value: string | undefined): value is Href & string {
   return typeof value === 'string' && value.startsWith('/(app)/') && !value.includes('..')
 }

--- a/apps/mobile/src/lib/navigation.ts
+++ b/apps/mobile/src/lib/navigation.ts
@@ -1,0 +1,7 @@
+import { router, type Href } from 'expo-router'
+import { backHref } from './backHref'
+
+/** Go to this screen's parent. See `backHref` for why it is not `router.back()`. */
+export function goBackTo(fallback: Href, from?: string): void {
+  router.replace(backHref(from, fallback))
+}

--- a/apps/mobile/src/lib/paywall.ts
+++ b/apps/mobile/src/lib/paywall.ts
@@ -15,9 +15,10 @@ import { router } from 'expo-router'
  * paywall is a route: it has to survive a deep link and a back-navigation,
  * and a store would not.
  */
-export function openPaywall(feature?: PlanFeature): void {
+export function openPaywall(feature?: PlanFeature, from?: string): void {
+  const params = { ...(feature ? { feature } : {}), ...(from ? { from } : {}) }
   router.push({
     pathname: '/(app)/paywall',
-    ...(feature ? { params: { feature } } : {}),
+    ...(Object.keys(params).length > 0 ? { params } : {}),
   })
 }


### PR DESCRIPTION
## What you reported

Back from `/store` opened Chats instead of the profile.

## What it actually is

Not the store — **every full-screen route in the app**. Measured in a browser:

| from | opened | back landed |
|---|---|---|
| profile → store | `/store` | `/chats` ✗ |
| profile → viewers | `/viewers` | `/chats` ✗ |
| settings → blocked | `/blocked` | `/chats` ✗ |
| discover → filters | `/filters` | `/chats` ✗ |

Browser history depth was 2, 3 and 4 respectively — so this is not "there was nothing to go back to".

`app/(app)/intro.tsx` already carried the reason in a comment: *"Inside a tab navigator 'back' is whatever the stack happens to hold, and it landed on Discover when this screen was opened on a fresh load."* Every screen under `(app)` is registered as a `Tabs.Screen` with `href: null` — which is what stops the tab bar drawing under it — and that makes it a **tab**, not a stack entry. Moving between tabs replaces rather than stacks, so there is nothing to pop and `back()` resets to the first tab. That was Discover; it became **Chats** when the tabs were reordered, which is when you noticed.

## The obvious fix does not work, and I checked before writing it

`router.canGoBack() ? router.back() : router.replace(parent)` looks like the answer. It isn't: `canGoBack()` returns **`true`** from these screens and `back()` still lands on the first tab. I wired it up, measured it, and got `/chats` again — then instrumented the screen to print `canGoBack=true` while a plain `router.replace('/(app)/me')` went to the right place.

So the destination is named, which is what `intro.tsx` had already settled on for itself.

## Shape

- **One entry point → name the parent**: store, viewers, settings, edit-profile → `/(app)/me`; blocked → `/(app)/settings`; filters → `/(app)/discover`.
- **Several entry points → carry `from`**: `profile/[handle]` (Discover, viewers, leaderboard, a chat header), `paywall` (five call sites, all through `openPaywall`), and `chat/[id]` — which needs no param, since leaving a thread lands on the list of threads whichever way you arrived.
- `backHref` only honours a `from` inside `(app)`. It arrives as a string off a URL, and a back button is not a place to accept an arbitrary destination.

`backHref` is its own file so it stays testable: importing `expo-router` for a value pulls in react-native, which the mobile test setup cannot parse.

## Verified

Seven paths in a browser, including two opened cold with no history — all correct, store and settings included. Plus `backHref.test.ts` for the `from` validation.

Full suite green: 365 api, 112 mobile, 104 shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)