### PR TITLE
Trim 448K of unused font, make the feed page O(posts), paint the system background

### DIFF
--- a/apps/api/src/modules/feed/feed.ts
+++ b/apps/api/src/modules/feed/feed.ts
@@ -92,23 +92,75 @@ function levelOf(profile: Profile | undefined, language: string): FeedPost['leve
   return parsed.success ? parsed.data : null
 }
 
+/**
+ * The one correction each card shows, and whether the viewer has already
+ * answered — without reading the rest.
+ *
+ * The obvious version fetches every correction for the page and picks the first
+ * of each in JS. That is fine for a post with two answers and quadratic-feeling
+ * for one with three hundred: a single popular post makes every request that
+ * happens to include it transfer its whole correction list to compute two
+ * booleans' worth of output.
+ *
+ * `$group`/`$first` after an index-backed `$sort` returns one document per
+ * post, so what crosses the wire is O(posts) rather than O(corrections). The
+ * viewer lookup is a separate targeted query on `post_author_unique` rather
+ * than a second pass over the same documents — it reads at most one row per
+ * post by definition, since that index is unique.
+ */
+async function readCorrectionSummary(
+  db: Db,
+  userId: string,
+  ids: ObjectId[],
+): Promise<{ topByPost: Map<string, PostCorrectionDoc>; viewerCorrected: Set<string> }> {
+  if (ids.length === 0) return { topByPost: new Map(), viewerCorrected: new Set() }
+
+  const corrections = db.collection<PostCorrectionDoc>(COLLECTIONS.postCorrections)
+  const [tops, mine] = await Promise.all([
+    corrections
+      .aggregate<{ _id: ObjectId; top: PostCorrectionDoc }>([
+        { $match: { postId: { $in: ids } } },
+        // Matches `post_created` ({ postId: 1, createdAt: 1 }), so the sort is
+        // a scan of the index rather than an in-memory sort of the documents.
+        { $sort: { postId: 1, createdAt: 1 } },
+        { $group: { _id: '$postId', top: { $first: '$$ROOT' } } },
+      ])
+      .toArray(),
+    corrections
+      .find({ postId: { $in: ids }, authorId: userId })
+      .project<{ postId: ObjectId }>({ postId: 1 })
+      .toArray(),
+  ])
+
+  return {
+    topByPost: new Map(tops.map((row) => [row._id.toHexString(), row.top])),
+    viewerCorrected: new Set(mine.map((row) => row.postId.toHexString())),
+  }
+}
+
 export async function listFeed(db: Db, userId: string, query: ListFeedQuery): Promise<FeedPage> {
   const posts = db.collection<Post>(COLLECTIONS.posts)
 
   // Blocks are symmetric here as everywhere else: `blockedUserIds` returns
   // both directions, so neither party appears in the other's feed.
-  const hidden = await blockedUserIds(db, userId)
+  // Independent of each other, so they go together: the block list does not
+  // narrow the conversation lookup, it filters its result.
+  const [hidden, conversations] = await Promise.all([
+    blockedUserIds(db, userId),
+    query.filter === 'following'
+      ? db
+          .collection<{ participants: string[] }>(COLLECTIONS.conversations)
+          .find({ participants: userId })
+          .project<{ participants: string[] }>({ participants: 1 })
+          .toArray()
+      : Promise.resolve([]),
+  ])
   const filter: Document = hidden.length > 0 ? { authorId: { $nin: hidden } } : {}
 
   if (query.filter === 'following') {
     // "Following" has no follow graph to read, so it means the people you have
     // actually talked to — which is the relationship this app has instead of
     // one. A feed of strangers is what the other tab already is.
-    const conversations = await db
-      .collection<{ participants: string[] }>(COLLECTIONS.conversations)
-      .find({ participants: userId })
-      .project<{ participants: string[] }>({ participants: 1 })
-      .toArray()
     const known = [
       ...new Set(conversations.flatMap((c) => c.participants).filter((id) => id !== userId)),
     ]
@@ -150,19 +202,7 @@ export async function listFeed(db: Db, userId: string, query: ListFeedQuery): Pr
   const last = items.at(-1)
 
   const ids = items.map((post) => post._id)
-  const corrections = await db
-    .collection<PostCorrectionDoc>(COLLECTIONS.postCorrections)
-    .find({ postId: { $in: ids } })
-    .sort({ postId: 1, createdAt: 1 })
-    .toArray()
-
-  const topByPost = new Map<string, PostCorrectionDoc>()
-  const viewerCorrected = new Set<string>()
-  for (const correction of corrections) {
-    const key = correction.postId.toHexString()
-    if (!topByPost.has(key)) topByPost.set(key, correction)
-    if (correction.authorId === userId) viewerCorrected.add(key)
-  }
+  const { topByPost, viewerCorrected } = await readCorrectionSummary(db, userId, ids)
 
   const authors = await loadAuthors(db, [
     ...items.map((post) => post.authorId),

--- a/apps/api/src/routes/feed.test.ts
+++ b/apps/api/src/routes/feed.test.ts
@@ -224,6 +224,33 @@ describe('community feed', () => {
     expect(item?.correctedByViewer).toBe(true)
   })
 
+  it('returns one correction per post however many it has', async () => {
+    const author = await newUser('many-author@example.com')
+    const helpers = []
+    for (let i = 0; i < 4; i++) helpers.push(await newUser(`many-helper-${i}@example.com`))
+    const postId = (await post(author, 'I has been there.')).json<{ _id: string }>()._id
+
+    for (const [i, helper] of helpers.entries()) {
+      await correct(helper, postId, `I have been there. (${i})`)
+    }
+
+    const item = (await feed(helpers[0]!))
+      .json<{
+        items: {
+          _id: string
+          correctionCount: number
+          topCorrection: { corrected: string } | null
+        }[]
+      }>()
+      .items.find((i) => i._id === postId)
+
+    // The count is the denormalized field; the payload carries exactly one
+    // correction regardless, which is what stops a popular post making every
+    // page that includes it transfer its whole answer list.
+    expect(item?.correctionCount).toBe(4)
+    expect(item?.topCorrection?.corrected).toBe('I have been there. (0)')
+  })
+
   it('hides posts by someone the viewer has blocked, in both directions', async () => {
     const viewer = await newUser('block-viewer@example.com')
     const blocked = await newUser('block-author@example.com')

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,4 +1,13 @@
-import { Comfortaa_700Bold, useFonts } from '@expo-google-fonts/comfortaa'
+/**
+ * The single weight, by subpath.
+ *
+ * The package root is a barrel whose five `export const … = require(…)` lines
+ * all evaluate on import, so pulling one weight from it bundles the other four
+ * — 560K of TTF to use 112K of it, in the web bundle and in every store
+ * binary. `700Bold/index.js` requires exactly one file.
+ */
+import { Comfortaa_700Bold } from '@expo-google-fonts/comfortaa/700Bold'
+import { useFonts } from 'expo-font'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Stack } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'

--- a/apps/mobile/src/lib/theme/ThemeProvider.tsx
+++ b/apps/mobile/src/lib/theme/ThemeProvider.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import { useColorScheme, type ViewStyle } from 'react-native'
+import * as SystemUI from 'expo-system-ui'
 import { FLAG_KEYS, readFlag, writeFlag } from '../localFlags'
 import {
   font,
@@ -81,13 +82,30 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     void writeFlag(FLAG_KEYS.themePreference, next)
   }, [])
 
-  const value = useMemo<ThemeContextValue>(() => {
-    // `useColorScheme` can also report 'unspecified'; anything that is not an
-    // explicit 'dark' is treated as light.
-    const scheme: ColorScheme =
-      preference === 'auto' ? (deviceScheme === 'dark' ? 'dark' : 'light') : preference
-    return { theme: buildTheme(scheme), preference, setPreference }
-  }, [preference, deviceScheme, setPreference])
+  // `useColorScheme` can also report 'unspecified'; anything that is not an
+  // explicit 'dark' is treated as light.
+  const scheme: ColorScheme =
+    preference === 'auto' ? (deviceScheme === 'dark' ? 'dark' : 'light') : preference
+
+  /**
+   * The one surface React does not paint: the Android window behind the root
+   * view, and the web `<body>` the overscroll rubber-band exposes. Both keep
+   * their default — white — so in dark mode a pull past the top of any list
+   * flashed white behind a `#1c1e26` app.
+   *
+   * `expo-system-ui` was already a dependency and had never been called. It
+   * needs no lazy import the way `expo-notifications` does: the package ships
+   * an `.web.js` that sets `document.body.style.backgroundColor`, so Metro
+   * resolves a real implementation on both platforms.
+   */
+  useEffect(() => {
+    void SystemUI.setBackgroundColorAsync(palettes[scheme].colors.bg)
+  }, [scheme])
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ theme: buildTheme(scheme), preference, setPreference }),
+    [scheme, preference, setPreference],
+  )
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
 }


### PR DESCRIPTION
Follow-ups to #968, all measured rather than assumed.

## 448K of dead font in every bundle

`@expo-google-fonts/comfortaa`'s root is a barrel whose five
`export const … = require(…)` lines all evaluate on import, so asking it for one
weight bundles the other four. `@expo-google-fonts/comfortaa/700Bold` requires
exactly one file.

Measured on a real `expo export`:

| | before | after |
| --- | --- | --- |
| Comfortaa assets | 560K (5 weights) | 112K (1 weight) |
| `dist` total | 9.5M | 9.1M |

The same weight ships inside every store binary, so this is not a web-only
saving.

## The feed page read every correction on it

`listFeed` fetched the whole `postCorrections` set for the page's twenty posts
in order to compute, per post, one top correction and one boolean. Fine at two
answers per post; pathological at three hundred — one popular post made every
page that happened to include it transfer its entire answer list to the API
process.

- top correction: `$group`/`$first` after a `$sort` that matches `post_created`,
  so one document comes back per post
- viewer check: a targeted query on `post_author_unique`, which by definition
  reads at most one row per post because that index is unique

What crosses the wire is now O(posts), not O(corrections). A test pins it: four
corrections on one post, one correction in the payload.

The block list and the "following" conversation lookup now also run together —
neither narrows the other, the second only filters the first's result.

## Dark mode had a white edge

The Android window behind the root view and the web `<body>` are the one surface
React never paints, so both kept their default white: a pull past the top of any
list rubber-banded to white behind a `#1c1e26` app.

`expo-system-ui` was already a dependency and had never once been called. It
needs no lazy import the way `expo-notifications` does — the package ships a
`.web.js` that sets `document.body.style.backgroundColor` — so one effect in
`ThemeProvider` closes it. Verified in a browser at both schemes:
`rgb(244, 248, 251)` and `rgb(28, 30, 38)`.

Credit to the parallel `langx-fa` session, which spotted the unused dependency
while reading the chat screen.

## Verification

`typecheck`, `lint`, `format:check` pass; 375 API + 120 mobile + 108 shared tests
pass. The font and body-background claims were both measured, not reasoned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
