### PR TITLE
Reply to a message, and jump to the one it quotes

### DIFF
--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -125,6 +125,22 @@ export const INDEXES: Partial<IndexSpec> = {
 
   [COLLECTIONS.messages]: [
     { key: { conversationId: 1, createdAt: -1 }, name: 'conversation_created' },
+    /**
+     * The same prefix with the tiebreak in the key, which the descending index
+     * above cannot supply.
+     *
+     * `listMessagesAround` scans forwards as well as backwards — its "newer
+     * than the anchor" half sorts `{ createdAt: 1, _id: 1 }` — and a compound
+     * index walks either way as long as every field reverses together. The
+     * two-field index does not contain `_id`, so the forwards half would fall
+     * back to an in-memory sort on a thread of any length.
+     *
+     * Added under a new name rather than by widening `conversation_created`:
+     * changing a live index's key in place is an `IndexOptionsConflict`, not a
+     * rebuild. The narrower one is now redundant and can be dropped once this
+     * has shipped.
+     */
+    { key: { conversationId: 1, createdAt: -1, _id: -1 }, name: 'conversation_created_id' },
     { key: { senderId: 1, createdAt: -1 }, name: 'sender_created' },
     /**
      * Backs `markConversationRead`'s `updateMany`, which selects the unread

--- a/apps/api/src/modules/chat/conversations.ts
+++ b/apps/api/src/modules/chat/conversations.ts
@@ -32,6 +32,19 @@ export interface Message {
   type: MessageType
   /** Caption for an attachment, the whole message for text, the fix for a correction. */
   body: string
+  /**
+   * A snapshot of the message this one answers, not a live join.
+   *
+   * Same shape and same reason as `correction.original`: the target can be
+   * deleted, and a quote that empties itself would rewrite what the
+   * conversation looks like it said. `messageId` is kept so tapping the quote
+   * can still jump, and that jump is allowed to find nothing.
+   */
+  replyTo?: {
+    messageId: ObjectId
+    senderId: string
+    preview: string
+  }
   correction?: { targetMessageId: ObjectId; original: string; corrected: string; note?: string }
   media?: MessageMedia
   /**

--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -4,6 +4,7 @@ import {
   isImageContentType,
   MAX_AUDIO_BYTES,
   MAX_IMAGE_BYTES,
+  REPLY_PREVIEW_MAX_LENGTH,
   type SendCorrectionInput,
   type SendMediaMessageInput,
   type SendTextMessageInput,
@@ -34,6 +35,42 @@ function previewFor(type: Message['type']): string {
   if (type === 'image') return '📷 Photo'
   if (type === 'audio') return '🎤 Voice message'
   return ''
+}
+
+/**
+ * The quoted message, resolved once at send time.
+ *
+ * Scoped to the conversation exactly the way `sendCorrection` scopes its
+ * target: an id from another thread must read as "not found" rather than as a
+ * permission error, because the two are indistinguishable to someone guessing
+ * ids and only one of them confirms the message exists.
+ */
+async function resolveReplyTo(
+  db: Db,
+  conversation: Conversation,
+  replyToMessageId: string | undefined,
+): Promise<Message['replyTo'] | undefined> {
+  if (!replyToMessageId) return undefined
+
+  let targetId: ObjectId
+  try {
+    targetId = new ObjectId(replyToMessageId)
+  } catch {
+    throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Malformed reply target id')
+  }
+
+  const target = await db
+    .collection<Message>(COLLECTIONS.messages)
+    .findOne({ _id: targetId, conversationId: conversation._id })
+  if (!target) {
+    throw new ApiError(ERROR_CODES.NOT_FOUND, 'Reply target not found in this conversation')
+  }
+
+  return {
+    messageId: target._id,
+    senderId: target.senderId,
+    preview: (target.body || previewFor(target.type)).slice(0, REPLY_PREVIEW_MAX_LENGTH),
+  }
 }
 
 async function recordMessage(
@@ -83,6 +120,7 @@ export async function sendTextMessage(
   input: SendTextMessageInput,
 ): Promise<SendResult> {
   const conversation = await assertConversationAccess(db, input.conversationId, senderId)
+  const replyTo = await resolveReplyTo(db, conversation, input.replyToMessageId)
 
   const message: Message = {
     _id: new ObjectId(),
@@ -90,6 +128,7 @@ export async function sendTextMessage(
     senderId,
     type: 'text',
     body: input.body,
+    ...(replyTo ? { replyTo } : {}),
     createdAt: new Date(),
   }
 
@@ -184,6 +223,8 @@ export async function sendMediaMessage(
     )
   }
 
+  const replyTo = await resolveReplyTo(db, conversation, input.replyToMessageId)
+
   const message: Message = {
     _id: new ObjectId(),
     conversationId: conversation._id,
@@ -191,6 +232,7 @@ export async function sendMediaMessage(
     type: input.kind,
     body: input.body ?? '',
     media: input.media,
+    ...(replyTo ? { replyTo } : {}),
     createdAt: new Date(),
   }
 
@@ -200,44 +242,152 @@ export async function sendMediaMessage(
 
 export interface MessagePage {
   items: Message[]
+  /** Feed to `cursor` for the page *before* this one. Null at the beginning of history. */
   nextCursor: string | null
+  /**
+   * Feed to `after` for the page *after* this one. Null means this page
+   * already reaches the live tail, which is what lets a client know whether a
+   * newly arrived message belongs in it.
+   */
+  prevCursor: string | null
   participants: string[]
+  /** Set only by `listMessagesAround`, so a client knows what to scroll to. */
+  anchorId?: string
 }
 
 /**
- * Newest page first, but each page's `items` come back oldest-first — a chat
- * UI appends `nextCursor`'s page above what's already rendered without
- * needing to reverse anything itself.
+ * Newest page first, but each page's `items` come back oldest-first.
+ *
+ * `cursor` walks backwards into history and `after` walks forwards toward the
+ * newest; only one of the two, and neither means "the newest page". Forwards
+ * exists for `listMessagesAround`'s window, which starts in the middle of a
+ * thread and has to be able to page in both directions to reach the tail.
  */
 export async function listMessages(
   db: Db,
   userId: string,
   conversationId: string,
-  query: { cursor?: string | undefined; limit: number },
+  query: { cursor?: string | undefined; after?: string | undefined; limit: number },
 ): Promise<MessagePage> {
+  if (query.cursor && query.after) {
+    throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Pass cursor or after, not both')
+  }
   const conversation = await assertConversationAccess(db, conversationId, userId)
   const messages = db.collection<Message>(COLLECTIONS.messages)
 
+  const forwards = Boolean(query.after)
   const filter: Document = { conversationId: conversation._id }
-  if (query.cursor) {
-    const { date, id } = decodeDateIdCursor(query.cursor)
-    filter.$or = [{ createdAt: { $lt: date } }, { createdAt: date, _id: { $lt: id } }]
+  const boundary = query.after ?? query.cursor
+  if (boundary) {
+    const { date, id } = decodeDateIdCursor(boundary)
+    filter.$or = forwards
+      ? [{ createdAt: { $gt: date } }, { createdAt: date, _id: { $gt: id } }]
+      : [{ createdAt: { $lt: date } }, { createdAt: date, _id: { $lt: id } }]
   }
 
+  const direction = forwards ? 1 : -1
   const page = await messages
     .find(filter)
-    .sort({ createdAt: -1, _id: -1 })
+    .sort({ createdAt: direction, _id: direction })
     .limit(query.limit + 1)
     .toArray()
 
   const hasMore = page.length > query.limit
-  const items = hasMore ? page.slice(0, query.limit) : page
-  const oldest = items.at(-1)
-  const nextCursor = hasMore && oldest ? encodeDateIdCursor(oldest.createdAt, oldest._id) : null
+  const window = hasMore ? page.slice(0, query.limit) : page
+  // Descending queries come back newest-first; the wire format is oldest-first.
+  const items = forwards ? window : window.reverse()
 
-  // The thread header needs the counterpart even before anyone has replied,
-  // and a one-sided thread has no message to read a partner id off.
-  return { items: items.reverse(), nextCursor, participants: conversation.participants }
+  const oldest = items[0]
+  const newest = items.at(-1)
+  return {
+    items,
+    // Only the direction actually being paged reports more: the caller already
+    // holds everything on the side it came from, and claiming otherwise would
+    // have an infinite query walk back over pages it has.
+    nextCursor:
+      !forwards && hasMore && oldest ? encodeDateIdCursor(oldest.createdAt, oldest._id) : null,
+    prevCursor:
+      forwards && hasMore && newest ? encodeDateIdCursor(newest.createdAt, newest._id) : null,
+    // The thread header needs the counterpart even before anyone has replied,
+    // and a one-sided thread has no message to read a partner id off.
+    participants: conversation.participants,
+  }
+}
+
+/**
+ * A window centred on one message, for jumping to it.
+ *
+ * Two queries rather than one because a keyset cursor only walks one way: the
+ * anchor's neighbours on either side are two different scans off the same
+ * `(createdAt, _id)` key. Both cursors come back, so the window can then be
+ * paged in either direction until it meets the tail.
+ *
+ * Used by a reply's quote, and later by the pinned banner and the starred
+ * list — all three are "show me this message in its context".
+ */
+export async function listMessagesAround(
+  db: Db,
+  userId: string,
+  conversationId: string,
+  query: { around: string; limit: number },
+): Promise<MessagePage> {
+  const conversation = await assertConversationAccess(db, conversationId, userId)
+  const messages = db.collection<Message>(COLLECTIONS.messages)
+
+  let anchorId: ObjectId
+  try {
+    anchorId = new ObjectId(query.around)
+  } catch {
+    throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Malformed message id')
+  }
+
+  const anchor = await messages.findOne({ _id: anchorId, conversationId: conversation._id })
+  if (!anchor) {
+    throw new ApiError(ERROR_CODES.NOT_FOUND, 'Message not found in this conversation')
+  }
+
+  const half = Math.max(1, Math.floor(query.limit / 2))
+  const [olderPage, newerPage] = await Promise.all([
+    messages
+      .find({
+        conversationId: conversation._id,
+        $or: [
+          { createdAt: { $lt: anchor.createdAt } },
+          { createdAt: anchor.createdAt, _id: { $lt: anchor._id } },
+        ],
+      })
+      .sort({ createdAt: -1, _id: -1 })
+      .limit(half + 1)
+      .toArray(),
+    messages
+      .find({
+        conversationId: conversation._id,
+        $or: [
+          { createdAt: { $gt: anchor.createdAt } },
+          { createdAt: anchor.createdAt, _id: { $gt: anchor._id } },
+        ],
+      })
+      .sort({ createdAt: 1, _id: 1 })
+      .limit(half + 1)
+      .toArray(),
+  ])
+
+  const hasOlder = olderPage.length > half
+  const hasNewer = newerPage.length > half
+  const older = (hasOlder ? olderPage.slice(0, half) : olderPage).reverse()
+  const newer = hasNewer ? newerPage.slice(0, half) : newerPage
+
+  const items = [...older, anchor, ...newer]
+  const oldest = items[0]
+  const newest = items.at(-1)
+
+  return {
+    items,
+    nextCursor: hasOlder && oldest ? encodeDateIdCursor(oldest.createdAt, oldest._id) : null,
+    prevCursor: hasNewer && newest ? encodeDateIdCursor(newest.createdAt, newest._id) : null,
+    participants: conversation.participants,
+    anchorId: anchor._id.toHexString(),
+  }
 }
 
 /**

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -467,4 +467,165 @@ describe('Faz 5 — conversation/message history REST', () => {
       expect(profile?.quota.initiations).toHaveLength(1) // just the conversation they opened
     })
   })
+
+  describe('replies and the around window', () => {
+    async function thread(prefix: string, count: number) {
+      const a = await newUser(`${prefix}-a@example.com`)
+      const b = await newUser(`${prefix}-b@example.com`)
+      const { _id: conversationId } = await startConversation(a, b.userId, 'opening')
+      const { sendTextMessage } = await import('../modules/chat/messages')
+      const ids: string[] = []
+      for (let i = 1; i <= count; i++) {
+        const sender = i % 2 === 0 ? b : a
+        const { message } = await sendTextMessage(handle.db, sender.userId, {
+          conversationId,
+          body: `m${i}`,
+        })
+        ids.push(message._id.toHexString())
+      }
+      return { a, b, conversationId, ids }
+    }
+
+    it('snapshots the quoted message rather than joining to it', async () => {
+      const { a, b, conversationId, ids } = await thread('reply-snap', 2)
+      const { sendTextMessage } = await import('../modules/chat/messages')
+
+      const { message } = await sendTextMessage(handle.db, b.userId, {
+        conversationId,
+        body: 'answering that',
+        replyToMessageId: ids[0],
+      })
+
+      expect(message.replyTo?.messageId.toHexString()).toBe(ids[0])
+      expect(message.replyTo?.senderId).toBe(a.userId)
+      expect(message.replyTo?.preview).toBe('m1')
+    })
+
+    /** The reason it is a snapshot: the quote has to outlive its target. */
+    it('keeps the quote readable after the target is blanked', async () => {
+      const { b, conversationId, ids } = await thread('reply-outlive', 1)
+      const { sendTextMessage } = await import('../modules/chat/messages')
+      const { message } = await sendTextMessage(handle.db, b.userId, {
+        conversationId,
+        body: 'answering',
+        replyToMessageId: ids[0],
+      })
+
+      const targetId = message.replyTo?.messageId
+      if (!targetId) throw new Error('the reply carried no snapshot to begin with')
+      await handle.db
+        .collection(COLLECTIONS.messages)
+        .updateOne({ _id: targetId }, { $set: { body: '' } })
+
+      const stored = await handle.db
+        .collection<{ replyTo?: { preview: string } }>(COLLECTIONS.messages)
+        .findOne({ _id: message._id })
+      expect(stored?.replyTo?.preview).toBe('m1')
+    })
+
+    it('refuses a reply target from another conversation', async () => {
+      const first = await thread('reply-cross-1', 1)
+      const second = await thread('reply-cross-2', 1)
+      const { sendTextMessage } = await import('../modules/chat/messages')
+
+      await expect(
+        sendTextMessage(handle.db, second.a.userId, {
+          conversationId: second.conversationId,
+          body: 'wrong thread',
+          replyToMessageId: first.ids[0],
+        }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    })
+
+    it('centres the window on the anchor and offers a cursor both ways', async () => {
+      const { a, conversationId, ids } = await thread('around-centre', 40)
+      const anchor = ids[20]
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/conversations/${conversationId}/messages?around=${anchor}&limit=10`,
+        headers: { cookie: a.cookie },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+      const body = response.json<{
+        items: { _id: string; body: string }[]
+        nextCursor: string | null
+        prevCursor: string | null
+        anchorId: string
+      }>()
+
+      expect(body.anchorId).toBe(anchor)
+      expect(body.items.map((m) => m._id)).toContain(anchor)
+      // Older on one side, newer on the other, oldest-first on the wire.
+      const at = body.items.findIndex((m) => m._id === anchor)
+      expect(at).toBeGreaterThan(0)
+      expect(at).toBeLessThan(body.items.length - 1)
+      expect(body.nextCursor).not.toBeNull()
+      expect(body.prevCursor).not.toBeNull()
+    })
+
+    it('walks forwards to the tail with after, and says when it gets there', async () => {
+      const { a, conversationId, ids } = await thread('around-forward', 12)
+
+      const start = await app.inject({
+        method: 'GET',
+        url: `/conversations/${conversationId}/messages?around=${ids[0]}&limit=4`,
+        headers: { cookie: a.cookie },
+      })
+      let body = start.json<{
+        items: { body: string }[]
+        prevCursor: string | null
+      }>()
+
+      const seen = body.items.map((m) => m.body)
+      let guard = 0
+      while (body.prevCursor && guard++ < 10) {
+        const next = await app.inject({
+          method: 'GET',
+          url: `/conversations/${conversationId}/messages?after=${encodeURIComponent(body.prevCursor)}&limit=4`,
+          headers: { cookie: a.cookie },
+        })
+        expect(next.statusCode, next.body).toBe(200)
+        body = next.json<{ items: { body: string }[]; prevCursor: string | null }>()
+        seen.push(...body.items.map((m) => m.body))
+      }
+
+      // A null prevCursor is the claim that this page reaches the live tail,
+      // which is what a client trusts before splicing a new message into it.
+      expect(body.prevCursor).toBeNull()
+      expect(seen).toContain('m12')
+      expect(new Set(seen).size).toBe(seen.length)
+    })
+
+    it('reports no newer page on the default page, which is already the tail', async () => {
+      const { a, conversationId } = await thread('around-tail', 3)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/conversations/${conversationId}/messages`,
+        headers: { cookie: a.cookie },
+      })
+      expect(response.json<{ prevCursor: string | null }>().prevCursor).toBeNull()
+    })
+
+    it('refuses around together with cursor', async () => {
+      const { a, conversationId, ids } = await thread('around-both', 2)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/conversations/${conversationId}/messages?around=${ids[0]}&cursor=anything`,
+        headers: { cookie: a.cookie },
+      })
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('404s an anchor that is not in this conversation', async () => {
+      const first = await thread('around-foreign-1', 1)
+      const second = await thread('around-foreign-2', 1)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/conversations/${second.conversationId}/messages?around=${first.ids[0]}`,
+        headers: { cookie: second.a.cookie },
+      })
+      expect(response.statusCode).toBe(404)
+    })
+  })
 })

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -1,7 +1,13 @@
-import { listConversationsQuerySchema, listMessagesQuerySchema } from '@langx/shared'
+import { ERROR_CODES, listConversationsQuerySchema, listMessagesQuerySchema } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { ApiError } from '../lib/ApiError'
 import { requireAuth } from '../middleware/requireAuth'
-import { listConversations, listMessages, markConversationRead } from '../modules/chat/messages'
+import {
+  listConversations,
+  listMessages,
+  listMessagesAround,
+  markConversationRead,
+} from '../modules/chat/messages'
 
 // eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
 export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
@@ -22,7 +28,23 @@ export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async (request, reply) => {
       const { id } = request.params as { id: string }
-      const page = await listMessages(app.mongo.db, request.userId, id, request.query)
+      const { around, ...rest } = request.query
+      // Same path, same guard, same response shape — `around` only changes
+      // which way the cursor is anchored, so it does not earn a second route.
+      if (around !== undefined) {
+        if (rest.cursor !== undefined || rest.after !== undefined) {
+          throw new ApiError(
+            ERROR_CODES.VALIDATION_FAILED,
+            'Pass around on its own, without cursor or after',
+          )
+        }
+        const window = await listMessagesAround(app.mongo.db, request.userId, id, {
+          around,
+          limit: rest.limit,
+        })
+        return reply.send(window)
+      }
+      const page = await listMessages(app.mongo.db, request.userId, id, rest)
       return reply.send(page)
     },
   )

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -20,6 +20,7 @@ import {
   uploadMessageMedia,
   useMe,
   useMessages,
+  useMessageWindow,
   useReportUser,
   useTranslate,
   type MessageDto,
@@ -45,13 +46,16 @@ import { openPaywall } from '../../../src/lib/paywall'
 import { showToast } from '../../../src/lib/toast'
 import { messagesNewestFirst } from '../../../src/lib/messageCache'
 import { dayLabel, messageRows, type MessageRow } from '../../../src/lib/messageGroups'
+import { planJump } from '../../../src/lib/messageJump'
 import { makeStyles, useTheme } from '../../../src/lib/theme'
 
 export default function ChatScreen() {
   const { colors } = useTheme()
   const styles = useStyles()
 
-  const { id } = useLocalSearchParams<{ id: string }>()
+  // `at` is the single entry point for "open this thread at that message": a
+  // tapped quote uses it, and so will the pinned banner and the starred list.
+  const { id, at } = useLocalSearchParams<{ id: string; at?: string }>()
   const conversationId = id ?? ''
   const me = useMe()
   const queryClient = useQueryClient()
@@ -72,13 +76,28 @@ export default function ChatScreen() {
    * visibility and, via its position in `items`, as the count on it.
    */
   const [awayFrom, setAwayFrom] = useState<string | null>(null)
+  const [replyingTo, setReplyingTo] = useState<MessageDto | null>(null)
+  /**
+   * The message a jump is centred on, or null while the live thread is showing.
+   *
+   * The window is a *separate* cache rather than the live query paged in both
+   * directions — see `useMessageWindow`. Which one is on screen is the only
+   * difference between the two modes.
+   */
+  const [jumpAnchor, setJumpAnchor] = useState<string | null>(at ?? null)
+  const [highlighted, setHighlighted] = useState<string | null>(null)
   const translateApi = useTranslate()
   const report = useReportUser()
   const recorder = useVoiceRecorder()
   const [sendingMedia, setSendingMedia] = useState(false)
   const typingTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const items = useMemo(() => messagesNewestFirst(messages.data), [messages.data])
+  const windowed = useMessageWindow(conversationId, jumpAnchor)
+  // One of the two, never a merge of them: a window that has not paged to the
+  // tail describes a different slice of the thread than the live query does.
+  const thread = jumpAnchor ? windowed : messages
+
+  const items = useMemo(() => messagesNewestFirst(thread.data), [thread.data])
   const rows = useMemo(() => messageRows(items), [items])
   // Newest first, so the anchor's index *is* how many arrived while away.
   const missed = awayFrom
@@ -88,8 +107,8 @@ export default function ChatScreen() {
       )
     : 0
   const state = listState({
-    isPending: messages.isPending,
-    isError: messages.isError,
+    isPending: thread.isPending,
+    isError: thread.isError,
     itemCount: items.length,
   })
   // From the participant list, not from the messages: a thread nobody has
@@ -221,10 +240,18 @@ export default function ChatScreen() {
         })
         setCorrecting(null)
       } else {
-        await emitWithAck(socket, 'message:send', { conversationId, body })
+        await emitWithAck(socket, 'message:send', {
+          conversationId,
+          body,
+          ...(replyingTo ? { replyToMessageId: replyingTo._id } : {}),
+        })
+        setReplyingTo(null)
       }
       setDraft('')
       notifyTyping(false)
+      // Sending is a statement about the live conversation, so it ends a
+      // detour into the history rather than posting into the middle of it.
+      setJumpAnchor(null)
       // Inverted, so the newest message is offset 0.
       listRef.current?.scrollToOffset({ offset: 0, animated: true })
       setAwayFrom(null)
@@ -284,7 +311,9 @@ export default function ChatScreen() {
     if (actions.length === 0) return
 
     const picked = await openMessageMenu(message.body || messageTypeLabel(message.type), actions)
-    if (picked === 'copy') {
+    if (picked === 'reply') {
+      setReplyingTo(message)
+    } else if (picked === 'copy') {
       await Clipboard.setStringAsync(message.body)
       showToast('Copied')
     } else if (picked === 'translate') {
@@ -296,6 +325,57 @@ export default function ChatScreen() {
       await reportMessage(message)
     }
   }
+
+  /**
+   * Tapping a quote.
+   *
+   * `planJump` decides between scrolling and fetching, and the common case is
+   * scrolling — most replies answer something a few rows up. `rowsRef` keeps
+   * this handler stable so it does not defeat `MessageBubble`'s memo, the same
+   * trick `onLongPress` uses below.
+   */
+  const rowsRef = useRef(rows)
+  useEffect(() => {
+    rowsRef.current = rows
+  })
+
+  const flash = useCallback((messageId: string) => {
+    setHighlighted(messageId)
+    setTimeout(() => setHighlighted((current) => (current === messageId ? null : current)), 1400)
+  }, [])
+
+  const onJumpTo = useCallback(
+    (messageId: string) => {
+      const plan = planJump(rowsRef.current, messageId)
+      if (plan.kind === 'scroll') {
+        listRef.current?.scrollToIndex({ index: plan.index, viewPosition: 0.5, animated: true })
+      } else {
+        setJumpAnchor(plan.anchorId)
+      }
+      flash(messageId)
+    },
+    [flash],
+  )
+
+  const onReply = useCallback((message: MessageDto) => setReplyingTo(message), [])
+
+  /**
+   * Centre the window on what it was opened for, once — not on every page it
+   * loads afterwards, or paging further back would keep yanking the reader
+   * to the anchor.
+   */
+  const centred = useRef<string | null>(null)
+  useEffect(() => {
+    if (!jumpAnchor) {
+      centred.current = null
+      return
+    }
+    if (centred.current === jumpAnchor) return
+    const index = rows.findIndex((row) => row.kind === 'message' && row.key === jumpAnchor)
+    if (index < 0) return
+    centred.current = jumpAnchor
+    listRef.current?.scrollToIndex({ index, viewPosition: 0.5, animated: false })
+  }, [jumpAnchor, rows])
 
   /**
    * Referentially stable for the life of the screen, which is what keeps
@@ -412,15 +492,36 @@ export default function ChatScreen() {
              * `onStartReached`, which react-native-web's FlatList does not have.
              */
             onEndReached={() => {
-              if (messages.hasNextPage && !messages.isFetchingNextPage) {
-                void messages.fetchNextPage()
+              if (thread.hasNextPage && !thread.isFetchingNextPage) {
+                void thread.fetchNextPage()
               }
             }}
             onEndReachedThreshold={0.4}
             /** Footer, not header: inverted, the footer is what sits on top. */
             ListFooterComponent={
-              messages.isFetchingNextPage ? <ActivityIndicator style={styles.older} /> : null
+              thread.isFetchingNextPage ? <ActivityIndicator style={styles.older} /> : null
             }
+            /**
+             * Mandatory, not defensive: bubbles are variable height and there
+             * is no `getItemLayout`, so `scrollToIndex` throws outright on a
+             * row the list has not measured. Nudging to an estimate and asking
+             * again is the documented recovery.
+             */
+            onScrollToIndexFailed={(info) => {
+              listRef.current?.scrollToOffset({
+                offset: info.averageItemLength * info.index,
+                animated: false,
+              })
+              setTimeout(
+                () =>
+                  listRef.current?.scrollToIndex({
+                    index: info.index,
+                    viewPosition: 0.5,
+                    animated: false,
+                  }),
+                120,
+              )
+            }}
             onScroll={({ nativeEvent }) => {
               // Nothing to measure against the content height any more: the
               // bottom of an inverted list is offset 0.
@@ -444,14 +545,33 @@ export default function ChatScreen() {
                   partnerName={partner?.displayName ?? 'them'}
                   translation={translations[row.message._id]}
                   translating={translating === row.message._id}
+                  replyToMine={row.message.replyTo?.senderId === me.data?._id}
+                  highlighted={highlighted === row.message._id}
                   onLongPress={onLongPress}
+                  onReply={onReply}
+                  onJumpTo={onJumpTo}
                 />
               )
             }
           />
         )}
 
-        {awayFrom !== null ? (
+        {/*
+          A window is a detour, and the way back has to be obvious — otherwise
+          the only exit is sending a message or leaving the screen.
+        */}
+        {jumpAnchor !== null ? (
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => setJumpAnchor(null)}
+            style={styles.backToLatest}
+          >
+            <Feather name="arrow-down-circle" size={15} color={colors.primaryText} />
+            <Text style={styles.backToLatestText}>Back to latest</Text>
+          </Pressable>
+        ) : null}
+
+        {awayFrom !== null && jumpAnchor === null ? (
           <Pressable
             accessibilityRole="button"
             accessibilityLabel={
@@ -476,6 +596,30 @@ export default function ChatScreen() {
         truncated to a line: a correction is an edit, and an edit made from a
         half-remembered original is how a wrong one gets sent.
       */}
+      {/*
+        Sibling of the correcting banner below, and deliberately quieter: a
+        reply is the ordinary case and a correction is the teaching one, so the
+        correction keeps the success colour and this gets the accent edge.
+      */}
+      {replyingTo && !correcting ? (
+        <View style={styles.replyingBanner}>
+          <View style={styles.replyingBar} />
+          <View style={styles.replyingText}>
+            <Text style={styles.replyingTitle} numberOfLines={1}>
+              {isMine(replyingTo)
+                ? 'Replying to yourself'
+                : `Replying to ${partner?.displayName ?? 'them'}`}
+            </Text>
+            <Text style={styles.replyingPreview} numberOfLines={1}>
+              {replyingTo.body || messageTypeLabel(replyingTo.type)}
+            </Text>
+          </View>
+          <Pressable onPress={() => setReplyingTo(null)} hitSlop={8}>
+            <Text style={styles.replyingCancel}>Cancel</Text>
+          </Pressable>
+        </View>
+      ) : null}
+
       {correcting ? (
         <View style={styles.correctingBanner}>
           <View style={styles.correctingHead}>
@@ -662,6 +806,40 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
     right: spacing.lg,
   },
   jumpCount: { ...font.caption, color: colors.primaryText, fontWeight: '700' },
+  backToLatest: {
+    ...cardShadow,
+    alignItems: 'center',
+    alignSelf: 'center',
+    backgroundColor: colors.primary,
+    borderRadius: radius.pill,
+    flexDirection: 'row',
+    gap: 6,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 7,
+    position: 'absolute',
+    top: spacing.md,
+  },
+  backToLatestText: { ...font.caption, color: colors.primaryText, fontWeight: '700' },
+  replyingBanner: {
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    borderTopColor: colors.border,
+    borderTopWidth: 1,
+    flexDirection: 'row',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+  },
+  replyingBar: {
+    alignSelf: 'stretch',
+    backgroundColor: colors.accent,
+    borderRadius: radius.pill,
+    width: 3,
+  },
+  replyingText: { flex: 1, gap: 1, minWidth: 0 },
+  replyingTitle: { ...font.caption, color: colors.accent, fontWeight: '700' },
+  replyingPreview: { ...font.caption, color: colors.textMuted },
+  replyingCancel: { ...font.caption, color: colors.textMuted, fontWeight: '600' },
   older: { paddingVertical: spacing.md },
   correctingBanner: {
     backgroundColor: colors.successBg,

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -45,6 +45,12 @@ export const keys = {
   discovery: (filters: string) => ['discovery', filters] as const,
   conversations: ['conversations'] as const,
   messages: (id: string) => ['messages', id] as const,
+  /**
+   * Deliberately a child of `messages(id)`: a socket patch written with
+   * `setQueriesData` and that prefix reaches the live thread and any open jump
+   * window in one call, which is the only thing keeping the two in step.
+   */
+  messagesAround: (id: string, anchorId: string) => ['messages', id, 'around', anchorId] as const,
   tokens: ['tokens'] as const,
   wallet: ['wallet'] as const,
   badges: ['badges'] as const,
@@ -247,6 +253,8 @@ export interface MessageDto {
   body: string
   media?: MessageMediaDto
   correction?: { original: string; corrected: string; note?: string }
+  /** A snapshot taken when the reply was sent, so it survives the target. */
+  replyTo?: { messageId: string; senderId: string; preview: string }
   deliveredAt?: string
   readAt?: string
   createdAt: string
@@ -263,10 +271,54 @@ export function useMessages(conversationId: string) {
       ),
     initialPageParam: '',
     // The cursor walks *backwards* into history, so "the next page" is older
-    // messages and `pages[0]` stays the newest. `flattenMessagePages` is the
+    // messages and `pages[0]` stays the newest. `messagesNewestFirst` is the
     // only sanctioned way to read this — see the note there.
     getNextPageParam: (last) => last.nextCursor ?? undefined,
     enabled: conversationId.length > 0,
+  })
+}
+
+/** Which end of the window a page is being fetched from. */
+export interface MessageWindowParam {
+  dir: 'around' | 'older' | 'newer'
+  value: string
+}
+
+function windowUrl(conversationId: string, param: MessageWindowParam): string {
+  const key = param.dir === 'around' ? 'around' : param.dir === 'older' ? 'cursor' : 'after'
+  return `/conversations/${conversationId}/messages?${key}=${encodeURIComponent(param.value)}`
+}
+
+/**
+ * A thread opened in the middle, at one particular message.
+ *
+ * A separate cache from `useMessages` on purpose. Making the live query
+ * bidirectional would break the invariant three other modules are built on —
+ * that `pages[0]` is the newest page, which is where `appendIncomingMessage`
+ * writes and where `useSocket` expects a new message to land. A window has no
+ * append target and no such invariant, so it is free to page both ways, and
+ * the live thread is left untouched underneath it.
+ *
+ * The key is a child of `keys.messages(id)`, so socket patches written with
+ * that prefix reach this cache too.
+ */
+export function useMessageWindow(conversationId: string, anchorId: string | null) {
+  // Annotated rather than asserted: the literal has to keep its narrow `dir`
+  // type, and a plain object literal in the option bag widens it to `string`.
+  const start: MessageWindowParam = { dir: 'around', value: anchorId ?? '' }
+
+  return useInfiniteQuery({
+    queryKey: keys.messagesAround(conversationId, anchorId ?? ''),
+    queryFn: ({ pageParam }) => api.get<MessagePageDto>(windowUrl(conversationId, pageParam)),
+    initialPageParam: start,
+    getNextPageParam: (last): MessageWindowParam | undefined =>
+      last.nextCursor ? { dir: 'older', value: last.nextCursor } : undefined,
+    getPreviousPageParam: (first): MessageWindowParam | undefined =>
+      first.prevCursor ? { dir: 'newer', value: first.prevCursor } : undefined,
+    enabled: conversationId.length > 0 && Boolean(anchorId),
+    // A jump is a detour, not a place to live: let it fall out of cache once
+    // the reader is back on the live thread.
+    gcTime: 60_000,
   })
 }
 

--- a/apps/mobile/src/components/MessageBubble.tsx
+++ b/apps/mobile/src/components/MessageBubble.tsx
@@ -1,7 +1,8 @@
 import Feather from '@expo/vector-icons/Feather'
-import { memo } from 'react'
-import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { memo, useMemo, useRef } from 'react'
+import { Animated, PanResponder, Platform, Pressable, StyleSheet, Text, View } from 'react-native'
 import type { MessageDto } from '../api/queries'
+import { shouldCaptureSwipe, swipeReleased, swipeTranslation } from '../lib/swipeToReply'
 import { makeStyles, useTheme } from '../lib/theme'
 import { AudioBubble, ImageBubble } from './MediaBubble'
 import { MessageMeta } from './MessageMeta'
@@ -15,7 +16,13 @@ export interface MessageBubbleProps {
   partnerName: string
   translation?: string | undefined
   translating: boolean
+  /** Whether the *quoted* message is the reader's own, for the quote's byline. */
+  replyToMine: boolean
+  /** Briefly ringed after a jump, so the reader sees where they landed. */
+  highlighted: boolean
   onLongPress: (message: MessageDto, alreadyTranslated: boolean) => void
+  onReply: (message: MessageDto) => void
+  onJumpTo: (messageId: string) => void
 }
 
 /**
@@ -35,41 +42,96 @@ export const MessageBubble = memo(function MessageBubble({
   partnerName,
   translation,
   translating,
+  replyToMine,
+  highlighted,
   onLongPress,
+  onReply,
+  onJumpTo,
 }: MessageBubbleProps) {
   const { colors } = useTheme()
   const styles = useStyles()
   const press = () => onLongPress(message, Boolean(translation))
 
+  /**
+   * Swipe right to reply — native only.
+   *
+   * Off on web deliberately. react-native-web does map mouse events onto the
+   * responder system, so a drag reaches this, but it fights the browser's own
+   * text selection and a trackpad's horizontal gesture is a `wheel` event that
+   * never arrives here at all. A gesture that works for some inputs and not
+   * others is worse than one that is plainly absent; in a browser the menu's
+   * Reply row is the way in.
+   */
+  const translateX = useRef(new Animated.Value(0)).current
+  const responder = useMemo(() => {
+    const settle = () =>
+      Animated.spring(translateX, { toValue: 0, useNativeDriver: true, bounciness: 0 }).start()
+    return PanResponder.create({
+      // Never on start: that would swallow the tap and the long press.
+      onStartShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponder: (_event, gesture) => shouldCaptureSwipe(gesture.dx, gesture.dy),
+      onPanResponderMove: (_event, gesture) => translateX.setValue(swipeTranslation(gesture.dx)),
+      onPanResponderRelease: (_event, gesture) => {
+        if (swipeReleased(gesture.dx)) onReply(message)
+        settle()
+      },
+      onPanResponderTerminate: settle,
+      // The list asking for the responder back mid-scroll wins, always.
+      onPanResponderTerminationRequest: () => true,
+    })
+  }, [message, onReply, translateX])
+
+  const pan = Platform.OS === 'web' ? {} : responder.panHandlers
+  const flash = highlighted ? styles.highlighted : null
+  const replyTo = message.replyTo
+
+  const quote = replyTo ? (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Go to the quoted message"
+      onPress={() => onJumpTo(replyTo.messageId)}
+      style={[styles.quote, mine ? styles.quoteMine : styles.quoteTheirs]}
+    >
+      <Text style={[styles.quoteAuthor, mine && styles.quoteAuthorMine]} numberOfLines={1}>
+        {replyToMine ? 'You' : partnerName}
+      </Text>
+      <Text style={[styles.quoteText, mine && styles.quoteTextMine]} numberOfLines={2}>
+        {replyTo.preview || 'Attachment'}
+      </Text>
+    </Pressable>
+  ) : null
+
   if (message.type === 'correction') {
     return (
-      <Pressable
-        onLongPress={press}
-        style={[styles.correction, mine ? styles.correctionMine : null]}
-      >
-        {/*
+      <Animated.View style={{ transform: [{ translateX }] }} {...pan}>
+        <Pressable
+          onLongPress={press}
+          style={[styles.correction, mine ? styles.correctionMine : null, flash]}
+        >
+          {/*
           The success pair, and only ever the success pair. A correction is
           another person changing your sentence; the info pair belongs to
           Copilot, which proposes one you have not sent. The two must never be
           confusable — see `Callout`.
         */}
-        <View style={styles.correctionHead}>
-          <Feather name="edit-3" size={14} color={colors.success} />
-          <Text style={styles.correctionLabel}>
-            {mine ? 'Your correction' : `Correction from ${partnerName}`}
-          </Text>
-        </View>
-        <View style={styles.correctionBody}>
-          {message.correction ? (
-            <Text style={styles.correctionOriginal}>{message.correction.original}</Text>
-          ) : null}
-          <Text style={styles.correctionText}>{message.body}</Text>
-          {message.correction?.note ? (
-            <Text style={styles.correctionNote}>{message.correction.note}</Text>
-          ) : null}
-          <MessageMeta message={message} mine={mine} />
-        </View>
-      </Pressable>
+          <View style={styles.correctionHead}>
+            <Feather name="edit-3" size={14} color={colors.success} />
+            <Text style={styles.correctionLabel}>
+              {mine ? 'Your correction' : `Correction from ${partnerName}`}
+            </Text>
+          </View>
+          <View style={styles.correctionBody}>
+            {message.correction ? (
+              <Text style={styles.correctionOriginal}>{message.correction.original}</Text>
+            ) : null}
+            <Text style={styles.correctionText}>{message.body}</Text>
+            {message.correction?.note ? (
+              <Text style={styles.correctionNote}>{message.correction.note}</Text>
+            ) : null}
+            <MessageMeta message={message} mine={mine} />
+          </View>
+        </Pressable>
+      </Animated.View>
     )
   }
 
@@ -77,39 +139,45 @@ export const MessageBubble = memo(function MessageBubble({
 
   if (message.type === 'image' || message.type === 'audio') {
     return (
-      <Pressable
-        onLongPress={press}
-        style={[styles.bubble, mine ? styles.mine : styles.theirs, tail]}
-      >
-        {message.type === 'image' ? (
-          <ImageBubble message={message} />
-        ) : (
-          <AudioBubble message={message} mine={mine} />
-        )}
-        {message.body ? (
-          <Text style={[styles.bubbleText, mine && styles.bubbleTextMine, styles.caption]}>
-            {message.body}
-          </Text>
-        ) : null}
-        <MessageMeta message={message} mine={mine} />
-      </Pressable>
+      <Animated.View style={{ transform: [{ translateX }] }} {...pan}>
+        <Pressable
+          onLongPress={press}
+          style={[styles.bubble, mine ? styles.mine : styles.theirs, tail, flash]}
+        >
+          {quote}
+          {message.type === 'image' ? (
+            <ImageBubble message={message} />
+          ) : (
+            <AudioBubble message={message} mine={mine} />
+          )}
+          {message.body ? (
+            <Text style={[styles.bubbleText, mine && styles.bubbleTextMine, styles.caption]}>
+              {message.body}
+            </Text>
+          ) : null}
+          <MessageMeta message={message} mine={mine} />
+        </Pressable>
+      </Animated.View>
     )
   }
 
   return (
-    <Pressable
-      onLongPress={press}
-      style={[styles.bubble, mine ? styles.mine : styles.theirs, tail]}
-    >
-      <Text style={[styles.bubbleText, mine && styles.bubbleTextMine]}>{message.body}</Text>
-      {translation ? (
-        <Text style={[styles.translation, mine && styles.translationMine]}>{translation}</Text>
-      ) : null}
-      {/* The link is gone — translate is a menu row now. This only reports the
-          request already in flight. */}
-      {translating ? <Text style={styles.translateLink}>Translating…</Text> : null}
-      <MessageMeta message={message} mine={mine} />
-    </Pressable>
+    <Animated.View style={{ transform: [{ translateX }] }} {...pan}>
+      <Pressable
+        onLongPress={press}
+        style={[styles.bubble, mine ? styles.mine : styles.theirs, tail, flash]}
+      >
+        {quote}
+        <Text style={[styles.bubbleText, mine && styles.bubbleTextMine]}>{message.body}</Text>
+        {translation ? (
+          <Text style={[styles.translation, mine && styles.translationMine]}>{translation}</Text>
+        ) : null}
+        {/* The link is gone — translate is a menu row now. This only reports the
+            request already in flight. */}
+        {translating ? <Text style={styles.translateLink}>Translating…</Text> : null}
+        <MessageMeta message={message} mine={mine} />
+      </Pressable>
+    </Animated.View>
   )
 })
 
@@ -135,6 +203,30 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
    */
   tailMine: { borderBottomRightRadius: radius.sm / 2 },
   tailTheirs: { borderBottomLeftRadius: radius.sm / 2 },
+  /**
+   * The quote reads as a layer under the reply rather than as a message of its
+   * own: one accent edge, a tint of whatever bubble it sits in, two lines at
+   * most. Any longer and a reply to a long message looks like a reply *from* it.
+   */
+  quote: {
+    borderLeftWidth: 3,
+    borderRadius: radius.sm,
+    marginBottom: spacing.sm,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 6,
+  },
+  quoteTheirs: { backgroundColor: colors.bg, borderLeftColor: colors.accent },
+  quoteMine: { backgroundColor: colors.primaryShade, borderLeftColor: colors.primaryText },
+  quoteAuthor: { ...font.caption, color: colors.accent, fontWeight: '700' },
+  quoteAuthorMine: { color: colors.primaryText },
+  quoteText: { ...font.caption, color: colors.textMuted },
+  quoteTextMine: { color: colors.primaryTextMuted },
+  /**
+   * A ring rather than a fill: the bubble already carries meaning in its
+   * colour — whose it is, and whether it is a correction — and a wash over
+   * that would say the wrong thing for a second and a half.
+   */
+  highlighted: { borderColor: colors.accent, borderWidth: 2 },
   bubbleText: { ...font.body, color: colors.text, lineHeight: 22 },
   bubbleTextMine: { color: colors.primaryText },
   caption: { marginTop: spacing.xs },

--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -43,8 +43,16 @@ export function useSocket(): void {
             ? message.conversationId
             : String(message.conversationId)
 
-        queryClient.setQueryData<InfiniteData<MessagePageDto>>(
-          keys.messages(conversationId),
+        /**
+         * `setQueriesData` with the *prefix*, not `setQueryData` with the key:
+         * `keys.messagesAround` lives under `keys.messages(id)`, so a jump
+         * window open on this thread is patched by the same call. Without it
+         * the window silently stops receiving anything while it is on screen.
+         * `appendIncomingMessage` decides for itself whether a given cache is
+         * one a new message belongs in.
+         */
+        queryClient.setQueriesData<InfiniteData<MessagePageDto>>(
+          { queryKey: keys.messages(conversationId) },
           (old) => appendIncomingMessage(old, message) ?? old,
         )
 
@@ -95,8 +103,8 @@ export function useSocket(): void {
           deliveredTo: string
           deliveredAt: string
         }) => {
-          queryClient.setQueryData<InfiniteData<MessagePageDto>>(
-            keys.messages(conversationId),
+          queryClient.setQueriesData<InfiniteData<MessagePageDto>>(
+            { queryKey: keys.messages(conversationId) },
             (old) => applyDeliveredAt(old, { deliveredTo, deliveredAt }) ?? old,
           )
         },

--- a/apps/mobile/src/lib/messageActions.test.ts
+++ b/apps/mobile/src/lib/messageActions.test.ts
@@ -12,12 +12,12 @@ const ids = (over: Partial<MessageActionContext> = {}) =>
 
 describe('messageActionsFor', () => {
   it('offers the full set on the other person`s text', () => {
-    expect(ids()).toEqual(['copy', 'translate', 'correct', 'report'])
+    expect(ids()).toEqual(['reply', 'copy', 'translate', 'correct', 'report'])
   })
 
   /** Correcting your own message, or reporting yourself, is not a thing. */
   it('leaves only copy on your own message', () => {
-    expect(ids({ mine: true })).toEqual(['copy'])
+    expect(ids({ mine: true })).toEqual(['reply', 'copy'])
   })
 
   it('does not offer to correct anything but text', () => {
@@ -37,7 +37,7 @@ describe('messageActionsFor', () => {
 
   /** A voice note without a caption has no text to copy or translate. */
   it('drops the text actions when there is no body', () => {
-    expect(ids({ type: 'audio', hasBody: false })).toEqual(['report'])
+    expect(ids({ type: 'audio', hasBody: false })).toEqual(['reply', 'report'])
   })
 
   it('always leaves a way to report the other person', () => {
@@ -46,8 +46,12 @@ describe('messageActionsFor', () => {
     }
   })
 
-  it('never offers a menu with nothing in it for your own captionless media', () => {
-    // Nothing to do: the caller must not open an empty sheet.
-    expect(ids({ mine: true, type: 'audio', hasBody: false })).toEqual([])
+  /**
+   * This used to return nothing at all, and the screen had to guard against
+   * opening an empty sheet. Reply applies to every message, including one with
+   * no text of its own, so there is always at least one row.
+   */
+  it('offers reply even on your own captionless media, where nothing else applies', () => {
+    expect(ids({ mine: true, type: 'audio', hasBody: false })).toEqual(['reply'])
   })
 })

--- a/apps/mobile/src/lib/messageActions.ts
+++ b/apps/mobile/src/lib/messageActions.ts
@@ -1,4 +1,4 @@
-export const MESSAGE_ACTION_IDS = ['copy', 'translate', 'correct', 'report'] as const
+export const MESSAGE_ACTION_IDS = ['reply', 'copy', 'translate', 'correct', 'report'] as const
 export type MessageActionId = (typeof MESSAGE_ACTION_IDS)[number]
 
 export interface MessageAction {
@@ -29,9 +29,14 @@ export interface MessageActionContext {
 export function messageActionsFor(context: MessageActionContext): MessageAction[] {
   const actions: MessageAction[] = []
 
-  // Reply, edit, react, star, pin and delete are deliberately absent: each
-  // needs a field on `Message` and a way to mutate one that already exists,
-  // which is one piece of plumbing they should share rather than four.
+  // Every message can be answered, including a captionless voice note — the
+  // quote carries a label for those rather than a body. First in the list
+  // because on web it is the only way in: the swipe gesture is native-only.
+  actions.push({ id: 'reply', label: 'Reply', icon: 'arrow-undo-outline' })
+
+  // Edit, react, star, pin and delete are still absent: each needs a field on
+  // `Message` and a way to mutate one that already exists, which is one piece
+  // of plumbing they should share rather than four.
   if (context.hasBody) {
     actions.push({ id: 'copy', label: 'Copy', icon: 'copy-outline' })
   }

--- a/apps/mobile/src/lib/messageCache.test.ts
+++ b/apps/mobile/src/lib/messageCache.test.ts
@@ -25,7 +25,12 @@ function message(id: string, senderId = THEM, deliveredAt?: string): MessageDto 
 
 function pages(...groups: MessageDto[][]): InfiniteData<MessagePageDto> {
   return {
-    pages: groups.map((items) => ({ items, nextCursor: null, participants: [ME, THEM] })),
+    pages: groups.map((items) => ({
+      items,
+      nextCursor: null,
+      prevCursor: null,
+      participants: [ME, THEM],
+    })),
     pageParams: groups.map((_, i) => (i === 0 ? '' : 'c')),
   }
 }
@@ -64,6 +69,20 @@ describe('appendIncomingMessage', () => {
     const data = pages([message('new1')], [message('old1')])
     const next = appendIncomingMessage(data, message('fresh'))
     expect(messagesNewestFirst(next).map((m) => m._id)).toEqual(['fresh', 'new1', 'old1'])
+  })
+
+  /**
+   * A window opened mid-history is a slice, not the tail. Splicing a message
+   * sent seconds ago in after one from last year is the failure this prevents,
+   * and `prevCursor` is the only thing that distinguishes the two caches.
+   */
+  it('refuses to append to a window that has not reached the tail', () => {
+    const data = pages([message('old1')])
+    const windowed = {
+      ...data,
+      pages: [{ ...data.pages[0]!, prevCursor: 'newer-than-this' }],
+    }
+    expect(appendIncomingMessage(windowed, message('fresh'))).toBe(windowed)
   })
 
   /** The sender appended optimistically and the socket echoes to both. */

--- a/apps/mobile/src/lib/messageCache.ts
+++ b/apps/mobile/src/lib/messageCache.ts
@@ -3,8 +3,13 @@ import type { MessageDto } from '../api/queries'
 
 export interface MessagePageDto {
   items: MessageDto[]
+  /** Older than this page; null at the beginning of history. */
   nextCursor: string | null
+  /** Newer than this page; null means the page already reaches the live tail. */
+  prevCursor: string | null
   participants: string[]
+  /** Only a jump window has one — the message it was opened on. */
+  anchorId?: string
 }
 
 type Pages = InfiniteData<MessagePageDto> | undefined
@@ -22,6 +27,11 @@ export function appendIncomingMessage(data: Pages, message: MessageDto): Pages {
   // The sender already appended this optimistically and the socket echoes to
   // *both* participants, so guard against a duplicate.
   if (data.pages.some((page) => page.items.some((m) => sameId(m, message)))) return data
+  // A jump window that has not paged forward to the tail is a slice out of the
+  // middle of the thread. Appending to it would splice a message sent seconds
+  // ago in after one from last year. Live pages never carry `prevCursor`, so
+  // this is a no-op for them.
+  if (first.prevCursor) return data
   return { ...data, pages: [{ ...first, items: [...first.items, message] }, ...rest] }
 }
 

--- a/apps/mobile/src/lib/messageJump.test.ts
+++ b/apps/mobile/src/lib/messageJump.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import type { MessageDto } from '../api/queries'
+import type { MessageRow } from './messageGroups'
+import { planJump } from './messageJump'
+
+function row(id: string): MessageRow {
+  return {
+    kind: 'message',
+    key: id,
+    endsGroup: true,
+    message: { _id: id } as MessageDto,
+  }
+}
+
+const DAY: MessageRow = { kind: 'day', key: 'day:2026-08-29', day: '2026-08-29' }
+
+describe('planJump', () => {
+  it('scrolls to a target that is already mounted', () => {
+    expect(planJump([row('a'), row('b')], 'b')).toEqual({ kind: 'scroll', index: 1 })
+  })
+
+  /** The index addresses rendered rows, and headings are rendered rows. */
+  it('counts date headings in the index', () => {
+    expect(planJump([row('a'), DAY, row('b')], 'b')).toEqual({ kind: 'scroll', index: 2 })
+  })
+
+  it('fetches a window for a target that has paged out', () => {
+    expect(planJump([row('a')], 'gone')).toEqual({ kind: 'fetch', anchorId: 'gone' })
+  })
+
+  it('fetches when nothing is loaded at all', () => {
+    expect(planJump([], 'x')).toEqual({ kind: 'fetch', anchorId: 'x' })
+  })
+})

--- a/apps/mobile/src/lib/messageJump.ts
+++ b/apps/mobile/src/lib/messageJump.ts
@@ -1,0 +1,20 @@
+import type { MessageRow } from './messageGroups'
+
+export type JumpPlan = { kind: 'scroll'; index: number } | { kind: 'fetch'; anchorId: string }
+
+/**
+ * Tapping a quote: scroll to it, or go and get it.
+ *
+ * Most replies answer something a few rows up, which is already mounted — and
+ * fetching a window for a message that is on screen would swap the live thread
+ * for a detached one, lose the reader's place and cost a request, all to end up
+ * where a `scrollToIndex` would have gone. Only a quote whose target has paged
+ * out is worth a round trip.
+ *
+ * Rows rather than messages, because the index has to count the date headings
+ * between them — `scrollToIndex` addresses what the list renders.
+ */
+export function planJump(rows: MessageRow[], messageId: string): JumpPlan {
+  const index = rows.findIndex((row) => row.kind === 'message' && row.key === messageId)
+  return index >= 0 ? { kind: 'scroll', index } : { kind: 'fetch', anchorId: messageId }
+}

--- a/apps/mobile/src/lib/swipeToReply.test.ts
+++ b/apps/mobile/src/lib/swipeToReply.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SWIPE_ACTIVATE_PX,
+  SWIPE_MAX_PX,
+  shouldCaptureSwipe,
+  swipeReleased,
+  swipeTranslation,
+} from './swipeToReply'
+
+describe('shouldCaptureSwipe', () => {
+  it('ignores movement too small to have a direction yet', () => {
+    expect(shouldCaptureSwipe(4, 0)).toBe(false)
+  })
+
+  it('takes a clearly horizontal drag to the right', () => {
+    expect(shouldCaptureSwipe(40, 5)).toBe(true)
+  })
+
+  /** The case that decides whether the thread still scrolls. */
+  it('leaves a diagonal flick to the list', () => {
+    expect(shouldCaptureSwipe(30, 25)).toBe(false)
+    expect(shouldCaptureSwipe(30, -25)).toBe(false)
+  })
+
+  it('never captures a leftward drag', () => {
+    expect(shouldCaptureSwipe(-40, 2)).toBe(false)
+  })
+})
+
+describe('swipeTranslation', () => {
+  it('follows the finger up to the limit', () => {
+    expect(swipeTranslation(40)).toBe(40)
+    expect(swipeTranslation(SWIPE_MAX_PX)).toBe(SWIPE_MAX_PX)
+  })
+
+  it('resists past it rather than stopping dead', () => {
+    const overshoot = swipeTranslation(SWIPE_MAX_PX + 100)
+    expect(overshoot).toBeGreaterThan(SWIPE_MAX_PX)
+    expect(overshoot).toBeLessThan(SWIPE_MAX_PX + 100)
+  })
+
+  it('does not follow a leftward drag', () => {
+    expect(swipeTranslation(-30)).toBe(0)
+  })
+})
+
+describe('swipeReleased', () => {
+  it('fires at the activation distance and not before', () => {
+    expect(swipeReleased(SWIPE_ACTIVATE_PX - 1)).toBe(false)
+    expect(swipeReleased(SWIPE_ACTIVATE_PX)).toBe(true)
+  })
+})

--- a/apps/mobile/src/lib/swipeToReply.ts
+++ b/apps/mobile/src/lib/swipeToReply.ts
@@ -1,0 +1,36 @@
+/** Past this, the gesture is a reply rather than a scroll. */
+export const SWIPE_ACTIVATE_PX = 56
+/** Where the bubble stops following the finger one-to-one. */
+export const SWIPE_MAX_PX = 80
+/** Movement below this is still undecided. */
+export const SWIPE_LOCK_PX = 10
+/** How much of the overshoot past `SWIPE_MAX_PX` still moves the bubble. */
+const RUBBER = 0.15
+/**
+ * How much more horizontal than vertical the movement has to be.
+ *
+ * This ratio is the whole answer to "why does the thread not scroll any more".
+ * A flick up a long thread is never perfectly vertical, and at 1.0 a slightly
+ * diagonal one reads as a swipe and eats the scroll.
+ */
+const HORIZONTAL_BIAS = 1.5
+
+/**
+ * Is this a reply swipe, or the list scrolling?
+ *
+ * Rightwards only. One accepted sign keeps the test above meaningful and
+ * leaves the other direction free for a later action.
+ */
+export function shouldCaptureSwipe(dx: number, dy: number): boolean {
+  return dx > SWIPE_LOCK_PX && dx > Math.abs(dy) * HORIZONTAL_BIAS
+}
+
+/** Follows the finger, then resists — so the limit is felt, not hit. */
+export function swipeTranslation(dx: number): number {
+  if (dx <= 0) return 0
+  return dx <= SWIPE_MAX_PX ? dx : SWIPE_MAX_PX + (dx - SWIPE_MAX_PX) * RUBBER
+}
+
+export function swipeReleased(dx: number): boolean {
+  return dx >= SWIPE_ACTIVATE_PX
+}

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -35,9 +35,20 @@ export type QuotaStatus = z.infer<typeof quotaStatusSchema>
 export const MESSAGE_TYPES = ['text', 'correction', 'image', 'audio'] as const
 export type MessageType = (typeof MESSAGE_TYPES)[number]
 
+/**
+ * How much of the quoted message a reply carries.
+ *
+ * The quote is a snapshot taken at send time, not a live read of the target —
+ * the same shape `correction.original` uses, and for the same reason: the
+ * target can be deleted, and a quote that empties itself rewrites what the
+ * conversation looks like it said.
+ */
+export const REPLY_PREVIEW_MAX_LENGTH = 140
+
 export const sendTextMessageSchema = z.object({
   conversationId: z.string().trim().min(1),
   body: messageBodySchema,
+  replyToMessageId: z.string().trim().min(1).optional(),
 })
 export type SendTextMessageInput = z.infer<typeof sendTextMessageSchema>
 
@@ -59,9 +70,23 @@ export type SendCorrectionInput = z.infer<typeof sendCorrectionSchema>
 export const MESSAGE_PAGE_SIZE_DEFAULT = 30
 export const MESSAGE_PAGE_SIZE_MAX = 100
 
-/** `GET /conversations/:id/messages` — cursor pages backwards into history, newest page first. */
+/**
+ * `GET /conversations/:id/messages`.
+ *
+ * Three ways in, and they are mutually exclusive — enforced in the module
+ * rather than with `.refine()`, because a `ZodEffects` wrapper is not a plain
+ * object schema and `fastify-type-provider-zod` will not take one for a
+ * querystring.
+ *
+ * - neither: the newest page
+ * - `cursor`: the page *before* it, walking backwards into history
+ * - `after`: the page after it, walking forwards toward the newest
+ * - `around`: a window centred on one message, with a cursor out of both ends
+ */
 export const listMessagesQuerySchema = z.object({
   cursor: z.string().optional(),
+  after: z.string().optional(),
+  around: z.string().trim().min(1).optional(),
   limit: z.coerce
     .number()
     .int()
@@ -141,6 +166,7 @@ export const sendMediaMessageSchema = z.object({
   kind: z.enum(['image', 'audio']),
   media: messageMediaSchema,
   body: z.string().trim().max(MAX_MESSAGE_LENGTH).optional(),
+  replyToMessageId: z.string().trim().min(1).optional(),
 })
 export type SendMediaMessageInput = z.infer<typeof sendMediaMessageSchema>
 


### PR DESCRIPTION
Stacked on #970 — base is `chat/smooth-list`, so review that one first. Second of five branches from the chat plan.

A reply carries a **snapshot** of what it answers (sender + a 140-character preview), not a join to it. Same shape as `correction.original` and for the same reason: the target can be deleted, and a quote that empties itself rewrites what the conversation looks like it said. There is a test that blanks the target and asserts the quote still reads.

Tapping that quote has to go somewhere, and that is the larger half of this PR.

## Server

- **`listMessages` gains a second direction.** `cursor` still walks back into history; `after` walks forwards toward the newest. Only the direction being paged reports more — claiming otherwise would send an infinite query back over pages it already holds. `prevCursor: null` is the page's claim that it reaches the live tail, and the client leans on exactly that.
- **`listMessagesAround`** centres a window on one message using two scans off the same `(createdAt, _id)` key — a keyset cursor only walks one way — and returns a cursor for each end. Same route, same guard, same response shape.
- **New index `conversation_created_id`.** The forwards scan sorts `{ createdAt: 1, _id: 1 }`, which `conversation_created` cannot serve: no `_id` in the key, so the sort falls into memory on a thread of any length. Added under a new name because changing a live index's key in place is an `IndexOptionsConflict`, not a rebuild — the narrower one is now redundant and can be dropped in a follow-up.

## Client

- **The jump window is a separate query key**, not the live query paged both ways. `fetchPreviousPage` prepends to `pages[0]`, and "pages[0] is the newest page" is the invariant `appendIncomingMessage` and `useSocket` are built on. The key is a *child* of `keys.messages(id)`, so one `setQueriesData` with that prefix patches the live thread and any open window together — the socket writes moved off `setQueryData` for exactly that.
- **`appendIncomingMessage` now refuses a page carrying `prevCursor`**, which is what stops a message sent seconds ago being spliced in after one from last year.
- **`planJump`** chooses between scrolling and fetching, and the common case is scrolling: most replies answer something a few rows up, and fetching a window for a message already on screen would trade the live thread for a detached one to end up where a `scrollToIndex` would have gone. That call needs `onScrollToIndexFailed` to exist at all — variable-height bubbles, no `getItemLayout`, and it throws on an unmeasured row.
- **Swipe-to-reply** is `PanResponder` + the legacy `Animated` API: gesture-handler does not resolve from `apps/mobile`, and reanimated is declared but unimported with no worklets plugin in the babel config. `shouldCaptureSwipe` requires the drag to be 1.5× more horizontal than vertical — that ratio is the whole answer to "why does the thread still scroll" — and capture phase is deliberately not used, since it steals the responder from the ScrollView and kills scrolling outright.

**Swipe is off on web.** A mouse drag fights the browser's text selection and a trackpad's horizontal gesture is a `wheel` event that never reaches a responder. A gesture that works for some inputs and not others is worse than one that is plainly absent, so the browser gets the menu's new **Reply** row instead — which is also why Reply is offered on every message, including a captionless voice note that used to produce an empty sheet.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — 633 tests, 8 new on the API and 10 new pure ones on mobile.

The API tests cover: the snapshot outliving a blanked target, a reply target from another conversation 404ing, `around` centring the anchor with a cursor out of both ends, `after` walking to the tail and reporting `prevCursor: null` when it arrives, `around` with `cursor` rejected, and a foreign anchor 404ing.

Not yet driven in a browser — the hands-on pass for the quote tap and the highlight lands with the rest of the chat work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)