### PR TITLE
React to a message, delete it, and project what leaves the server

### DIFF
--- a/apps/api/src/modules/account/deletion.ts
+++ b/apps/api/src/modules/account/deletion.ts
@@ -166,6 +166,20 @@ export async function purgeExpiredAccounts(
       { $set: { body: '', deletedWithAccount: true }, $unset: { correction: '', media: '' } },
     )
 
+    /**
+     * The chat list reads `lastMessage.body` verbatim, and nothing has ever
+     * recomputed it — so blanking the messages above left the purged user's
+     * last sentence sitting in the other person's list, which is precisely the
+     * text a purge is supposed to remove. Patched rather than recomputed, for
+     * the same reason a withdrawal is: the newest message is still that row.
+     */
+    await db
+      .collection<Conversation>(COLLECTIONS.conversations)
+      .updateMany(
+        { participants: userId, 'lastMessage.senderId': userId },
+        { $set: { 'lastMessage.body': '', 'lastMessage.deleted': true } },
+      )
+
     await Promise.all([
       db.collection(COLLECTIONS.profiles).deleteOne({ _id: userId as unknown as never }),
       db.collection(COLLECTIONS.devices).deleteMany({ userId }),

--- a/apps/api/src/modules/chat/conversations.ts
+++ b/apps/api/src/modules/chat/conversations.ts
@@ -16,7 +16,7 @@ export interface Conversation {
   _id: ObjectId
   pairKey: string
   participants: [string, string]
-  lastMessage: { body: string; senderId: string; createdAt: Date }
+  lastMessage: { body: string; senderId: string; createdAt: Date; deleted?: boolean }
   unread: Record<string, number>
   firstMessageBy: string
   firstMessageAt: Date
@@ -52,6 +52,20 @@ export interface Message {
    * v2. Carried so `messages.legacy_id_unique` can refuse a second import of
    * the same message, which is what lets the importer be replayed safely.
    */
+  /**
+   * Emoji → the users who chose it. A dot path (`reactions.👍`) is safe here
+   * only because the keys come from `MESSAGE_REACTIONS`; an open set would let
+   * a `.` or `$` in a key rewrite the document.
+   */
+  reactions?: Record<string, string[]>
+  /**
+   * "Delete for me": the row stays, because it is half of someone else's
+   * thread, but it is projected away for these users.
+   */
+  hiddenFor?: string[]
+  /** "Delete for everyone": a tombstone, not a removal. */
+  deletedAt?: Date
+  deletedBy?: string
   legacyId?: string
   /**
    * When the message reached the recipient's device — the second tick. Set by

--- a/apps/api/src/modules/chat/messageView.test.ts
+++ b/apps/api/src/modules/chat/messageView.test.ts
@@ -1,0 +1,92 @@
+import { ObjectId } from 'mongodb'
+import { describe, expect, it } from 'vitest'
+import type { Message } from './conversations'
+import { toMessageView } from './messageView'
+
+const ME = 'me'
+const THEM = 'them'
+
+function message(overrides: Partial<Message> = {}): Message {
+  return {
+    _id: new ObjectId(),
+    conversationId: new ObjectId(),
+    senderId: THEM,
+    type: 'text',
+    body: 'hello',
+    createdAt: new Date('2026-08-29T09:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+describe('toMessageView', () => {
+  it('turns ids and dates into the strings the wire uses', () => {
+    const doc = message({ deliveredAt: new Date('2026-08-29T09:00:01.000Z') })
+    const view = toMessageView(doc, ME)
+    expect(view._id).toBe(doc._id.toHexString())
+    expect(view.conversationId).toBe(doc.conversationId.toHexString())
+    expect(view.createdAt).toBe('2026-08-29T09:00:00.000Z')
+    expect(view.deliveredAt).toBe('2026-08-29T09:00:01.000Z')
+  })
+
+  /** The whole reason this function exists. */
+  it('never ships who hid the message, only whether the viewer did', () => {
+    const doc = message({ hiddenFor: [THEM] })
+    expect(toMessageView(doc, THEM).hidden).toBe(true)
+    expect(toMessageView(doc, ME).hidden).toBeUndefined()
+    expect(JSON.stringify(toMessageView(doc, ME))).not.toContain('hiddenFor')
+  })
+
+  it('reports the viewer their own reaction, and everyone the whole tally', () => {
+    const doc = message({ reactions: { '👍': [THEM], '🔥': [ME] } })
+    expect(toMessageView(doc, ME).myReaction).toBe('🔥')
+    expect(toMessageView(doc, THEM).myReaction).toBe('👍')
+    expect(toMessageView(doc, ME).reactions).toEqual({ '👍': [THEM], '🔥': [ME] })
+  })
+
+  /** `$pull` leaves the key behind, and an empty one would draw an empty badge. */
+  it('drops an emoji nobody has chosen any more', () => {
+    const doc = message({ reactions: { '👍': [], '🔥': [ME] } })
+    expect(toMessageView(doc, ME).reactions).toEqual({ '🔥': [ME] })
+  })
+
+  it('omits reactions entirely when there are none', () => {
+    expect(toMessageView(message({ reactions: {} }), ME).reactions).toBeUndefined()
+  })
+
+  /**
+   * The row survives because it is half of someone else's thread, so the
+   * emptying has to happen on the way out — a reader who queried the
+   * collection directly would otherwise still find the body.
+   */
+  it('empties a withdrawn message rather than removing it', () => {
+    const doc = message({
+      body: 'regretted',
+      deletedAt: new Date(),
+      deletedBy: THEM,
+      media: { url: 'https://cdn/x.jpg', contentType: 'image/jpeg', sizeBytes: 1 },
+      replyTo: { messageId: new ObjectId(), senderId: ME, preview: 'quoted' },
+      reactions: { '🔥': [ME] },
+    })
+    const view = toMessageView(doc, ME)
+    expect(view.deleted).toBe(true)
+    expect(view.body).toBe('')
+    expect(view.media).toBeUndefined()
+    expect(view.replyTo).toBeUndefined()
+    expect(view.reactions).toBeUndefined()
+    // The row keeps its place in the timeline.
+    expect(view.createdAt).toBe('2026-08-29T09:00:00.000Z')
+  })
+
+  it('carries a reply quote through unchanged', () => {
+    const target = new ObjectId()
+    const view = toMessageView(
+      message({ replyTo: { messageId: target, senderId: ME, preview: 'the original' } }),
+      ME,
+    )
+    expect(view.replyTo).toEqual({
+      messageId: target.toHexString(),
+      senderId: ME,
+      preview: 'the original',
+    })
+  })
+})

--- a/apps/api/src/modules/chat/messageView.ts
+++ b/apps/api/src/modules/chat/messageView.ts
@@ -1,0 +1,95 @@
+import type { MessageType } from '@langx/shared'
+import type { Message } from './conversations'
+
+/**
+ * A message as one particular person is allowed to see it.
+ *
+ * `listMessages` used to return raw documents, which was fine while every
+ * field on a message was mutual. It stops being fine the moment per-user state
+ * lands on the same document: `hiddenFor` says who has hidden it and
+ * `starredBy` will say who starred it, and shipping either one raw tells the
+ * other person things they have no business knowing. One projection, applied
+ * everywhere a message leaves the server, is the only way that stays true as
+ * fields keep being added.
+ *
+ * It is also where the tombstone is enforced. A deleted message keeps its row
+ * — it is half of someone else's thread and the timeline would otherwise close
+ * over the gap — so the emptying has to happen on the way out rather than in
+ * the database, where a later reader could still find the body.
+ */
+export interface MessageView {
+  _id: string
+  conversationId: string
+  senderId: string
+  type: MessageType
+  body: string
+  media?: Message['media']
+  correction?: {
+    targetMessageId: string
+    original: string
+    corrected: string
+    note?: string
+  }
+  replyTo?: { messageId: string; senderId: string; preview: string }
+  /** Mutual by design: a reaction is meant to be seen. */
+  reactions?: Record<string, string[]>
+  /** Which one is the viewer's own, so the strip can show it selected. */
+  myReaction?: string
+  deleted?: boolean
+  /** The viewer deleted it for themselves; the client drops the row. */
+  hidden?: boolean
+  deliveredAt?: string
+  readAt?: string
+  createdAt: string
+}
+
+export function toMessageView(message: Message, viewerId: string): MessageView {
+  const deleted = Boolean(message.deletedAt)
+  const hidden = Boolean(message.hiddenFor?.includes(viewerId))
+  const myReaction = Object.entries(message.reactions ?? {}).find(([, users]) =>
+    users.includes(viewerId),
+  )?.[0]
+
+  const view: MessageView = {
+    _id: message._id.toHexString(),
+    conversationId: message.conversationId.toHexString(),
+    senderId: message.senderId,
+    type: message.type,
+    // A tombstone carries no body, no attachment and no correction. The client
+    // draws "This message was deleted" from the flag alone.
+    body: deleted ? '' : message.body,
+    createdAt: message.createdAt.toISOString(),
+  }
+
+  if (deleted) view.deleted = true
+  if (hidden) view.hidden = true
+  if (!deleted && message.media) view.media = message.media
+  if (!deleted && message.correction) {
+    view.correction = {
+      targetMessageId: message.correction.targetMessageId.toHexString(),
+      original: message.correction.original,
+      corrected: message.correction.corrected,
+      ...(message.correction.note !== undefined ? { note: message.correction.note } : {}),
+    }
+  }
+  // The quote survives the deletion of *this* message's target, and of this
+  // message itself only insofar as the tombstone keeps nothing.
+  if (!deleted && message.replyTo) {
+    view.replyTo = {
+      messageId: message.replyTo.messageId.toHexString(),
+      senderId: message.replyTo.senderId,
+      preview: message.replyTo.preview,
+    }
+  }
+  // `$pull` leaves the key behind with an empty array; an emoji nobody has
+  // chosen is not a reaction, and shipping it would draw an empty badge.
+  const reactions = Object.fromEntries(
+    Object.entries(message.reactions ?? {}).filter(([, users]) => users.length > 0),
+  )
+  if (!deleted && Object.keys(reactions).length > 0) view.reactions = reactions
+  if (!deleted && myReaction) view.myReaction = myReaction
+  if (message.deliveredAt) view.deliveredAt = message.deliveredAt.toISOString()
+  if (message.readAt) view.readAt = message.readAt.toISOString()
+
+  return view
+}

--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -16,6 +16,7 @@ import { ApiError } from '../../lib/ApiError'
 import { blockedUserIds } from '../moderation/blocks'
 import { awardForSend } from '../tokens/awards'
 import { assertConversationAccess } from './access'
+import { toMessageView, type MessageView } from './messageView'
 import type { Conversation, Message } from './conversations'
 
 export interface SendResult {
@@ -241,7 +242,11 @@ export async function sendMediaMessage(
 }
 
 export interface MessagePage {
-  items: Message[]
+  /**
+   * Projected, never raw. Per-user state lives on the same document now, so a
+   * page has to be built for the person asking for it — see `toMessageView`.
+   */
+  items: MessageView[]
   /** Feed to `cursor` for the page *before* this one. Null at the beginning of history. */
   nextCursor: string | null
   /**
@@ -300,7 +305,7 @@ export async function listMessages(
   const oldest = items[0]
   const newest = items.at(-1)
   return {
-    items,
+    items: items.map((message) => toMessageView(message, userId)),
     // Only the direction actually being paged reports more: the caller already
     // holds everything on the side it came from, and claiming otherwise would
     // have an infinite query walk back over pages it has.
@@ -382,7 +387,7 @@ export async function listMessagesAround(
   const newest = items.at(-1)
 
   return {
-    items,
+    items: items.map((message) => toMessageView(message, userId)),
     nextCursor: hasOlder && oldest ? encodeDateIdCursor(oldest.createdAt, oldest._id) : null,
     prevCursor: hasNewer && newest ? encodeDateIdCursor(newest.createdAt, newest._id) : null,
     participants: conversation.participants,

--- a/apps/api/src/modules/chat/mutations.ts
+++ b/apps/api/src/modules/chat/mutations.ts
@@ -1,0 +1,246 @@
+import {
+  canDeleteForEveryone,
+  ERROR_CODES,
+  MESSAGE_REACTIONS,
+  type DeleteMessageInput,
+  type ReactToMessageInput,
+} from '@langx/shared'
+import { ObjectId, type Db, type UpdateFilter } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { ApiError } from '../../lib/ApiError'
+import { supportsPut, type StorageProvider } from '../../storage/StorageProvider'
+import { assertConversationAccess } from './access'
+import type { Conversation, Message } from './conversations'
+
+export interface MessageMutationResult {
+  message: Message
+  conversation: Conversation
+  /**
+   * Who the change is addressed to.
+   *
+   * `both` for anything the two people share — a reaction, a withdrawal.
+   * `actor` for per-user state, which is emitted only so the actor's *other*
+   * devices converge: hiding a message on the phone has to hide it on the web
+   * tab, and must tell the other person nothing at all.
+   */
+  audience: 'both' | 'actor'
+}
+
+/**
+ * The single door every mutation goes through.
+ *
+ * `assertConversationAccess` first, then the message scoped to that
+ * conversation — so an id from another thread reads as "not found" rather than
+ * as a permission error, the same way `sendCorrection` handles its target. One
+ * function rather than a check per mutation is what makes "socket events pass
+ * through the same guards as REST" enforceable instead of aspirational: there
+ * is one place to read, and adding a mutation cannot skip it by accident.
+ */
+export async function loadMutableMessage(
+  db: Db,
+  userId: string,
+  conversationId: string,
+  messageId: string,
+): Promise<{ conversation: Conversation; message: Message }> {
+  const conversation = await assertConversationAccess(db, conversationId, userId)
+
+  let id: ObjectId
+  try {
+    id = new ObjectId(messageId)
+  } catch {
+    throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Malformed message id')
+  }
+
+  const message = await db
+    .collection<Message>(COLLECTIONS.messages)
+    .findOne({ _id: id, conversationId: conversation._id })
+  if (!message) {
+    throw new ApiError(ERROR_CODES.NOT_FOUND, 'Message not found in this conversation')
+  }
+
+  return { conversation, message }
+}
+
+/**
+ * One reaction per person: tapping the same emoji clears it, tapping a
+ * different one moves it.
+ *
+ * Written as a pull from every emoji except the chosen one plus an add to that
+ * one, which is a single update over disjoint paths. Rewriting the whole map
+ * would have been simpler and wrong — it would clobber a reaction the other
+ * person added between the read and the write.
+ *
+ * Deliberately not on the token path: `awardForSend` is never called, no
+ * `dailyActivity` counter moves and the streak does not advance. A reaction
+ * costs one tap, and anything that pays out for one tap is a farm.
+ */
+export async function reactToMessage(
+  db: Db,
+  userId: string,
+  input: ReactToMessageInput,
+): Promise<MessageMutationResult> {
+  const { conversation, message } = await loadMutableMessage(
+    db,
+    userId,
+    input.conversationId,
+    input.messageId,
+  )
+  if (message.deletedAt) {
+    throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'That message was deleted')
+  }
+
+  const current = Object.entries(message.reactions ?? {}).find(([, users]) =>
+    users.includes(userId),
+  )?.[0]
+  const next = input.emoji && input.emoji !== current ? input.emoji : null
+
+  const pull: Record<string, string> = {}
+  for (const emoji of MESSAGE_REACTIONS) {
+    if (emoji !== next) pull[`reactions.${emoji}`] = userId
+  }
+  const update: UpdateFilter<Message> = { $pull: pull }
+  if (next) update.$addToSet = { [`reactions.${next}`]: userId }
+
+  const updated = await db
+    .collection<Message>(COLLECTIONS.messages)
+    .findOneAndUpdate({ _id: message._id }, update, { returnDocument: 'after' })
+  if (!updated) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Message not found')
+
+  return { message: updated, conversation, audience: 'both' }
+}
+
+export async function deleteMessage(
+  db: Db,
+  userId: string,
+  input: DeleteMessageInput,
+  storage?: StorageProvider,
+): Promise<MessageMutationResult> {
+  const { conversation, message } = await loadMutableMessage(
+    db,
+    userId,
+    input.conversationId,
+    input.messageId,
+  )
+  const messages = db.collection<Message>(COLLECTIONS.messages)
+
+  // "Delete for me" is a per-user filter and nothing more. It stays available
+  // forever, on anyone's message, including one already withdrawn.
+  if (input.scope === 'me') {
+    const updated = await messages.findOneAndUpdate(
+      { _id: message._id },
+      { $addToSet: { hiddenFor: userId } },
+      { returnDocument: 'after' },
+    )
+    if (!updated) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Message not found')
+    return { message: updated, conversation, audience: 'actor' }
+  }
+
+  /**
+   * Already withdrawn: succeed and change nothing.
+   *
+   * This has to come *before* the window check, because `canDeleteForEveryone`
+   * refuses a message that is already a tombstone — correctly, since that is
+   * what stops the menu offering the row twice. Without this branch a repeat
+   * would raise "only within two days", which is both untrue and unactionable,
+   * and the conditional update below — the actual concurrency design — would
+   * never be reached.
+   */
+  if (message.deletedAt) {
+    return { message, conversation, audience: 'both' }
+  }
+
+  if (!canDeleteForEveryone(message, userId, new Date())) {
+    throw new ApiError(
+      ERROR_CODES.VALIDATION_FAILED,
+      'Only your own messages, and only within two days of sending them',
+    )
+  }
+
+  const now = new Date()
+  /**
+   * The predicate lives in the filter, not in an `if` above it. Two devices
+   * pressing delete at once both pass the check and both reach here; only the
+   * first matches, and `modifiedCount` is what tells the second to stop before
+   * it decrements `unread` a second time.
+   */
+  const result = await messages.updateOne(
+    { _id: message._id, senderId: userId, deletedAt: { $exists: false } },
+    {
+      $set: { deletedAt: now, deletedBy: userId, body: '' },
+      $unset: { media: '', correction: '', replyTo: '' },
+    },
+  )
+
+  const updated = await messages.findOne({ _id: message._id })
+  if (!updated) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Message not found')
+  if (result.modifiedCount === 0) {
+    return { message: updated, conversation, audience: 'both' }
+  }
+
+  await applyDeleteSideEffects(db, conversation, message)
+  await deleteAttachment(message, storage)
+
+  return { message: updated, conversation, audience: 'both' }
+}
+
+/**
+ * What a withdrawal costs the conversation document.
+ *
+ * Both writes are conditional, and both conditions are in the filter rather
+ * than in a read followed by a decision — a message arriving mid-delete has to
+ * win, and it does, by making the filter stop matching.
+ */
+async function applyDeleteSideEffects(
+  db: Db,
+  conversation: Conversation,
+  deleted: Message,
+): Promise<void> {
+  const conversations = db.collection<Conversation>(COLLECTIONS.conversations)
+
+  /**
+   * `lastMessage` is patched in place, not recomputed. Under a tombstone the
+   * newest message is still this row, so there is no next survivor to find, no
+   * empty-thread case, and no risk of `$unset`ing the field `listConversations`
+   * sorts on. If a new message landed first, `recordMessage` has already moved
+   * `lastMessage` on and this matches nothing — which is the right answer.
+   */
+  await conversations.updateOne(
+    {
+      _id: conversation._id,
+      'lastMessage.createdAt': deleted.createdAt,
+      'lastMessage.senderId': deleted.senderId,
+    },
+    { $set: { 'lastMessage.body': '', 'lastMessage.deleted': true } },
+  )
+
+  const recipientId = conversation.participants.find((id) => id !== deleted.senderId)
+  if (!recipientId || deleted.readAt) return
+
+  /**
+   * `$inc: -1` rather than a recount, because it *commutes* with the `$inc: +1`
+   * a concurrent send is doing. A `countDocuments` followed by a `$set` would
+   * silently discard that send. `$gt: 0` is the floor.
+   */
+  await conversations.updateOne(
+    { _id: conversation._id, [`unread.${recipientId}`]: { $gt: 0 } },
+    { $inc: { [`unread.${recipientId}`]: -1 } },
+  )
+}
+
+/**
+ * Mongo first, bucket second, and never the other way round: unsetting the
+ * reference after deleting the bytes leaves a window where the message points
+ * at a 404. Best-effort, like the account purge — a storage failure must not
+ * undo a deletion the user has already been told happened.
+ */
+async function deleteAttachment(message: Message, storage?: StorageProvider): Promise<void> {
+  const url = message.media?.url
+  if (!url || !storage || !supportsPut(storage)) return
+  const key = storage.keyFromPublicUrl(url)
+  if (!key) return
+  try {
+    await storage.deleteObject(key)
+  } catch {
+    // Swallowed on purpose: the row is already a tombstone.
+  }
+}

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -1,4 +1,5 @@
 import { MAX_IMAGE_BYTES, PLAN_LIMITS } from '@langx/shared'
+import { ObjectId } from 'mongodb'
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
 import type { FastifyInstance } from 'fastify'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -626,6 +627,198 @@ describe('Faz 5 — conversation/message history REST', () => {
         headers: { cookie: second.a.cookie },
       })
       expect(response.statusCode).toBe(404)
+    })
+  })
+
+  describe('reactions and deletion', () => {
+    async function pair(prefix: string) {
+      const a = await newUser(`${prefix}-a@example.com`)
+      const b = await newUser(`${prefix}-b@example.com`)
+      const { _id: conversationId } = await startConversation(a, b.userId, 'opening')
+      const { sendTextMessage } = await import('../modules/chat/messages')
+      const { message } = await sendTextMessage(handle.db, a.userId, {
+        conversationId,
+        body: 'the message',
+      })
+      return { a, b, conversationId, messageId: message._id.toHexString(), message }
+    }
+
+    it('moves a reaction rather than stacking them, and clears on a repeat', async () => {
+      const { b, conversationId, messageId } = await pair('react-toggle')
+      const { reactToMessage } = await import('../modules/chat/mutations')
+
+      const first = await reactToMessage(handle.db, b.userId, {
+        conversationId,
+        messageId,
+        emoji: '👍',
+      })
+      expect(first.message.reactions?.['👍']).toEqual([b.userId])
+
+      const moved = await reactToMessage(handle.db, b.userId, {
+        conversationId,
+        messageId,
+        emoji: '🔥',
+      })
+      expect(moved.message.reactions?.['👍']).toEqual([])
+      expect(moved.message.reactions?.['🔥']).toEqual([b.userId])
+
+      const cleared = await reactToMessage(handle.db, b.userId, {
+        conversationId,
+        messageId,
+        emoji: '🔥',
+      })
+      expect(cleared.message.reactions?.['🔥']).toEqual([])
+    })
+
+    /** One tap must never be a payout, or the emoji strip becomes a farm. */
+    it('pays nothing for a reaction', async () => {
+      const { b, conversationId, messageId } = await pair('react-free')
+      const { reactToMessage } = await import('../modules/chat/mutations')
+
+      const before = await handle.db
+        .collection(COLLECTIONS.tokenLedger)
+        .countDocuments({ userId: b.userId })
+      await reactToMessage(handle.db, b.userId, { conversationId, messageId, emoji: '❤️' })
+      const after = await handle.db
+        .collection(COLLECTIONS.tokenLedger)
+        .countDocuments({ userId: b.userId })
+
+      expect(after).toBe(before)
+    })
+
+    it('hides a message for the person who hid it and nobody else', async () => {
+      const { a, b, conversationId, messageId } = await pair('delete-mine')
+      const { deleteMessage } = await import('../modules/chat/mutations')
+
+      const result = await deleteMessage(handle.db, b.userId, {
+        conversationId,
+        messageId,
+        scope: 'me',
+      })
+      expect(result.audience).toBe('actor')
+
+      const forThem = await app.inject({
+        method: 'GET',
+        url: `/conversations/${conversationId}/messages`,
+        headers: { cookie: b.cookie },
+      })
+      const forSender = await app.inject({
+        method: 'GET',
+        url: `/conversations/${conversationId}/messages`,
+        headers: { cookie: a.cookie },
+      })
+
+      const theirs = forThem.json<{ items: { _id: string; hidden?: boolean }[] }>().items
+      const senders = forSender.json<{ items: { _id: string; hidden?: boolean }[] }>().items
+      expect(theirs.find((m) => m._id === messageId)?.hidden).toBe(true)
+      expect(senders.find((m) => m._id === messageId)?.hidden).toBeUndefined()
+    })
+
+    it('refuses to withdraw a message you did not send', async () => {
+      const { b, conversationId, messageId } = await pair('delete-not-mine')
+      const { deleteMessage } = await import('../modules/chat/mutations')
+
+      await expect(
+        deleteMessage(handle.db, b.userId, { conversationId, messageId, scope: 'everyone' }),
+      ).rejects.toMatchObject({ code: 'VALIDATION_FAILED' })
+    })
+
+    it('refuses to withdraw a message older than the window', async () => {
+      const { a, conversationId, messageId, message } = await pair('delete-stale')
+      const { deleteMessage } = await import('../modules/chat/mutations')
+
+      const longAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000)
+      await handle.db
+        .collection(COLLECTIONS.messages)
+        .updateOne({ _id: message._id }, { $set: { createdAt: longAgo } })
+
+      await expect(
+        deleteMessage(handle.db, a.userId, { conversationId, messageId, scope: 'everyone' }),
+      ).rejects.toMatchObject({ code: 'VALIDATION_FAILED' })
+    })
+
+    it('empties the message, the chat-list preview and the unread count', async () => {
+      const { a, b, conversationId, messageId } = await pair('delete-everyone')
+      const { deleteMessage } = await import('../modules/chat/mutations')
+
+      const before = await handle.db
+        .collection<{ unread: Record<string, number> }>(COLLECTIONS.conversations)
+        .findOne({ _id: new ObjectId(conversationId) })
+      expect(before?.unread[b.userId]).toBeGreaterThan(0)
+
+      await deleteMessage(handle.db, a.userId, { conversationId, messageId, scope: 'everyone' })
+
+      const after = await handle.db
+        .collection<{
+          unread: Record<string, number>
+          lastMessage: { body: string; deleted?: boolean }
+        }>(COLLECTIONS.conversations)
+        .findOne({ _id: new ObjectId(conversationId) })
+      expect(after?.lastMessage.body).toBe('')
+      expect(after?.lastMessage.deleted).toBe(true)
+      expect(after?.unread[b.userId]).toBe((before?.unread[b.userId] ?? 1) - 1)
+
+      const page = await app.inject({
+        method: 'GET',
+        url: `/conversations/${conversationId}/messages`,
+        headers: { cookie: b.cookie },
+      })
+      const row = page
+        .json<{ items: { _id: string; body: string; deleted?: boolean }[] }>()
+        .items.find((m) => m._id === messageId)
+      // The row stays: it is half of someone else's thread.
+      expect(row?.deleted).toBe(true)
+      expect(row?.body).toBe('')
+    })
+
+    /** Two devices pressing delete at once must not decrement unread twice. */
+    it('is idempotent, so a second withdrawal changes nothing', async () => {
+      const { a, b, conversationId, messageId } = await pair('delete-twice')
+      const { deleteMessage } = await import('../modules/chat/mutations')
+
+      await deleteMessage(handle.db, a.userId, { conversationId, messageId, scope: 'everyone' })
+      const once = await handle.db
+        .collection<{ unread: Record<string, number> }>(COLLECTIONS.conversations)
+        .findOne({ _id: new ObjectId(conversationId) })
+
+      await deleteMessage(handle.db, a.userId, { conversationId, messageId, scope: 'everyone' })
+      const twice = await handle.db
+        .collection<{ unread: Record<string, number> }>(COLLECTIONS.conversations)
+        .findOne({ _id: new ObjectId(conversationId) })
+
+      expect(twice?.unread[b.userId]).toBe(once?.unread[b.userId])
+    })
+
+    /**
+     * A newer message wins the race by making the `lastMessage` filter stop
+     * matching — no transaction, and no read-modify-write to lose.
+     */
+    it('leaves the chat-list preview alone when a newer message arrived first', async () => {
+      const { a, conversationId, messageId } = await pair('delete-raced')
+      const { sendTextMessage } = await import('../modules/chat/messages')
+      const { deleteMessage } = await import('../modules/chat/mutations')
+
+      await sendTextMessage(handle.db, a.userId, { conversationId, body: 'came after' })
+      await deleteMessage(handle.db, a.userId, { conversationId, messageId, scope: 'everyone' })
+
+      const conversation = await handle.db
+        .collection<{ lastMessage: { body: string } }>(COLLECTIONS.conversations)
+        .findOne({ _id: new ObjectId(conversationId) })
+      expect(conversation?.lastMessage.body).toBe('came after')
+    })
+
+    it('404s a message id from another conversation', async () => {
+      const first = await pair('mutate-foreign-1')
+      const second = await pair('mutate-foreign-2')
+      const { reactToMessage } = await import('../modules/chat/mutations')
+
+      await expect(
+        reactToMessage(handle.db, second.a.userId, {
+          conversationId: second.conversationId,
+          messageId: first.messageId,
+          emoji: '👍',
+        }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' })
     })
   })
 })

--- a/apps/api/src/routes/moderation.test.ts
+++ b/apps/api/src/routes/moderation.test.ts
@@ -596,6 +596,36 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
       expect(message?.deletedWithAccount).toBe(true)
     })
 
+    /**
+     * The chat list reads `lastMessage.body` verbatim and nothing ever
+     * recomputed it, so blanking a purged user's messages used to leave their
+     * last sentence sitting in the other person's list — the exact text the
+     * purge exists to remove.
+     */
+    it('clears the purged user last sentence out of the other person chat list', async () => {
+      const leaving = await newUser()
+      const staying = await newUser()
+
+      const started = await app.inject({
+        method: 'POST',
+        url: '/conversations',
+        headers: { cookie: leaving.cookie },
+        payload: { toUserId: staying.userId, body: 'something they should not keep seeing' },
+      })
+      expect(started.statusCode, started.body).toBe(201)
+
+      await post(leaving, '/me/delete', { confirm: 'DELETE' })
+      await purgeExpiredAccounts(handle.db, {
+        now: new Date(Date.now() + (ACCOUNT_DELETION_GRACE_DAYS + 1) * 86_400_000),
+      })
+
+      const conversation = await handle.db
+        .collection<{ lastMessage: { body: string; deleted?: boolean } }>(COLLECTIONS.conversations)
+        .findOne({ participants: staying.userId })
+      expect(conversation?.lastMessage.body).toBe('')
+      expect(conversation?.lastMessage.deleted).toBe(true)
+    })
+
     it('removes the images from storage, and never touches an object it does not own', async () => {
       const user = await newUser()
       const deleted: string[] = []

--- a/apps/api/src/ws/chat.test.ts
+++ b/apps/api/src/ws/chat.test.ts
@@ -570,4 +570,128 @@ describe('Faz 5 — realtime chat over Socket.io', () => {
       expect(codes).toContain('RATE_LIMITED')
     })
   })
+
+  describe('message mutations', () => {
+    /** Nothing arriving is the assertion, so it needs a window rather than a wait. */
+    function expectNothing(socket: ClientSocket, event: string, windowMs = 600): Promise<void> {
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(resolve, windowMs)
+        socket.once(event, (payload: unknown) => {
+          clearTimeout(timer)
+          reject(new Error(`unexpected "${event}": ${JSON.stringify(payload)}`))
+        })
+      })
+    }
+
+    async function sent(prefix: string) {
+      const alice = await newUser(`${prefix}-alice@example.com`)
+      const bob = await newUser(`${prefix}-bob@example.com`)
+      const conversation = await startConversation(alice, bob.userId, 'opening')
+      const aliceSocket = await connectSocket(alice.cookie)
+      const bobSocket = await connectSocket(bob.cookie)
+
+      const ack = await new Promise<{ ok: boolean; data?: { _id: string } }>((resolve) => {
+        aliceSocket.emit(
+          'message:send',
+          { conversationId: conversation._id, body: 'the message' },
+          (response: { ok: boolean; data?: { _id: string } }) => resolve(response),
+        )
+      })
+      return {
+        alice,
+        bob,
+        aliceSocket,
+        bobSocket,
+        conversationId: conversation._id,
+        messageId: ack.data?._id ?? '',
+      }
+    }
+
+    it('shows a reaction to both people', async () => {
+      const { aliceSocket, bobSocket, conversationId, messageId, bob } = await sent('ws-react')
+
+      const onSender = waitForEvent<{ _id: string; reactions?: Record<string, string[]> }>(
+        aliceSocket,
+        'message:updated',
+      )
+      bobSocket.emit('message:react', { conversationId, messageId, emoji: '🔥' })
+
+      const seen = await onSender
+      expect(seen._id).toBe(messageId)
+      expect(seen.reactions?.['🔥']).toEqual([bob.userId])
+    })
+
+    /**
+     * The projection is per viewer, so the same row reaches the two of them as
+     * two different objects — only the person who reacted is told it was them.
+     */
+    it('marks the reaction as the viewer own only for the viewer', async () => {
+      const { aliceSocket, bobSocket, conversationId, messageId } = await sent('ws-react-mine')
+
+      const onSender = waitForEvent<{ myReaction?: string }>(aliceSocket, 'message:updated')
+      const onReactor = waitForEvent<{ myReaction?: string }>(bobSocket, 'message:updated')
+      bobSocket.emit('message:react', { conversationId, messageId, emoji: '👍' })
+
+      expect((await onReactor).myReaction).toBe('👍')
+      expect((await onSender).myReaction).toBeUndefined()
+    })
+
+    /** Hiding a message is nobody else business, and the wire has to say so. */
+    it('tells the other person nothing when a message is hidden for one', async () => {
+      const { aliceSocket, bobSocket, conversationId, messageId } = await sent('ws-hide')
+
+      const onActor = waitForEvent<{ hidden?: boolean }>(bobSocket, 'message:updated')
+      const onPeer = expectNothing(aliceSocket, 'message:updated')
+      bobSocket.emit('message:delete', { conversationId, messageId, scope: 'me' })
+
+      expect((await onActor).hidden).toBe(true)
+      await onPeer
+    })
+
+    it('empties a withdrawn message on the other person device', async () => {
+      const { aliceSocket, bobSocket, conversationId, messageId } = await sent('ws-withdraw')
+
+      const onPeer = waitForEvent<{ _id: string; body: string; deleted?: boolean }>(
+        bobSocket,
+        'message:updated',
+      )
+      aliceSocket.emit('message:delete', { conversationId, messageId, scope: 'everyone' })
+
+      const seen = await onPeer
+      expect(seen._id).toBe(messageId)
+      expect(seen.deleted).toBe(true)
+      expect(seen.body).toBe('')
+    })
+
+    it('refuses to withdraw someone else message, over the socket too', async () => {
+      const { bobSocket, conversationId, messageId } = await sent('ws-withdraw-not-mine')
+
+      const ack = await new Promise<{ ok: boolean; error?: { code: string } }>((resolve) => {
+        bobSocket.emit(
+          'message:delete',
+          { conversationId, messageId, scope: 'everyone' },
+          (response: { ok: boolean; error?: { code: string } }) => resolve(response),
+        )
+      })
+      expect(ack.ok).toBe(false)
+      expect(ack.error?.code).toBe('VALIDATION_FAILED')
+    })
+
+    /** `loadMutableMessage` is the guard, and it is the only one. */
+    it('refuses a mutation from someone outside the conversation', async () => {
+      const { conversationId, messageId } = await sent('ws-outsider')
+      const outsider = await newUser('ws-outsider-third@example.com')
+      const outsiderSocket = await connectSocket(outsider.cookie)
+
+      const ack = await new Promise<{ ok: boolean; error?: { code: string } }>((resolve) => {
+        outsiderSocket.emit(
+          'message:react',
+          { conversationId, messageId, emoji: '👍' },
+          (response: { ok: boolean; error?: { code: string } }) => resolve(response),
+        )
+      })
+      expect(ack.ok).toBe(false)
+      expect(ack.error?.code).toBe('NOT_FOUND')
+    })
+  })
 })

--- a/apps/api/src/ws/fanOut.ts
+++ b/apps/api/src/ws/fanOut.ts
@@ -1,5 +1,7 @@
 import type { FastifyInstance } from 'fastify'
 import type { ObjectId } from 'mongodb'
+import type { Message } from '../modules/chat/conversations'
+import { toMessageView } from '../modules/chat/messageView'
 import { markDelivered } from '../modules/chat/messages'
 import { sendPush, tokensFor } from '../modules/push/devices'
 import { userRoom, type AppServer } from './types'
@@ -10,11 +12,12 @@ interface FannedConversation {
   participants: readonly string[]
 }
 
-interface FannedMessage {
-  senderId: string
-  body: string
-  conversationId: { toHexString: () => string }
-}
+/**
+ * The whole document, because the emit is now a per-viewer projection rather
+ * than the raw row — see `toMessageView`. Narrowing this to the three fields
+ * the push notification needs is what let per-user state reach the wire.
+ */
+type FannedMessage = Message
 
 /**
  * Everything that happens to a message once it is durably written: both
@@ -41,8 +44,10 @@ export async function fanOutMessage(
   { pushWhenAway }: { pushWhenAway: boolean },
 ): Promise<void> {
   try {
+    // Projected per participant: two people are sent two different objects
+    // from the same row, because what each is allowed to see differs.
     for (const participantId of conversation.participants) {
-      io.to(userRoom(participantId)).emit('message:new', message)
+      io.to(userRoom(participantId)).emit('message:new', toMessageView(message, participantId))
     }
 
     const recipientId = conversation.participants.find((id) => id !== message.senderId)
@@ -82,5 +87,36 @@ export async function fanOutMessage(
     })
   } catch (error) {
     app.log.warn({ err: error }, 'post-send fan-out failed')
+  }
+}
+
+/**
+ * A message that already exists has changed.
+ *
+ * One event for every mutation — reaction, withdrawal, and later edit, star and
+ * pin — carrying the message's whole new state rather than a description of
+ * what changed. A client that applies "the message is now this" cannot drift;
+ * one that applies a patch has to be right about the order they arrive in.
+ *
+ * Withdrawal is not a separate event either: a deleted message is a
+ * `message:updated` whose body the projection has emptied.
+ *
+ * Synchronous and silent — no delivery stamping, no push. Nothing about a
+ * reaction is worth waking a phone for.
+ */
+export function fanOutMessageUpdate(
+  io: AppServer,
+  conversation: FannedConversation,
+  message: Message,
+  audience: 'both' | 'actor',
+  actorId: string,
+): void {
+  // `actor` is per-user state — a hide, or later a star. It goes to the
+  // actor's own room only, so their other devices converge and the other
+  // person is told nothing whatsoever.
+  const recipients = audience === 'actor' ? [actorId] : conversation.participants
+
+  for (const participantId of recipients) {
+    io.to(userRoom(participantId)).emit('message:updated', toMessageView(message, participantId))
   }
 }

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -1,4 +1,10 @@
-import { sendCorrectionSchema, sendMediaMessageSchema, sendTextMessageSchema } from '@langx/shared'
+import {
+  deleteMessageSchema,
+  reactToMessageSchema,
+  sendCorrectionSchema,
+  sendMediaMessageSchema,
+  sendTextMessageSchema,
+} from '@langx/shared'
 import type { FastifyInstance } from 'fastify'
 import { Server as SocketIOServer } from 'socket.io'
 import { z, ZodError } from 'zod'
@@ -8,6 +14,8 @@ import { consumeQuota } from '../lib/quota'
 import { effectiveTier } from '../modules/profiles/entitlement'
 import { getProfile } from '../modules/profiles/profiles'
 import { assertConversationAccess } from '../modules/chat/access'
+import { toMessageView } from '../modules/chat/messageView'
+import { deleteMessage, reactToMessage } from '../modules/chat/mutations'
 import {
   markConversationRead,
   markPendingDelivered,
@@ -15,7 +23,7 @@ import {
   sendMediaMessage,
   sendTextMessage,
 } from '../modules/chat/messages'
-import { fanOutMessage } from './fanOut'
+import { fanOutMessage, fanOutMessageUpdate } from './fanOut'
 import { PresenceThrottle, touchPresence } from '../modules/presence/presence'
 import { SocketRateLimiter } from './rateLimit'
 import { userRoom, type AppServer, type AppSocket } from './types'
@@ -192,6 +200,35 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
           // recipient chose to be in, not something to wake a phone for.
           void fanOutMessage(app, io, conversation, message, { pushWhenAway: false })
           ack?.({ ok: true, data: message })
+        })
+        .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))
+    })
+
+    /**
+     * Both of these go through `loadMutableMessage`, which is where the
+     * conversation guard lives — the handler itself checks nothing, and that
+     * is the point: a third mutation added later cannot forget to.
+     */
+    socket.on('message:react', (payload: unknown, ack: Ack) => {
+      if (!limited('message:react', ack)) return
+      reactToMessageSchema
+        .parseAsync(payload)
+        .then((input) => reactToMessage(app.mongo.db, userId, input))
+        .then(({ message, conversation, audience }) => {
+          fanOutMessageUpdate(io, conversation, message, audience, userId)
+          ack?.({ ok: true, data: toMessageView(message, userId) })
+        })
+        .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))
+    })
+
+    socket.on('message:delete', (payload: unknown, ack: Ack) => {
+      if (!limited('message:delete', ack)) return
+      deleteMessageSchema
+        .parseAsync(payload)
+        .then((input) => deleteMessage(app.mongo.db, userId, input, app.storage))
+        .then(({ message, conversation, audience }) => {
+          fanOutMessageUpdate(io, conversation, message, audience, userId)
+          ack?.({ ok: true, data: toMessageView(message, userId) })
         })
         .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))
     })

--- a/apps/api/src/ws/rateLimit.ts
+++ b/apps/api/src/ws/rateLimit.ts
@@ -32,6 +32,11 @@ export const EVENT_LIMITS: Record<string, BucketConfig> = {
   'message:correct': { capacity: 20, refillPerSecond: 1 },
   // Tighter than text: each one is an upload we store and serve.
   'message:media': { capacity: 10, refillPerSecond: 0.5 },
+  // Cheap and tappable: a reaction is one small write and people do change
+  // their minds, but a held finger on an emoji must not become a write loop.
+  'message:react': { capacity: 30, refillPerSecond: 2 },
+  // Destructive, and never something anyone does in a burst.
+  'message:delete': { capacity: 10, refillPerSecond: 0.5 },
   'conversation:read': { capacity: 30, refillPerSecond: 2 },
   typing: { capacity: 40, refillPerSecond: 10 },
   // One per 20s sustained, burst of 4. A 60s heartbeat passes with room; a

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -1,5 +1,5 @@
 import Feather from '@expo/vector-icons/Feather'
-import { PLAN_LIMITS, TOKEN_RULES } from '@langx/shared'
+import { canDeleteForEveryone, MESSAGE_REACTIONS, PLAN_LIMITS, TOKEN_RULES } from '@langx/shared'
 import { useQueryClient } from '@tanstack/react-query'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -40,7 +40,7 @@ import { errorCodeOf } from '../../../src/lib/errors'
 import { listState } from '../../../src/lib/listState'
 import { shouldSubmitOnEnter } from '../../../src/lib/submitOnEnter'
 import { messageActionsFor } from '../../../src/lib/messageActions'
-import { openMessageMenu } from '../../../src/lib/messageMenu'
+import { openMessageMenu, type AnchorRect } from '../../../src/lib/messageMenu'
 import { goBackTo } from '../../../src/lib/navigation'
 import { openPaywall } from '../../../src/lib/paywall'
 import { showToast } from '../../../src/lib/toast'
@@ -299,30 +299,100 @@ export default function ChatScreen() {
    * other person's text only; it is one row here, which is what let the other
    * three exist at all.
    */
-  async function openActions(message: MessageDto, alreadyTranslated: boolean): Promise<void> {
+  async function openActions(
+    message: MessageDto,
+    alreadyTranslated: boolean,
+    anchor?: AnchorRect,
+  ): Promise<void> {
+    // Nothing left to act on: a withdrawn message is a placeholder, and the
+    // one thing anyone might want — hiding it — is offered through the same
+    // row, so it is still worth opening.
     const actions = messageActionsFor({
       mine: isMine(message),
       type: message.type,
       hasBody: message.body.trim().length > 0,
       alreadyTranslated,
     })
-    // Your own captionless voice note has nothing to offer; an empty sheet is
-    // worse than no sheet.
-    if (actions.length === 0) return
 
-    const picked = await openMessageMenu(message.body || messageTypeLabel(message.type), actions)
-    if (picked === 'reply') {
+    const picked = await openMessageMenu({
+      preview: message.body || messageTypeLabel(message.type),
+      mine: isMine(message),
+      actions,
+      ...(anchor ? { anchor } : {}),
+      // A withdrawn message cannot carry a reaction, so it gets no strip.
+      ...(message.deleted ? {} : { reactions: MESSAGE_REACTIONS, myReaction: message.myReaction }),
+    })
+    if (!picked) return
+
+    if (picked.kind === 'reaction') {
+      await react(message, picked.emoji)
+      return
+    }
+
+    if (picked.id === 'reply') {
       setReplyingTo(message)
-    } else if (picked === 'copy') {
+    } else if (picked.id === 'copy') {
       await Clipboard.setStringAsync(message.body)
       showToast('Copied')
-    } else if (picked === 'translate') {
+    } else if (picked.id === 'translate') {
       await translate(message, alreadyTranslated)
-    } else if (picked === 'correct') {
+    } else if (picked.id === 'correct') {
       setCorrecting(message)
       setDraft(message.body)
-    } else if (picked === 'report') {
+    } else if (picked.id === 'delete') {
+      await removeMessage(message)
+    } else if (picked.id === 'report') {
       await reportMessage(message)
+    }
+  }
+
+  /**
+   * Tapping the emoji already on the message clears it — the server treats a
+   * repeat as a toggle, so nothing here has to know the current state.
+   */
+  async function react(message: MessageDto, emoji: string): Promise<void> {
+    const socket = await getSocket()
+    try {
+      await emitWithAck(socket, 'message:react', {
+        conversationId,
+        messageId: message._id,
+        emoji,
+      })
+    } catch {
+      void showAlert('Could not react', 'That did not go through. Try again.')
+    }
+  }
+
+  /**
+   * Two different things behind one row.
+   *
+   * "Delete for me" is a filter on your own copy and never expires; withdrawing
+   * it from the other person is only your own message, only within
+   * `MESSAGE_DELETE_WINDOW_MS`, and is the one that needs asking about. When
+   * only one of them is possible there is nothing to choose between, so it is
+   * confirmed rather than offered as a menu of one.
+   */
+  async function removeMessage(message: MessageDto): Promise<void> {
+    const canWithdraw = canDeleteForEveryone(message, me.data?._id ?? '', new Date())
+    const scope = canWithdraw
+      ? await chooseAlert('Delete message', 'This cannot be undone.', [
+          { label: 'Delete for everyone', value: 'everyone' },
+          { label: 'Delete for me', value: 'me' },
+        ])
+      : await chooseAlert('Delete message', 'It stays on their device.', [
+          { label: 'Delete for me', value: 'me' },
+        ])
+    if (!scope) return
+
+    const socket = await getSocket()
+    try {
+      await emitWithAck(socket, 'message:delete', {
+        conversationId,
+        messageId: message._id,
+        scope,
+      })
+    } catch {
+      void showAlert('Could not delete', 'That did not go through. Try again.')
     }
   }
 
@@ -387,9 +457,12 @@ export default function ChatScreen() {
   useEffect(() => {
     openActionsRef.current = openActions
   })
-  const onLongPress = useCallback((message: MessageDto, alreadyTranslated: boolean) => {
-    void openActionsRef.current(message, alreadyTranslated)
-  }, [])
+  const onLongPress = useCallback(
+    (message: MessageDto, alreadyTranslated: boolean, anchor?: AnchorRect) => {
+      void openActionsRef.current(message, alreadyTranslated, anchor)
+    },
+    [],
+  )
 
   async function reportMessage(message: MessageDto): Promise<void> {
     const reason = await chooseAlert('Report', 'Why are you reporting this message?', [

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -255,6 +255,14 @@ export interface MessageDto {
   correction?: { original: string; corrected: string; note?: string }
   /** A snapshot taken when the reply was sent, so it survives the target. */
   replyTo?: { messageId: string; senderId: string; preview: string }
+  /** Emoji → the users who chose it. Mutual: a reaction is meant to be seen. */
+  reactions?: Record<string, string[]>
+  /** Which of them is mine, so the strip can show it selected. */
+  myReaction?: string
+  /** Withdrawn by its sender: the row stays, emptied. */
+  deleted?: boolean
+  /** Hidden by me alone. `messagesNewestFirst` drops these. */
+  hidden?: boolean
   deliveredAt?: string
   readAt?: string
   createdAt: string

--- a/apps/mobile/src/components/MessageBubble.tsx
+++ b/apps/mobile/src/components/MessageBubble.tsx
@@ -2,6 +2,7 @@ import Feather from '@expo/vector-icons/Feather'
 import { memo, useMemo, useRef } from 'react'
 import { Animated, PanResponder, Platform, Pressable, StyleSheet, Text, View } from 'react-native'
 import type { MessageDto } from '../api/queries'
+import type { AnchorRect } from '../lib/messageMenu'
 import { shouldCaptureSwipe, swipeReleased, swipeTranslation } from '../lib/swipeToReply'
 import { makeStyles, useTheme } from '../lib/theme'
 import { AudioBubble, ImageBubble } from './MediaBubble'
@@ -20,7 +21,7 @@ export interface MessageBubbleProps {
   replyToMine: boolean
   /** Briefly ringed after a jump, so the reader sees where they landed. */
   highlighted: boolean
-  onLongPress: (message: MessageDto, alreadyTranslated: boolean) => void
+  onLongPress: (message: MessageDto, alreadyTranslated: boolean, anchor?: AnchorRect) => void
   onReply: (message: MessageDto) => void
   onJumpTo: (messageId: string) => void
 }
@@ -50,7 +51,24 @@ export const MessageBubble = memo(function MessageBubble({
 }: MessageBubbleProps) {
   const { colors } = useTheme()
   const styles = useStyles()
-  const press = () => onLongPress(message, Boolean(translation))
+  /**
+   * The bubble reports where it is, so the menu can be drawn against it rather
+   * than at the bottom of the screen. `measureInWindow` exists on
+   * react-native-web's View too — it is `getBoundingClientRect` underneath — so
+   * this is genuinely cross-platform despite being the app's first use of it.
+   * If it never calls back, the menu falls back to the sheet.
+   */
+  const box = useRef<View>(null)
+  const press = () => {
+    const alreadyTranslated = Boolean(translation)
+    if (!box.current) {
+      onLongPress(message, alreadyTranslated)
+      return
+    }
+    box.current.measureInWindow((x, y, width, height) =>
+      onLongPress(message, alreadyTranslated, { x, y, width, height }),
+    )
+  }
 
   /**
    * Swipe right to reply — native only.
@@ -83,6 +101,24 @@ export const MessageBubble = memo(function MessageBubble({
 
   const pan = Platform.OS === 'web' ? {} : responder.panHandlers
   const flash = highlighted ? styles.highlighted : null
+
+  /**
+   * Counts, not avatars: a 1-1 thread has at most two people on an emoji, so
+   * a number is only ever "2" and the badge is mostly there to say which
+   * emojis were used at all.
+   */
+  const reactions = Object.entries(message.reactions ?? {}).filter(([, users]) => users.length > 0)
+  const badge =
+    reactions.length > 0 ? (
+      <View style={[styles.reactions, mine ? styles.reactionsMine : styles.reactionsTheirs]}>
+        {reactions.map(([emoji, users]) => (
+          <View key={emoji} style={styles.reaction}>
+            <Text style={styles.reactionGlyph}>{emoji}</Text>
+            {users.length > 1 ? <Text style={styles.reactionCount}>{users.length}</Text> : null}
+          </View>
+        ))}
+      </View>
+    ) : null
   const replyTo = message.replyTo
 
   const quote = replyTo ? (
@@ -101,9 +137,31 @@ export const MessageBubble = memo(function MessageBubble({
     </Pressable>
   ) : null
 
+  /**
+   * A withdrawal keeps its place in the thread rather than closing the gap.
+   * The alternative — removing the row — rewrites the shape of a conversation
+   * the other person remembers having, which is worse than an obvious hole.
+   */
+  if (message.deleted) {
+    return (
+      <Animated.View ref={box} style={{ transform: [{ translateX }] }} {...pan}>
+        <Pressable
+          onLongPress={press}
+          style={[styles.bubble, mine ? styles.mine : styles.theirs, styles.tombstone, flash]}
+        >
+          <View style={styles.tombstoneRow}>
+            <Feather name="slash" size={13} color={colors.textMuted} />
+            <Text style={styles.tombstoneText}>This message was deleted</Text>
+          </View>
+          <MessageMeta message={message} mine={mine} />
+        </Pressable>
+      </Animated.View>
+    )
+  }
+
   if (message.type === 'correction') {
     return (
-      <Animated.View style={{ transform: [{ translateX }] }} {...pan}>
+      <Animated.View ref={box} style={{ transform: [{ translateX }] }} {...pan}>
         <Pressable
           onLongPress={press}
           style={[styles.correction, mine ? styles.correctionMine : null, flash]}
@@ -130,6 +188,7 @@ export const MessageBubble = memo(function MessageBubble({
             ) : null}
             <MessageMeta message={message} mine={mine} />
           </View>
+          {badge}
         </Pressable>
       </Animated.View>
     )
@@ -139,7 +198,7 @@ export const MessageBubble = memo(function MessageBubble({
 
   if (message.type === 'image' || message.type === 'audio') {
     return (
-      <Animated.View style={{ transform: [{ translateX }] }} {...pan}>
+      <Animated.View ref={box} style={{ transform: [{ translateX }] }} {...pan}>
         <Pressable
           onLongPress={press}
           style={[styles.bubble, mine ? styles.mine : styles.theirs, tail, flash]}
@@ -156,13 +215,14 @@ export const MessageBubble = memo(function MessageBubble({
             </Text>
           ) : null}
           <MessageMeta message={message} mine={mine} />
+          {badge}
         </Pressable>
       </Animated.View>
     )
   }
 
   return (
-    <Animated.View style={{ transform: [{ translateX }] }} {...pan}>
+    <Animated.View ref={box} style={{ transform: [{ translateX }] }} {...pan}>
       <Pressable
         onLongPress={press}
         style={[styles.bubble, mine ? styles.mine : styles.theirs, tail, flash]}
@@ -176,12 +236,13 @@ export const MessageBubble = memo(function MessageBubble({
             request already in flight. */}
         {translating ? <Text style={styles.translateLink}>Translating…</Text> : null}
         <MessageMeta message={message} mine={mine} />
+        {badge}
       </Pressable>
     </Animated.View>
   )
 })
 
-const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
+const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => ({
   bubble: {
     borderRadius: radius.lg,
     maxWidth: '82%',
@@ -227,6 +288,33 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
    * that would say the wrong thing for a second and a half.
    */
   highlighted: { borderColor: colors.accent, borderWidth: 2 },
+  tombstone: { backgroundColor: colors.surface, borderColor: colors.border, borderWidth: 1 },
+  tombstoneRow: { alignItems: 'center', flexDirection: 'row', gap: 6 },
+  tombstoneText: { ...font.body, color: colors.textMuted, fontStyle: 'italic' },
+  /**
+   * Inside the bubble, not overhanging it. An overhang reads better, but the
+   * correction card clips to its rounded header (`overflow: 'hidden'`, which
+   * the header border needs) and would cut the badge in half — one shape for
+   * all four beats a special case that only looks right in three of them.
+   */
+  reactions: {
+    ...cardShadow,
+    alignSelf: 'flex-start',
+    backgroundColor: colors.bg,
+    borderColor: colors.border,
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: 2,
+    marginTop: 6,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  reactionsMine: { alignSelf: 'flex-end' },
+  reactionsTheirs: { alignSelf: 'flex-start' },
+  reaction: { alignItems: 'center', flexDirection: 'row', gap: 2 },
+  reactionGlyph: { fontSize: 13, lineHeight: 18 },
+  reactionCount: { ...font.caption, color: colors.textMuted, fontWeight: '700' },
   bubbleText: { ...font.body, color: colors.text, lineHeight: 22 },
   bubbleTextMine: { color: colors.primaryText },
   caption: { marginTop: spacing.xs },

--- a/apps/mobile/src/components/MessageMenuHost.tsx
+++ b/apps/mobile/src/components/MessageMenuHost.tsx
@@ -1,25 +1,39 @@
 import { Ionicons } from '@expo/vector-icons'
 import { useEffect, useState } from 'react'
-import { Modal, Platform, Pressable, StyleSheet, Text } from 'react-native'
+import {
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  useWindowDimensions,
+  View,
+} from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import {
   resolveMessageMenu,
   subscribeToMessageMenu,
   type MessageMenuRequest,
 } from '../lib/messageMenu'
+import { messageMenuLayout } from '../lib/messageMenuLayout'
 import { makeStyles, useTheme } from '../lib/theme'
 
 /**
  * Draws whatever `src/lib/messageMenu.ts` has open.
  *
- * `Modal`, mounted at the root above the navigator, for `AlertHost`'s reason:
- * react-native-web renders a Modal into its own layer, while an absolutely
- * positioned overlay inside the tab navigator sits *under* the tab bar — which
- * is exactly where a bottom sheet's actions would be.
+ * Two shapes from one host. With a measured bubble it draws against it — a copy
+ * of the bubble lifted out of the thread, the emoji strip over it and the
+ * actions under it. Without one it falls back to the sheet, which is what a
+ * caller with nothing to measure still gets, and what every caller got before.
  *
- * A sheet on a phone and a centred card in a browser, because a sheet pinned
- * to the bottom of a desktop window is a long way from the message it belongs
- * to.
+ * Still a `Modal`. The anchored layout is absolutely positioned *inside* it
+ * rather than at the app root: `measureInWindow` and a full-screen Modal are
+ * both in window coordinates, so they agree, and the Modal keeps two things
+ * that would otherwise have to be rebuilt — it paints above the tab bar on
+ * every platform without depending on mount order, and `onRequestClose` is
+ * Android's back button. A root layer would need `BackHandler` for the second
+ * and would sit under the tab bar if it were ever mounted before the navigator.
  */
 export function MessageMenuHost() {
   const { colors, spacing } = useTheme()
@@ -27,12 +41,117 @@ export function MessageMenuHost() {
 
   const [request, setRequest] = useState<MessageMenuRequest | null>(null)
   const insets = useSafeAreaInsets()
+  const screen = useWindowDimensions()
 
   useEffect(() => subscribeToMessageMenu(setRequest), [])
 
   if (!request) return null
   const dismiss = (): void => resolveMessageMenu(request.id, null)
   const wide = Platform.OS === 'web'
+
+  const rows = request.actions.map((action) => (
+    <Pressable
+      key={action.id}
+      accessibilityRole="button"
+      onPress={() => resolveMessageMenu(request.id, { kind: 'action', id: action.id })}
+      style={({ pressed }) => [styles.action, pressed && styles.actionPressed]}
+    >
+      <Ionicons
+        // The icon set types its own names; the action table is plain data and
+        // does not import them.
+        name={action.icon as never}
+        size={20}
+        color={action.destructive ? colors.danger : colors.text}
+      />
+      <Text style={[styles.label, action.destructive && styles.destructive]}>{action.label}</Text>
+    </Pressable>
+  ))
+
+  const strip = request.reactions ? (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.stripInner}
+      style={styles.strip}
+    >
+      {request.reactions.map((emoji) => (
+        <Pressable
+          key={emoji}
+          accessibilityRole="button"
+          accessibilityLabel={`React with ${emoji}`}
+          onPress={() => resolveMessageMenu(request.id, { kind: 'reaction', emoji })}
+          style={[styles.emoji, request.myReaction === emoji && styles.emojiChosen]}
+        >
+          <Text style={styles.emojiGlyph}>{emoji}</Text>
+        </Pressable>
+      ))}
+    </ScrollView>
+  ) : null
+
+  if (request.anchor) {
+    /**
+     * Heights are derived, not measured. Measuring after mounting means one
+     * frame drawn in the wrong place and a visible jump on exactly the gesture
+     * that has to feel immediate, so the flip is decided before first paint.
+     */
+    const menuHeight = request.actions.length * ROW_HEIGHT + MENU_CHROME
+    const stripWidth = Math.min(STRIP_MAX_WIDTH, screen.width - 24)
+    const layout = messageMenuLayout({
+      anchor: request.anchor,
+      screen: { width: screen.width, height: screen.height },
+      insets: { top: insets.top, bottom: insets.bottom },
+      menu: { width: MENU_WIDTH, height: menuHeight },
+      strip: { width: stripWidth, height: STRIP_HEIGHT },
+      mine: request.mine,
+    })
+
+    return (
+      <Modal transparent animationType="fade" visible onRequestClose={dismiss}>
+        <Pressable style={styles.anchoredBackdrop} onPress={dismiss}>
+          {strip ? (
+            <View
+              style={[
+                styles.stripHolder,
+                { top: layout.strip.top, left: layout.strip.left, width: stripWidth },
+              ]}
+            >
+              {strip}
+            </View>
+          ) : null}
+
+          {/*
+            A copy of the bubble rather than the bubble itself: the real one is
+            still in the list under the scrim, and lifting it out would mean
+            re-mounting a row that owns a pan responder and a measurement.
+          */}
+          <View
+            style={[
+              styles.copy,
+              request.mine ? styles.copyMine : styles.copyTheirs,
+              {
+                top: layout.bubble.top,
+                left: layout.bubble.left,
+                maxWidth: Math.max(120, request.anchor.width),
+              },
+            ]}
+          >
+            <Text style={[styles.copyText, request.mine && styles.copyTextMine]} numberOfLines={6}>
+              {request.preview}
+            </Text>
+          </View>
+
+          <View
+            style={[
+              styles.menu,
+              { top: layout.menu.top, left: layout.menu.left, width: MENU_WIDTH },
+            ]}
+          >
+            {rows}
+          </View>
+        </Pressable>
+      </Modal>
+    )
+  }
 
   return (
     <Modal transparent animationType="fade" visible onRequestClose={dismiss}>
@@ -48,35 +167,26 @@ export function MessageMenuHost() {
           ]}
           onPress={() => {}}
         >
+          {strip}
           <Text style={styles.preview} numberOfLines={2}>
             {request.preview}
           </Text>
-          {request.actions.map((action) => (
-            <Pressable
-              key={action.id}
-              accessibilityRole="button"
-              onPress={() => resolveMessageMenu(request.id, action.id)}
-              style={({ pressed }) => [styles.action, pressed && styles.actionPressed]}
-            >
-              <Ionicons
-                // The icon set types its own names; the action table is plain
-                // data and does not import them.
-                name={action.icon as never}
-                size={20}
-                color={action.destructive ? colors.danger : colors.text}
-              />
-              <Text style={[styles.label, action.destructive && styles.destructive]}>
-                {action.label}
-              </Text>
-            </Pressable>
-          ))}
+          {rows}
         </Pressable>
       </Pressable>
     </Modal>
   )
 }
 
-const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
+/** Matches `action`'s padding and icon size below; the layout needs it up front. */
+const ROW_HEIGHT = 46
+/** The menu's own padding, top and bottom. */
+const MENU_CHROME = 16
+const MENU_WIDTH = 232
+const STRIP_HEIGHT = 54
+const STRIP_MAX_WIDTH = 336
+
+const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => ({
   action: {
     alignItems: 'center',
     borderRadius: radius.md,
@@ -89,6 +199,7 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   backdrop: { backgroundColor: colors.scrim, flex: 1 },
   backdropBottom: { justifyContent: 'flex-end' },
   backdropCentred: { alignItems: 'center', justifyContent: 'center' },
+  anchoredBackdrop: { backgroundColor: colors.scrim, flex: 1 },
   destructive: { color: colors.danger },
   label: { ...font.body, color: colors.text },
   preview: {
@@ -112,5 +223,39 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
     maxWidth: 360,
     paddingBottom: spacing.md,
     width: '100%',
+  },
+  stripHolder: { position: 'absolute' },
+  strip: {
+    ...cardShadow,
+    backgroundColor: colors.bg,
+    borderRadius: radius.pill,
+    flexGrow: 0,
+  },
+  stripInner: { alignItems: 'center', gap: 2, paddingHorizontal: 6, paddingVertical: 6 },
+  emoji: {
+    alignItems: 'center',
+    borderRadius: radius.pill,
+    height: 42,
+    justifyContent: 'center',
+    width: 42,
+  },
+  emojiChosen: { backgroundColor: colors.surface },
+  emojiGlyph: { fontSize: 24, lineHeight: 30 },
+  copy: {
+    borderRadius: radius.lg,
+    paddingHorizontal: 14,
+    paddingVertical: spacing.md,
+    position: 'absolute',
+  },
+  copyMine: { backgroundColor: colors.primary },
+  copyTheirs: { backgroundColor: colors.surface, borderColor: colors.border, borderWidth: 1 },
+  copyText: { ...font.body, color: colors.text, lineHeight: 22 },
+  copyTextMine: { color: colors.primaryText },
+  menu: {
+    ...cardShadow,
+    backgroundColor: colors.bg,
+    borderRadius: radius.lg,
+    paddingVertical: spacing.sm,
+    position: 'absolute',
   },
 }))

--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -5,7 +5,12 @@ import { useEffect } from 'react'
 import type { MessageDto } from '../api/queries'
 import { keys } from '../api/queries'
 import { applyIncomingMessage, type ConversationPageDto } from '../lib/conversationCache'
-import { appendIncomingMessage, applyDeliveredAt, type MessagePageDto } from '../lib/messageCache'
+import {
+  appendIncomingMessage,
+  applyDeliveredAt,
+  applyMessageUpdate,
+  type MessagePageDto,
+} from '../lib/messageCache'
 import { closeSocket, getSocket } from '../lib/socket'
 
 /**
@@ -92,6 +97,24 @@ export function useSocket(): void {
        * rarer event and clear an unread count the client cannot recompute,
        * which is why that one still goes back to the server.
        */
+      /**
+       * One event for every mutation, carrying the message's whole new state.
+       * A client that applies "the message is now this" cannot drift; one that
+       * applied a patch would have to be right about the order they arrive in.
+       */
+      socket.on('message:updated', (message: MessageDto) => {
+        const conversationId = String(message.conversationId)
+        queryClient.setQueriesData<InfiniteData<MessagePageDto>>(
+          { queryKey: keys.messages(conversationId) },
+          (old) => applyMessageUpdate(old, message) ?? old,
+        )
+        // A withdrawal empties the chat list's preview too, and that is the
+        // one thing this cannot patch from here.
+        if (message.deleted) {
+          void queryClient.invalidateQueries({ queryKey: keys.conversations })
+        }
+      })
+
       socket.on(
         'conversation:delivered',
         ({

--- a/apps/mobile/src/lib/messageActions.test.ts
+++ b/apps/mobile/src/lib/messageActions.test.ts
@@ -12,12 +12,12 @@ const ids = (over: Partial<MessageActionContext> = {}) =>
 
 describe('messageActionsFor', () => {
   it('offers the full set on the other person`s text', () => {
-    expect(ids()).toEqual(['reply', 'copy', 'translate', 'correct', 'report'])
+    expect(ids()).toEqual(['reply', 'copy', 'translate', 'correct', 'delete', 'report'])
   })
 
   /** Correcting your own message, or reporting yourself, is not a thing. */
   it('leaves only copy on your own message', () => {
-    expect(ids({ mine: true })).toEqual(['reply', 'copy'])
+    expect(ids({ mine: true })).toEqual(['reply', 'copy', 'delete'])
   })
 
   it('does not offer to correct anything but text', () => {
@@ -37,7 +37,7 @@ describe('messageActionsFor', () => {
 
   /** A voice note without a caption has no text to copy or translate. */
   it('drops the text actions when there is no body', () => {
-    expect(ids({ type: 'audio', hasBody: false })).toEqual(['reply', 'report'])
+    expect(ids({ type: 'audio', hasBody: false })).toEqual(['reply', 'delete', 'report'])
   })
 
   it('always leaves a way to report the other person', () => {
@@ -52,6 +52,13 @@ describe('messageActionsFor', () => {
    * no text of its own, so there is always at least one row.
    */
   it('offers reply even on your own captionless media, where nothing else applies', () => {
-    expect(ids({ mine: true, type: 'audio', hasBody: false })).toEqual(['reply'])
+    expect(ids({ mine: true, type: 'audio', hasBody: false })).toEqual(['reply', 'delete'])
+  })
+
+  /** A filter on your own copy, so it never depends on age or authorship. */
+  it('offers delete on every message, whoever sent it', () => {
+    for (const mine of [true, false]) {
+      expect(ids({ mine })).toContain('delete')
+    }
   })
 })

--- a/apps/mobile/src/lib/messageActions.ts
+++ b/apps/mobile/src/lib/messageActions.ts
@@ -1,4 +1,11 @@
-export const MESSAGE_ACTION_IDS = ['reply', 'copy', 'translate', 'correct', 'report'] as const
+export const MESSAGE_ACTION_IDS = [
+  'reply',
+  'copy',
+  'translate',
+  'correct',
+  'delete',
+  'report',
+] as const
 export type MessageActionId = (typeof MESSAGE_ACTION_IDS)[number]
 
 export interface MessageAction {
@@ -58,6 +65,15 @@ export function messageActionsFor(context: MessageActionContext): MessageAction[
   if (!context.mine && context.type === 'text') {
     actions.push({ id: 'correct', label: 'Correct', icon: 'pencil-outline' })
   }
+
+  /**
+   * Always offered, on anyone's message and at any age: "delete for me" is a
+   * filter on your own copy and never expires. Whether *withdrawing* it from
+   * the other person is also on the table is the caller's question — the rule
+   * is `canDeleteForEveryone` in shared, and the screen asks with it rather
+   * than the menu guessing.
+   */
+  actions.push({ id: 'delete', label: 'Delete', icon: 'trash-outline', destructive: true })
 
   if (!context.mine) {
     actions.push({ id: 'report', label: 'Report', icon: 'flag-outline', destructive: true })

--- a/apps/mobile/src/lib/messageCache.test.ts
+++ b/apps/mobile/src/lib/messageCache.test.ts
@@ -4,6 +4,7 @@ import type { MessageDto } from '../api/queries'
 import {
   appendIncomingMessage,
   applyDeliveredAt,
+  applyMessageUpdate,
   messagesNewestFirst,
   type MessagePageDto,
 } from './messageCache'
@@ -113,5 +114,57 @@ describe('applyDeliveredAt', () => {
     const data = pages([message('a', ME, earlier)])
     const next = applyDeliveredAt(data, { deliveredTo: THEM, deliveredAt: at })
     expect(next?.pages[0]?.items[0]?.deliveredAt).toBe(earlier)
+  })
+})
+
+describe('applyMessageUpdate', () => {
+  it('replaces the message wholesale rather than merging into it', () => {
+    const data = pages([{ ...message('a'), body: 'before' }])
+    const withdrawn = { ...message('a'), body: '', deleted: true }
+    const next = applyMessageUpdate(data, withdrawn)
+
+    expect(next?.pages[0]?.items[0]).toEqual(withdrawn)
+  })
+
+  /**
+   * A merge would resurrect exactly what the server's projection took away —
+   * the attachment of a message that was just deleted, most obviously.
+   */
+  it('does not carry a dropped field through from the old copy', () => {
+    const withMedia = {
+      ...message('a'),
+      media: { url: 'https://cdn/x.jpg', contentType: 'image/jpeg', sizeBytes: 1 },
+    }
+    const next = applyMessageUpdate(pages([withMedia]), { ...message('a'), deleted: true })
+    expect(next?.pages[0]?.items[0]?.media).toBeUndefined()
+  })
+
+  it('finds the message on any page', () => {
+    const data = pages([message('new1')], [message('old1')])
+    const next = applyMessageUpdate(data, { ...message('old1'), body: 'edited' })
+    expect(next?.pages[1]?.items[0]?.body).toBe('edited')
+  })
+
+  /** An update for something not loaded is not an invitation to insert it. */
+  it('is a no-op for a message outside the loaded pages', () => {
+    const data = pages([message('a')])
+    expect(applyMessageUpdate(data, message('elsewhere'))).toBe(data)
+  })
+})
+
+describe('messagesNewestFirst and hidden messages', () => {
+  /**
+   * Filtered here rather than on the server: dropping rows from a keyset page
+   * would make a page of 30 arrive as 12, and the paging would have to
+   * compensate for a number only this viewer knows.
+   */
+  it('drops the ones this reader hid, and keeps the rest', () => {
+    const data = pages([message('a'), { ...message('b'), hidden: true }, message('c')])
+    expect(messagesNewestFirst(data).map((m) => m._id)).toEqual(['c', 'a'])
+  })
+
+  it('keeps a message withdrawn for everyone, which still occupies its place', () => {
+    const data = pages([{ ...message('a'), deleted: true, body: '' }])
+    expect(messagesNewestFirst(data).map((m) => m._id)).toEqual(['a'])
   })
 })

--- a/apps/mobile/src/lib/messageCache.ts
+++ b/apps/mobile/src/lib/messageCache.ts
@@ -71,7 +71,37 @@ export function applyDeliveredAt(
  */
 export function messagesNewestFirst(data: Pages): MessageDto[] {
   if (!data) return []
-  return data.pages.flatMap((page) => [...page.items].reverse())
+  // `hidden` is filtered here rather than on the server: dropping rows from a
+  // keyset page would make a page of 30 arrive as 12, and the paging would
+  // have to compensate for a number only the viewer knows.
+  return data.pages.flatMap((page) => [...page.items].reverse().filter((m) => !m.hidden))
+}
+
+/**
+ * A message that already exists has changed — a reaction, a withdrawal, and
+ * later an edit or a star.
+ *
+ * Replaced wholesale rather than merged. The server sends the message's entire
+ * new state as that viewer is allowed to see it, and merging would resurrect
+ * exactly the fields the projection took away: the `media` of a message that
+ * was just deleted, most obviously.
+ *
+ * Not found is a no-op, not an insert. An update for a message outside the
+ * loaded pages means the reader has not scrolled to it, and the page will
+ * carry the right state whenever they do.
+ */
+export function applyMessageUpdate(data: Pages, message: MessageDto): Pages {
+  if (!data) return data
+  let changed = false
+  const pages = data.pages.map((page) => ({
+    ...page,
+    items: page.items.map((existing) => {
+      if (!sameId(existing, message)) return existing
+      changed = true
+      return message
+    }),
+  }))
+  return changed ? { ...data, pages } : data
 }
 
 function sameId(a: MessageDto, b: MessageDto): boolean {

--- a/apps/mobile/src/lib/messageMenu.test.ts
+++ b/apps/mobile/src/lib/messageMenu.test.ts
@@ -18,19 +18,19 @@ describe('messageMenu', () => {
     const seen: (MessageMenuRequest | null)[] = []
     subscribeToMessageMenu((r) => seen.push(r))
 
-    const picked = openMessageMenu('hello', COPY)
+    const picked = openMessageMenu({ mine: false, preview: 'hello', actions: COPY })
     const request = seen.at(-1)
     expect(request?.preview).toBe('hello')
 
-    resolveMessageMenu(request!.id, 'copy')
-    await expect(picked).resolves.toBe('copy')
+    resolveMessageMenu(request!.id, { kind: 'action', id: 'copy' })
+    await expect(picked).resolves.toEqual({ kind: 'action', id: 'copy' })
     expect(seen.at(-1)).toBeNull()
   })
 
   it('resolves null when dismissed', async () => {
     let request: MessageMenuRequest | null = null
     subscribeToMessageMenu((r) => (request = r))
-    const picked = openMessageMenu('hello', COPY)
+    const picked = openMessageMenu({ mine: false, preview: 'hello', actions: COPY })
     resolveMessageMenu(request!.id, null)
     await expect(picked).resolves.toBeNull()
   })
@@ -43,29 +43,29 @@ describe('messageMenu', () => {
     let request: MessageMenuRequest | null = null
     subscribeToMessageMenu((r) => (request = r))
 
-    const first = openMessageMenu('one', COPY)
-    const second = openMessageMenu('two', COPY)
+    const first = openMessageMenu({ mine: false, preview: 'one', actions: COPY })
+    const second = openMessageMenu({ mine: false, preview: 'two', actions: COPY })
     await expect(first).resolves.toBeNull()
 
     expect(request!.preview).toBe('two')
-    resolveMessageMenu(request!.id, 'copy')
-    await expect(second).resolves.toBe('copy')
+    resolveMessageMenu(request!.id, { kind: 'action', id: 'copy' })
+    await expect(second).resolves.toEqual({ kind: 'action', id: 'copy' })
   })
 
   it('ignores a resolve for a menu that is no longer open', async () => {
     let request: MessageMenuRequest | null = null
     subscribeToMessageMenu((r) => (request = r))
-    const picked = openMessageMenu('hello', COPY)
+    const picked = openMessageMenu({ mine: false, preview: 'hello', actions: COPY })
     const staleId = request!.id
 
-    resolveMessageMenu(staleId, 'copy')
-    await expect(picked).resolves.toBe('copy')
+    resolveMessageMenu(staleId, { kind: 'action', id: 'copy' })
+    await expect(picked).resolves.toEqual({ kind: 'action', id: 'copy' })
 
     // A late press on a menu already gone must not throw or reopen anything.
     const onChange = vi.fn()
     subscribeToMessageMenu(onChange)
     onChange.mockClear()
-    resolveMessageMenu(staleId, 'report')
+    resolveMessageMenu(staleId, { kind: 'action', id: 'report' })
     expect(onChange).not.toHaveBeenCalled()
   })
 
@@ -74,7 +74,7 @@ describe('messageMenu', () => {
     const off = subscribeToMessageMenu(listener)
     off()
     listener.mockClear()
-    void openMessageMenu('hello', COPY)
+    void openMessageMenu({ mine: false, preview: 'hello', actions: COPY })
     expect(listener).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/lib/messageMenu.ts
+++ b/apps/mobile/src/lib/messageMenu.ts
@@ -10,18 +10,47 @@ import type { MessageAction, MessageActionId } from './messageActions'
  * gesture on one message; a second one arriving means the first is stale, so
  * it is dismissed rather than stacked behind.
  */
+/** Where on screen the bubble was when it was pressed. */
+export interface AnchorRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
 export interface MessageMenuRequest {
   id: number
   /** Shown above the actions so it is obvious which message is being acted on. */
   preview: string
+  /** Tints the copy of the bubble the anchored layout draws. */
+  mine: boolean
   actions: MessageAction[]
+  /**
+   * The measured bubble. Present means the menu is drawn against it; absent
+   * falls back to the sheet, which is what a caller with nothing to measure —
+   * or a platform where the measurement failed — still gets.
+   */
+  anchor?: AnchorRect
+  /** The emoji strip, when the message can carry a reaction. */
+  reactions?: readonly string[]
+  /** Which of them is already the viewer's, drawn selected. */
+  myReaction?: string | undefined
 }
+
+/**
+ * Two ways out, because the strip and the rows are one gesture's worth of UI
+ * but not one kind of answer.
+ */
+export type MessageMenuResult =
+  { kind: 'action'; id: MessageActionId } | { kind: 'reaction'; emoji: string }
 
 type Listener = (request: MessageMenuRequest | null) => void
 
 let nextId = 1
-let open: { request: MessageMenuRequest; resolve: (value: MessageActionId | null) => void } | null =
-  null
+let open: {
+  request: MessageMenuRequest
+  resolve: (value: MessageMenuResult | null) => void
+} | null = null
 let listener: Listener | null = null
 
 function publish(): void {
@@ -37,21 +66,26 @@ export function subscribeToMessageMenu(next: Listener): () => void {
   }
 }
 
-/** Resolves with the chosen action, or `null` when dismissed. */
+/**
+ * Resolves with what was chosen, or `null` when dismissed.
+ *
+ * One options object rather than positional arguments: the anchor, the strip
+ * and the current reaction all arrive together, and a fifth positional
+ * parameter is where a call site starts passing them in the wrong order.
+ */
 export function openMessageMenu(
-  preview: string,
-  actions: MessageAction[],
-): Promise<MessageActionId | null> {
+  request: Omit<MessageMenuRequest, 'id'>,
+): Promise<MessageMenuResult | null> {
   return new Promise((resolve) => {
     // A menu already up belongs to a message the user has moved on from.
     open?.resolve(null)
-    open = { request: { id: nextId++, preview, actions }, resolve }
+    open = { request: { ...request, id: nextId++ }, resolve }
     publish()
   })
 }
 
 /** Called by the host when an action is picked or the menu is dismissed. */
-export function resolveMessageMenu(id: number, value: MessageActionId | null): void {
+export function resolveMessageMenu(id: number, value: MessageMenuResult | null): void {
   if (!open || open.request.id !== id) return
   const { resolve } = open
   open = null

--- a/apps/mobile/src/lib/messageMenuLayout.test.ts
+++ b/apps/mobile/src/lib/messageMenuLayout.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { messageMenuLayout, type MenuLayoutInput } from './messageMenuLayout'
+
+const BASE: MenuLayoutInput = {
+  anchor: { x: 40, y: 400, width: 240, height: 60 },
+  screen: { width: 400, height: 800 },
+  insets: { top: 48, bottom: 34 },
+  menu: { width: 220, height: 200 },
+  strip: { width: 300, height: 48 },
+  mine: false,
+}
+
+const layout = (overrides: Partial<MenuLayoutInput> = {}) =>
+  messageMenuLayout({ ...BASE, ...overrides })
+
+describe('messageMenuLayout', () => {
+  it('puts the strip over the bubble and the menu under it when there is room', () => {
+    const result = layout()
+    expect(result.placement).toBe('below')
+    expect(result.strip.top).toBeLessThan(result.bubble.top)
+    expect(result.menu.top).toBeGreaterThan(result.bubble.top)
+    // The bubble stays exactly where it was measured.
+    expect(result.bubble.top).toBe(BASE.anchor.y)
+  })
+
+  /** Near the bottom the menu has nowhere to go, so the two swap. */
+  it('flips the menu above the bubble against the bottom of the screen', () => {
+    const result = layout({ anchor: { x: 40, y: 600, width: 240, height: 60 } })
+    expect(result.placement).toBe('above')
+    expect(result.menu.top).toBeLessThan(result.bubble.top)
+    expect(result.strip.top).toBeGreaterThan(result.bubble.top)
+  })
+
+  it('keeps the flipped menu clear of the top inset', () => {
+    const result = layout({ anchor: { x: 40, y: 600, width: 240, height: 60 } })
+    expect(result.menu.top).toBeGreaterThanOrEqual(BASE.insets.top)
+  })
+
+  it('hangs the menu off the right of your own bubble and the left of theirs', () => {
+    const anchor = { x: 120, y: 400, width: 240, height: 60 }
+    expect(layout({ anchor, mine: false }).menu.left).toBe(120)
+    // Right edges line up: 120 + 240 - 220.
+    expect(layout({ anchor, mine: true }).menu.left).toBe(140)
+  })
+
+  it('never lets the strip leave the screen on either side', () => {
+    const offRight = layout({ anchor: { x: 380, y: 400, width: 240, height: 60 }, mine: true })
+    expect(offRight.strip.left + BASE.strip.width).toBeLessThanOrEqual(BASE.screen.width)
+
+    const offLeft = layout({ anchor: { x: -20, y: 400, width: 240, height: 60 } })
+    expect(offLeft.strip.left).toBeGreaterThanOrEqual(0)
+  })
+
+  /**
+   * A tall bubble on a short screen fits neither way round, and the bubble
+   * moving off its measured position is the price of showing the whole stack.
+   */
+  it('centres the whole stack when neither arrangement fits', () => {
+    const result = layout({
+      anchor: { x: 40, y: 300, width: 240, height: 260 },
+      screen: { width: 400, height: 640 },
+    })
+    expect(result.strip.top).toBeGreaterThanOrEqual(BASE.insets.top)
+    expect(result.menu.top + BASE.menu.height).toBeLessThanOrEqual(640 - BASE.insets.bottom)
+    expect(result.bubble.top).not.toBe(300)
+  })
+
+  it('keeps the three in order whichever way it lands', () => {
+    for (const y of [100, 300, 500, 700]) {
+      const result = layout({ anchor: { x: 40, y, width: 240, height: 60 } })
+      const [first, second] =
+        result.placement === 'below'
+          ? [result.strip.top, result.menu.top]
+          : [result.menu.top, result.strip.top]
+      expect(first).toBeLessThan(result.bubble.top)
+      expect(second).toBeGreaterThan(result.bubble.top)
+    }
+  })
+})

--- a/apps/mobile/src/lib/messageMenuLayout.ts
+++ b/apps/mobile/src/lib/messageMenuLayout.ts
@@ -1,0 +1,93 @@
+import type { AnchorRect } from './messageMenu'
+
+export interface MenuLayoutInput {
+  anchor: AnchorRect
+  screen: { width: number; height: number }
+  insets: { top: number; bottom: number }
+  menu: { width: number; height: number }
+  strip: { width: number; height: number }
+  /** Own messages hang off the right edge, the other person's off the left. */
+  mine: boolean
+}
+
+export interface MenuLayout {
+  /** Where the *menu* went. The strip always takes the opposite side. */
+  placement: 'below' | 'above'
+  strip: { top: number; left: number }
+  menu: { top: number; left: number }
+  /**
+   * Where to draw the copy of the bubble.
+   *
+   * An output, not the measured rect it came in as: when neither arrangement
+   * fits — a tall bubble on a short screen — the whole stack is centred in the
+   * safe area, and the bubble has to move with it.
+   */
+  bubble: { top: number; left: number }
+}
+
+const GUTTER = 12
+const GAP = 8
+
+/**
+ * Where the strip, the bubble and the menu go once a bubble has been pressed.
+ *
+ * Pure, and given the menu's height rather than left to measure it: measuring
+ * after mounting means one frame drawn in the wrong place and a visible jump
+ * on exactly the gesture that is supposed to feel immediate. Deriving the
+ * height from the row count decides the flip before the first paint, and keeps
+ * every one of these rules testable without a renderer.
+ */
+export function messageMenuLayout(input: MenuLayoutInput): MenuLayout {
+  const { anchor, screen, insets, menu, strip, mine } = input
+
+  const safeTop = insets.top + GUTTER
+  const safeBottom = screen.height - insets.bottom - GUTTER
+
+  const align = (width: number): number => {
+    const preferred = mine ? anchor.x + anchor.width - width : anchor.x
+    const most = Math.max(GUTTER, screen.width - width - GUTTER)
+    return Math.min(Math.max(preferred, GUTTER), most)
+  }
+
+  // Preferred: the strip sits over the bubble and the menu under it, which is
+  // the order the thumb meets them coming up from the composer.
+  const belowTop = anchor.y - GAP - strip.height
+  const belowBottom = anchor.y + anchor.height + GAP + menu.height
+  const fitsBelow = belowTop >= safeTop && belowBottom <= safeBottom
+
+  // Near the bottom of the screen the menu has nowhere to go, so the two swap.
+  const aboveTop = anchor.y - GAP - menu.height
+  const aboveBottom = anchor.y + anchor.height + GAP + strip.height
+  const fitsAbove = aboveTop >= safeTop && aboveBottom <= safeBottom
+
+  const stripLeft = align(strip.width)
+  const menuLeft = align(menu.width)
+  const bubbleLeft = anchor.x
+
+  if (fitsBelow || !fitsAbove) {
+    // The fallback branch too: neither fits, so the whole stack is centred in
+    // the safe area and the bubble moves off its measured position with it.
+    const total = strip.height + GAP + anchor.height + GAP + menu.height
+    const stackTop = fitsBelow
+      ? belowTop
+      : // Clamped bottom-first, then top: a stack taller than the safe area
+        // fits nowhere, and pinning it to the top at least leaves the strip and
+        // the bubble reachable. The other order pushes both off the top instead.
+        Math.max(safeTop, Math.min((safeTop + safeBottom - total) / 2, safeBottom - total))
+    const bubbleTop = stackTop + strip.height + GAP
+
+    return {
+      placement: 'below',
+      strip: { top: stackTop, left: stripLeft },
+      bubble: { top: bubbleTop, left: bubbleLeft },
+      menu: { top: bubbleTop + anchor.height + GAP, left: menuLeft },
+    }
+  }
+
+  return {
+    placement: 'above',
+    menu: { top: aboveTop, left: menuLeft },
+    bubble: { top: anchor.y, left: bubbleLeft },
+    strip: { top: anchor.y + anchor.height + GAP, left: stripLeft },
+  }
+}

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -67,6 +67,60 @@ export const sendCorrectionSchema = z.object({
 })
 export type SendCorrectionInput = z.infer<typeof sendCorrectionSchema>
 
+/**
+ * The reaction strip.
+ *
+ * Seven, because the row has to fit beside a `+` on the narrowest phone we
+ * support, and because a longer strip stops being a glance and starts being a
+ * decision. Plain 🔥 rather than WhatsApp's ❤️‍🔥: the flame is already the
+ * streak's symbol in this app and reusing it here keeps one meaning per glyph.
+ */
+export const MESSAGE_REACTIONS = ['👍', '❤️', '😂', '😮', '😢', '🙏', '🔥'] as const
+export type MessageReaction = (typeof MESSAGE_REACTIONS)[number]
+
+/**
+ * How long a sender can withdraw a message from the other person's device.
+ *
+ * Two days, the same window WhatsApp settled on. Past it, "delete for me"
+ * stays available forever — what expires is the ability to reach into someone
+ * else's copy, not the ability to tidy your own.
+ */
+export const MESSAGE_DELETE_WINDOW_MS = 2 * 24 * 60 * 60 * 1000
+
+export const reactToMessageSchema = z.object({
+  conversationId: z.string().trim().min(1),
+  messageId: z.string().trim().min(1),
+  /** Null clears whatever this user had on the message. */
+  emoji: z.enum(MESSAGE_REACTIONS).nullable(),
+})
+export type ReactToMessageInput = z.infer<typeof reactToMessageSchema>
+
+export const deleteMessageSchema = z.object({
+  conversationId: z.string().trim().min(1),
+  messageId: z.string().trim().min(1),
+  scope: z.enum(['me', 'everyone']),
+})
+export type DeleteMessageInput = z.infer<typeof deleteMessageSchema>
+
+/**
+ * Whether a message can still be withdrawn from the other person.
+ *
+ * Shared so the menu and the mutation cannot disagree: a client that offers
+ * the row when the server would refuse it produces an error the user cannot
+ * act on, and one that hides it early takes away something they still have.
+ */
+export function canDeleteForEveryone(
+  message: { senderId: string; createdAt: string | Date; deletedAt?: string | Date | null },
+  userId: string,
+  now: Date,
+): boolean {
+  if (message.senderId !== userId) return false
+  if (message.deletedAt) return false
+  const sent = new Date(message.createdAt).getTime()
+  if (Number.isNaN(sent)) return false
+  return now.getTime() - sent <= MESSAGE_DELETE_WINDOW_MS
+}
+
 export const MESSAGE_PAGE_SIZE_DEFAULT = 30
 export const MESSAGE_PAGE_SIZE_MAX = 100
 


### PR DESCRIPTION
Stacked on #971, which is stacked on #970. Third of five branches from the chat plan.

Six mutations all want a field on `Message` and a way to change one that already exists. This PR is that shared way, plus the first two that use it.

## The projection comes first, because without it the rest is a leak

`listMessages` returned raw documents. That was fine while every field on a message was mutual — `hiddenFor` is not, and `starredBy` will not be either. `toMessageView` builds a message *for the person asking for it*: per-user arrays become the booleans `hidden` and `myReaction`, and a withdrawn message is emptied on the way out rather than in the database, where a later reader could still find the body. Applied in both list endpoints and both fan-outs, so the two participants are now sent two different objects built from one row.

## `loadMutableMessage` is the only door

Conversation access, then the message scoped to that conversation — an id from another thread reads as "not found" rather than as a permission error. The socket handlers check nothing themselves, which is the point: a third mutation cannot forget to.

## One event

`message:updated` carries the message's whole new state, not a description of what changed — a client applying "it is now this" cannot drift; one applying a patch has to be right about arrival order. Deletion is not a second event either.

`audience: 'actor'` is what keeps per-user state private: hiding a message emits to the actor's own room only, so their other devices converge and the other person is told nothing. There is a socket test asserting exactly that silence.

## Reactions

One per person — the same emoji clears it, a different one moves it. Written as a pull from every emoji except the chosen one plus an add to that one: a single update over disjoint paths, because rewriting the whole map would clobber a reaction the other person added between the read and the write.

**Deliberately off the token path.** `awardForSend` is never called, no `dailyActivity` counter moves, the streak does not advance — with a test asserting the ledger does not grow. Anything that pays out for one tap is a farm.

## Deletion is two things

- **For me** — `hiddenFor` plus a filter in `messagesNewestFirst`. Filtered on the client because dropping rows from a keyset page would make a page of 30 arrive as 12, and the paging would have to compensate for a number only that viewer knows.
- **For everyone** — a tombstone inside a two-day window. The conditional `updateOne` is the whole concurrency design: `lastMessage` is patched with the deleted row's own timestamp *in the filter*, so a message that arrived first makes it match nothing; `unread` uses `$inc: -1`, which commutes with a concurrent send where a `countDocuments` + `$set` would silently discard it. Bytes leave the bucket after Mongo, never before.

A repeat withdrawal is a no-op rather than an error — the idempotency test caught this. `canDeleteForEveryone` refuses an existing tombstone, correctly, so the menu stops offering the row; but that check ran *before* the conditional update meant to handle the race, so the concurrency design was unreachable.

**Adjacent bug fixed, one line from the same idea:** the account purge blanked every message a leaving user sent but never touched `conversation.lastMessage`, leaving their last sentence in the other person's chat list — the exact text a purge exists to remove.

## The menu is now anchored to the bubble

`messageMenuLayout` is pure and tested, and decides the flip from *derived* heights rather than measured ones, so it lands before the first paint instead of one frame late. The bubble reports its rect with `measureInWindow` and falls back to the old sheet if it never calls back.

**Two deliberate departures from the plan, both worth arguing with:**

1. **It stays a `Modal`** rather than moving to a root absolute layer. `measureInWindow` and a full-screen Modal are both in window coordinates, so they agree; the Modal already paints above the tab bar without depending on mount order, and `onRequestClose` is Android's back button for free. A root layer needs `BackHandler` and sits under the tab bar if it is ever mounted before the navigator.
2. **The two-page menu is not here.** Six rows fit one page, and a `More…` holding a single item is worse than none. It arrives in 3b with edit, star and pin.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — 670 tests, 37 new.

New coverage: the projection never ships `hiddenFor` (7 pure cases), reaction toggle/replace, a reaction costing no tokens, hide visible to one side only, withdrawal refused for the wrong sender and past the window, `lastMessage` and `unread` after a withdrawal, `lastMessage` left alone when a newer message won the race, a second withdrawal changing nothing, a foreign message id 404ing, the purge clearing the chat-list preview, and six socket cases including the peer receiving nothing on a hide.

Not yet driven in a browser; the hands-on pass for the anchored menu lands with the rest of the chat work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)