### PR TITLE
Edit, star and pin, and split the menu in two

### DIFF
--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -143,6 +143,18 @@ export const INDEXES: Partial<IndexSpec> = {
     { key: { conversationId: 1, createdAt: -1, _id: -1 }, name: 'conversation_created_id' },
     { key: { senderId: 1, createdAt: -1 }, name: 'sender_created' },
     /**
+     * The starred screen, which is a `find` by one user across every
+     * conversation they are in — without this it is a scan of the whole
+     * messages collection, and it grows with the app rather than with the
+     * user. Sparse because `starredBy` is absent on almost every message, and
+     * the query only ever looks for its presence.
+     */
+    {
+      key: { starredBy: 1, createdAt: -1 },
+      name: 'starred_created',
+      sparse: true,
+    },
+    /**
      * Backs `markConversationRead`'s `updateMany`, which selects the unread
      * messages in one conversation. Without it that update scans every message
      * in the thread on every read — and a read happens each time the screen is

--- a/apps/api/src/modules/chat/conversations.ts
+++ b/apps/api/src/modules/chat/conversations.ts
@@ -18,6 +18,8 @@ export interface Conversation {
   participants: [string, string]
   lastMessage: { body: string; senderId: string; createdAt: Date; deleted?: boolean }
   unread: Record<string, number>
+  /** One per conversation, replaced rather than appended — see `MAX_PINNED_PER_CONVERSATION`. */
+  pinned?: { messageId: ObjectId; byUserId: string; at: Date }
   firstMessageBy: string
   firstMessageAt: Date
   bothSpoke: boolean
@@ -66,6 +68,17 @@ export interface Message {
   /** "Delete for everyone": a tombstone, not a removal. */
   deletedAt?: Date
   deletedBy?: string
+  /** Private to each user — projected away, never shipped as a list. */
+  starredBy?: string[]
+  editedAt?: Date
+  /**
+   * Stamped when someone writes a correction of this message.
+   *
+   * Kept on the target rather than derived, so the edit rule is a field read
+   * instead of a query: `sendCorrection` already loads this document, so the
+   * stamp is free where a lookup would not be.
+   */
+  correctedAt?: Date
   legacyId?: string
   /**
    * When the message reached the recipient's device — the second tick. Set by

--- a/apps/api/src/modules/chat/messageView.ts
+++ b/apps/api/src/modules/chat/messageView.ts
@@ -38,6 +38,11 @@ export interface MessageView {
   deleted?: boolean
   /** The viewer deleted it for themselves; the client drops the row. */
   hidden?: boolean
+  /** The viewer starred it. Who else did is nobody's business. */
+  starred?: boolean
+  editedAt?: string
+  /** Someone has corrected this sentence, so it can no longer be edited. */
+  corrected?: boolean
   deliveredAt?: string
   readAt?: string
   createdAt: string
@@ -63,6 +68,9 @@ export function toMessageView(message: Message, viewerId: string): MessageView {
 
   if (deleted) view.deleted = true
   if (hidden) view.hidden = true
+  if (message.starredBy?.includes(viewerId)) view.starred = true
+  if (!deleted && message.editedAt) view.editedAt = message.editedAt.toISOString()
+  if (!deleted && message.correctedAt) view.corrected = true
   if (!deleted && message.media) view.media = message.media
   if (!deleted && message.correction) {
     view.correction = {

--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -177,6 +177,16 @@ export async function sendCorrection(
     createdAt: new Date(),
   }
 
+  /**
+   * The target is already loaded, so stamping it costs nothing — and it is
+   * what makes `canEditMessage` a field read rather than a second query. The
+   * sentence someone has just taught about must stop being editable, or the
+   * `original` snapshot above ends up quoting something that no longer exists.
+   */
+  await db
+    .collection<Message>(COLLECTIONS.messages)
+    .updateOne({ _id: target._id }, { $set: { correctedAt: message.createdAt } })
+
   const updatedConversation = await recordMessage(db, conversation, message)
   return { message, conversation: updatedConversation }
 }
@@ -256,6 +266,12 @@ export interface MessagePage {
    */
   prevCursor: string | null
   participants: string[]
+  /**
+   * The pinned message, on the page for the same reason `participants` is: the
+   * thread's banner needs it before anything else has loaded, and the client
+   * never fetches the conversation document on its own.
+   */
+  pinned: { messageId: string; byUserId: string; at: string } | null
   /** Set only by `listMessagesAround`, so a client knows what to scroll to. */
   anchorId?: string
 }
@@ -316,6 +332,13 @@ export async function listMessages(
     // The thread header needs the counterpart even before anyone has replied,
     // and a one-sided thread has no message to read a partner id off.
     participants: conversation.participants,
+    pinned: conversation.pinned
+      ? {
+          messageId: conversation.pinned.messageId.toHexString(),
+          byUserId: conversation.pinned.byUserId,
+          at: conversation.pinned.at.toISOString(),
+        }
+      : null,
   }
 }
 
@@ -391,6 +414,13 @@ export async function listMessagesAround(
     nextCursor: hasOlder && oldest ? encodeDateIdCursor(oldest.createdAt, oldest._id) : null,
     prevCursor: hasNewer && newest ? encodeDateIdCursor(newest.createdAt, newest._id) : null,
     participants: conversation.participants,
+    pinned: conversation.pinned
+      ? {
+          messageId: conversation.pinned.messageId.toHexString(),
+          byUserId: conversation.pinned.byUserId,
+          at: conversation.pinned.at.toISOString(),
+        }
+      : null,
     anchorId: anchor._id.toHexString(),
   }
 }

--- a/apps/api/src/modules/chat/mutations.ts
+++ b/apps/api/src/modules/chat/mutations.ts
@@ -1,9 +1,13 @@
 import {
   canDeleteForEveryone,
+  canEditMessage,
   ERROR_CODES,
   MESSAGE_REACTIONS,
   type DeleteMessageInput,
+  type EditMessageInput,
+  type PinMessageInput,
   type ReactToMessageInput,
+  type StarMessageInput,
 } from '@langx/shared'
 import { ObjectId, type Db, type UpdateFilter } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
@@ -243,4 +247,163 @@ async function deleteAttachment(message: Message, storage?: StorageProvider): Pr
   } catch {
     // Swallowed on purpose: the row is already a tombstone.
   }
+}
+
+/**
+ * Editing your own text, inside the window and only if nobody has corrected it.
+ *
+ * No new tokens. The message was already paid for when it was sent, and paying
+ * again for changing a word would make editing a way to earn.
+ */
+export async function editMessage(
+  db: Db,
+  userId: string,
+  input: EditMessageInput,
+): Promise<MessageMutationResult> {
+  const { conversation, message } = await loadMutableMessage(
+    db,
+    userId,
+    input.conversationId,
+    input.messageId,
+  )
+
+  if (
+    !canEditMessage({ ...message, corrected: Boolean(message.correctedAt) }, userId, new Date())
+  ) {
+    throw new ApiError(
+      ERROR_CODES.VALIDATION_FAILED,
+      message.correctedAt
+        ? 'That message has been corrected, so it can no longer be edited'
+        : 'Only your own text messages, and only within two days of sending them',
+    )
+  }
+
+  const now = new Date()
+  const updated = await db
+    .collection<Message>(COLLECTIONS.messages)
+    .findOneAndUpdate(
+      { _id: message._id, senderId: userId },
+      { $set: { body: input.body, editedAt: now } },
+      { returnDocument: 'after' },
+    )
+  if (!updated) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Message not found')
+
+  /**
+   * The chat list keeps a copy of the last message's text, so an edit to that
+   * one has to reach it. Conditional on the same pair a withdrawal uses: if
+   * something newer arrived, this is no longer the last message and the filter
+   * correctly matches nothing.
+   */
+  await db.collection<Conversation>(COLLECTIONS.conversations).updateOne(
+    {
+      _id: conversation._id,
+      'lastMessage.createdAt': message.createdAt,
+      'lastMessage.senderId': message.senderId,
+    },
+    { $set: { 'lastMessage.body': input.body } },
+  )
+
+  return { message: updated, conversation, audience: 'both' }
+}
+
+/**
+ * Starring is private and one-sided — a bookmark, not a signal. It is the
+ * clearest case for `audience: 'actor'`: the emit exists only so the same
+ * person's other devices agree, and the peer is told nothing.
+ */
+export async function starMessage(
+  db: Db,
+  userId: string,
+  input: StarMessageInput,
+): Promise<MessageMutationResult> {
+  const { conversation, message } = await loadMutableMessage(
+    db,
+    userId,
+    input.conversationId,
+    input.messageId,
+  )
+
+  const updated = await db
+    .collection<Message>(COLLECTIONS.messages)
+    .findOneAndUpdate(
+      { _id: message._id },
+      input.starred ? { $addToSet: { starredBy: userId } } : { $pull: { starredBy: userId } },
+      { returnDocument: 'after' },
+    )
+  if (!updated) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Message not found')
+
+  return { message: updated, conversation, audience: 'actor' }
+}
+
+export interface PinResult {
+  conversation: Conversation
+}
+
+/**
+ * One pin per conversation, and either person can set or clear it.
+ *
+ * Shared rather than personal, unlike a star: a pin is how the two of them
+ * agree on what this thread is about. In a 1-1 conversation there is no
+ * asymmetry to protect — letting only the pinner unpin would leave the other
+ * person stuck with a banner they cannot dismiss.
+ */
+export async function pinMessage(
+  db: Db,
+  userId: string,
+  input: PinMessageInput,
+): Promise<PinResult> {
+  if (input.messageId === null) {
+    const cleared = await db
+      .collection<Conversation>(COLLECTIONS.conversations)
+      .findOneAndUpdate(
+        { _id: (await assertConversationAccess(db, input.conversationId, userId))._id },
+        { $unset: { pinned: '' } },
+        { returnDocument: 'after' },
+      )
+    if (!cleared) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Conversation not found')
+    return { conversation: cleared }
+  }
+
+  const { conversation, message } = await loadMutableMessage(
+    db,
+    userId,
+    input.conversationId,
+    input.messageId,
+  )
+  if (message.deletedAt) {
+    throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'That message was deleted')
+  }
+
+  // Replaced, not appended: `MAX_PINNED_PER_CONVERSATION` is one, and a second
+  // pin would need an order and a way to see the list.
+  const updated = await db
+    .collection<Conversation>(COLLECTIONS.conversations)
+    .findOneAndUpdate(
+      { _id: conversation._id },
+      { $set: { pinned: { messageId: message._id, byUserId: userId, at: new Date() } } },
+      { returnDocument: 'after' },
+    )
+  if (!updated) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Conversation not found')
+
+  return { conversation: updated }
+}
+
+/**
+ * Everything this reader has starred, newest first.
+ *
+ * Backed by `messages.starred_created`; without that index this is a scan of
+ * every message the user can see, which is the whole collection on a busy
+ * account.
+ */
+export async function listStarredMessages(
+  db: Db,
+  userId: string,
+  limit: number,
+): Promise<Message[]> {
+  return db
+    .collection<Message>(COLLECTIONS.messages)
+    .find({ starredBy: userId, deletedAt: { $exists: false } })
+    .sort({ createdAt: -1 })
+    .limit(limit)
+    .toArray()
 }

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -821,4 +821,179 @@ describe('Faz 5 — conversation/message history REST', () => {
       ).rejects.toMatchObject({ code: 'NOT_FOUND' })
     })
   })
+
+  describe('editing, starring and pinning', () => {
+    async function pair(prefix: string, body = 'the original sentence') {
+      const a = await newUser(`${prefix}-a@example.com`)
+      const b = await newUser(`${prefix}-b@example.com`)
+      const { _id: conversationId } = await startConversation(a, b.userId, 'opening')
+      const { sendTextMessage } = await import('../modules/chat/messages')
+      const { message } = await sendTextMessage(handle.db, a.userId, { conversationId, body })
+      return { a, b, conversationId, message, messageId: message._id.toHexString() }
+    }
+
+    it('rewrites the message and the chat-list preview together', async () => {
+      const { a, conversationId, messageId } = await pair('edit-basic')
+      const { editMessage } = await import('../modules/chat/mutations')
+
+      const { message } = await editMessage(handle.db, a.userId, {
+        conversationId,
+        messageId,
+        body: 'the corrected sentence',
+      })
+      expect(message.body).toBe('the corrected sentence')
+      expect(message.editedAt).toBeInstanceOf(Date)
+
+      const conversation = await handle.db
+        .collection<{ lastMessage: { body: string } }>(COLLECTIONS.conversations)
+        .findOne({ _id: new ObjectId(conversationId) })
+      expect(conversation?.lastMessage.body).toBe('the corrected sentence')
+    })
+
+    it('refuses to edit someone else message', async () => {
+      const { b, conversationId, messageId } = await pair('edit-not-mine')
+      const { editMessage } = await import('../modules/chat/mutations')
+
+      await expect(
+        editMessage(handle.db, b.userId, { conversationId, messageId, body: 'not yours' }),
+      ).rejects.toMatchObject({ code: 'VALIDATION_FAILED' })
+    })
+
+    it('refuses to edit one past the window', async () => {
+      const { a, conversationId, messageId, message } = await pair('edit-stale')
+      const { editMessage } = await import('../modules/chat/mutations')
+
+      await handle.db
+        .collection(COLLECTIONS.messages)
+        .updateOne(
+          { _id: message._id },
+          { $set: { createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000) } },
+        )
+
+      await expect(
+        editMessage(handle.db, a.userId, { conversationId, messageId, body: 'too late' }),
+      ).rejects.toMatchObject({ code: 'VALIDATION_FAILED' })
+    })
+
+    /**
+     * The lock that keeps `correction.original` honest. Editing a sentence
+     * someone has already corrected would leave their correction quoting
+     * something that exists nowhere.
+     */
+    it('locks a message once the other person has corrected it', async () => {
+      const { a, b, conversationId, messageId } = await pair('edit-corrected', 'I has a book')
+      const { sendCorrection } = await import('../modules/chat/messages')
+      const { editMessage } = await import('../modules/chat/mutations')
+
+      await sendCorrection(handle.db, b.userId, {
+        conversationId,
+        targetMessageId: messageId,
+        corrected: 'I have a book',
+      })
+
+      // The stamp is on the target, so the client can grey the row out too.
+      const page = await app.inject({
+        method: 'GET',
+        url: `/conversations/${conversationId}/messages`,
+        headers: { cookie: a.cookie },
+      })
+      const target = page
+        .json<{ items: { _id: string; corrected?: boolean }[] }>()
+        .items.find((m) => m._id === messageId)
+      expect(target?.corrected).toBe(true)
+
+      await expect(
+        editMessage(handle.db, a.userId, { conversationId, messageId, body: 'I have a book' }),
+      ).rejects.toMatchObject({ code: 'VALIDATION_FAILED' })
+    })
+
+    it('keeps a star to the person who set it', async () => {
+      const { a, b, conversationId, messageId } = await pair('star-private')
+      const { starMessage } = await import('../modules/chat/mutations')
+
+      const result = await starMessage(handle.db, b.userId, {
+        conversationId,
+        messageId,
+        starred: true,
+      })
+      expect(result.audience).toBe('actor')
+
+      const forStarrer = await app.inject({
+        method: 'GET',
+        url: '/me/starred',
+        headers: { cookie: b.cookie },
+      })
+      const forSender = await app.inject({
+        method: 'GET',
+        url: '/me/starred',
+        headers: { cookie: a.cookie },
+      })
+      expect(forStarrer.json<{ items: { _id: string }[] }>().items.map((m) => m._id)).toEqual([
+        messageId,
+      ])
+      expect(forSender.json<{ items: unknown[] }>().items).toEqual([])
+
+      // And the flag is per viewer, not a list of who starred it.
+      const thread = await app.inject({
+        method: 'GET',
+        url: `/conversations/${conversationId}/messages`,
+        headers: { cookie: a.cookie },
+      })
+      const row = thread
+        .json<{ items: { _id: string; starred?: boolean }[] }>()
+        .items.find((m) => m._id === messageId)
+      expect(row?.starred).toBeUndefined()
+      expect(thread.body).not.toContain('starredBy')
+    })
+
+    it('unstars, and drops it off the list', async () => {
+      const { b, conversationId, messageId } = await pair('star-toggle')
+      const { starMessage } = await import('../modules/chat/mutations')
+
+      await starMessage(handle.db, b.userId, { conversationId, messageId, starred: true })
+      await starMessage(handle.db, b.userId, { conversationId, messageId, starred: false })
+
+      const list = await app.inject({
+        method: 'GET',
+        url: '/me/starred',
+        headers: { cookie: b.cookie },
+      })
+      expect(list.json<{ items: unknown[] }>().items).toEqual([])
+    })
+
+    it('pins one message at a time, and either person can change it', async () => {
+      const { a, b, conversationId, messageId } = await pair('pin-one')
+      const { sendTextMessage } = await import('../modules/chat/messages')
+      const { pinMessage } = await import('../modules/chat/mutations')
+
+      const second = await sendTextMessage(handle.db, b.userId, {
+        conversationId,
+        body: 'the second one',
+      })
+
+      await pinMessage(handle.db, a.userId, { conversationId, messageId })
+      // The other person replaces it rather than being locked out of it.
+      const replaced = await pinMessage(handle.db, b.userId, {
+        conversationId,
+        messageId: second.message._id.toHexString(),
+      })
+      expect(replaced.conversation.pinned?.messageId.toHexString()).toBe(
+        second.message._id.toHexString(),
+      )
+      expect(replaced.conversation.pinned?.byUserId).toBe(b.userId)
+
+      const cleared = await pinMessage(handle.db, a.userId, { conversationId, messageId: null })
+      expect(cleared.conversation.pinned).toBeUndefined()
+    })
+
+    it('refuses to pin a withdrawn message', async () => {
+      const { a, conversationId, messageId } = await pair('pin-deleted')
+      const { deleteMessage, pinMessage } = await import('../modules/chat/mutations')
+
+      await deleteMessage(handle.db, a.userId, { conversationId, messageId, scope: 'everyone' })
+      await expect(
+        pinMessage(handle.db, a.userId, { conversationId, messageId }),
+      ).rejects.toMatchObject({ code: 'VALIDATION_FAILED' })
+    })
+  })
 })

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -1,4 +1,9 @@
-import { ERROR_CODES, listConversationsQuerySchema, listMessagesQuerySchema } from '@langx/shared'
+import {
+  ERROR_CODES,
+  listConversationsQuerySchema,
+  listMessagesQuerySchema,
+  listStarredQuerySchema,
+} from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { ApiError } from '../lib/ApiError'
 import { requireAuth } from '../middleware/requireAuth'
@@ -8,6 +13,8 @@ import {
   listMessagesAround,
   markConversationRead,
 } from '../modules/chat/messages'
+import { toMessageView } from '../modules/chat/messageView'
+import { listStarredMessages } from '../modules/chat/mutations'
 
 // eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
 export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
@@ -46,6 +53,22 @@ export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
       }
       const page = await listMessages(app.mongo.db, request.userId, id, rest)
       return reply.send(page)
+    },
+  )
+
+  /**
+   * Starred messages, across every conversation.
+   *
+   * REST rather than a socket event because it is a screen someone opens, not
+   * a stream — and it is the only read in the chat area that is not scoped to
+   * one thread, which is why it hangs off `/me` rather than `/conversations`.
+   */
+  app.get(
+    '/me/starred',
+    { preHandler: requireAuth, schema: { querystring: listStarredQuerySchema } },
+    async (request, reply) => {
+      const messages = await listStarredMessages(app.mongo.db, request.userId, request.query.limit)
+      return reply.send({ items: messages.map((m) => toMessageView(m, request.userId)) })
     },
   )
 

--- a/apps/api/src/ws/fanOut.ts
+++ b/apps/api/src/ws/fanOut.ts
@@ -120,3 +120,31 @@ export function fanOutMessageUpdate(
     io.to(userRoom(participantId)).emit('message:updated', toMessageView(message, participantId))
   }
 }
+
+/**
+ * The pinned message changed, and both people see the banner.
+ *
+ * A conversation event rather than a `message:updated`, because what moved is
+ * on the conversation document — the message itself is untouched, and telling
+ * clients otherwise would have them patch a row that did not change.
+ */
+export function fanOutConversationPinned(
+  io: AppServer,
+  conversation: FannedConversation & {
+    pinned?: { messageId: { toHexString: () => string }; byUserId: string; at: Date }
+  },
+): void {
+  const payload = {
+    conversationId: conversation._id.toHexString(),
+    pinned: conversation.pinned
+      ? {
+          messageId: conversation.pinned.messageId.toHexString(),
+          byUserId: conversation.pinned.byUserId,
+          at: conversation.pinned.at.toISOString(),
+        }
+      : null,
+  }
+  for (const participantId of conversation.participants) {
+    io.to(userRoom(participantId)).emit('conversation:pinned', payload)
+  }
+}

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -1,6 +1,9 @@
 import {
   deleteMessageSchema,
+  editMessageSchema,
+  pinMessageSchema,
   reactToMessageSchema,
+  starMessageSchema,
   sendCorrectionSchema,
   sendMediaMessageSchema,
   sendTextMessageSchema,
@@ -15,7 +18,13 @@ import { effectiveTier } from '../modules/profiles/entitlement'
 import { getProfile } from '../modules/profiles/profiles'
 import { assertConversationAccess } from '../modules/chat/access'
 import { toMessageView } from '../modules/chat/messageView'
-import { deleteMessage, reactToMessage } from '../modules/chat/mutations'
+import {
+  deleteMessage,
+  editMessage,
+  pinMessage,
+  reactToMessage,
+  starMessage,
+} from '../modules/chat/mutations'
 import {
   markConversationRead,
   markPendingDelivered,
@@ -23,7 +32,7 @@ import {
   sendMediaMessage,
   sendTextMessage,
 } from '../modules/chat/messages'
-import { fanOutMessage, fanOutMessageUpdate } from './fanOut'
+import { fanOutConversationPinned, fanOutMessage, fanOutMessageUpdate } from './fanOut'
 import { PresenceThrottle, touchPresence } from '../modules/presence/presence'
 import { SocketRateLimiter } from './rateLimit'
 import { userRoom, type AppServer, type AppSocket } from './types'
@@ -229,6 +238,42 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
         .then(({ message, conversation, audience }) => {
           fanOutMessageUpdate(io, conversation, message, audience, userId)
           ack?.({ ok: true, data: toMessageView(message, userId) })
+        })
+        .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))
+    })
+
+    socket.on('message:edit', (payload: unknown, ack: Ack) => {
+      if (!limited('message:edit', ack)) return
+      editMessageSchema
+        .parseAsync(payload)
+        .then((input) => editMessage(app.mongo.db, userId, input))
+        .then(({ message, conversation, audience }) => {
+          fanOutMessageUpdate(io, conversation, message, audience, userId)
+          ack?.({ ok: true, data: toMessageView(message, userId) })
+        })
+        .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))
+    })
+
+    socket.on('message:star', (payload: unknown, ack: Ack) => {
+      if (!limited('message:star', ack)) return
+      starMessageSchema
+        .parseAsync(payload)
+        .then((input) => starMessage(app.mongo.db, userId, input))
+        .then(({ message, conversation, audience }) => {
+          fanOutMessageUpdate(io, conversation, message, audience, userId)
+          ack?.({ ok: true, data: toMessageView(message, userId) })
+        })
+        .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))
+    })
+
+    socket.on('conversation:pin', (payload: unknown, ack: Ack) => {
+      if (!limited('conversation:pin', ack)) return
+      pinMessageSchema
+        .parseAsync(payload)
+        .then((input) => pinMessage(app.mongo.db, userId, input))
+        .then(({ conversation }) => {
+          fanOutConversationPinned(io, conversation)
+          ack?.({ ok: true, data: { pinned: conversation.pinned ?? null } })
         })
         .catch((error: unknown) => ack?.({ ok: false, error: errorPayload(error) }))
     })

--- a/apps/api/src/ws/rateLimit.ts
+++ b/apps/api/src/ws/rateLimit.ts
@@ -37,6 +37,11 @@ export const EVENT_LIMITS: Record<string, BucketConfig> = {
   'message:react': { capacity: 30, refillPerSecond: 2 },
   // Destructive, and never something anyone does in a burst.
   'message:delete': { capacity: 10, refillPerSecond: 0.5 },
+  // Private and cheap, but a bookmark is not something anyone taps in a loop.
+  'message:star': { capacity: 30, refillPerSecond: 2 },
+  'message:edit': { capacity: 10, refillPerSecond: 0.5 },
+  // Shared state, so both people see every change: worth a tighter bucket.
+  'conversation:pin': { capacity: 10, refillPerSecond: 0.5 },
   'conversation:read': { capacity: 30, refillPerSecond: 2 },
   typing: { capacity: 40, refillPerSecond: 10 },
   // One per 20s sustained, burst of 4. A 60s heartbeat passes with room; a

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -107,6 +107,7 @@ export default function AppLayout() {
         <Tabs.Screen name="edit-profile" options={FULL_SCREEN} />
         <Tabs.Screen name="blocked" options={FULL_SCREEN} />
         <Tabs.Screen name="settings" options={FULL_SCREEN} />
+        <Tabs.Screen name="starred" options={FULL_SCREEN} />
         <Tabs.Screen name="paywall" options={FULL_SCREEN} />
         <Tabs.Screen name="viewers" options={FULL_SCREEN} />
         <Tabs.Screen name="filters" options={FULL_SCREEN} />

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -1,5 +1,11 @@
 import Feather from '@expo/vector-icons/Feather'
-import { canDeleteForEveryone, MESSAGE_REACTIONS, PLAN_LIMITS, TOKEN_RULES } from '@langx/shared'
+import {
+  canDeleteForEveryone,
+  canEditMessage,
+  MESSAGE_REACTIONS,
+  PLAN_LIMITS,
+  TOKEN_RULES,
+} from '@langx/shared'
 import { useQueryClient } from '@tanstack/react-query'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -77,6 +83,7 @@ export default function ChatScreen() {
    */
   const [awayFrom, setAwayFrom] = useState<string | null>(null)
   const [replyingTo, setReplyingTo] = useState<MessageDto | null>(null)
+  const [editing, setEditing] = useState<MessageDto | null>(null)
   /**
    * The message a jump is centred on, or null while the live thread is showing.
    *
@@ -106,6 +113,7 @@ export default function ChatScreen() {
         items.findIndex((m) => String(m._id) === awayFrom),
       )
     : 0
+  const pinned = thread.data?.pages[0]?.pinned ?? null
   const state = listState({
     isPending: thread.isPending,
     isError: thread.isError,
@@ -232,6 +240,16 @@ export default function ChatScreen() {
     setSending(true)
     try {
       const socket = await getSocket()
+      if (editing) {
+        await emitWithAck(socket, 'message:edit', {
+          conversationId,
+          messageId: editing._id,
+          body,
+        })
+        setEditing(null)
+        setDraft('')
+        return
+      }
       if (correcting) {
         await emitWithAck(socket, 'message:correct', {
           conversationId,
@@ -312,6 +330,12 @@ export default function ChatScreen() {
       type: message.type,
       hasBody: message.body.trim().length > 0,
       alreadyTranslated,
+      // Evaluated here rather than in the menu, so the row and the server
+      // agree on one rule from `@langx/shared` instead of two copies of it.
+      canEdit: canEditMessage(message, me.data?._id ?? '', new Date()),
+      corrected: message.corrected === true,
+      starred: message.starred === true,
+      pinned: pinned?.messageId === message._id,
     })
 
     const picked = await openMessageMenu({
@@ -341,8 +365,39 @@ export default function ChatScreen() {
       setDraft(message.body)
     } else if (picked.id === 'delete') {
       await removeMessage(message)
+    } else if (picked.id === 'edit') {
+      setEditing(message)
+      setCorrecting(null)
+      setReplyingTo(null)
+      setDraft(message.body)
+    } else if (picked.id === 'star') {
+      await emit('message:star', {
+        conversationId,
+        messageId: message._id,
+        starred: message.starred !== true,
+      })
+    } else if (picked.id === 'pin') {
+      await emit('conversation:pin', {
+        conversationId,
+        messageId: pinned?.messageId === message._id ? null : message._id,
+      })
     } else if (picked.id === 'report') {
       await reportMessage(message)
+    }
+  }
+
+  /**
+   * Every mutation is the same three lines, and the failure is always the same
+   * sentence: the server has already refused with a reason the user cannot act
+   * on ("only within two days"), so the alert says what happened rather than
+   * repeating a rule the menu should not have offered in the first place.
+   */
+  async function emit(event: string, payload: Record<string, unknown>): Promise<void> {
+    const socket = await getSocket()
+    try {
+      await emitWithAck(socket, event, payload)
+    } catch {
+      void showAlert('That did not go through', 'Try again in a moment.')
     }
   }
 
@@ -351,16 +406,7 @@ export default function ChatScreen() {
    * repeat as a toggle, so nothing here has to know the current state.
    */
   async function react(message: MessageDto, emoji: string): Promise<void> {
-    const socket = await getSocket()
-    try {
-      await emitWithAck(socket, 'message:react', {
-        conversationId,
-        messageId: message._id,
-        emoji,
-      })
-    } catch {
-      void showAlert('Could not react', 'That did not go through. Try again.')
-    }
+    await emit('message:react', { conversationId, messageId: message._id, emoji })
   }
 
   /**
@@ -384,16 +430,7 @@ export default function ChatScreen() {
         ])
     if (!scope) return
 
-    const socket = await getSocket()
-    try {
-      await emitWithAck(socket, 'message:delete', {
-        conversationId,
-        messageId: message._id,
-        scope,
-      })
-    } catch {
-      void showAlert('Could not delete', 'That did not go through. Try again.')
-    }
+    await emit('message:delete', { conversationId, messageId: message._id, scope })
   }
 
   /**
@@ -524,6 +561,33 @@ export default function ChatScreen() {
           </View>
         </Pressable>
       </View>
+
+      {/*
+        Above the thread rather than floating over it: a pin is a standing fact
+        about the conversation, not a transient control, and it has to survive
+        scrolling to the top of the history.
+      */}
+      {pinned ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Go to the pinned message"
+          onPress={() => onJumpTo(pinned.messageId)}
+          style={styles.pinBanner}
+        >
+          <Feather name="bookmark" size={14} color={colors.accent} />
+          <Text style={styles.pinText} numberOfLines={1}>
+            {items.find((m) => m._id === pinned.messageId)?.body ?? 'Pinned message'}
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Unpin"
+            hitSlop={8}
+            onPress={() => void emit('conversation:pin', { conversationId, messageId: null })}
+          >
+            <Feather name="x" size={15} color={colors.textMuted} />
+          </Pressable>
+        </Pressable>
+      ) : null}
 
       {/* The jump button floats over the thread, so it lives in the thread's
           own box rather than the screen's — that keeps it above the composer
@@ -674,7 +738,7 @@ export default function ChatScreen() {
         reply is the ordinary case and a correction is the teaching one, so the
         correction keeps the success colour and this gets the accent edge.
       */}
-      {replyingTo && !correcting ? (
+      {replyingTo && !correcting && !editing ? (
         <View style={styles.replyingBanner}>
           <View style={styles.replyingBar} />
           <View style={styles.replyingText}>
@@ -688,6 +752,27 @@ export default function ChatScreen() {
             </Text>
           </View>
           <Pressable onPress={() => setReplyingTo(null)} hitSlop={8}>
+            <Text style={styles.replyingCancel}>Cancel</Text>
+          </Pressable>
+        </View>
+      ) : null}
+
+      {editing ? (
+        <View style={styles.replyingBanner}>
+          <View style={[styles.replyingBar, styles.editingBar]} />
+          <View style={styles.replyingText}>
+            <Text style={[styles.replyingTitle, styles.editingTitle]}>Editing</Text>
+            <Text style={styles.replyingPreview} numberOfLines={1}>
+              {editing.body}
+            </Text>
+          </View>
+          <Pressable
+            onPress={() => {
+              setEditing(null)
+              setDraft('')
+            }}
+            hitSlop={8}
+          >
             <Text style={styles.replyingCancel}>Cancel</Text>
           </Pressable>
         </View>
@@ -913,6 +998,19 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
   replyingTitle: { ...font.caption, color: colors.accent, fontWeight: '700' },
   replyingPreview: { ...font.caption, color: colors.textMuted },
   replyingCancel: { ...font.caption, color: colors.textMuted, fontWeight: '600' },
+  editingBar: { backgroundColor: colors.warning },
+  editingTitle: { color: colors.warning },
+  pinBanner: {
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    borderBottomColor: colors.border,
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+  },
+  pinText: { ...font.caption, color: colors.text, flex: 1 },
   older: { paddingVertical: spacing.md },
   correctingBanner: {
     backgroundColor: colors.successBg,

--- a/apps/mobile/app/(app)/chats.tsx
+++ b/apps/mobile/app/(app)/chats.tsx
@@ -1,3 +1,4 @@
+import Feather from '@expo/vector-icons/Feather'
 import { router } from 'expo-router'
 import {
   ActivityIndicator,
@@ -32,7 +33,7 @@ function relativeTime(iso: string): string {
 }
 
 export default function ChatsScreen() {
-  const { layout } = useTheme()
+  const { colors, layout } = useTheme()
   const styles = useStyles()
 
   const me = useMe()
@@ -55,7 +56,21 @@ export default function ChatsScreen() {
 
   return (
     <Screen fluid>
-      <Text style={styles.title}>Chats</Text>
+      {/*
+        The only way into the starred list. A star is private and one-sided, so
+        without an entry point here it is a write with no read.
+      */}
+      <View style={styles.titleRow}>
+        <Text style={styles.title}>Chats</Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Starred messages"
+          hitSlop={10}
+          onPress={() => router.push('/(app)/starred')}
+        >
+          <Feather name="star" size={20} color={colors.textMuted} />
+        </Pressable>
+      </View>
 
       {state === 'skeleton' ? (
         <View style={styles.list}>
@@ -155,6 +170,7 @@ export default function ChatsScreen() {
 }
 
 const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
+  titleRow: { alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between' },
   title: { ...font.title, color: colors.text, paddingTop: spacing.md },
   list: { paddingBottom: spacing.xxl, paddingTop: spacing.md },
   footer: { paddingVertical: spacing.lg },

--- a/apps/mobile/app/(app)/starred.tsx
+++ b/apps/mobile/app/(app)/starred.tsx
@@ -1,0 +1,101 @@
+import Feather from '@expo/vector-icons/Feather'
+import { router } from 'expo-router'
+import { ActivityIndicator, FlatList, Pressable, Text, View } from 'react-native'
+import { useStarred, type MessageDto } from '../../src/api/queries'
+import { EmptyState } from '../../src/components/ui/EmptyState'
+import { Screen } from '../../src/components/ui/Screen'
+import { dayLabel } from '../../src/lib/messageGroups'
+import { goBackTo } from '../../src/lib/navigation'
+import { makeStyles, useTheme } from '../../src/lib/theme'
+
+/**
+ * Every starred message, newest first, across every conversation.
+ *
+ * A star is private and one-sided, so this is the only place one is visible at
+ * all — without the screen, starring is a write with no read. Each row goes
+ * back to the message in its thread through the same `?at=` window a reply
+ * quote uses; the star does not copy the message, it points at it.
+ */
+export default function StarredScreen() {
+  const { colors } = useTheme()
+  const styles = useStyles()
+  const starred = useStarred()
+
+  const items = starred.data?.items ?? []
+
+  return (
+    <Screen fluid>
+      <Pressable onPress={() => goBackTo('/(app)/chats')} hitSlop={12} style={styles.backRow}>
+        <Text style={styles.back}>‹ Back</Text>
+      </Pressable>
+      <Text style={styles.title}>Starred</Text>
+
+      {starred.isPending ? (
+        <ActivityIndicator style={styles.loading} />
+      ) : items.length === 0 ? (
+        <EmptyState
+          icon="star"
+          title="Nothing starred yet"
+          body="Hold a message and choose Star to keep it here."
+        />
+      ) : (
+        <FlatList
+          data={items}
+          keyExtractor={(item) => item._id}
+          contentContainerStyle={styles.list}
+          renderItem={({ item }) => <Row message={item} colors={colors} styles={styles} />}
+        />
+      )}
+    </Screen>
+  )
+}
+
+function Row({
+  message,
+  colors,
+  styles,
+}: {
+  message: MessageDto
+  colors: { textMuted: string }
+  styles: ReturnType<typeof useStyles>
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={() =>
+        router.push(`/(app)/chat/${message.conversationId}?at=${encodeURIComponent(message._id)}`)
+      }
+      style={styles.row}
+    >
+      <View style={styles.rowText}>
+        <Text style={styles.body} numberOfLines={2}>
+          {message.body || 'Attachment'}
+        </Text>
+        <Text style={styles.when}>{dayLabel(message.createdAt.slice(0, 10))}</Text>
+      </View>
+      <Feather name="chevron-right" size={18} color={colors.textMuted} />
+    </Pressable>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
+  backRow: { paddingBottom: spacing.sm, paddingTop: spacing.sm },
+  back: { ...font.body, color: colors.textMuted },
+  title: { ...font.title, color: colors.text, paddingBottom: spacing.md },
+  loading: { paddingVertical: spacing.xl },
+  list: { gap: spacing.sm, paddingBottom: spacing.xl },
+  row: {
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.md,
+  },
+  rowText: { flex: 1, gap: 3, minWidth: 0 },
+  body: { ...font.body, color: colors.text },
+  when: { ...font.caption, color: colors.textMuted },
+}))

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -51,6 +51,7 @@ export const keys = {
    * window in one call, which is the only thing keeping the two in step.
    */
   messagesAround: (id: string, anchorId: string) => ['messages', id, 'around', anchorId] as const,
+  starred: ['starred'] as const,
   tokens: ['tokens'] as const,
   wallet: ['wallet'] as const,
   badges: ['badges'] as const,
@@ -263,6 +264,11 @@ export interface MessageDto {
   deleted?: boolean
   /** Hidden by me alone. `messagesNewestFirst` drops these. */
   hidden?: boolean
+  /** Starred by me alone; who else did never leaves the server. */
+  starred?: boolean
+  editedAt?: string
+  /** Somebody corrected this sentence, so it can no longer be edited. */
+  corrected?: boolean
   deliveredAt?: string
   readAt?: string
   createdAt: string
@@ -283,6 +289,20 @@ export function useMessages(conversationId: string) {
     // only sanctioned way to read this — see the note there.
     getNextPageParam: (last) => last.nextCursor ?? undefined,
     enabled: conversationId.length > 0,
+  })
+}
+
+/**
+ * Everything this reader has starred, across every conversation.
+ *
+ * A plain query rather than an infinite one: a bookmark list people actually
+ * keep is tens of items, and the server caps it — paging it would be machinery
+ * for a case that does not arrive.
+ */
+export function useStarred() {
+  return useQuery({
+    queryKey: keys.starred,
+    queryFn: () => api.get<{ items: MessageDto[] }>('/me/starred'),
   })
 }
 

--- a/apps/mobile/src/components/MessageBubble.tsx
+++ b/apps/mobile/src/components/MessageBubble.tsx
@@ -235,6 +235,11 @@ export const MessageBubble = memo(function MessageBubble({
         {/* The link is gone — translate is a menu row now. This only reports the
             request already in flight. */}
         {translating ? <Text style={styles.translateLink}>Translating…</Text> : null}
+        {/* Beside the clock, not in place of it: "when" and "changed since" are
+            two different facts and the reader wants both. */}
+        {message.editedAt ? (
+          <Text style={[styles.edited, mine && styles.editedMine]}>Edited</Text>
+        ) : null}
         <MessageMeta message={message} mine={mine} />
         {badge}
       </Pressable>
@@ -289,6 +294,8 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
    */
   highlighted: { borderColor: colors.accent, borderWidth: 2 },
   tombstone: { backgroundColor: colors.surface, borderColor: colors.border, borderWidth: 1 },
+  edited: { ...font.caption, color: colors.textMuted, fontStyle: 'italic' },
+  editedMine: { color: colors.primaryTextMuted },
   tombstoneRow: { alignItems: 'center', flexDirection: 'row', gap: 6 },
   tombstoneText: { ...font.body, color: colors.textMuted, fontStyle: 'italic' },
   /**

--- a/apps/mobile/src/components/MessageMenuHost.tsx
+++ b/apps/mobile/src/components/MessageMenuHost.tsx
@@ -11,6 +11,7 @@ import {
   View,
 } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { paginateActions, type MessageActionPage } from '../lib/messageActions'
 import {
   resolveMessageMenu,
   subscribeToMessageMenu,
@@ -40,32 +41,78 @@ export function MessageMenuHost() {
   const styles = useStyles()
 
   const [request, setRequest] = useState<MessageMenuRequest | null>(null)
+  const [page, setPage] = useState<MessageActionPage>('primary')
   const insets = useSafeAreaInsets()
   const screen = useWindowDimensions()
 
-  useEffect(() => subscribeToMessageMenu(setRequest), [])
+  useEffect(
+    () =>
+      subscribeToMessageMenu((next) => {
+        // A new menu always opens on the first page; leaving it on `more`
+        // would show the second page of a message nobody asked about.
+        setPage('primary')
+        setRequest(next)
+      }),
+    [],
+  )
 
   if (!request) return null
   const dismiss = (): void => resolveMessageMenu(request.id, null)
   const wide = Platform.OS === 'web'
 
-  const rows = request.actions.map((action) => (
-    <Pressable
-      key={action.id}
-      accessibilityRole="button"
-      onPress={() => resolveMessageMenu(request.id, { kind: 'action', id: action.id })}
-      style={({ pressed }) => [styles.action, pressed && styles.actionPressed]}
-    >
-      <Ionicons
-        // The icon set types its own names; the action table is plain data and
-        // does not import them.
-        name={action.icon as never}
-        size={20}
-        color={action.destructive ? colors.danger : colors.text}
-      />
-      <Text style={[styles.label, action.destructive && styles.destructive]}>{action.label}</Text>
-    </Pressable>
-  ))
+  const { actions, hasMore } = paginateActions(request.actions, page)
+
+  const rows = (
+    <>
+      {page === 'more' ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Back to the first page"
+          onPress={() => setPage('primary')}
+          style={({ pressed }) => [styles.action, pressed && styles.actionPressed]}
+        >
+          <Ionicons name="chevron-back" size={20} color={colors.textMuted} />
+          <Text style={[styles.label, styles.muted]}>Back</Text>
+        </Pressable>
+      ) : null}
+
+      {actions.map((action) => (
+        <Pressable
+          key={action.id}
+          accessibilityRole="button"
+          disabled={action.disabled === true}
+          onPress={() => resolveMessageMenu(request.id, { kind: 'action', id: action.id })}
+          style={({ pressed }) => [
+            styles.action,
+            pressed && !action.disabled && styles.actionPressed,
+            action.disabled === true && styles.actionDisabled,
+          ]}
+        >
+          <Ionicons
+            // The icon set types its own names; the action table is plain data
+            // and does not import them.
+            name={action.icon as never}
+            size={20}
+            color={action.destructive ? colors.danger : colors.text}
+          />
+          <Text style={[styles.label, action.destructive && styles.destructive]}>
+            {action.label}
+          </Text>
+        </Pressable>
+      ))}
+
+      {hasMore ? (
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => setPage('more')}
+          style={({ pressed }) => [styles.action, pressed && styles.actionPressed]}
+        >
+          <Ionicons name="ellipsis-horizontal" size={20} color={colors.textMuted} />
+          <Text style={[styles.label, styles.muted]}>More…</Text>
+        </Pressable>
+      ) : null}
+    </>
+  )
 
   const strip = request.reactions ? (
     <ScrollView
@@ -94,7 +141,10 @@ export function MessageMenuHost() {
      * frame drawn in the wrong place and a visible jump on exactly the gesture
      * that has to feel immediate, so the flip is decided before first paint.
      */
-    const menuHeight = request.actions.length * ROW_HEIGHT + MENU_CHROME
+    // The rows on *this* page, plus whichever navigation row it carries — a
+    // height derived from the full action list would flip the wrong way.
+    const rowCount = actions.length + (hasMore ? 1 : 0) + (page === 'more' ? 1 : 0)
+    const menuHeight = rowCount * ROW_HEIGHT + MENU_CHROME
     const stripWidth = Math.min(STRIP_MAX_WIDTH, screen.width - 24)
     const layout = messageMenuLayout({
       anchor: request.anchor,
@@ -196,6 +246,8 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
     paddingVertical: spacing.md,
   },
   actionPressed: { backgroundColor: colors.surface },
+  actionDisabled: { opacity: 0.45 },
+  muted: { color: colors.textMuted },
   backdrop: { backgroundColor: colors.scrim, flex: 1 },
   backdropBottom: { justifyContent: 'flex-end' },
   backdropCentred: { alignItems: 'center', justifyContent: 'center' },

--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -9,6 +9,7 @@ import {
   appendIncomingMessage,
   applyDeliveredAt,
   applyMessageUpdate,
+  applyPinned,
   type MessagePageDto,
 } from '../lib/messageCache'
 import { closeSocket, getSocket } from '../lib/socket'
@@ -114,6 +115,22 @@ export function useSocket(): void {
           void queryClient.invalidateQueries({ queryKey: keys.conversations })
         }
       })
+
+      socket.on(
+        'conversation:pinned',
+        ({
+          conversationId,
+          pinned,
+        }: {
+          conversationId: string
+          pinned: MessagePageDto['pinned']
+        }) => {
+          queryClient.setQueriesData<InfiniteData<MessagePageDto>>(
+            { queryKey: keys.messages(conversationId) },
+            (old) => applyPinned(old, pinned) ?? old,
+          )
+        },
+      )
 
       socket.on(
         'conversation:delivered',

--- a/apps/mobile/src/lib/messageActions.test.ts
+++ b/apps/mobile/src/lib/messageActions.test.ts
@@ -1,64 +1,109 @@
 import { describe, expect, it } from 'vitest'
-import { messageActionsFor, type MessageActionContext } from './messageActions'
+import { messageActionsFor, paginateActions, type MessageActionContext } from './messageActions'
 
-const text: MessageActionContext = {
+const theirs: MessageActionContext = {
   mine: false,
   type: 'text',
   hasBody: true,
   alreadyTranslated: false,
+  canEdit: false,
+  corrected: false,
+  starred: false,
+  pinned: false,
 }
-const ids = (over: Partial<MessageActionContext> = {}) =>
-  messageActionsFor({ ...text, ...over }).map((a) => a.id)
+
+const ids = (overrides: Partial<MessageActionContext> = {}) =>
+  messageActionsFor({ ...theirs, ...overrides }).map((a) => a.id)
+
+const find = (overrides: Partial<MessageActionContext>, id: string) =>
+  messageActionsFor({ ...theirs, ...overrides }).find((a) => a.id === id)
 
 describe('messageActionsFor', () => {
-  it('offers the full set on the other person`s text', () => {
-    expect(ids()).toEqual(['reply', 'copy', 'translate', 'correct', 'delete', 'report'])
+  it('offers the full set on the other person text', () => {
+    expect(ids()).toEqual([
+      'reply',
+      'correct',
+      'translate',
+      'copy',
+      'delete',
+      'star',
+      'pin',
+      'report',
+    ])
   })
 
-  /** Correcting your own message, or reporting yourself, is not a thing. */
-  it('leaves only copy on your own message', () => {
-    expect(ids({ mine: true })).toEqual(['reply', 'copy', 'delete'])
+  it('never offers to correct, translate or report your own message', () => {
+    const own = ids({ mine: true })
+    expect(own).not.toContain('correct')
+    expect(own).not.toContain('translate')
+    expect(own).not.toContain('report')
   })
 
-  it('does not offer to correct anything but text', () => {
-    expect(ids({ type: 'image' })).not.toContain('correct')
-    expect(ids({ type: 'audio' })).not.toContain('correct')
-    expect(ids({ type: 'correction' })).not.toContain('correct')
-  })
-
-  /** A correction is already both languages side by side. */
-  it('does not offer to translate a correction', () => {
-    expect(ids({ type: 'correction' })).not.toContain('translate')
-  })
-
-  it('drops translate once the message has been translated', () => {
+  it('drops translate once it has been translated', () => {
     expect(ids({ alreadyTranslated: true })).not.toContain('translate')
   })
 
-  /** A voice note without a caption has no text to copy or translate. */
-  it('drops the text actions when there is no body', () => {
-    expect(ids({ type: 'audio', hasBody: false })).toEqual(['reply', 'delete', 'report'])
-  })
-
-  it('always leaves a way to report the other person', () => {
-    for (const type of ['text', 'correction', 'image', 'audio'] as const) {
-      expect(ids({ type, hasBody: false })).toContain('report')
+  it('only corrects text, never an attachment or another correction', () => {
+    for (const type of ['image', 'audio', 'correction'] as const) {
+      expect(ids({ type })).not.toContain('correct')
     }
   })
 
-  /**
-   * This used to return nothing at all, and the screen had to guard against
-   * opening an empty sheet. Reply applies to every message, including one with
-   * no text of its own, so there is always at least one row.
-   */
-  it('offers reply even on your own captionless media, where nothing else applies', () => {
-    expect(ids({ mine: true, type: 'audio', hasBody: false })).toEqual(['reply', 'delete'])
+  it('has nothing to copy on a captionless voice note', () => {
+    expect(ids({ type: 'audio', hasBody: false })).not.toContain('copy')
   })
 
   /** A filter on your own copy, so it never depends on age or authorship. */
-  it('offers delete on every message, whoever sent it', () => {
+  it('offers delete and star on every message, whoever sent it', () => {
     for (const mine of [true, false]) {
       expect(ids({ mine })).toContain('delete')
+      expect(ids({ mine })).toContain('star')
     }
+  })
+
+  it('offers edit only when the caller says the rules allow it', () => {
+    expect(ids({ mine: true, canEdit: true })).toContain('edit')
+    expect(ids({ mine: true, canEdit: false })).not.toContain('edit')
+  })
+
+  /**
+   * Shown rather than hidden: on your own recent message a missing Edit reads
+   * as a bug, so the row stays and says why it cannot be used.
+   */
+  it('explains the lock on a corrected message instead of hiding it', () => {
+    const edit = find({ mine: true, canEdit: false, corrected: true }, 'edit')
+    expect(edit?.disabled).toBe(true)
+    expect(edit?.label).toMatch(/Corrected/)
+  })
+
+  it('names star and pin for what pressing them will do', () => {
+    expect(find({ starred: true }, 'star')?.label).toBe('Unstar')
+    expect(find({ starred: false }, 'star')?.label).toBe('Star')
+    expect(find({ pinned: true }, 'pin')?.label).toBe('Unpin')
+  })
+})
+
+describe('paginateActions', () => {
+  const all = messageActionsFor(theirs)
+
+  it('keeps the everyday five on the first page', () => {
+    const { actions, hasMore } = paginateActions(all, 'primary')
+    expect(actions.map((a) => a.id)).toEqual(['reply', 'correct', 'translate', 'copy', 'delete'])
+    expect(hasMore).toBe(true)
+  })
+
+  it('puts the rest behind More', () => {
+    const { actions, hasMore } = paginateActions(all, 'more')
+    expect(actions.map((a) => a.id)).toEqual(['star', 'pin', 'report'])
+    expect(hasMore).toBe(false)
+  })
+
+  /** A `More…` row that opens an empty page is worse than one row too many. */
+  it('offers no second page when there is nothing on it', () => {
+    const primaryOnly = all.filter((a) => a.page === 'primary')
+    expect(paginateActions(primaryOnly, 'primary')).toEqual({
+      actions: primaryOnly,
+      hasMore: false,
+    })
   })
 })

--- a/apps/mobile/src/lib/messageActions.ts
+++ b/apps/mobile/src/lib/messageActions.ts
@@ -4,16 +4,29 @@ export const MESSAGE_ACTION_IDS = [
   'translate',
   'correct',
   'delete',
+  'edit',
+  'star',
+  'pin',
   'report',
 ] as const
 export type MessageActionId = (typeof MESSAGE_ACTION_IDS)[number]
+
+/** Which of the menu's two pages a row belongs on. */
+export type MessageActionPage = 'primary' | 'more'
 
 export interface MessageAction {
   id: MessageActionId
   label: string
   /** Ionicons name. */
   icon: string
+  page: MessageActionPage
   destructive?: boolean
+  /**
+   * Shown, but not selectable — the only case is a message somebody has
+   * corrected. Hiding Edit there would look like a bug on your own recent
+   * message; saying why is the point.
+   */
+  disabled?: boolean
 }
 
 export interface MessageActionContext {
@@ -23,6 +36,12 @@ export interface MessageActionContext {
   /** A voice note without a caption has nothing to copy, quote or translate. */
   hasBody: boolean
   alreadyTranslated: boolean
+  /** `canEditMessage` from shared, evaluated by the caller against the clock. */
+  canEdit: boolean
+  /** Somebody has corrected this sentence, so editing it is locked off. */
+  corrected: boolean
+  starred: boolean
+  pinned: boolean
 }
 
 /**
@@ -39,13 +58,13 @@ export function messageActionsFor(context: MessageActionContext): MessageAction[
   // Every message can be answered, including a captionless voice note — the
   // quote carries a label for those rather than a body. First in the list
   // because on web it is the only way in: the swipe gesture is native-only.
-  actions.push({ id: 'reply', label: 'Reply', icon: 'arrow-undo-outline' })
+  actions.push({ id: 'reply', label: 'Reply', icon: 'arrow-undo-outline', page: 'primary' })
 
-  // Edit, react, star, pin and delete are still absent: each needs a field on
-  // `Message` and a way to mutate one that already exists, which is one piece
-  // of plumbing they should share rather than four.
-  if (context.hasBody) {
-    actions.push({ id: 'copy', label: 'Copy', icon: 'copy-outline' })
+  // The teaching gesture, and the highest-earning action in the app. Only on
+  // the other person's text: there is nothing to correct in an image, and
+  // correcting a correction is a thread nobody wants.
+  if (!context.mine && context.type === 'text') {
+    actions.push({ id: 'correct', label: 'Correct', icon: 'pencil-outline', page: 'primary' })
   }
 
   // Translating your own message is a round trip to something you already
@@ -56,14 +75,11 @@ export function messageActionsFor(context: MessageActionContext): MessageAction[
     context.type !== 'correction' &&
     !context.alreadyTranslated
   ) {
-    actions.push({ id: 'translate', label: 'Translate', icon: 'language-outline' })
+    actions.push({ id: 'translate', label: 'Translate', icon: 'language-outline', page: 'primary' })
   }
 
-  // The teaching gesture, and the highest-earning action in the app. Only on
-  // the other person's text: there is nothing to correct in an image, and
-  // correcting a correction is a thread nobody wants.
-  if (!context.mine && context.type === 'text') {
-    actions.push({ id: 'correct', label: 'Correct', icon: 'pencil-outline' })
+  if (context.hasBody) {
+    actions.push({ id: 'copy', label: 'Copy', icon: 'copy-outline', page: 'primary' })
   }
 
   /**
@@ -73,11 +89,71 @@ export function messageActionsFor(context: MessageActionContext): MessageAction[
    * is `canDeleteForEveryone` in shared, and the screen asks with it rather
    * than the menu guessing.
    */
-  actions.push({ id: 'delete', label: 'Delete', icon: 'trash-outline', destructive: true })
+  actions.push({
+    id: 'delete',
+    label: 'Delete',
+    icon: 'trash-outline',
+    page: 'primary',
+    destructive: true,
+  })
+
+  if (context.canEdit) {
+    actions.push({ id: 'edit', label: 'Edit', icon: 'create-outline', page: 'more' })
+  } else if (context.mine && context.type === 'text' && context.corrected) {
+    actions.push({
+      id: 'edit',
+      label: "Corrected — can't be edited",
+      icon: 'lock-closed-outline',
+      page: 'more',
+      disabled: true,
+    })
+  }
+
+  actions.push({
+    id: 'star',
+    label: context.starred ? 'Unstar' : 'Star',
+    icon: context.starred ? 'star' : 'star-outline',
+    page: 'more',
+  })
+
+  actions.push({
+    id: 'pin',
+    label: context.pinned ? 'Unpin' : 'Pin',
+    icon: 'pin-outline',
+    page: 'more',
+  })
 
   if (!context.mine) {
-    actions.push({ id: 'report', label: 'Report', icon: 'flag-outline', destructive: true })
+    actions.push({
+      id: 'report',
+      label: 'Report',
+      icon: 'flag-outline',
+      page: 'more',
+      destructive: true,
+    })
   }
 
   return actions
+}
+
+/**
+ * The menu's two pages.
+ *
+ * A page rather than one long list because the anchored menu has to fit
+ * between a bubble and the edge of the screen, and nine rows do not. Pure so
+ * the split is testable: which rows are behind `More…` is a product decision,
+ * and a wrong one is invisible in a screenshot of the first page.
+ */
+export function paginateActions(
+  actions: MessageAction[],
+  page: MessageActionPage,
+): { actions: MessageAction[]; hasMore: boolean } {
+  const primary = actions.filter((action) => action.page === 'primary')
+  const more = actions.filter((action) => action.page === 'more')
+  // Nothing behind the divider means no divider: a `More…` row that opens an
+  // empty page is worse than one row too many on the first.
+  if (more.length === 0) return { actions: primary, hasMore: false }
+  return page === 'primary'
+    ? { actions: primary, hasMore: true }
+    : { actions: more, hasMore: false }
 }

--- a/apps/mobile/src/lib/messageCache.test.ts
+++ b/apps/mobile/src/lib/messageCache.test.ts
@@ -5,6 +5,7 @@ import {
   appendIncomingMessage,
   applyDeliveredAt,
   applyMessageUpdate,
+  applyPinned,
   messagesNewestFirst,
   type MessagePageDto,
 } from './messageCache'
@@ -30,6 +31,7 @@ function pages(...groups: MessageDto[][]): InfiniteData<MessagePageDto> {
       items,
       nextCursor: null,
       prevCursor: null,
+      pinned: null,
       participants: [ME, THEM],
     })),
     pageParams: groups.map((_, i) => (i === 0 ? '' : 'c')),
@@ -166,5 +168,28 @@ describe('messagesNewestFirst and hidden messages', () => {
   it('keeps a message withdrawn for everyone, which still occupies its place', () => {
     const data = pages([{ ...message('a'), deleted: true, body: '' }])
     expect(messagesNewestFirst(data).map((m) => m._id)).toEqual(['a'])
+  })
+})
+
+describe('applyPinned', () => {
+  const pin = { messageId: 'a', byUserId: ME, at: '2026-08-29T09:00:00.000Z' }
+
+  /** The pin rides in on every page, so a change has to reach every page. */
+  it('writes the pin to all of them, not just the newest', () => {
+    const next = applyPinned(pages([message('a')], [message('b')]), pin)
+    expect(next?.pages.map((p) => p.pinned?.messageId)).toEqual(['a', 'a'])
+  })
+
+  it('clears it', () => {
+    const withPin = applyPinned(pages([message('a')]), pin)
+    expect(applyPinned(withPin, null)?.pages[0]?.pinned).toBeNull()
+  })
+
+  /** A re-emit of the pin already held must not re-render the thread. */
+  it('returns the same object when nothing moved', () => {
+    const data = pages([message('a')])
+    expect(applyPinned(data, null)).toBe(data)
+    const withPin = applyPinned(data, pin)
+    expect(applyPinned(withPin, pin)).toBe(withPin)
   })
 })

--- a/apps/mobile/src/lib/messageCache.ts
+++ b/apps/mobile/src/lib/messageCache.ts
@@ -8,6 +8,7 @@ export interface MessagePageDto {
   /** Newer than this page; null means the page already reaches the live tail. */
   prevCursor: string | null
   participants: string[]
+  pinned: { messageId: string; byUserId: string; at: string } | null
   /** Only a jump window has one — the message it was opened on. */
   anchorId?: string
 }
@@ -106,4 +107,19 @@ export function applyMessageUpdate(data: Pages, message: MessageDto): Pages {
 
 function sameId(a: MessageDto, b: MessageDto): boolean {
   return String(a._id) === String(b._id)
+}
+
+/**
+ * The pin is on the conversation, not on a message, but it rides in on every
+ * page — so a change has to be written to every page rather than to one row.
+ *
+ * Same `changed`-guard discipline as the rest: a re-emit of the pin already
+ * held returns the identical object and re-renders nothing.
+ */
+export function applyPinned(data: Pages, pinned: MessagePageDto['pinned']): Pages {
+  if (!data) return data
+  const same = (a: MessagePageDto['pinned'], b: MessagePageDto['pinned']): boolean =>
+    a?.messageId === b?.messageId && a?.byUserId === b?.byUserId
+  if (data.pages.every((page) => same(page.pinned, pinned))) return data
+  return { ...data, pages: data.pages.map((page) => ({ ...page, pinned })) }
 }

--- a/apps/mobile/src/lib/messageMenu.test.ts
+++ b/apps/mobile/src/lib/messageMenu.test.ts
@@ -7,7 +7,9 @@ import {
   subscribeToMessageMenu,
 } from './messageMenu'
 
-const COPY = [{ id: 'copy' as const, label: 'Copy', icon: 'copy-outline' }]
+const COPY = [
+  { id: 'copy' as const, label: 'Copy', icon: 'copy-outline', page: 'primary' as const },
+]
 
 afterEach(() => {
   resetMessageMenuForTest()

--- a/packages/shared/src/chat.test.ts
+++ b/packages/shared/src/chat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { DELIVERY_STATES, deliveryStateOf } from './chat'
+import { DELIVERY_STATES, canDeleteForEveryone, canEditMessage, deliveryStateOf } from './chat'
 
 describe('deliveryStateOf', () => {
   it('is sent when the server has it and nothing more is known', () => {
@@ -35,5 +35,58 @@ describe('deliveryStateOf', () => {
 
   it('lists the states in the order a message passes through them', () => {
     expect(DELIVERY_STATES).toEqual(['sent', 'delivered', 'read'])
+  })
+})
+
+describe('canDeleteForEveryone', () => {
+  const now = new Date('2026-08-29T12:00:00.000Z')
+  const mine = { senderId: 'me', createdAt: '2026-08-29T11:00:00.000Z' }
+
+  it('allows the sender inside the window', () => {
+    expect(canDeleteForEveryone(mine, 'me', now)).toBe(true)
+  })
+
+  it('refuses someone else message', () => {
+    expect(canDeleteForEveryone(mine, 'them', now)).toBe(false)
+  })
+
+  it('refuses one already withdrawn, which is what stops the row being offered twice', () => {
+    expect(canDeleteForEveryone({ ...mine, deletedAt: now }, 'me', now)).toBe(false)
+  })
+
+  it('refuses one past the window', () => {
+    const old = { senderId: 'me', createdAt: '2026-08-26T11:00:00.000Z' }
+    expect(canDeleteForEveryone(old, 'me', now)).toBe(false)
+  })
+})
+
+describe('canEditMessage', () => {
+  const now = new Date('2026-08-29T12:00:00.000Z')
+  const mine = { senderId: 'me', type: 'text', createdAt: '2026-08-29T11:00:00.000Z' }
+
+  it('allows your own recent text', () => {
+    expect(canEditMessage(mine, 'me', now)).toBe(true)
+  })
+
+  it('refuses someone else message, and anything that is not text', () => {
+    expect(canEditMessage(mine, 'them', now)).toBe(false)
+    for (const type of ['image', 'audio', 'correction']) {
+      expect(canEditMessage({ ...mine, type }, 'me', now)).toBe(false)
+    }
+  })
+
+  /**
+   * The clause that keeps `correction.original` honest: editing a sentence
+   * someone has already corrected would leave their correction quoting
+   * something that no longer exists.
+   */
+  it('refuses one somebody has corrected', () => {
+    expect(canEditMessage({ ...mine, corrected: true }, 'me', now)).toBe(false)
+  })
+
+  it('refuses one past the window, and one already withdrawn', () => {
+    const old = { ...mine, createdAt: '2026-08-26T11:00:00.000Z' }
+    expect(canEditMessage(old, 'me', now)).toBe(false)
+    expect(canEditMessage({ ...mine, deletedAt: now }, 'me', now)).toBe(false)
   })
 })

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -87,6 +87,77 @@ export type MessageReaction = (typeof MESSAGE_REACTIONS)[number]
  */
 export const MESSAGE_DELETE_WINDOW_MS = 2 * 24 * 60 * 60 * 1000
 
+/**
+ * How long a text message stays editable.
+ *
+ * The same two days as withdrawing it, and deliberately so: both are the
+ * sender reaching back into something already read, and one window is easier
+ * to explain than two. It is also why the correction lock below matters — two
+ * days is long enough for the other person to have taught something about the
+ * sentence in the meantime.
+ */
+export const MESSAGE_EDIT_WINDOW_MS = 2 * 24 * 60 * 60 * 1000
+
+/**
+ * One pin per conversation for now. A second would need an order, a way to see
+ * the list and a way to say which one the banner shows; a single pin needs
+ * none of that and covers the case people actually have.
+ */
+export const MAX_PINNED_PER_CONVERSATION = 1
+
+export const editMessageSchema = z.object({
+  conversationId: z.string().trim().min(1),
+  messageId: z.string().trim().min(1),
+  body: messageBodySchema,
+})
+export type EditMessageInput = z.infer<typeof editMessageSchema>
+
+export const starMessageSchema = z.object({
+  conversationId: z.string().trim().min(1),
+  messageId: z.string().trim().min(1),
+  starred: z.boolean(),
+})
+export type StarMessageInput = z.infer<typeof starMessageSchema>
+
+export const pinMessageSchema = z.object({
+  conversationId: z.string().trim().min(1),
+  /** Null clears whatever is pinned. */
+  messageId: z.string().trim().min(1).nullable(),
+})
+export type PinMessageInput = z.infer<typeof pinMessageSchema>
+
+/**
+ * Whether a message can still be edited.
+ *
+ * The `corrected` clause is the interesting one. Once someone has written a
+ * correction of a sentence, that correction carries a snapshot of the original
+ * — so editing the original afterwards leaves the correction quoting a
+ * sentence that no longer exists anywhere, and the teaching record becomes a
+ * lie about what was said. The lock is not politeness; it is what keeps
+ * `correction.original` true.
+ */
+export function canEditMessage(
+  message: {
+    senderId: string
+    type: string
+    createdAt: string | Date
+    deletedAt?: string | Date | null
+    corrected?: boolean
+  },
+  userId: string,
+  now: Date,
+): boolean {
+  if (message.senderId !== userId) return false
+  // Only text: there is nothing to edit in an image, and a correction is
+  // itself a record of what someone else said.
+  if (message.type !== 'text') return false
+  if (message.deletedAt) return false
+  if (message.corrected) return false
+  const sent = new Date(message.createdAt).getTime()
+  if (Number.isNaN(sent)) return false
+  return now.getTime() - sent <= MESSAGE_EDIT_WINDOW_MS
+}
+
 export const reactToMessageSchema = z.object({
   conversationId: z.string().trim().min(1),
   messageId: z.string().trim().min(1),
@@ -120,6 +191,13 @@ export function canDeleteForEveryone(
   if (Number.isNaN(sent)) return false
   return now.getTime() - sent <= MESSAGE_DELETE_WINDOW_MS
 }
+
+export const STARRED_PAGE_SIZE_MAX = 100
+
+/** `GET /me/starred` — a flat list, newest first, across every conversation. */
+export const listStarredQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(STARRED_PAGE_SIZE_MAX).default(50),
+})
 
 export const MESSAGE_PAGE_SIZE_DEFAULT = 30
 export const MESSAGE_PAGE_SIZE_MAX = 100


### PR DESCRIPTION
Stacked on #972 → #971 → #970. Fourth of five branches from the chat plan.

Three actions on the plumbing #972 laid down, and the menu finally needs its second page — nine rows do not fit between a bubble and the edge of a screen.

## Edit is locked once someone has corrected the sentence

This is the whole reason the feature needed thinking about rather than writing. A correction carries a **snapshot** of the original, so editing that original afterwards leaves the correction quoting a sentence that exists nowhere, and the teaching record becomes a lie about what was said.

`sendCorrection` already loads its target, so stamping `correctedAt` on it costs nothing and turns the rule into a field read instead of a query. The menu does **not** hide the row when it fires — on your own recent message a missing Edit reads as a bug — it shows `Corrected — can't be edited`, disabled.

The window is the same two days as withdrawing a message, deliberately: both are the sender reaching back into something already read, and one number is easier to explain than two. That length is also what makes the lock matter, since two days is long enough for someone to have taught you something about the sentence in between.

Editing **pays no new tokens** — the message was paid for when it was sent, and paying again for changing a word would make editing a way to earn. If it was the last message the chat-list preview follows it, conditional on the same pair a withdrawal uses so a newer message wins the race.

## Star is private; pin is shared

Opposite calls, on purpose.

- **Star** is the clearest case for `audience: 'actor'`: a bookmark, the peer told nothing, the emit existing only so the same person's other devices agree. `starredBy` never leaves the server — the projection turns it into a boolean, with a test asserting the response body does not even contain the field name. Backed by a sparse `starred_created` index, because the starred screen is the one read in the chat area not scoped to a conversation, and without it that is a scan of every message in the app.
- **Pin** is shared and either person can change it. A pin is how the two of them agree what the thread is about; letting only the pinner unpin would leave the other stuck with a banner they cannot dismiss. One per conversation — a second needs an order, a list, and a way to say which one the banner shows.

A star is a write with no read until there is somewhere to see it, so `/(app)/starred` and a way in from the chat list are part of the same change. Each row jumps through the `?at=` window a reply quote already uses.

The pin travels on the message page beside `participants`, for the same reason that does: the banner needs it before anything else has loaded, and the client never fetches the conversation document on its own. `applyPinned` writes it to every page, since it rides in on all of them.

## The two-page menu

`paginateActions` is pure, so which rows sit behind `More…` stays a decision with a test on it rather than something invisible in a screenshot of the first page. Primary is Reply · Correct · Translate · Copy · Delete; `More…` holds Edit · Star · Pin · Report.

The host derives its height from the rows on the **current** page plus whichever navigation row it carries — using the full list would flip the menu the wrong way near a screen edge. A `More…` that would open an empty page is not rendered.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — 689 tests, 19 new.

New coverage: `canEditMessage` and `canDeleteForEveryone` as pure rules; an edit rewriting the message and the chat-list preview together; edits refused for the wrong sender, past the window, and **after a correction**, with the `corrected` flag reaching the client; a star visible only to the starrer in both the thread and `/me/starred`, and `starredBy` absent from the response; unstarring dropping it off the list; one pin at a time with either person able to replace or clear it; pinning a withdrawn message refused; and the two-page split.

Not yet driven in a browser; the hands-on pass lands with the rest of the chat work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)