### PR TITLE
Draw the activity map, and let a missed day be bought back

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -24,6 +24,7 @@ import { feedRoutes } from './routes/feed'
 import { handleRoutes } from './routes/handles'
 import { healthRoutes } from './routes/health'
 import { mediaRoutes } from './routes/media'
+import { activityRoutes } from './routes/activity'
 import { messageRoutes } from './routes/messages'
 import { moderationRoutes } from './routes/moderation'
 import { profileRoutes } from './routes/profiles'
@@ -215,6 +216,7 @@ export async function buildApp({
   await app.register(translationRoutes)
   await app.register(billingRoutes)
   await app.register(xpRoutes)
+  await app.register(activityRoutes)
   await app.register(leaderboardRoutes)
   await app.register(moderationRoutes)
   await app.register(accountRoutes)

--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -52,6 +52,7 @@ export const COLLECTIONS = {
   tokenLedger: 'tokenLedger',
   tokenAggregates: 'tokenAggregates',
   dailyActivity: 'dailyActivity',
+  streakDays: 'streakDays',
 
   /** One row per user per local day a streak nudge was sent — the dedupe key. */
   streakReminders: 'streakReminders',

--- a/apps/api/src/modules/handles/legacyRestore.ts
+++ b/apps/api/src/modules/handles/legacyRestore.ts
@@ -262,7 +262,7 @@ function buildProfile(userId: string, legacy: LegacyProfile, now: Date): Profile
     learning: legacy.learning,
     interests: [],
     settings: { discoverable: true, notifications: true },
-    privacy: { incognito: false, hideOnlineStatus: false },
+    privacy: { incognito: false, hideOnlineStatus: false, activityMapVisible: true },
     entitlement: { tier: 'free', updatedAt: now },
     quota: { initiations: [], translations: [], media: [] },
     /**

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -59,7 +59,7 @@ export interface Profile {
     discoverable: boolean
     notifications: boolean
   }
-  privacy: { incognito: boolean; hideOnlineStatus?: boolean }
+  privacy: { incognito: boolean; hideOnlineStatus?: boolean; activityMapVisible?: boolean }
   entitlement: {
     tier: PlanTier
     expiresAt?: Date
@@ -161,7 +161,7 @@ export async function createProfile(
       discoverable: true,
       notifications: true,
     },
-    privacy: { incognito: false, hideOnlineStatus: false },
+    privacy: { incognito: false, hideOnlineStatus: false, activityMapVisible: true },
     entitlement: { tier: 'free', updatedAt: now },
     quota: { initiations: [], translations: [], media: [] },
     streak: { current: 0, longest: 0, lastQualifiedDay: null },

--- a/apps/api/src/modules/tokens/streak.ts
+++ b/apps/api/src/modules/tokens/streak.ts
@@ -9,6 +9,7 @@ import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import type { Profile } from '../profiles/profiles'
 import { awardTokens } from './ledger'
+import { recordStreakDay } from './streakDays'
 import { consumeStreakFreeze } from './wallet'
 
 export interface StreakResult {
@@ -63,6 +64,14 @@ export async function recordQualifyingAction(
     milestoneXp: 0,
     freezeUsed: false,
   }
+  /**
+   * Before the early return, deliberately. The square's *shading* is a count of
+   * qualifying actions, so stopping here on the day's second message would
+   * leave every day looking equally busy — and the set of filled days is what
+   * a repair later has to recompute a streak length from.
+   */
+  await recordStreakDay(db, profile._id, today)
+
   if (profile.streak.lastQualifiedDay === today) return held
 
   // A freeze bridges *exactly one* missed day. Wider gaps are not for sale —

--- a/apps/api/src/modules/tokens/streakDays.test.ts
+++ b/apps/api/src/modules/tokens/streakDays.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { isRepairable, streakDayId, streakFromDays } from './streakDays'
+
+describe('streakFromDays', () => {
+  const today = '2026-08-29'
+
+  it('counts back from today while the days are unbroken', () => {
+    const days = new Set(['2026-08-29', '2026-08-28', '2026-08-27'])
+    expect(streakFromDays(days, today)).toBe(3)
+  })
+
+  /**
+   * A user who has not sent anything yet today still has the run that ended
+   * yesterday — the streak is not lost until a day passes without one.
+   */
+  it('starts from yesterday when today is not filled yet', () => {
+    const days = new Set(['2026-08-28', '2026-08-27'])
+    expect(streakFromDays(days, today)).toBe(2)
+  })
+
+  it('is zero once yesterday is missing too', () => {
+    expect(streakFromDays(new Set(['2026-08-27']), today)).toBe(0)
+    expect(streakFromDays(new Set(), today)).toBe(0)
+  })
+
+  /**
+   * The reason a repair recomputes rather than increments: filling one square
+   * can join two runs that were never adjacent while they were being lived.
+   */
+  it('joins two runs when the day between them is filled', () => {
+    const broken = new Set(['2026-08-29', '2026-08-28', '2026-08-26', '2026-08-25'])
+    expect(streakFromDays(broken, today)).toBe(2)
+
+    const repaired = new Set([...broken, '2026-08-27'])
+    expect(streakFromDays(repaired, today)).toBe(5)
+  })
+
+  it('ignores days after today', () => {
+    const days = new Set(['2026-08-30', '2026-08-29'])
+    expect(streakFromDays(days, today)).toBe(1)
+  })
+})
+
+describe('isRepairable', () => {
+  const now = new Date('2026-08-29T12:00:00.000Z')
+  const today = '2026-08-29'
+
+  it('refuses today, which is earned rather than bought', () => {
+    expect(isRepairable(today, today, 'UTC', now)).toBe(false)
+  })
+
+  it('refuses a day that has not happened', () => {
+    expect(isRepairable('2026-08-30', today, 'UTC', now)).toBe(false)
+  })
+
+  it('allows yesterday and the edge of the window', () => {
+    expect(isRepairable('2026-08-28', today, 'UTC', now)).toBe(true)
+    expect(isRepairable('2026-08-15', today, 'UTC', now)).toBe(true)
+  })
+
+  it('refuses one day past the window', () => {
+    expect(isRepairable('2026-08-14', today, 'UTC', now)).toBe(false)
+  })
+})
+
+describe('streakDayId', () => {
+  /** The prefix range that reads a calendar off the primary index depends on it. */
+  it('is the user and the day, in that order', () => {
+    expect(streakDayId('u1', '2026-08-29')).toBe('u1:2026-08-29')
+  })
+})

--- a/apps/api/src/modules/tokens/streakDays.ts
+++ b/apps/api/src/modules/tokens/streakDays.ts
@@ -1,0 +1,97 @@
+import { localDayKey, shiftDayKey, TOKEN_RULES } from '@langx/shared'
+
+// Re-exported so callers here keep one import; the walk itself lives in shared,
+// because the client has to predict the same number before a repair is bought.
+export { streakFromDays } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+
+/**
+ * One document per user per **local** day they were active.
+ *
+ * Nothing recorded which days a user showed up. `profile.streak` keeps a
+ * number and a `lastQualifiedDay`, which is all the streak itself needs and
+ * nothing a calendar can be drawn from — and it is also why a repaired day
+ * could not previously be turned back into a streak length. This is that
+ * missing set.
+ *
+ * `_id` is `<userId>:<day>`, the same shape `dailyActivity` uses. It gives the
+ * uniqueness that makes a day physically impossible to fill twice, and a
+ * prefix range that reads a user's calendar off the `_id` index — so no second
+ * index is needed for either.
+ */
+export interface StreakDay {
+  _id: string
+  userId: string
+  /** `YYYY-MM-DD` in the user's own timezone, like the streak and unlike everything else. */
+  day: string
+  /** How the square came to be filled. `purchase` is the only one that cost anything. */
+  source: 'activity' | 'purchase'
+  /** Qualifying actions that day — the map's shading, not its fill. */
+  actions: number
+}
+
+export function streakDayId(userId: string, day: string): string {
+  return `${userId}:${day}`
+}
+
+/**
+ * Counts a qualifying action against today's square.
+ *
+ * Called on every message, not only the first of the day: the count is what
+ * shades the square, so an early return on "already qualified" would leave
+ * every day looking equally busy. Upsert rather than read-then-write for the
+ * same reason `recordActivity` is one — two messages landing together must
+ * both count.
+ */
+export async function recordStreakDay(
+  db: Db,
+  userId: string,
+  day: string,
+  source: StreakDay['source'] = 'activity',
+): Promise<void> {
+  await db.collection<StreakDay>(COLLECTIONS.streakDays).updateOne(
+    { _id: streakDayId(userId, day) },
+    {
+      $inc: { actions: 1 },
+      $setOnInsert: { userId, day, source },
+    },
+    { upsert: true },
+  )
+}
+
+/**
+ * The days a user was active, within an inclusive range.
+ *
+ * A prefix range over `_id` rather than a `{userId, day}` query, so it rides
+ * the primary index. `\\uffff` closes the range above every day key that could
+ * follow the prefix.
+ */
+export async function listStreakDays(
+  db: Db,
+  userId: string,
+  from: string,
+  to: string,
+): Promise<StreakDay[]> {
+  return db
+    .collection<StreakDay>(COLLECTIONS.streakDays)
+    .find({ _id: { $gte: streakDayId(userId, from), $lte: streakDayId(userId, `${to}￿`) } })
+    .toArray()
+}
+
+/** How many repairs this user has bought in the calendar month `day` falls in. */
+export async function repairsInMonth(db: Db, userId: string, day: string): Promise<number> {
+  const month = day.slice(0, 7)
+  return db.collection<StreakDay>(COLLECTIONS.streakDays).countDocuments({
+    _id: { $gte: streakDayId(userId, `${month}-01`), $lte: streakDayId(userId, `${month}-31￿`) },
+    source: 'purchase',
+  })
+}
+
+/** Whether a day is inside the window a repair may still reach. */
+export function isRepairable(day: string, today: string, timeZone: string, now: Date): boolean {
+  // Today is earned, not bought, and tomorrow has not happened.
+  if (day >= today) return false
+  const oldest = shiftDayKey(localDayKey(now, timeZone), -TOKEN_RULES.sinks.dayRepairMaxAgeDays)
+  return day >= oldest
+}

--- a/apps/api/src/modules/tokens/wallet.ts
+++ b/apps/api/src/modules/tokens/wallet.ts
@@ -4,16 +4,26 @@ import {
   STREAK_RESTORE_SKU,
   TOKEN_RULES,
   findCosmetic,
+  localDayKey,
   periodKeys,
+  shiftDayKey,
   streakRestorePrice,
-  utcDayKey,
   type Wallet,
+  utcDayKey,
 } from '@langx/shared'
 import { ObjectId, type Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import { ApiError } from '../../lib/ApiError'
 import type { Profile } from '../profiles/profiles'
 import { streakDay } from './streak'
+import {
+  isRepairable,
+  listStreakDays,
+  repairsInMonth,
+  streakDayId,
+  streakFromDays,
+  type StreakDay,
+} from './streakDays'
 import { readAggregates, type TokenLedgerEntry } from './ledger'
 
 export function walletOf(profile: Profile, earned: number): Wallet {
@@ -211,4 +221,108 @@ async function restoreStreak(db: Db, profile: Profile, earned: number): Promise<
 
   await recordSpend(db, profile._id, STREAK_RESTORE_SKU, price)
   return { sku: STREAK_RESTORE_SKU, price, wallet: walletOf(updated, earned) }
+}
+
+export interface RepairResult {
+  day: string
+  price: number
+  streak: { current: number; longest: number }
+  wallet: Wallet
+  repairsLeftThisMonth: number
+}
+
+/**
+ * Buys back one missed day.
+ *
+ * Two writes, in two collections, so there is no single atomic update to lean
+ * on the way a cosmetic purchase does — the money is on `profiles.tokenSpent`
+ * and the day is a `streakDays` document. The order is what makes that safe:
+ * insert the day first, because its `_id` is `<userId>:<day>` and a duplicate
+ * key is a far better "already filled" check than a read could ever be, then
+ * charge, and delete the day again if the charge does not go through. The
+ * reverse order could take the tokens and fail to fill the square, which is
+ * the failure worth designing against.
+ */
+export async function repairDay(db: Db, userId: string, day: string): Promise<RepairResult> {
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  const profile = await profiles.findOne({ _id: userId })
+  if (!profile) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Complete onboarding first')
+
+  const now = new Date()
+  const timeZone = profile.timezone ?? 'UTC'
+  const today = localDayKey(now, timeZone)
+
+  if (!isRepairable(day, today, timeZone, now)) {
+    throw new ApiError(
+      ERROR_CODES.VALIDATION_FAILED,
+      `Only the last ${TOKEN_RULES.sinks.dayRepairMaxAgeDays} days, and not today — today is earned`,
+    )
+  }
+
+  const used = await repairsInMonth(db, userId, day)
+  if (used >= TOKEN_RULES.sinks.dayRepairPerMonth) {
+    throw new ApiError(
+      ERROR_CODES.VALIDATION_FAILED,
+      `You have used both repairs for ${day.slice(0, 7)}`,
+    )
+  }
+
+  const price = TOKEN_RULES.sinks.dayRepair
+  const days = db.collection<StreakDay>(COLLECTIONS.streakDays)
+  try {
+    await days.insertOne({
+      _id: streakDayId(userId, day),
+      userId,
+      day,
+      source: 'purchase',
+      actions: 0,
+    })
+  } catch {
+    // The only way `insertOne` fails here is the unique `_id`, which is
+    // exactly "that day is already filled".
+    throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'That day is already filled')
+  }
+
+  const earned = (await readAggregates(db, userId)).all
+  const charged = await profiles.findOneAndUpdate(
+    {
+      _id: userId,
+      $expr: { $lte: [{ $add: [{ $ifNull: ['$tokenSpent', 0] }, price] }, earned] },
+    },
+    { $inc: { tokenSpent: price } },
+    { returnDocument: 'after' },
+  )
+
+  if (!charged) {
+    // Hand the day back rather than leaving a square nobody paid for.
+    await days.deleteOne({ _id: streakDayId(userId, day) })
+    throw new ApiError(
+      ERROR_CODES.VALIDATION_FAILED,
+      `Not enough token — a repair costs ${price}, you have ${earned - (profile.tokenSpent ?? 0)}`,
+    )
+  }
+
+  await recordSpend(db, userId, `dayRepair:${day}`, price)
+
+  /**
+   * Recomputed from the filled days, not incremented. A repair can join two
+   * runs that were never adjacent while they were being lived, so the only way
+   * to know the new length is to walk them.
+   */
+  const window = await listStreakDays(db, userId, shiftDayKey(today, -400), today)
+  const current = streakFromDays(new Set(window.map((d) => d.day)), today)
+  const longest = Math.max(profile.streak.longest, current)
+  const after = await profiles.findOneAndUpdate(
+    { _id: userId },
+    { $set: { 'streak.current': current, 'streak.longest': longest, updatedAt: now } },
+    { returnDocument: 'after' },
+  )
+
+  return {
+    day,
+    price,
+    streak: { current, longest },
+    wallet: walletOf(after ?? charged, earned),
+    repairsLeftThisMonth: TOKEN_RULES.sinks.dayRepairPerMonth - used - 1,
+  }
 }

--- a/apps/api/src/modules/tokens/wallet.ts
+++ b/apps/api/src/modules/tokens/wallet.ts
@@ -310,7 +310,19 @@ export async function repairDay(db: Db, userId: string, day: string): Promise<Re
    * to know the new length is to walk them.
    */
   const window = await listStreakDays(db, userId, shiftDayKey(today, -400), today)
-  const current = streakFromDays(new Set(window.map((d) => d.day)), today)
+  const walked = streakFromDays(new Set(window.map((d) => d.day)), today)
+
+  /**
+   * Never below what they already had.
+   *
+   * `streakDays` only starts existing when this ships, so every account that
+   * predates it has a history of nothing — and the walk above would price a
+   * two-hundred-day streak at zero. Buying a repair must not be able to take a
+   * streak away, which is what the max guarantees whatever the history looks
+   * like. As the collection fills in, the walk becomes the larger of the two on
+   * its own and this stops doing anything.
+   */
+  const current = Math.max(profile.streak.current, walked)
   const longest = Math.max(profile.streak.longest, current)
   const after = await profiles.findOneAndUpdate(
     { _id: userId },

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -1,0 +1,107 @@
+import {
+  activityRangeSchema,
+  ERROR_CODES,
+  localDayKey,
+  repairDaySchema,
+  TOKEN_RULES,
+} from '@langx/shared'
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { ApiError } from '../lib/ApiError'
+import { requireAuth } from '../middleware/requireAuth'
+import { getProfile } from '../modules/profiles/profiles'
+import { blockedUserIds } from '../modules/moderation/blocks'
+import { listStreakDays, repairsInMonth } from '../modules/tokens/streakDays'
+import { repairDay } from '../modules/tokens/wallet'
+
+/**
+ * The activity map, and buying back a day of it.
+ *
+ * Under `/me` rather than `/profiles/me`, because what it reads is the token
+ * economy's record of a user's days rather than anything on their profile —
+ * the same reason `/me/tokens` and `/me/wallet` live there.
+ */
+// eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
+export const activityRoutes: FastifyPluginAsyncZod = async (app) => {
+  app.get(
+    '/me/activity',
+    { preHandler: requireAuth, schema: { querystring: activityRangeSchema } },
+    async (request, reply) => {
+      const profile = await getProfile(app.mongo.db, request.userId)
+      if (!profile) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Complete onboarding first')
+
+      const { from, to } = request.query
+      const today = localDayKey(new Date(), profile.timezone ?? 'UTC')
+      const days = await listStreakDays(app.mongo.db, request.userId, from, to)
+
+      return reply.send({
+        today,
+        days: days.map((d) => ({ day: d.day, actions: d.actions, source: d.source })),
+        repair: {
+          price: TOKEN_RULES.sinks.dayRepair,
+          maxAgeDays: TOKEN_RULES.sinks.dayRepairMaxAgeDays,
+          perMonth: TOKEN_RULES.sinks.dayRepairPerMonth,
+          usedThisMonth: await repairsInMonth(app.mongo.db, request.userId, today),
+        },
+      })
+    },
+  )
+
+  app.post(
+    '/me/activity/repair',
+    { preHandler: requireAuth, schema: { body: repairDaySchema } },
+    async (request, reply) => {
+      return reply.send(await repairDay(app.mongo.db, request.userId, request.body.day))
+    },
+  )
+
+  /**
+   * Somebody else's map: filled or not, and how busy, but never the counts and
+   * never which squares were bought.
+   *
+   * A separate endpoint rather than a field on the public profile, because
+   * `toPublicProfile` is an allow-list and a range query does not belong in
+   * it — and because this way the privacy flag is checked in one place.
+   */
+  app.get(
+    '/profiles/:handle/activity',
+    { preHandler: requireAuth, schema: { querystring: activityRangeSchema } },
+    async (request, reply) => {
+      const { handle } = request.params as { handle: string }
+      const target = await app.mongo.db
+        .collection<{ _id: string; privacy?: { activityMapVisible?: boolean } }>('profiles')
+        .findOne({ handle })
+
+      // Blocked either way reads as "no such person", the same as the profile
+      // itself — a 403 here would confirm the account exists.
+      const hidden = await blockedUserIds(app.mongo.db, request.userId)
+      if (!target || hidden.includes(target._id)) {
+        throw new ApiError(ERROR_CODES.NOT_FOUND, 'Profile not found')
+      }
+      // Absent means on: the flag was added after these profiles were written.
+      if (target.privacy?.activityMapVisible === false) {
+        return reply.send({ visible: false, days: [] })
+      }
+
+      const { from, to } = request.query
+      const days = await listStreakDays(app.mongo.db, target._id, from, to)
+      return reply.send({
+        visible: true,
+        // No counts and no source: how hard someone worked on a Tuesday, and
+        // whether they paid for it, are theirs.
+        days: days.map((d) => ({ day: d.day, intensity: intensityOf(d.actions) })),
+      })
+    },
+  )
+}
+
+/**
+ * Four buckets, because the exact count is the private part and the shape of a
+ * habit is not. Thresholds rather than a scale so one very loud day cannot
+ * flatten a year of ordinary ones.
+ */
+function intensityOf(actions: number): 1 | 2 | 3 | 4 {
+  if (actions >= 30) return 4
+  if (actions >= 10) return 3
+  if (actions >= 3) return 2
+  return 1
+}

--- a/apps/api/src/routes/tokens.test.ts
+++ b/apps/api/src/routes/tokens.test.ts
@@ -526,6 +526,33 @@ describe('Faz 8 — streak, token ledger and direct awards', () => {
       expect(profile?.streak.current).toBe(5)
     })
 
+    /**
+     * `streakDays` only starts existing when this ships, so every account that
+     * predates it has a history of nothing — and a walk over that history
+     * would price a long streak at zero. Found by watching the profile card
+     * say 1 while the repair confirmation said 2.
+     */
+    it('never lowers a streak that predates the day records', async () => {
+      const user = await funded('repair-legacy@example.com', 1000)
+      await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .updateOne({ _id: user.userId }, { $set: { 'streak.current': 200, 'streak.longest': 200 } })
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/me/activity/repair',
+        headers: { cookie: user.cookie },
+        payload: { day: dayKey(1) },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+      expect(response.json<{ streak: { current: number } }>().streak.current).toBe(200)
+
+      const profile = await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .findOne({ _id: user.userId })
+      expect(profile?.streak.current).toBe(200)
+    })
+
     /** The leaderboard ranks token earned. Spending must not move anyone. */
     it('does not touch the leaderboard aggregates', async () => {
       const user = await funded('repair-rank@example.com', 1000)

--- a/apps/api/src/routes/tokens.test.ts
+++ b/apps/api/src/routes/tokens.test.ts
@@ -19,6 +19,7 @@ import { loadEnv } from '../env'
 import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
 import type { Profile } from '../modules/profiles/profiles'
 import { awardTokens, type TokenLedgerEntry } from '../modules/tokens/ledger'
+import type { StreakDay } from '../modules/tokens/streakDays'
 import { createStorageProvider } from '../storage/createStorageProvider'
 import { CapturingEmailSender, signUpAndSignIn, type SignedUpUser } from '../testSupport/authFlow'
 import { createTranslationProvider } from '../translation/createTranslationProvider'
@@ -451,5 +452,217 @@ describe('Faz 8 — streak, token ledger and direct awards', () => {
     const profile = await profiles.findOne({ _id: a.userId })
     expect(profile?.stats.lastActiveAt.getTime()).toBeGreaterThan(Date.now() - 60_000)
     expect(profile?.stats.messagesSent).toBe(1)
+  })
+
+  describe('the activity map and buying back a day', () => {
+    /** Enough earned token to afford repairs, without going through sends. */
+    async function funded(email: string, tokens: number) {
+      const user = await newUser(email)
+      await awardTokens(handle.db, {
+        userId: user.userId,
+        kind: 'adjustment',
+        amount: tokens,
+        refId: `fund-${user.userId}`,
+      })
+      return user
+    }
+
+    const dayKey = (offsetDays: number) =>
+      new Date(Date.now() - offsetDays * 86_400_000).toISOString().slice(0, 10)
+
+    it('records the day a message was sent, and counts the ones after it', async () => {
+      const a = await newUser('activity-sender@example.com')
+      const b = await newUser('activity-partner@example.com')
+      const conversationId = await startConversation(a, b.userId)
+      const { sendTextMessage } = await import('../modules/chat/messages')
+      await sendTextMessage(handle.db, a.userId, { conversationId, body: 'second' })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/me/activity?from=${dayKey(7)}&to=${dayKey(0)}`,
+        headers: { cookie: a.cookie },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+      const body = response.json<{ days: { day: string; actions: number }[] }>()
+      // Two qualifying actions, one square: the count is what shades it.
+      expect(body.days).toHaveLength(1)
+      expect(body.days[0]?.actions).toBe(2)
+    })
+
+    it('fills a missed day, charges for it, and rejoins the streak across it', async () => {
+      const user = await funded('repair-joins@example.com', 1000)
+      const days = handle.db.collection<StreakDay>(COLLECTIONS.streakDays)
+      // Two runs with one day missing between them.
+      for (const offset of [0, 1, 3, 4]) {
+        await days.insertOne({
+          _id: `${user.userId}:${dayKey(offset)}`,
+          userId: user.userId,
+          day: dayKey(offset),
+          source: 'activity',
+          actions: 1,
+        })
+      }
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/me/activity/repair',
+        headers: { cookie: user.cookie },
+        payload: { day: dayKey(2) },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+      const body = response.json<{
+        price: number
+        streak: { current: number }
+        repairsLeftThisMonth: number
+      }>()
+      expect(body.price).toBe(TOKEN_RULES.sinks.dayRepair)
+      expect(body.streak.current).toBe(5)
+      expect(body.repairsLeftThisMonth).toBe(TOKEN_RULES.sinks.dayRepairPerMonth - 1)
+
+      const profile = await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .findOne({ _id: user.userId })
+      expect(profile?.tokenSpent).toBe(TOKEN_RULES.sinks.dayRepair)
+      expect(profile?.streak.current).toBe(5)
+    })
+
+    /** The leaderboard ranks token earned. Spending must not move anyone. */
+    it('does not touch the leaderboard aggregates', async () => {
+      const user = await funded('repair-rank@example.com', 1000)
+      const before = await handle.db
+        .collection<{ _id: string; tokens: number }>(COLLECTIONS.tokenAggregates)
+        .findOne({ _id: `${user.userId}:all:all` })
+
+      await app.inject({
+        method: 'POST',
+        url: '/me/activity/repair',
+        headers: { cookie: user.cookie },
+        payload: { day: dayKey(1) },
+      })
+
+      const after = await handle.db
+        .collection<{ _id: string; tokens: number }>(COLLECTIONS.tokenAggregates)
+        .findOne({ _id: `${user.userId}:all:all` })
+      expect(after?.tokens).toBe(before?.tokens)
+    })
+
+    it('refuses today, a day outside the window, and one already filled', async () => {
+      const user = await funded('repair-window@example.com', 5000)
+
+      const today = await app.inject({
+        method: 'POST',
+        url: '/me/activity/repair',
+        headers: { cookie: user.cookie },
+        payload: { day: dayKey(0) },
+      })
+      expect(today.statusCode).toBe(400)
+
+      const tooOld = await app.inject({
+        method: 'POST',
+        url: '/me/activity/repair',
+        headers: { cookie: user.cookie },
+        payload: { day: dayKey(TOKEN_RULES.sinks.dayRepairMaxAgeDays + 1) },
+      })
+      expect(tooOld.statusCode).toBe(400)
+
+      await app.inject({
+        method: 'POST',
+        url: '/me/activity/repair',
+        headers: { cookie: user.cookie },
+        payload: { day: dayKey(1) },
+      })
+      const again = await app.inject({
+        method: 'POST',
+        url: '/me/activity/repair',
+        headers: { cookie: user.cookie },
+        payload: { day: dayKey(1) },
+      })
+      expect(again.statusCode).toBe(400)
+    })
+
+    /** The cap, not the price, is what stops a balance buying a streak. */
+    it('allows only two repairs a month however much token is held', async () => {
+      const user = await funded('repair-cap@example.com', 100_000)
+      const codes: number[] = []
+      for (const offset of [1, 2, 3]) {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/me/activity/repair',
+          headers: { cookie: user.cookie },
+          payload: { day: dayKey(offset) },
+        })
+        codes.push(response.statusCode)
+      }
+      expect(codes.slice(0, TOKEN_RULES.sinks.dayRepairPerMonth)).toEqual([200, 200])
+      expect(codes[2]).toBe(400)
+    })
+
+    /**
+     * Two writes in two collections, so the order matters: the day goes in
+     * first and has to come back out when the charge fails, or the map would
+     * show a square nobody paid for.
+     */
+    it('hands the day back when there is not enough token', async () => {
+      const user = await funded('repair-broke@example.com', 10)
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/me/activity/repair',
+        headers: { cookie: user.cookie },
+        payload: { day: dayKey(1) },
+      })
+      expect(response.statusCode).toBe(400)
+
+      const day = await handle.db
+        .collection<StreakDay>(COLLECTIONS.streakDays)
+        .findOne({ _id: `${user.userId}:${dayKey(1)}` })
+      expect(day).toBeNull()
+    })
+
+    it('shows someone else the shape of the map but never the counts', async () => {
+      const owner = await newUser('map-owner@example.com', { handle: 'mapowner' })
+      const viewer = await newUser('map-viewer@example.com')
+      await handle.db.collection<StreakDay>(COLLECTIONS.streakDays).insertOne({
+        _id: `${owner.userId}:${dayKey(1)}`,
+        userId: owner.userId,
+        day: dayKey(1),
+        source: 'purchase',
+        actions: 42,
+      })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/profiles/mapowner/activity?from=${dayKey(7)}&to=${dayKey(0)}`,
+        headers: { cookie: viewer.cookie },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+      expect(response.body).not.toContain('42')
+      // Nor whether a square was bought.
+      expect(response.body).not.toContain('purchase')
+      const body = response.json<{ visible: boolean; days: { intensity: number }[] }>()
+      expect(body.visible).toBe(true)
+      expect(body.days).toHaveLength(1)
+    })
+
+    it('hides the map when its owner has turned it off', async () => {
+      const owner = await newUser('map-private@example.com', { handle: 'mapprivate' })
+      const viewer = await newUser('map-private-viewer@example.com')
+      await app.inject({
+        method: 'PATCH',
+        url: '/profiles/me',
+        headers: { cookie: owner.cookie },
+        payload: { privacy: { activityMapVisible: false } },
+      })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/profiles/mapprivate/activity?from=${dayKey(7)}&to=${dayKey(0)}`,
+        headers: { cookie: viewer.cookie },
+      })
+      expect(response.json<{ visible: boolean; days: unknown[] }>()).toEqual({
+        visible: false,
+        days: [],
+      })
+    })
   })
 })

--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -1,3 +1,4 @@
+import { ActivityMap } from '../../src/components/ActivityMap'
 import { countryFlag, formatAccountAge, getCountry, type Gender } from '@langx/shared'
 import Feather from '@expo/vector-icons/Feather'
 import { router } from 'expo-router'
@@ -131,6 +132,15 @@ export default function MeScreen() {
       </View>
 
       {summary ? <WeeklyChart week={summary.week} /> : null}
+
+      {/*
+        Under the week's chart and above the links: the chart says how this
+        week went, the map says how the last six months did, and a square you
+        can still buy back is only interesting while the day is recent.
+      */}
+      <Card inset style={styles.card}>
+        <ActivityMap />
+      </Card>
 
       <Card inset style={styles.card}>
         {/* Free users get the count and a locked list; that contrast is the

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -178,6 +178,22 @@ export default function SettingsScreen() {
             />
           }
         />
+        {/* Free, unlike the two Pro rows around it: the streak this is drawn
+            from is already on the public profile, so hiding the squares is a
+            preference rather than a feature. */}
+        <ListRow
+          title="Show my activity map"
+          subtitle="The squares on your profile. Your streak stays visible either way."
+          accessory={
+            <Toggle
+              accessibilityLabel="Show my activity map"
+              value={profile?.privacy.activityMapVisible ?? true}
+              onValueChange={(activityMapVisible) =>
+                update.mutate({ privacy: { activityMapVisible } })
+              }
+            />
+          }
+        />
         <ListRow
           title="Hide when I'm online"
           subtitle={isPro ? 'You can still see theirs.' : '✦ Pro'}

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -52,6 +52,7 @@ export const keys = {
    */
   messagesAround: (id: string, anchorId: string) => ['messages', id, 'around', anchorId] as const,
   starred: ['starred'] as const,
+  activity: (from: string, to: string) => ['activity', from, to] as const,
   tokens: ['tokens'] as const,
   wallet: ['wallet'] as const,
   badges: ['badges'] as const,
@@ -93,7 +94,7 @@ export interface MeProfile {
   learning: { code: string; level: LanguageLevel; priority: number }[]
   interests: string[]
   settings: { discoverable: boolean; notifications: boolean }
-  privacy: { incognito: boolean; hideOnlineStatus: boolean }
+  privacy: { incognito: boolean; hideOnlineStatus: boolean; activityMapVisible?: boolean }
   /**
    * Present only while the user is sharing one, which is exactly what the
    * Settings toggle reads: there is no separate "sharing is on" flag on the
@@ -289,6 +290,47 @@ export function useMessages(conversationId: string) {
     // only sanctioned way to read this — see the note there.
     getNextPageParam: (last) => last.nextCursor ?? undefined,
     enabled: conversationId.length > 0,
+  })
+}
+
+export interface ActivityDayDto {
+  day: string
+  actions: number
+  source: 'activity' | 'purchase'
+}
+
+export interface ActivityDto {
+  /** The server's idea of the user's local day — the client must not guess it. */
+  today: string
+  days: ActivityDayDto[]
+  repair: { price: number; maxAgeDays: number; perMonth: number; usedThisMonth: number }
+}
+
+/**
+ * The activity map's own data.
+ *
+ * `today` comes from the server rather than the device, because the streak's
+ * day is the profile's timezone and a device set to another one would draw the
+ * grid off by a square — and then offer to sell the wrong day.
+ */
+export function useActivity(from: string, to: string) {
+  return useQuery({
+    queryKey: keys.activity(from, to),
+    queryFn: () => api.get<ActivityDto>(`/me/activity?from=${from}&to=${to}`),
+  })
+}
+
+export function useRepairDay() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (day: string) =>
+      api.post<{ day: string; streak: { current: number } }>('/me/activity/repair', { day }),
+    onSuccess: () => {
+      // The map, the balance and the streak all move together.
+      void queryClient.invalidateQueries({ queryKey: ['activity'] })
+      void queryClient.invalidateQueries({ queryKey: keys.wallet })
+      void queryClient.invalidateQueries({ queryKey: keys.tokens })
+    },
   })
 }
 

--- a/apps/mobile/src/components/ActivityMap.tsx
+++ b/apps/mobile/src/components/ActivityMap.tsx
@@ -1,0 +1,152 @@
+import { shiftDayKey } from '@langx/shared'
+import { useMemo } from 'react'
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native'
+import { useActivity, useRepairDay, useWallet } from '../api/queries'
+import { activityGrid, repairEffect, type ActivityCell } from '../lib/activityMap'
+import { confirmAlert, showAlert } from '../lib/alert'
+import { dayLabel } from '../lib/messageGroups'
+import { makeStyles, useTheme } from '../lib/theme'
+import { showToast } from '../lib/toast'
+
+/** Half a year, which is as much as fits without the squares becoming dots. */
+const WEEKS = 26
+
+/**
+ * Every day this person showed up, and the ones they can still buy back.
+ *
+ * The grid is drawn from `streakDays` rather than from `dailyActivity`: the
+ * streak's day is the user's local one and `dailyActivity` counts UTC days, so
+ * shading the squares from the latter would slide the whole map by one for
+ * anyone far enough east or west. One source, one meaning.
+ */
+export function ActivityMap() {
+  const { colors } = useTheme()
+  const styles = useStyles()
+
+  const to = new Date().toISOString().slice(0, 10)
+  // Generous: the server clamps the range, and the grid only draws what it needs.
+  const from = shiftDayKey(to, -(WEEKS + 1) * 7)
+  const activity = useActivity(from, to)
+  const wallet = useWallet()
+  const repair = useRepairDay()
+
+  const columns = useMemo(() => {
+    if (!activity.data) return []
+    return activityGrid({
+      today: activity.data.today,
+      weeks: WEEKS,
+      days: new Map(activity.data.days.map((d) => [d.day, d.actions])),
+      maxAgeDays: activity.data.repair.maxAgeDays,
+    })
+  }, [activity.data])
+
+  if (activity.isPending) return <ActivityIndicator style={styles.loading} />
+  if (!activity.data) return null
+
+  const { repair: rules, today, days } = activity.data
+  const filled = new Set(days.map((d) => d.day))
+  const left = Math.max(0, rules.perMonth - rules.usedThisMonth)
+
+  async function onPressDay(cell: ActivityCell): Promise<void> {
+    if (cell.state !== 'repairable') return
+    if (left === 0) {
+      await showAlert('No repairs left', `You can fill in ${rules.perMonth} days a month.`)
+      return
+    }
+
+    const effect = repairEffect({
+      day: cell.day,
+      today,
+      filled,
+      price: rules.price,
+      balance: wallet.data?.balance ?? 0,
+    })
+    if (!effect.affordable) {
+      await showAlert(
+        'Not enough token',
+        `Filling a day costs ${rules.price}. You have ${wallet.data?.balance ?? 0}.`,
+      )
+      return
+    }
+
+    /**
+     * The whole point of the confirmation: it says what the purchase does
+     * *before* it happens, including when the answer is "nothing much". A
+     * square in the middle of a fortnight nobody was active in fills and joins
+     * no streak, and saying so is worth more than the sale.
+     */
+    const label = dayLabel(cell.day, new Date(`${today}T12:00:00`))
+    const streakLine = effect.changesStreak
+      ? `Your streak goes from ${effect.streakBefore} to ${effect.streakAfter} days.`
+      : 'It fills the square, but does not change your streak.'
+    const confirmed = await confirmAlert({
+      title: `Fill in ${label}?`,
+      message: `${streakLine}\nYour balance goes ${wallet.data?.balance ?? 0} → ${effect.balanceAfter}.`,
+      confirmLabel: 'Fill it in',
+    })
+    if (!confirmed) return
+
+    repair.mutate(cell.day, {
+      onSuccess: () => showToast('Day filled in'),
+      onError: () => void showAlert('Could not fill that day', 'Try again in a moment.'),
+    })
+  }
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.head}>
+        <Text style={styles.title}>Activity</Text>
+        <Text style={styles.hint}>
+          {left > 0
+            ? `${left} of ${rules.perMonth} repairs left · ${rules.price} tokens`
+            : 'No repairs left this month'}
+        </Text>
+      </View>
+
+      {/* Ends on today, so the newest week is what you see first. */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.grid}
+      >
+        {columns.map((column) => (
+          <View key={column[0]?.day} style={styles.column}>
+            {column.map((cell) => (
+              <Pressable
+                key={cell.day}
+                accessibilityRole={cell.state === 'repairable' ? 'button' : undefined}
+                accessibilityLabel={cell.state === 'repairable' ? `Fill in ${cell.day}` : undefined}
+                disabled={cell.state !== 'repairable'}
+                onPress={() => void onPressDay(cell)}
+                style={[
+                  styles.cell,
+                  cell.state === 'future' && styles.future,
+                  cell.state === 'repairable' && styles.repairable,
+                  cell.intensity > 0 && {
+                    backgroundColor: colors.streak,
+                    opacity: 0.25 + cell.intensity * 0.1875,
+                  },
+                ]}
+              />
+            ))}
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, spacing }) => ({
+  loading: { paddingVertical: spacing.lg },
+  wrap: { gap: spacing.sm },
+  head: { alignItems: 'baseline', flexDirection: 'row', justifyContent: 'space-between' },
+  title: { ...font.heading, color: colors.text, fontSize: 15 },
+  hint: { ...font.caption, color: colors.textMuted },
+  grid: { flexDirection: 'row', gap: 3, paddingVertical: spacing.xs },
+  column: { gap: 3 },
+  cell: { backgroundColor: colors.surface, borderRadius: 3, height: 13, width: 13 },
+  // Drawn as a gap rather than a square: a day that has not happened is not an
+  // empty day.
+  future: { backgroundColor: 'transparent' },
+  repairable: { borderColor: colors.border, borderStyle: 'dashed', borderWidth: 1 },
+}))

--- a/apps/mobile/src/components/ActivityMap.tsx
+++ b/apps/mobile/src/components/ActivityMap.tsx
@@ -1,5 +1,5 @@
 import { shiftDayKey } from '@langx/shared'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native'
 import { useActivity, useRepairDay, useWallet } from '../api/queries'
 import { activityGrid, repairEffect, type ActivityCell } from '../lib/activityMap'
@@ -29,6 +29,7 @@ export function ActivityMap() {
   const activity = useActivity(from, to)
   const wallet = useWallet()
   const repair = useRepairDay()
+  const scroller = useRef<ScrollView>(null)
 
   const columns = useMemo(() => {
     if (!activity.data) return []
@@ -103,11 +104,18 @@ export function ActivityMap() {
         </Text>
       </View>
 
-      {/* Ends on today, so the newest week is what you see first. */}
+      {/*
+        Opened at the far end, because the grid runs oldest-first and the newest
+        week is the one worth seeing. Left alone it opens on six months ago,
+        which is a calendar of nothing. `onContentSizeChange` rather than an
+        effect: the offset only means anything once the columns have a width.
+      */}
       <ScrollView
+        ref={scroller}
         horizontal
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.grid}
+        onContentSizeChange={() => scroller.current?.scrollToEnd({ animated: false })}
       >
         {columns.map((column) => (
           <View key={column[0]?.day} style={styles.column}>
@@ -144,7 +152,13 @@ const useStyles = makeStyles(({ colors, font, spacing }) => ({
   hint: { ...font.caption, color: colors.textMuted },
   grid: { flexDirection: 'row', gap: 3, paddingVertical: spacing.xs },
   column: { gap: 3 },
-  cell: { backgroundColor: colors.surface, borderRadius: 3, height: 13, width: 13 },
+  /**
+   * `border`, not `surface`. The map sits on a card whose own background is
+   * `surface`, so an empty square drawn in it disappears — and a calendar
+   * whose empty days are invisible is not a calendar, it is a scatter of dots.
+   * The gaps are half of what the grid is for.
+   */
+  cell: { backgroundColor: colors.border, borderRadius: 3, height: 13, width: 13 },
   // Drawn as a gap rather than a square: a day that has not happened is not an
   // empty day.
   future: { backgroundColor: 'transparent' },

--- a/apps/mobile/src/lib/activityMap.test.ts
+++ b/apps/mobile/src/lib/activityMap.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { activityGrid, repairEffect } from './activityMap'
+
+// A Saturday, so the "today is not the end of the column" case is the default.
+const TODAY = '2026-08-29'
+
+const grid = (overrides: Partial<Parameters<typeof activityGrid>[0]> = {}) =>
+  activityGrid({ today: TODAY, weeks: 4, days: new Map(), maxAgeDays: 14, ...overrides })
+
+const flat = (columns: ReturnType<typeof activityGrid>) => columns.flat()
+const cell = (columns: ReturnType<typeof activityGrid>, day: string) =>
+  flat(columns).find((c) => c.day === day)
+
+describe('activityGrid', () => {
+  it('is seven rows by as many weeks as asked for', () => {
+    const columns = grid({ weeks: 26 })
+    expect(columns).toHaveLength(26)
+    expect(columns.every((column) => column.length === 7)).toBe(true)
+  })
+
+  /** Monday at the top: every column has to start on the same weekday. */
+  it('starts every column on a Monday', () => {
+    for (const column of grid()) {
+      expect(new Date(`${column[0]!.day}T00:00:00`).getDay()).toBe(1)
+    }
+  })
+
+  it('includes today, in the last column', () => {
+    const columns = grid()
+    expect(columns.at(-1)?.some((c) => c.day === TODAY)).toBe(true)
+  })
+
+  it('marks the rest of this week as future rather than empty', () => {
+    const columns = grid()
+    expect(cell(columns, '2026-08-30')?.state).toBe('future')
+    expect(cell(columns, TODAY)?.state).not.toBe('future')
+  })
+
+  it('shades a filled day by how busy it was', () => {
+    const columns = grid({
+      days: new Map([
+        ['2026-08-28', 1],
+        ['2026-08-27', 5],
+        ['2026-08-26', 12],
+        ['2026-08-25', 40],
+      ]),
+    })
+    expect(cell(columns, '2026-08-28')?.intensity).toBe(1)
+    expect(cell(columns, '2026-08-27')?.intensity).toBe(2)
+    expect(cell(columns, '2026-08-26')?.intensity).toBe(3)
+    expect(cell(columns, '2026-08-25')?.intensity).toBe(4)
+  })
+
+  /** A bought day is present with no actions, and still reads as filled. */
+  it('treats a day with zero actions as filled, not empty', () => {
+    const columns = grid({ days: new Map([['2026-08-28', 0]]) })
+    expect(cell(columns, '2026-08-28')?.state).toBe('filled')
+    expect(cell(columns, '2026-08-28')?.intensity).toBe(1)
+  })
+
+  it('offers only the empty days inside the window', () => {
+    const columns = grid({ weeks: 6 })
+    expect(cell(columns, '2026-08-28')?.state).toBe('repairable')
+    expect(cell(columns, '2026-08-15')?.state).toBe('repairable')
+    expect(cell(columns, '2026-08-14')?.state).toBe('empty')
+  })
+
+  /** Today is earned, not bought — even though it is empty and in the window. */
+  it('never offers today', () => {
+    expect(cell(grid(), TODAY)?.state).toBe('empty')
+  })
+})
+
+describe('repairEffect', () => {
+  const filled = new Set(['2026-08-29', '2026-08-28', '2026-08-26', '2026-08-25'])
+
+  it('reports the streak the purchase would join', () => {
+    const effect = repairEffect({
+      day: '2026-08-27',
+      today: TODAY,
+      filled,
+      price: 300,
+      balance: 500,
+    })
+    expect(effect.streakBefore).toBe(2)
+    expect(effect.streakAfter).toBe(5)
+    expect(effect.changesStreak).toBe(true)
+    expect(effect.balanceAfter).toBe(200)
+  })
+
+  /**
+   * The honest case. A square in the middle of a fortnight nobody was active in
+   * fills and changes nothing, and the confirmation has to say so rather than
+   * letting the price imply otherwise.
+   */
+  it('says plainly when a square joins nothing', () => {
+    const effect = repairEffect({
+      day: '2026-08-10',
+      today: TODAY,
+      filled,
+      price: 300,
+      balance: 500,
+    })
+    expect(effect.changesStreak).toBe(false)
+    expect(effect.streakAfter).toBe(effect.streakBefore)
+  })
+
+  it('knows when it cannot be afforded', () => {
+    const effect = repairEffect({
+      day: '2026-08-27',
+      today: TODAY,
+      filled,
+      price: 300,
+      balance: 250,
+    })
+    expect(effect.affordable).toBe(false)
+    expect(effect.balanceAfter).toBe(-50)
+  })
+})

--- a/apps/mobile/src/lib/activityMap.ts
+++ b/apps/mobile/src/lib/activityMap.ts
@@ -1,0 +1,115 @@
+import { shiftDayKey, streakFromDays } from '@langx/shared'
+
+export type Intensity = 0 | 1 | 2 | 3 | 4
+
+export interface ActivityCell {
+  day: string
+  /** 0 is an empty square; 1–4 shade a filled one. */
+  intensity: Intensity
+  /** `future` squares are drawn as gaps, `repairable` ones are tappable. */
+  state: 'filled' | 'empty' | 'repairable' | 'future'
+}
+
+/**
+ * Seven rows by N columns, Monday at the top and ending on the week that holds
+ * today — a calendar, not a timeline, which is the whole point of the shape: a
+ * gap on the same row every week says something a flat run of squares cannot.
+ *
+ * Pure, so the two things that are easy to get wrong and invisible in a
+ * screenshot — which square is today, and which ones can still be bought — are
+ * testable without a renderer.
+ */
+export function activityGrid(input: {
+  today: string
+  weeks: number
+  /** Day → qualifying actions. A bought day is present with zero. */
+  days: Map<string, number>
+  maxAgeDays: number
+}): ActivityCell[][] {
+  const { today, weeks, days, maxAgeDays } = input
+  const oldestRepairable = shiftDayKey(today, -maxAgeDays)
+
+  // Wind forward to the Sunday that closes today's week, so the last column is
+  // a whole week and today sits on its own weekday row.
+  const end = shiftDayKey(today, 6 - mondayIndex(today))
+  const start = shiftDayKey(end, -(weeks * 7 - 1))
+
+  const columns: ActivityCell[][] = []
+  let day = start
+  for (let column = 0; column < weeks; column++) {
+    const cells: ActivityCell[] = []
+    for (let row = 0; row < 7; row++) {
+      const actions = days.get(day)
+      const filled = actions !== undefined
+      cells.push({
+        day,
+        intensity: filled ? intensityOf(actions) : 0,
+        state:
+          day > today
+            ? 'future'
+            : filled
+              ? 'filled'
+              : // Today is earned rather than bought, so it is never repairable
+                // even though it is empty and inside the window.
+                day < today && day >= oldestRepairable
+                ? 'repairable'
+                : 'empty',
+      })
+      day = shiftDayKey(day, 1)
+    }
+    columns.push(cells)
+  }
+  return columns
+}
+
+export interface RepairEffect {
+  streakBefore: number
+  streakAfter: number
+  balanceAfter: number
+  /** False when the square fills but joins nothing — said plainly rather than implied. */
+  changesStreak: boolean
+  affordable: boolean
+}
+
+/**
+ * What buying this square will actually do, worked out before it is bought.
+ *
+ * The honest case is the one worth having: a square in the middle of a fortnight
+ * nobody was active in fills in and changes no streak at all, and the
+ * confirmation says so rather than letting the price imply otherwise.
+ */
+export function repairEffect(input: {
+  day: string
+  today: string
+  filled: Set<string>
+  price: number
+  balance: number
+}): RepairEffect {
+  const { day, today, filled, price, balance } = input
+  const streakBefore = streakFromDays(filled, today)
+  const streakAfter = streakFromDays(new Set([...filled, day]), today)
+
+  return {
+    streakBefore,
+    streakAfter,
+    balanceAfter: balance - price,
+    changesStreak: streakAfter !== streakBefore,
+    affordable: balance >= price,
+  }
+}
+
+/** Monday-first weekday index for a `YYYY-MM-DD` key. */
+function mondayIndex(day: string): number {
+  return (new Date(`${day}T00:00:00`).getDay() + 6) % 7
+}
+
+/**
+ * Four buckets, matching the server's. Thresholds rather than a scale so one
+ * very loud day cannot flatten a year of ordinary ones into the palest shade.
+ */
+function intensityOf(actions: number): Intensity {
+  if (actions >= 30) return 4
+  if (actions >= 10) return 3
+  if (actions >= 3) return 2
+  return 1
+}

--- a/docs/legal/promise-change.md
+++ b/docs/legal/promise-change.md
@@ -36,7 +36,8 @@ the whole message.
 v1 shipped a token with wallets, a token leaderboard, and a litepaper
 describing something tradable, staked and eventually listed. **The name stays.
 The trading does not.** LangX Token in v2 is an in-app point: earned by
-practising and teaching, spent on a streak freeze and cosmetics, and nothing
+practising and teaching, spent on a streak freeze, on filling in a missed day,
+and on cosmetics, and nothing
 else. It cannot be bought, sold, traded, staked, withdrawn or transferred, and
 it can never unlock a Pro feature — the moment it could, farming tokens would
 become a substitute for subscribing, and the subscription is what funds the app.
@@ -82,8 +83,9 @@ Replace "free forever" with something that is true and still generous:
 And for the token section:
 
 > **Earn tokens by practising — and by teaching.** Correcting someone else's
-> sentence is worth more than sending one. Spend them on a streak freeze or on
-> cosmetics for your profile. LangX Token is an in-app point: it cannot be
+> sentence is worth more than sending one. Spend them on a streak freeze, on
+> filling in a day you missed, or on cosmetics for your profile. LangX Token is
+> an in-app point: it cannot be
 > bought, sold, traded or withdrawn, and it never will be.
 
 ### Terms — clauses that must change
@@ -92,7 +94,7 @@ And for the token section:
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Pricing          | Add the subscription, the free-tier limits, and that they are per rolling 24 hours (not per calendar day)                                                                                                      |
 | Token            | Redefine it: an in-app point with no cash value. Non-transferable, cannot be purchased, sold, traded, staked or withdrawn. State that v1 balances carry over at 1:100 and that nothing is redeemable for money |
-| Virtual items    | Cover the streak freeze and cosmetics; forfeited on account deletion                                                                                                                                           |
+| Virtual items    | Cover the streak freeze, filled-in activity days and cosmetics; forfeited on account deletion                                                                                                                  |
 | Account deletion | 30-day grace period, then permanent. Messages you sent stay in the other person's conversation with their content removed                                                                                      |
 | Minimum age      | 18+, enforced at profile creation                                                                                                                                                                              |
 

--- a/docs/token-messaging-brief.md
+++ b/docs/token-messaging-brief.md
@@ -63,8 +63,9 @@ that damages trust.
   what keeps it worth watching.
 - Keep a daily streak; hitting 7, 30, 100 and 365 days pays a bonus.
 - Weekly, monthly, yearly and all-time leaderboards.
-- Spend tokens on a **streak freeze** (rescues one missed day) and on
-  **cosmetic frames and titles**. That is the complete list of things to spend
+- Spend tokens on a **streak freeze** (rescues one missed day), on **filling in
+  a missed day** on your activity map (300 tokens, last 14 days, two a month),
+  and on **cosmetic frames and titles**. That is the complete list of things to spend
   on, and it is complete on purpose: if tokens could buy a Pro feature, farming
   tokens would become a substitute for subscribing.
 

--- a/packages/shared/src/profile.ts
+++ b/packages/shared/src/profile.ts
@@ -138,7 +138,18 @@ export const updateProfileSchema = z
      * the second key landed. See `updateProfile` — a partial `privacy` also
      * has to be written as dotted paths, or the `$set` drops the other flag.
      */
-    privacy: z.object({ incognito: z.boolean(), hideOnlineStatus: z.boolean() }).partial(),
+    privacy: z
+      .object({
+        incognito: z.boolean(),
+        hideOnlineStatus: z.boolean(),
+        /**
+         * The activity map on a public profile. Default on, because the streak
+         * it is drawn from is already public — and free, unlike the two above:
+         * this one is not a Pro feature, it is a preference.
+         */
+        activityMapVisible: z.boolean(),
+      })
+      .partial(),
   })
   .partial()
   .refine(

--- a/packages/shared/src/token.ts
+++ b/packages/shared/src/token.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { walletSchema } from './cosmetics'
+import { shiftDayKey } from './periods'
 
 /**
  * The token is a point, not a currency. It cannot be traded, withdrawn or
@@ -122,6 +123,25 @@ export interface TokenRules {
      */
     streakRestorePerDay: number
     streakRestoreMax: number
+    /**
+     * Price to fill in one missed day on the activity map.
+     *
+     * Dearer than a freeze, which is the point of the pair: a freeze is bought
+     * ahead of a day you might miss and costs you the foresight; a repair is
+     * bought after one you did miss and costs nothing but tokens. Pricing the
+     * retrospective one lower would make the freeze pointless.
+     */
+    dayRepair: number
+    /** How far back a day can still be repaired. */
+    dayRepairMaxAgeDays: number
+    /**
+     * Repairs allowed per calendar month.
+     *
+     * The cap, not the price, is what stops a balance buying a streak
+     * outright: at two a month even a rich account cannot manufacture a run it
+     * did not live, and the streak keeps meaning what it says.
+     */
+    dayRepairPerMonth: number
   }
   /**
    * v1 token balances are credited to **earned** token, divided by this.
@@ -196,6 +216,9 @@ export const TOKEN_RULES: TokenRules = {
     maxBankedStreakFreezes: 2,
     streakRestorePerDay: 20,
     streakRestoreMax: 2000,
+    dayRepair: 300,
+    dayRepairMaxAgeDays: 14,
+    dayRepairPerMonth: 2,
   },
   legacyTokenDivisor: 100,
   welcomeBackBonus: 250,
@@ -324,4 +347,43 @@ export function streakRestorePrice(frozenStreak: number, rules = TOKEN_RULES): n
     rules.sinks.streakRestoreMax,
     Math.ceil(frozenStreak) * rules.sinks.streakRestorePerDay,
   )
+}
+
+/** `GET /me/activity` — an inclusive local-day range. */
+export const activityRangeSchema = z.object({
+  from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+})
+
+/**
+ * `POST /me/activity/repair`.
+ *
+ * The day is in the body rather than the path, matching `/me/wallet/purchase`:
+ * path params are not zod-validated anywhere in this API, and a spend is not
+ * the place to start trusting one.
+ */
+export const repairDaySchema = z.object({
+  day: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+})
+
+/**
+ * The streak that a set of filled days implies, counting back from today.
+ *
+ * In shared because both sides need the same answer for different reasons: the
+ * server writes it after a repair, and the client has to *predict* it before
+ * one, to say what the purchase will do. Two implementations of this would be
+ * two different promises.
+ *
+ * Yesterday is where an unfinished today starts from — a user who has not sent
+ * anything yet today still has the run that ended yesterday.
+ */
+export function streakFromDays(days: Set<string>, today: string): number {
+  let cursor = days.has(today) ? today : shiftDayKey(today, -1)
+  if (!days.has(cursor)) return 0
+  let length = 0
+  while (days.has(cursor)) {
+    length++
+    cursor = shiftDayKey(cursor, -1)
+  }
+  return length
 }


### PR DESCRIPTION
Stacked on #974 → #972 → #971 → #970. Last of the five branches from the chat plan.

## The data did not exist

`profile.streak` keeps a number and a `lastQualifiedDay` — everything the streak itself needs, and nothing a calendar can be drawn from. It is also why a repaired day could not have been turned back into a streak length.

`streakDays` is that missing set: one document per user per **local** day, `_id` of `<userId>:<day>`, the same shape `dailyActivity` already uses. That `_id` gives both the uniqueness that makes a day physically impossible to fill twice *and* the prefix range that reads a user's calendar off the primary index — so neither needs an index of its own.

**Shaded from `streakDays`, not `dailyActivity`.** The streak's day is the user's local one and `dailyActivity` counts UTC days. Shading local squares with UTC counts slides the whole map by one for anyone far enough east or west, and then offers to sell them the wrong day. The count is incremented *before* `recordQualifyingAction`'s early return, because stopping on the day's second message would leave every day looking equally busy.

## Repair is two writes in two collections

There is no single atomic update to lean on the way a cosmetic purchase has — the money is on `profiles.tokenSpent`, the day is a `streakDays` document. The order is what makes it safe:

1. Insert the day. A duplicate `_id` is a better "already filled" check than a read could ever be.
2. Charge, with the same `$expr` balance guard `purchase` uses.
3. Delete the day again if the charge fails.

The reverse order could take the tokens and not fill the square, which is the failure worth designing against. There is a test that funds an account with 10 tokens and asserts the square does not survive.

The streak is **recomputed by walking the days**, not incremented: a repair can join two runs that were never adjacent while they were being lived, and only a walk knows the new length. It writes a `spend` row and leaves `tokenAggregates` alone, so filling a day cannot cost anyone their rank.

Priced at **300** against the freeze's 200, and that ordering is the point of the pair: a freeze is bought ahead of a day you might miss and costs you foresight; a repair after one you did, and costs only tokens. **Two a month** — and it is the cap, not the price, that stops a balance manufacturing a streak nobody lived.

## The confirmation is the feature

It says what the purchase does *before* it happens, including when the answer is "not much": a square in the middle of a fortnight nobody was active in fills and joins no streak, and it says so plainly rather than letting the price imply otherwise.

`streakFromDays` moved into `@langx/shared` for this. The client has to predict exactly the number the server will write, and two implementations of that walk would be two different promises.

## Privacy

Someone else's map shows shape and shading but never counts, and never which squares were bought — with a test asserting the response body contains neither the action count nor the word `purchase`. It is a separate endpoint rather than a field on the public profile: `toPublicProfile` is an allow-list, a range query does not belong in it, and this way the flag is checked in one place.

`activityMapVisible` defaults **on** and is **free**, unlike the two Pro rows beside it in settings — the streak it is drawn from is already public, so hiding the squares is a preference, not a feature.

## Claims

`docs/token-messaging-brief.md` says its spend list is "the complete list", which is only true if it is complete, and the Terms virtual-items clause in `docs/legal/promise-change.md` has to cover a filled-in day or the thing being sold is not in the contract. Both updated here.

**Two hand-kept mirrors follow in their own repositories** — `website/src/lib/data/token.ts` and the GitBook pages under `docs/`. Nothing checks that they agree with this, which is exactly why they are listed in `REPO_MAP.md`.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — 721 tests, 32 new.

New coverage: a sent message recording its day and counting the ones after it; a repair joining two runs and rewriting the streak; the leaderboard aggregates untouched; today, an out-of-window day and an already-filled day all refused; the monthly cap holding against a 100,000-token balance; the day handed back when the charge fails; another person's map showing shape but no counts; and the map hidden when its owner turns it off. Plus 21 pure cases for the day walk, the repair window, the grid and the effect text.

Not yet driven in a browser; the hands-on pass lands with the rest of the chat work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)