### PR TITLE
Swipe to reply on a touchscreen, and diff the correction

### DIFF
--- a/apps/mobile/src/components/MessageBubble.tsx
+++ b/apps/mobile/src/components/MessageBubble.tsx
@@ -1,13 +1,37 @@
 import Feather from '@expo/vector-icons/Feather'
-import { memo, useMemo, useRef } from 'react'
-import { Animated, PanResponder, Platform, Pressable, StyleSheet, Text, View } from 'react-native'
+import { memo, useMemo, useRef, type ReactNode } from 'react'
+import {
+  Animated,
+  PanResponder,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type ViewStyle,
+} from 'react-native'
 import type { MessageDto } from '../api/queries'
+import { diffCorrection } from '../lib/correctionDiff'
 import type { AnchorRect } from '../lib/messageMenu'
-import { shouldCaptureSwipe, swipeReleased, swipeTranslation } from '../lib/swipeToReply'
+import {
+  SWIPE_ACTIVATE_PX,
+  shouldCaptureSwipe,
+  swipeReleased,
+  swipeToReplyEnabled,
+  swipeTranslation,
+} from '../lib/swipeToReply'
 import { makeStyles, useTheme } from '../lib/theme'
 import { AudioBubble, ImageBubble } from './MediaBubble'
 import { MessageMeta } from './MessageMeta'
 import { useT } from '../i18n'
+
+/**
+ * Whether this device has a finger. Read once, at module scope: it cannot
+ * change for the life of the page, and `navigator` is absent while the web
+ * bundle is being exported — hence the `typeof` guard rather than a bare read.
+ */
+const HAS_TOUCH =
+  Platform.OS !== 'web' || (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0)
 
 export interface MessageBubbleProps {
   message: MessageDto
@@ -73,14 +97,17 @@ export const MessageBubble = memo(function MessageBubble({
   }
 
   /**
-   * Swipe right to reply — native only.
+   * Swipe right to reply — wherever there is a finger, which now includes a
+   * phone browser.
    *
-   * Off on web deliberately. react-native-web does map mouse events onto the
-   * responder system, so a drag reaches this, but it fights the browser's own
-   * text selection and a trackpad's horizontal gesture is a `wheel` event that
-   * never arrives here at all. A gesture that works for some inputs and not
-   * others is worse than one that is plainly absent; in a browser the menu's
-   * Reply row is the way in.
+   * Still off for a mouse. react-native-web maps mouse events onto the
+   * responder system, so a drag does reach this, but on a desktop that same
+   * drag is the browser selecting text: which one wins depends on whether the
+   * press landed on a word or on the padding, and a gesture that works from
+   * half of a bubble is worse than one that is plainly absent. There the
+   * menu's Reply row is the way in. `touchAction: 'pan-y'` below is the other
+   * half of making it work on a touchscreen: without it the browser claims the
+   * horizontal pan for its own scrolling before the responder ever sees it.
    */
   const translateX = useRef(new Animated.Value(0)).current
   const responder = useMemo(() => {
@@ -101,8 +128,46 @@ export const MessageBubble = memo(function MessageBubble({
     })
   }, [message, onReply, translateX])
 
-  const pan = Platform.OS === 'web' ? {} : responder.panHandlers
+  const pan = swipeToReplyEnabled(Platform.OS, HAS_TOUCH) ? responder.panHandlers : {}
   const flash = highlighted ? styles.highlighted : null
+
+  /**
+   * What the correction actually changed, worked out once per message rather
+   * than per render — the memo is the reason this bubble can stay `memo`'d at
+   * all while the screen re-renders on every keystroke in the composer.
+   */
+  const correction = message.correction
+  const diff = useMemo(
+    () => (correction ? diffCorrection(correction.original, message.body) : null),
+    [correction, message.body],
+  )
+
+  /**
+   * The arrow WhatsApp shows under the bubble as it slides. Driven by the same
+   * `Animated.Value` as the bubble, so it fades in exactly as far as the
+   * gesture has travelled and reaches full strength at the point where letting
+   * go actually replies.
+   */
+  const arrowOpacity = translateX.interpolate({
+    inputRange: [0, SWIPE_ACTIVATE_PX],
+    outputRange: [0, 1],
+    extrapolate: 'clamp',
+  })
+
+  /**
+   * Every branch below is the same shell: the arrow underneath, the bubble on
+   * top of it, and the pan handlers on the part that moves.
+   */
+  const shell = (children: ReactNode): ReactNode => (
+    <View style={styles.row}>
+      <Animated.View style={[styles.arrow, { opacity: arrowOpacity }]} pointerEvents="none">
+        <Feather name="corner-up-left" size={15} color={colors.textMuted} />
+      </Animated.View>
+      <Animated.View ref={box} style={styles.slider} {...pan}>
+        <Animated.View style={{ transform: [{ translateX }] }}>{children}</Animated.View>
+      </Animated.View>
+    </View>
+  )
 
   /**
    * Counts, not avatars: a 1-1 thread has at most two people on an emoji, so
@@ -145,113 +210,142 @@ export const MessageBubble = memo(function MessageBubble({
    * the other person remembers having, which is worse than an obvious hole.
    */
   if (message.deleted) {
-    return (
-      <Animated.View ref={box} style={{ transform: [{ translateX }] }} {...pan}>
-        <Pressable
-          onLongPress={press}
-          style={[styles.bubble, mine ? styles.mine : styles.theirs, styles.tombstone, flash]}
-        >
-          <View style={styles.tombstoneRow}>
-            <Feather name="slash" size={13} color={colors.textMuted} />
-            <Text style={styles.tombstoneText}>{t('chat.deleted')}</Text>
-          </View>
-          <MessageMeta message={message} mine={mine} />
-        </Pressable>
-      </Animated.View>
+    return shell(
+      <Pressable
+        onLongPress={press}
+        style={[styles.bubble, mine ? styles.mine : styles.theirs, styles.tombstone, flash]}
+      >
+        <View style={styles.tombstoneRow}>
+          <Feather name="slash" size={13} color={colors.textMuted} />
+          <Text style={styles.tombstoneText}>{t('chat.deleted')}</Text>
+        </View>
+        <MessageMeta message={message} mine={mine} />
+      </Pressable>,
     )
   }
 
   if (message.type === 'correction') {
-    return (
-      <Animated.View ref={box} style={{ transform: [{ translateX }] }} {...pan}>
-        <Pressable
-          onLongPress={press}
-          style={[styles.correction, mine ? styles.correctionMine : null, flash]}
-        >
-          {/*
+    return shell(
+      <Pressable
+        onLongPress={press}
+        style={[styles.correction, mine ? styles.correctionMine : null, flash]}
+      >
+        {/*
           The success pair, and only ever the success pair. A correction is
           another person changing your sentence; the info pair belongs to
           Copilot, which proposes one you have not sent. The two must never be
           confusable — see `Callout`.
         */}
-          <View style={styles.correctionHead}>
-            <Feather name="edit-3" size={14} color={colors.success} />
-            <Text style={styles.correctionLabel}>
-              {mine ? t('chat.yourCorrection') : t('chat.correctionFrom', { name: partnerName })}
+        <View style={styles.correctionHead}>
+          <Feather name="edit-3" size={14} color={colors.success} />
+          <Text style={styles.correctionLabel}>
+            {mine ? t('chat.yourCorrection') : t('chat.correctionFrom', { name: partnerName })}
+          </Text>
+        </View>
+        <View style={styles.correctionBody}>
+          {/*
+              Only the part that changed carries a colour. Striking the whole
+              sentence says "this was wrong" about one that was mostly right,
+              and buries the one thing the reader opened it for.
+            */}
+          {diff ? (
+            <Text style={styles.correctionOriginal}>
+              {diff.original.map((segment, index) => (
+                <Text key={index} style={segment.changed ? styles.removed : null}>
+                  {segment.text}
+                </Text>
+              ))}
             </Text>
-          </View>
-          <View style={styles.correctionBody}>
-            {message.correction ? (
-              <Text style={styles.correctionOriginal}>{message.correction.original}</Text>
-            ) : null}
-            <Text style={styles.correctionText}>{message.body}</Text>
-            {message.correction?.note ? (
-              <Text style={styles.correctionNote}>{message.correction.note}</Text>
-            ) : null}
-            <MessageMeta message={message} mine={mine} />
-          </View>
-          {badge}
-        </Pressable>
-      </Animated.View>
+          ) : null}
+          <Text style={styles.correctionText}>
+            {diff
+              ? diff.corrected.map((segment, index) => (
+                  <Text key={index} style={segment.changed ? styles.added : null}>
+                    {segment.text}
+                  </Text>
+                ))
+              : message.body}
+          </Text>
+          {message.correction?.note ? (
+            <Text style={styles.correctionNote}>{message.correction.note}</Text>
+          ) : null}
+          <MessageMeta message={message} mine={mine} />
+        </View>
+        {badge}
+      </Pressable>,
     )
   }
 
   const tail = endsGroup ? (mine ? styles.tailMine : styles.tailTheirs) : null
 
   if (message.type === 'image' || message.type === 'audio') {
-    return (
-      <Animated.View ref={box} style={{ transform: [{ translateX }] }} {...pan}>
-        <Pressable
-          onLongPress={press}
-          style={[styles.bubble, mine ? styles.mine : styles.theirs, tail, flash]}
-        >
-          {quote}
-          {message.media ? (
-            message.type === 'image' ? (
-              <ImageBubble media={message.media} />
-            ) : (
-              <AudioBubble media={message.media} mine={mine} />
-            )
-          ) : null}
-          {message.body ? (
-            <Text style={[styles.bubbleText, mine && styles.bubbleTextMine, styles.caption]}>
-              {message.body}
-            </Text>
-          ) : null}
-          <MessageMeta message={message} mine={mine} />
-          {badge}
-        </Pressable>
-      </Animated.View>
-    )
-  }
-
-  return (
-    <Animated.View ref={box} style={{ transform: [{ translateX }] }} {...pan}>
+    return shell(
       <Pressable
         onLongPress={press}
         style={[styles.bubble, mine ? styles.mine : styles.theirs, tail, flash]}
       >
         {quote}
-        <Text style={[styles.bubbleText, mine && styles.bubbleTextMine]}>{message.body}</Text>
-        {translation ? (
-          <Text style={[styles.translation, mine && styles.translationMine]}>{translation}</Text>
+        {message.media ? (
+          message.type === 'image' ? (
+            <ImageBubble media={message.media} />
+          ) : (
+            <AudioBubble media={message.media} mine={mine} />
+          )
         ) : null}
-        {/* The link is gone — translate is a menu row now. This only reports the
-            request already in flight. */}
-        {translating ? <Text style={styles.translateLink}>{t('chat.translating')}</Text> : null}
-        {/* Beside the clock, not in place of it: "when" and "changed since" are
-            two different facts and the reader wants both. */}
-        {message.editedAt ? (
-          <Text style={[styles.edited, mine && styles.editedMine]}>{t('messageMeta.edited')}</Text>
+        {message.body ? (
+          <Text style={[styles.bubbleText, mine && styles.bubbleTextMine, styles.caption]}>
+            {message.body}
+          </Text>
         ) : null}
         <MessageMeta message={message} mine={mine} />
         {badge}
-      </Pressable>
-    </Animated.View>
+      </Pressable>,
+    )
+  }
+
+  return shell(
+    <Pressable
+      onLongPress={press}
+      style={[styles.bubble, mine ? styles.mine : styles.theirs, tail, flash]}
+    >
+      {quote}
+      <Text style={[styles.bubbleText, mine && styles.bubbleTextMine]}>{message.body}</Text>
+      {translation ? (
+        <Text style={[styles.translation, mine && styles.translationMine]}>{translation}</Text>
+      ) : null}
+      {/* The link is gone — translate is a menu row now. This only reports the
+            request already in flight. */}
+      {translating ? <Text style={styles.translateLink}>{t('chat.translating')}</Text> : null}
+      {/* Beside the clock, not in place of it: "when" and "changed since" are
+            two different facts and the reader wants both. */}
+      {message.editedAt ? (
+        <Text style={[styles.edited, mine && styles.editedMine]}>{t('messageMeta.edited')}</Text>
+      ) : null}
+      <MessageMeta message={message} mine={mine} />
+      {badge}
+    </Pressable>,
   )
 })
 
 const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => ({
+  row: { justifyContent: 'center' },
+  /**
+   * `touch-action` is a web-only style and react-native's types do not know
+   * it, hence the cast. Without it a horizontal drag is claimed by the browser
+   * for its own scrolling — and on iOS Safari by the back gesture — before the
+   * responder system ever sees the move.
+   */
+  slider: (Platform.OS === 'web' ? { touchAction: 'pan-y' } : {}) as ViewStyle,
+  /** Under the bubble, on the side it is dragged away from. */
+  arrow: {
+    alignItems: 'center',
+    bottom: 0,
+    justifyContent: 'center',
+    position: 'absolute',
+    start: 6,
+    top: 0,
+    width: 24,
+  },
   bubble: {
     borderRadius: radius.lg,
     maxWidth: '82%',
@@ -368,8 +462,15 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
     color: colors.textMuted,
     fontWeight: '400',
     lineHeight: 21,
-    textDecorationLine: 'line-through',
   },
+  /**
+   * The pair that carries the whole meaning of the card: what went, and what
+   * came. Both are marked twice — colour *and* a second cue, strike or weight
+   * — because a correction that only differs by hue says nothing to a reader
+   * who cannot separate red from green.
+   */
+  removed: { color: colors.danger, textDecorationLine: 'line-through' },
+  added: { color: colors.success, fontWeight: '700' },
   correctionText: {
     ...font.body,
     color: colors.text,

--- a/apps/mobile/src/lib/correctionDiff.test.ts
+++ b/apps/mobile/src/lib/correctionDiff.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { diffCorrection, type DiffSegment } from './correctionDiff'
+
+const join = (segments: DiffSegment[]): string => segments.map((s) => s.text).join('')
+const changed = (segments: DiffSegment[]): string[] =>
+  segments.filter((s) => s.changed).map((s) => s.text)
+
+describe('diffCorrection', () => {
+  it('marks only the word that was replaced', () => {
+    const diff = diffCorrection('I go to school yesterday', 'I went to school yesterday')
+    expect(changed(diff.original)).toEqual(['go'])
+    expect(changed(diff.corrected)).toEqual(['went'])
+  })
+
+  it('marks an inserted word on the corrected side only', () => {
+    const diff = diffCorrection('I going home', 'I am going home')
+    expect(changed(diff.original)).toEqual([])
+    expect(changed(diff.corrected)).toEqual(['am'])
+  })
+
+  it('marks a removed word on the original side only', () => {
+    const diff = diffCorrection('I did not went there', 'I did not go there')
+    expect(changed(diff.original)).toEqual(['went'])
+    expect(changed(diff.corrected)).toEqual(['go'])
+  })
+
+  it('keeps two separate changes separate rather than merging the span between them', () => {
+    const diff = diffCorrection(
+      'she have a car and he have a bike',
+      'she has a car and he has a bike',
+    )
+    // `have` → `has` shares `ha`, so the character pass narrows both of them.
+    expect(changed(diff.original)).toEqual(['ve', 've'])
+    expect(changed(diff.corrected)).toEqual(['s', 's'])
+    expect(join(diff.original)).toBe('she have a car and he have a bike')
+  })
+
+  /**
+   * The Turkish case, and the reason the character pass exists: the mistake is
+   * a suffix, and colouring the whole word would hide which part of it moved.
+   */
+  it('narrows a one-word swap to the letters that differ', () => {
+    const diff = diffCorrection('yarın okula gidiyom', 'yarın okula gidiyorum')
+    expect(changed(diff.original)).toEqual([])
+    expect(changed(diff.corrected)).toEqual(['ru'])
+    expect(join(diff.corrected)).toBe('yarın okula gidiyorum')
+  })
+
+  it('narrows a punctuation fix to the punctuation', () => {
+    const diff = diffCorrection('thanks a lot', 'thanks a lot!')
+    expect(changed(diff.original)).toEqual([])
+    expect(changed(diff.corrected)).toEqual(['!'])
+  })
+
+  it('keeps two genuinely different words whole rather than splitting letters', () => {
+    const diff = diffCorrection('a big house', 'a large house')
+    expect(changed(diff.original)).toEqual(['big'])
+    expect(changed(diff.corrected)).toEqual(['large'])
+  })
+
+  /**
+   * Chinese and Japanese arrive as one token per side, so the word pass has
+   * nothing to align — the character pass is the only one that can say
+   * anything, and it does.
+   */
+  it('says something useful about text written without spaces', () => {
+    const diff = diffCorrection('我昨天去学校', '我昨天去了学校')
+    expect(changed(diff.original)).toEqual([])
+    expect(changed(diff.corrected)).toEqual(['了'])
+  })
+
+  it('leaves an unchanged sentence unmarked', () => {
+    const diff = diffCorrection('all good here', 'all good here')
+    expect(changed(diff.original)).toEqual([])
+    expect(changed(diff.corrected)).toEqual([])
+    expect(join(diff.original)).toBe('all good here')
+  })
+
+  it('never strikes the whitespace after a changed word', () => {
+    const diff = diffCorrection('I go home', 'I run home')
+    for (const segment of [...diff.original, ...diff.corrected]) {
+      if (segment.changed) expect(segment.text).toBe(segment.text.trim())
+    }
+  })
+
+  /**
+   * The invariant everything else rests on: whatever the diff decides, the
+   * pieces still spell the two sentences. A bug here would silently drop a
+   * word from a message on screen.
+   */
+  it.each([
+    ['I go to school yesterday', 'I went to school yesterday'],
+    ['  leading and trailing  ', 'leading and trailing'],
+    ['line one\nline two', 'line   one\nline two!'],
+    ['', 'a whole sentence appeared'],
+    ['everything was deleted', ''],
+    ['我昨天去学校', '我昨天去了学校'],
+    ['one', 'completely different words entirely'],
+  ])('joins back to exactly what went in: %j → %j', (original, corrected) => {
+    const diff = diffCorrection(original, corrected)
+    expect(join(diff.original)).toBe(original)
+    expect(join(diff.corrected)).toBe(corrected)
+  })
+
+  it('gives up on pathological input rather than building a huge table', () => {
+    const long = Array.from({ length: 800 }, (_, i) => `w${i}`).join(' ')
+    const diff = diffCorrection(long, `${long} more`)
+    expect(diff.original).toHaveLength(1)
+    expect(diff.corrected).toHaveLength(1)
+    expect(join(diff.corrected)).toBe(`${long} more`)
+  })
+})

--- a/apps/mobile/src/lib/correctionDiff.ts
+++ b/apps/mobile/src/lib/correctionDiff.ts
@@ -1,0 +1,232 @@
+/**
+ * What actually changed between a sentence and its correction.
+ *
+ * The old shape struck the whole original through, which says "this was wrong"
+ * about a sentence that was mostly right — and hides the one thing the reader
+ * is there for, which is *what* was wrong. So: a word-level diff, drawn as two
+ * lines where only the differing parts carry a colour.
+ *
+ * Pure and free of `react-native`, so vitest can load it (see
+ * `vitest.config.ts` and the mobile test notes) and so the two things that are
+ * easy to get wrong — which words moved, and whether the pieces still add up
+ * to the original text — are testable without a renderer.
+ */
+
+/** A run of text drawn as one `<Text>`. `changed` is the coloured half. */
+export interface DiffSegment {
+  text: string
+  changed: boolean
+}
+
+export interface CorrectionDiff {
+  /** Segments that join back to exactly the original string. */
+  original: DiffSegment[]
+  /** Segments that join back to exactly the corrected string. */
+  corrected: DiffSegment[]
+}
+
+/**
+ * Past this many tokens a side, the diff is dropped and each line is drawn
+ * whole. The quadratic table is bounded by the 2000-character message limit,
+ * but a message that is 2000 single characters is both pathological and
+ * illegible as a diff — one changed run over the lot says as much.
+ */
+const MAX_TOKENS = 600
+
+/**
+ * How long a replaced pair may be before the character-level pass gives up.
+ * The pass exists for `gidiyom → gidiyorum` and for a missing comma; running
+ * it on two long sentences that happen to align 1:1 buys nothing and costs the
+ * square of their length.
+ */
+const MAX_REFINE_CHARS = 120
+
+export function diffCorrection(original: string, corrected: string): CorrectionDiff {
+  if (original === corrected) {
+    return { original: whole(original), corrected: whole(corrected) }
+  }
+
+  const a = tokenize(original)
+  const b = tokenize(corrected)
+  if (a.length > MAX_TOKENS || b.length > MAX_TOKENS) {
+    return {
+      original: [{ text: original, changed: true }],
+      corrected: [{ text: corrected, changed: true }],
+    }
+  }
+
+  const left: DiffSegment[] = []
+  const right: DiffSegment[] = []
+
+  for (const block of blocks(a, b)) {
+    if (block.same) {
+      // Pushed per side rather than once: two tokens are "the same" when their
+      // words match, and one of them may still carry a newline the other does
+      // not. Sharing the text here would move that newline to the wrong line.
+      push(left, block.a.join(''), false)
+      push(right, block.b.join(''), false)
+      continue
+    }
+
+    if (refine(block, left, right)) continue
+
+    pushRun(left, block.a)
+    pushRun(right, block.b)
+  }
+
+  return { original: left, corrected: right }
+}
+
+/** One aligned stretch: either equal on both sides, or a replacement. */
+interface Block {
+  same: boolean
+  a: string[]
+  b: string[]
+}
+
+/**
+ * A word plus whatever whitespace follows it, so the tokens of a string join
+ * back to that exact string — the invariant the whole file rests on. Leading
+ * whitespace rides on the first token for the same reason.
+ */
+function tokenize(text: string): string[] {
+  const tokens = text.match(/\s*\S+\s*/g)
+  if (tokens) return tokens
+  return text.length > 0 ? [text] : []
+}
+
+/** The word inside a token, without the whitespace that surrounds it. */
+function word(token: string): string {
+  return token.trim()
+}
+
+function whole(text: string): DiffSegment[] {
+  return text.length > 0 ? [{ text, changed: false }] : []
+}
+
+/** Appends, merging into the previous segment when it is the same kind. */
+function push(into: DiffSegment[], text: string, changed: boolean): void {
+  if (text.length === 0) return
+  const last = into[into.length - 1]
+  if (last && last.changed === changed) last.text += text
+  else into.push({ text, changed })
+}
+
+/**
+ * A changed run, with its trailing whitespace left out of the colour: a strike
+ * through the space after a word reads as a strike through the gap between two
+ * sentences, which is not what was deleted.
+ */
+function pushRun(into: DiffSegment[], tokens: string[]): void {
+  if (tokens.length === 0) return
+  const text = tokens.join('')
+  const trimmed = text.trimEnd()
+  push(into, trimmed, true)
+  push(into, text.slice(trimmed.length), false)
+}
+
+/**
+ * One word swapped for one word: mark only the letters that differ.
+ *
+ * This is the case Turkish spends most of its time in — a correction is
+ * usually a suffix (`gidiyom` → `gidiyorum`), and colouring the whole word
+ * hides which part of it was the mistake. It is also what makes the diff
+ * useful for languages written without spaces, where the tokenizer produces
+ * one long token per side and this is the only pass that can say anything.
+ *
+ * Returns false when it does not apply, leaving the caller to mark the run
+ * whole.
+ */
+function refine(block: Block, left: DiffSegment[], right: DiffSegment[]): boolean {
+  if (block.a.length !== 1 || block.b.length !== 1) return false
+  const tokenA = block.a[0] as string
+  const tokenB = block.b[0] as string
+  const wordA = word(tokenA)
+  const wordB = word(tokenB)
+  if (wordA.length > MAX_REFINE_CHARS || wordB.length > MAX_REFINE_CHARS) return false
+
+  const shortest = Math.min(wordA.length, wordB.length)
+  let prefix = 0
+  while (prefix < shortest && wordA[prefix] === wordB[prefix]) prefix++
+  let suffix = 0
+  while (
+    suffix < shortest - prefix &&
+    wordA[wordA.length - 1 - suffix] === wordB[wordB.length - 1 - suffix]
+  ) {
+    suffix++
+  }
+
+  // Nothing in common worth keeping: two different words rather than one word
+  // edited, and splitting them into letters would only be noise.
+  if (prefix === 0 && suffix === 0) return false
+
+  const leadA = tokenA.slice(0, tokenA.indexOf(wordA))
+  const leadB = tokenB.slice(0, tokenB.indexOf(wordB))
+  push(left, leadA + wordA.slice(0, prefix), false)
+  push(right, leadB + wordB.slice(0, prefix), false)
+  push(left, wordA.slice(prefix, wordA.length - suffix), true)
+  push(right, wordB.slice(prefix, wordB.length - suffix), true)
+  push(left, wordA.slice(wordA.length - suffix) + tokenA.slice(leadA.length + wordA.length), false)
+  push(right, wordB.slice(wordB.length - suffix) + tokenB.slice(leadB.length + wordB.length), false)
+  return true
+}
+
+/**
+ * The alignment itself: a longest-common-subsequence over words, walked back
+ * into alternating equal and replaced blocks.
+ *
+ * Words rather than characters because a correction is edited in words, and a
+ * character diff of two sentences produces a confetti of one-letter runs that
+ * nobody can read. The character pass above is the deliberate exception.
+ */
+function blocks(a: string[], b: string[]): Block[] {
+  const keysA = a.map(word)
+  const keysB = b.map(word)
+  const n = a.length
+  const m = b.length
+  const width = m + 1
+  // Uint16 is enough: the table counts tokens, and `MAX_TOKENS` caps them well
+  // below 65535.
+  const table = new Uint16Array((n + 1) * width)
+
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      table[i * width + j] =
+        keysA[i] === keysB[j]
+          ? (table[(i + 1) * width + j + 1] as number) + 1
+          : Math.max(table[(i + 1) * width + j] as number, table[i * width + j + 1] as number)
+    }
+  }
+
+  const result: Block[] = []
+  let i = 0
+  let j = 0
+  while (i < n || j < m) {
+    if (i < n && j < m && keysA[i] === keysB[j]) {
+      const runA: string[] = []
+      const runB: string[] = []
+      while (i < n && j < m && keysA[i] === keysB[j]) {
+        runA.push(a[i++] as string)
+        runB.push(b[j++] as string)
+      }
+      result.push({ same: true, a: runA, b: runB })
+      continue
+    }
+
+    const runA: string[] = []
+    const runB: string[] = []
+    while (i < n || j < m) {
+      if (i < n && j < m && keysA[i] === keysB[j]) break
+      if (
+        j >= m ||
+        (i < n && (table[(i + 1) * width + j] as number) >= (table[i * width + j + 1] as number))
+      ) {
+        runA.push(a[i++] as string)
+      } else {
+        runB.push(b[j++] as string)
+      }
+    }
+    result.push({ same: false, a: runA, b: runB })
+  }
+  return result
+}

--- a/apps/mobile/src/lib/swipeToReply.test.ts
+++ b/apps/mobile/src/lib/swipeToReply.test.ts
@@ -4,6 +4,7 @@ import {
   SWIPE_MAX_PX,
   shouldCaptureSwipe,
   swipeReleased,
+  swipeToReplyEnabled,
   swipeTranslation,
 } from './swipeToReply'
 
@@ -48,5 +49,22 @@ describe('swipeReleased', () => {
   it('fires at the activation distance and not before', () => {
     expect(swipeReleased(SWIPE_ACTIVATE_PX - 1)).toBe(false)
     expect(swipeReleased(SWIPE_ACTIVATE_PX)).toBe(true)
+  })
+})
+
+describe('swipeToReplyEnabled', () => {
+  it('is on wherever there is a finger', () => {
+    expect(swipeToReplyEnabled('ios', true)).toBe(true)
+    expect(swipeToReplyEnabled('android', true)).toBe(true)
+    expect(swipeToReplyEnabled('web', true)).toBe(true)
+  })
+
+  /** A phone always has one; the flag is only ever consulted on the web. */
+  it('is on natively even when the touch flag says otherwise', () => {
+    expect(swipeToReplyEnabled('ios', false)).toBe(true)
+  })
+
+  it('is off in a browser driven by a mouse, where it would fight text selection', () => {
+    expect(swipeToReplyEnabled('web', false)).toBe(false)
   })
 })

--- a/apps/mobile/src/lib/swipeToReply.ts
+++ b/apps/mobile/src/lib/swipeToReply.ts
@@ -34,3 +34,18 @@ export function swipeTranslation(dx: number): number {
 export function swipeReleased(dx: number): boolean {
   return dx >= SWIPE_ACTIVATE_PX
 }
+
+/**
+ * Whether the gesture is offered at all.
+ *
+ * Native always. On the web only with a touch pointer, and that distinction is
+ * the whole of it: a finger drag reaches the responder system cleanly, while a
+ * mouse drag on a bubble is also the browser's own text selection — the two
+ * fight, and the one that wins depends on where in the bubble the drag
+ * started. A gesture that works from the padding and not from the words is
+ * worse than one that is plainly absent, so on a desktop the menu's Reply row
+ * stays the way in.
+ */
+export function swipeToReplyEnabled(platform: string, hasTouch: boolean): boolean {
+  return platform === 'web' ? hasTouch : true
+}


### PR DESCRIPTION
Two asks from the same session, both about a message someone else wrote.

## Reply by swiping now works in a phone browser

The gesture was already built; it was off in every browser. The reason it was off — a mouse drag on a bubble is also the browser selecting text, and which one wins depends on whether the press landed on a word or on the padding — only ever applied to a mouse. So it now turns on wherever there is a touch pointer:

- `swipeToReplyEnabled(platform, hasTouch)` in `swipeToReply.ts`, with the thresholds unchanged.
- `touch-action: pan-y` on the web, without which the browser claims the horizontal pan (and, on iOS Safari, the back gesture) before the responder system sees the move.
- A reply arrow fades in under the bubble as it travels, reaching full strength exactly where letting go replies.

On a desktop the menu's Reply row is still the way in, and mouse text selection keeps working.

## The correction shows what changed, not that everything did

The card struck the whole original through. New `correctionDiff.ts` aligns the two sentences by word (LCS) and marks only the parts that moved: red and struck on the original, green and bold on the correction. Both are marked twice — colour plus a second cue — so the card still reads without separating red from green.

A one-word swap is narrowed to the letters that differ, which is where Turkish spends most of its time (`gidiyom` → `gidiyo[ru]m`) and the only thing that can be said at all about a language written without spaces.

The module is pure and free of `react-native`, so vitest can load it. 18 tests, including the invariant that matters: the segments always join back to exactly the two input strings.

## Checks

`pnpm test` (749), `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` all green locally.