### PR TITLE
Put the numbers on every profile, and fix the map underneath them

### DIFF
--- a/apps/api/src/modules/chat/conversations.ts
+++ b/apps/api/src/modules/chat/conversations.ts
@@ -118,6 +118,24 @@ function isDuplicateKeyError(error: unknown, indexName: string): boolean {
  * ever sent this recipient — replying to an existing conversation is a
  * different, quota-free endpoint (Faz 5).
  */
+/**
+ * The conversation these two already have, if any.
+ *
+ * Read by the profile screen, which otherwise offers a "send a message" box to
+ * somebody you are already talking to — and sending from it fails, because
+ * `startConversation` refuses a second one. The answer belongs to the viewer,
+ * so it is computed per request rather than stored on either profile.
+ */
+export async function findConversationBetween(
+  db: Db,
+  viewerId: string,
+  otherId: string,
+): Promise<Conversation | null> {
+  return db
+    .collection<Conversation>(COLLECTIONS.conversations)
+    .findOne({ pairKey: pairKeyFor(viewerId, otherId) })
+}
+
 export async function startConversation(
   db: Db,
   viewerId: string,

--- a/apps/api/src/modules/handles/legacyRestore.ts
+++ b/apps/api/src/modules/handles/legacyRestore.ts
@@ -262,7 +262,12 @@ function buildProfile(userId: string, legacy: LegacyProfile, now: Date): Profile
     learning: legacy.learning,
     interests: [],
     settings: { discoverable: true, notifications: true },
-    privacy: { incognito: false, hideOnlineStatus: false, activityMapVisible: true },
+    privacy: {
+      incognito: false,
+      hideOnlineStatus: false,
+      activityMapVisible: true,
+      statsVisible: true,
+    },
     entitlement: { tier: 'free', updatedAt: now },
     quota: { initiations: [], translations: [], media: [] },
     /**

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -61,7 +61,12 @@ export interface Profile {
     discoverable: boolean
     notifications: boolean
   }
-  privacy: { incognito: boolean; hideOnlineStatus?: boolean; activityMapVisible?: boolean }
+  privacy: {
+    incognito: boolean
+    hideOnlineStatus?: boolean
+    activityMapVisible?: boolean
+    statsVisible?: boolean
+  }
   entitlement: {
     tier: PlanTier
     expiresAt?: Date
@@ -169,7 +174,12 @@ export async function createProfile(
       discoverable: true,
       notifications: true,
     },
-    privacy: { incognito: false, hideOnlineStatus: false, activityMapVisible: true },
+    privacy: {
+      incognito: false,
+      hideOnlineStatus: false,
+      activityMapVisible: true,
+      statsVisible: true,
+    },
     entitlement: { tier: 'free', updatedAt: now },
     quota: { initiations: [], translations: [], media: [] },
     streak: { current: 0, longest: 0, lastQualifiedDay: null },
@@ -427,6 +437,14 @@ export interface PublicProfile {
   /** Account creation, shown as an age — `formatAccountAge` does the wording. */
   createdAt: Date
   /**
+   * The conversation the viewer already has with this person, when there is
+   * one. Per-viewer, like `follow`, and computed by the route for the same
+   * reason: the profile screen otherwise offers a "send a message" box that
+   * cannot work — `startConversation` refuses a second conversation — and the
+   * way through is a link to the one that exists.
+   */
+  conversationId?: string
+  /**
    * Better Auth's flag, not one of ours: it lives on `user`, so it reaches
    * here through {@link isEmailVerified} rather than off the profile document.
    */
@@ -465,6 +483,8 @@ export function toPublicProfile(
    */
   follow: FollowState,
   now: Date = new Date(),
+  /** Set when the viewer and this person already have a thread. */
+  conversationId?: string,
 ): PublicProfile {
   const lastActiveAt = profile.stats?.lastActiveAt ?? profile.createdAt
   const hidden = hidesOnlineStatus(profile)
@@ -494,6 +514,7 @@ export function toPublicProfile(
   if (profile.bio !== undefined) result.bio = profile.bio
   if (profile.country !== undefined) result.country = profile.country
   if (profile.city !== undefined) result.city = profile.city
+  if (conversationId !== undefined) result.conversationId = conversationId
   return result
 }
 

--- a/apps/api/src/modules/tokens/publicSummary.ts
+++ b/apps/api/src/modules/tokens/publicSummary.ts
@@ -1,0 +1,54 @@
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import type { Profile } from '../profiles/profiles'
+import { readActivityWeek } from './dailyActivity'
+import { countCorrectionsWritten } from './corrections'
+import { readAggregates } from './ledger'
+
+/**
+ * What a profile shows about how somebody uses the app: the streak, how many
+ * corrections they have written, how many tokens they have earned, and the
+ * week's shape.
+ *
+ * A deliberately smaller thing than `getTokenSummary`, which is the owner's
+ * view: no wallet, no quota, no per-day counters, nothing about what was
+ * bought. Corrections and tokens are a record of teaching people, which is
+ * the point of the product and the reason this is on by default — but it is a
+ * measurement of a person, so `privacy.statsVisible` turns it off, and when it
+ * is off the fields are not sent at all rather than hidden by the client.
+ */
+export interface PublicSummary {
+  visible: boolean
+  streak?: { current: number; longest: number }
+  corrections?: number
+  tokens?: number
+  week?: { day: string; messages: number; corrections: number }[]
+}
+
+export async function getPublicSummary(
+  db: Db,
+  userId: string,
+  at: Date = new Date(),
+): Promise<PublicSummary> {
+  const profile = await db.collection<Profile>(COLLECTIONS.profiles).findOne({ _id: userId })
+  if (!profile) return { visible: false }
+  // Absent means on: the flag is newer than the profiles that predate it.
+  if (profile.privacy?.statsVisible === false) return { visible: false }
+
+  const [tokens, week, corrections] = await Promise.all([
+    readAggregates(db, userId, at),
+    readActivityWeek(db, userId, at),
+    countCorrectionsWritten(db, userId),
+  ])
+
+  return {
+    visible: true,
+    streak: { current: profile.streak.current, longest: profile.streak.longest },
+    corrections,
+    // The all-time total, which is what the owner's own profile shows too —
+    // not the balance, which moves when they spend and is nobody else's
+    // business.
+    tokens: tokens.all,
+    week,
+  }
+}

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -10,6 +10,7 @@ import { ApiError } from '../lib/ApiError'
 import { requireAuth } from '../middleware/requireAuth'
 import { getProfile } from '../modules/profiles/profiles'
 import { blockedUserIds } from '../modules/moderation/blocks'
+import { getPublicSummary } from '../modules/tokens/publicSummary'
 import { listStreakDays, repairsInMonth } from '../modules/tokens/streakDays'
 import { repairDay } from '../modules/tokens/wallet'
 
@@ -35,6 +36,19 @@ export const activityRoutes: FastifyPluginAsyncZod = async (app) => {
 
       return reply.send({
         today,
+        /**
+         * The streak, alongside the days.
+         *
+         * `streakDays` only started existing when the map shipped, so an
+         * account older than that has a streak counter with no squares behind
+         * it — and the map drew six months of empty boxes under a "🔥 40".
+         * The client fills the current run from these two numbers when a day
+         * has no row of its own; see `activityGrid`.
+         */
+        streak: {
+          current: profile.streak.current,
+          lastQualifiedDay: profile.streak.lastQualifiedDay,
+        },
         days: days.map((d) => ({ day: d.day, actions: d.actions, source: d.source })),
         repair: {
           price: TOKEN_RULES.sinks.dayRepair,
@@ -68,7 +82,12 @@ export const activityRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request, reply) => {
       const { handle } = request.params as { handle: string }
       const target = await app.mongo.db
-        .collection<{ _id: string; privacy?: { activityMapVisible?: boolean } }>('profiles')
+        .collection<{
+          _id: string
+          timezone?: string
+          streak?: { current: number; lastQualifiedDay: string | null }
+          privacy?: { activityMapVisible?: boolean }
+        }>('profiles')
         .findOne({ handle })
 
       // Blocked either way reads as "no such person", the same as the profile
@@ -86,12 +105,38 @@ export const activityRoutes: FastifyPluginAsyncZod = async (app) => {
       const days = await listStreakDays(app.mongo.db, target._id, from, to)
       return reply.send({
         visible: true,
+        today: localDayKey(new Date(), target.timezone ?? 'UTC'),
+        streak: {
+          current: target.streak?.current ?? 0,
+          lastQualifiedDay: target.streak?.lastQualifiedDay ?? null,
+        },
         // No counts and no source: how hard someone worked on a Tuesday, and
         // whether they paid for it, are theirs.
         days: days.map((d) => ({ day: d.day, intensity: intensityOf(d.actions) })),
       })
     },
   )
+
+  /**
+   * The numbers a profile shows about how somebody uses the app.
+   *
+   * Beside the map rather than inside `toPublicProfile` for the same two
+   * reasons: it costs three queries the profile route should not pay for, and
+   * its privacy flag is then checked in exactly one place.
+   */
+  app.get('/profiles/:handle/summary', { preHandler: requireAuth }, async (request, reply) => {
+    const { handle } = request.params as { handle: string }
+    const target = await app.mongo.db
+      .collection<{ _id: string }>('profiles')
+      .findOne({ handle }, { projection: { _id: 1 } })
+
+    const hidden = await blockedUserIds(app.mongo.db, request.userId)
+    if (!target || hidden.includes(target._id)) {
+      throw new ApiError(ERROR_CODES.NOT_FOUND, 'Profile not found')
+    }
+
+    return reply.send(await getPublicSummary(app.mongo.db, target._id))
+  })
 }
 
 /**

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -202,6 +202,63 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
     expect(viaLocation.json<Profile>().country).toBe('TR')
   })
 
+  /**
+   * The profile screen used to offer a "send a message" box to somebody you
+   * were already talking to, and sending from it failed — `startConversation`
+   * refuses a second thread. The screen needs to know, and only the viewer's
+   * own request can answer it.
+   */
+  it('tells the viewer about the conversation they already have', async () => {
+    const one = await newUser('pair-one@example.com')
+    const two = await newUser('pair-two@example.com')
+    await app.inject({
+      method: 'POST',
+      url: '/profiles',
+      headers: { cookie: one.cookie },
+      payload: onboardingBody({ handle: 'pairone' }),
+    })
+    await app.inject({
+      method: 'POST',
+      url: '/profiles',
+      headers: { cookie: two.cookie },
+      payload: onboardingBody({ handle: 'pairtwo' }),
+    })
+
+    const before = await app.inject({
+      method: 'GET',
+      url: '/profiles/pairtwo',
+      headers: { cookie: one.cookie },
+    })
+    expect(before.json<{ conversationId?: string }>().conversationId).toBeUndefined()
+
+    const started = await app.inject({
+      method: 'POST',
+      url: '/conversations',
+      headers: { cookie: one.cookie },
+      payload: { toUserId: two.userId, body: 'Merhaba' },
+    })
+    expect(started.statusCode, started.body).toBe(201)
+
+    const after = await app.inject({
+      method: 'GET',
+      url: '/profiles/pairtwo',
+      headers: { cookie: one.cookie },
+    })
+    expect(after.json<{ conversationId?: string }>().conversationId).toBe(
+      started.json<{ _id: string }>()._id,
+    )
+
+    // And the other way round: the same thread, from the other side.
+    const mirrored = await app.inject({
+      method: 'GET',
+      url: '/profiles/pairone',
+      headers: { cookie: two.cookie },
+    })
+    expect(mirrored.json<{ conversationId?: string }>().conversationId).toBe(
+      started.json<{ _id: string }>()._id,
+    )
+  })
+
   it('rejects an underage birthDate even though the client already validated it', async () => {
     const user = await newUser('underage-attempt@example.com')
 

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -7,6 +7,7 @@ import {
 } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { ApiError } from '../lib/ApiError'
+import { findConversationBetween } from '../modules/chat/conversations'
 import { countryFromHeaders } from '../lib/requestCountry'
 import { requireAuth, requireVerifiedEmail } from '../middleware/requireAuth'
 import { hashLegacyEmail } from '../modules/handles/legacyEmailHash'
@@ -107,11 +108,19 @@ export const profileRoutes: FastifyPluginAsyncZod = async (app) => {
       // Read after the block check, not with it: an unverified-email lookup
       // for a profile this viewer is not allowed to see is a query we should
       // never run.
-      const [emailVerified, follow] = await Promise.all([
+      const [emailVerified, follow, conversation] = await Promise.all([
         isEmailVerified(app.mongo.db, target._id),
         readFollowState(app.mongo.db, request.userId, target._id),
+        // Only for somebody else's profile: a conversation with yourself is
+        // not a thing, and `findConversationBetween` would answer for the
+        // pair (you, you).
+        target._id === request.userId
+          ? Promise.resolve(null)
+          : findConversationBetween(app.mongo.db, request.userId, target._id),
       ])
-      return reply.send(toPublicProfile(target, emailVerified, follow))
+      return reply.send(
+        toPublicProfile(target, emailVerified, follow, new Date(), conversation?._id.toHexString()),
+      )
     },
   )
 

--- a/apps/api/src/routes/tokens.test.ts
+++ b/apps/api/src/routes/tokens.test.ts
@@ -692,4 +692,56 @@ describe('Faz 8 — streak, token ledger and direct awards', () => {
       })
     })
   })
+
+  describe('somebody else’s numbers', () => {
+    it('answers with the streak, the corrections and the tokens', async () => {
+      const owner = await newUser('stats-owner@example.com', { handle: 'statsowner' })
+      const viewer = await newUser('stats-viewer@example.com')
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/profiles/statsowner/summary',
+        headers: { cookie: viewer.cookie },
+      })
+
+      expect(response.statusCode, response.body).toBe(200)
+      const body = response.json<{
+        visible: boolean
+        streak: { current: number }
+        corrections: number
+        tokens: number
+        week: unknown[]
+      }>()
+      expect(body.visible).toBe(true)
+      expect(body.streak.current).toBe(0)
+      expect(body.corrections).toBe(0)
+      // The sign-up bonus is already on the ledger, so this is a real number
+      // rather than a zero that would pass whatever the query did.
+      expect(body.tokens).toBeGreaterThan(0)
+      expect(body.week).toHaveLength(7)
+      void owner
+    })
+
+    /**
+     * Off means the fields are absent, not blanked: a client that decided to
+     * draw them anyway would have nothing to draw.
+     */
+    it('sends nothing at all when its owner has turned the numbers off', async () => {
+      const owner = await newUser('stats-private@example.com', { handle: 'statsprivate' })
+      const viewer = await newUser('stats-private-viewer@example.com')
+      await app.inject({
+        method: 'PATCH',
+        url: '/profiles/me',
+        headers: { cookie: owner.cookie },
+        payload: { privacy: { statsVisible: false } },
+      })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/profiles/statsprivate/summary',
+        headers: { cookie: viewer.cookie },
+      })
+      expect(response.json()).toEqual({ visible: false })
+    })
+  })
 })

--- a/apps/mobile/app/(app)/discover.tsx
+++ b/apps/mobile/app/(app)/discover.tsx
@@ -1,4 +1,5 @@
 import {
+  countryFlag,
   formatDistance,
   NEARBY_MAX_KM,
   NEARBY_RADIUS_OPTIONS_KM,
@@ -278,6 +279,12 @@ export default function DiscoverScreen() {
                     {item.displayName}
                   </Text>
                   <Text style={styles.age}>{item.age}</Text>
+                  {/* The flag, not the country's name: it is one glyph in a row
+                      that has none to spare, and it is the one thing on this
+                      card that is the same word in every language. */}
+                  {item.country ? (
+                    <Text style={styles.flag}>{countryFlag(item.country)}</Text>
+                  ) : null}
                   {item.streak.current > 0 ? (
                     <Text style={styles.streak} numberOfLines={1}>
                       🔥 {item.streak.current}
@@ -305,6 +312,7 @@ export default function DiscoverScreen() {
 }
 
 const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
+  flag: { fontSize: 15 },
   header: { paddingTop: spacing.md },
   titleRow: { alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between' },
   title: { ...font.title, color: colors.text, fontSize: 30 },

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -7,16 +7,21 @@ import {
   useBlockUser,
   useMe,
   useProfile,
+  usePublicSummary,
   useReportUser,
   useSetFollow,
   useStartConversation,
 } from '../../../src/api/queries'
+import { ActivityMap } from '../../../src/components/ActivityMap'
 import { Avatar } from '../../../src/components/ui/Avatar'
 import { Button } from '../../../src/components/ui/Button'
 import { LanguageCards } from '../../../src/components/LanguageCards'
 import { PhotoGallery } from '../../../src/components/PhotoGallery'
+import { WeeklyChart } from '../../../src/components/WeeklyChart'
 import { TierBadge } from '../../../src/components/TierBadge'
+import { Card } from '../../../src/components/ui/Card'
 import { Chip } from '../../../src/components/ui/Chip'
+import { StatTile } from '../../../src/components/ui/StatTile'
 import { Screen } from '../../../src/components/ui/Screen'
 import { chooseAlert, confirmAlert } from '../../../src/lib/alert'
 import { goBackTo, openFollows } from '../../../src/lib/navigation'
@@ -47,6 +52,7 @@ export default function ProfileScreen() {
   const setFollow = useSetFollow(handle ?? '')
   const here = `/(app)/profile/${handle}`
   const startConversation = useStartConversation()
+  const summary = usePublicSummary(handle ?? '')
   const block = useBlockUser()
   const report = useReportUser()
 
@@ -234,23 +240,68 @@ export default function ProfileScreen() {
         </>
       ) : null}
 
-      <Text style={styles.sectionTitle}>{t('profile.sendMessage')}</Text>
-      <TextInput
-        value={message}
-        onChangeText={setMessage}
-        placeholder={t('chat.sayHello', { name: user.displayName })}
-        placeholderTextColor={colors.textMuted}
-        style={styles.input}
-        multiline
-      />
-      {error ? <Text style={styles.error}>{error}</Text> : null}
-      <Button
-        label={t('common.send')}
-        disabled={message.trim().length === 0}
-        loading={startConversation.isPending}
-        onPress={send}
-        style={styles.send}
-      />
+      {/*
+        The numbers, and only if they are offered: `statsVisible` is checked on
+        the server, so a profile that turned them off sends nothing to hide.
+      */}
+      {summary.data?.visible ? (
+        <>
+          <View style={styles.tiles}>
+            <StatTile
+              tone="warning"
+              label={t('me.dayStreak')}
+              value={`🔥 ${summary.data.streak?.current ?? 0}`}
+            />
+            <StatTile
+              tone="success"
+              label={t('me.corrections')}
+              value={String(summary.data.corrections ?? 0)}
+            />
+            <StatTile label={t('me.tokens')} value={String(summary.data.tokens ?? 0)} />
+          </View>
+          {summary.data.week ? <WeeklyChart week={summary.data.week} /> : null}
+        </>
+      ) : null}
+
+      {/* Read-only, and drawn from the same component as your own — a second
+          implementation of a grid is a second grid to keep in step. */}
+      <Card inset style={styles.activityCard}>
+        <ActivityMap handle={user.handle} />
+      </Card>
+
+      {/*
+        A conversation that already exists is a link, not a form. The composer
+        below cannot start a second one — `startConversation` refuses, which
+        used to surface as "a conversation with this user already exists" after
+        typing a message out.
+      */}
+      {user.conversationId ? (
+        <Button
+          label={t('profile.openChat')}
+          onPress={() => router.push(`/(app)/chat/${user.conversationId}`)}
+          style={styles.send}
+        />
+      ) : (
+        <>
+          <Text style={styles.sectionTitle}>{t('profile.sendMessage')}</Text>
+          <TextInput
+            value={message}
+            onChangeText={setMessage}
+            placeholder={t('chat.sayHello', { name: user.displayName })}
+            placeholderTextColor={colors.textMuted}
+            style={styles.input}
+            multiline
+          />
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+          <Button
+            label={t('common.send')}
+            disabled={message.trim().length === 0}
+            loading={startConversation.isPending}
+            onPress={send}
+            style={styles.send}
+          />
+        </>
+      )}
 
       <View style={styles.danger}>
         <Pressable onPress={() => void confirmReport()} hitSlop={8}>
@@ -265,6 +316,8 @@ export default function ProfileScreen() {
 }
 
 const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
+  tiles: { flexDirection: 'row', gap: spacing.sm, marginTop: spacing.lg },
+  activityCard: { marginTop: spacing.md },
   followRow: { flexDirection: 'row', gap: 18, marginTop: 12 },
   followCount: { ...font.label, color: colors.text, fontWeight: '600' },
   followButton: { marginTop: 14 },

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -226,6 +226,20 @@ export default function SettingsScreen() {
             />
           }
         />
+        {/* The numbers above the map — streak, corrections, tokens, the week's
+            chart — travel together, because hiding the chart and leaving the
+            counts would be a setting that does not do what it says. */}
+        <ListRow
+          title={t('settings.showStats')}
+          subtitle={t('settings.showStatsBody')}
+          accessory={
+            <Toggle
+              accessibilityLabel={t('settings.showStats')}
+              value={profile?.privacy.statsVisible ?? true}
+              onValueChange={(statsVisible) => update.mutate({ privacy: { statsVisible } })}
+            />
+          }
+        />
         <ListRow
           title={t('settings.hideOnline')}
           subtitle={isPro ? t('settings.hideOnlineBody') : t('common.pro')}

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -111,7 +111,12 @@ export interface MeProfile {
   learning: { code: string; level: LanguageLevel; priority: number }[]
   interests: string[]
   settings: { discoverable: boolean; notifications: boolean }
-  privacy: { incognito: boolean; hideOnlineStatus: boolean; activityMapVisible?: boolean }
+  privacy: {
+    incognito: boolean
+    hideOnlineStatus: boolean
+    activityMapVisible?: boolean
+    statsVisible?: boolean
+  }
   /**
    * Present only while the user is sharing one, which is exactly what the
    * Settings toggle reads: there is no separate "sharing is on" flag on the
@@ -319,8 +324,46 @@ export interface ActivityDayDto {
 export interface ActivityDto {
   /** The server's idea of the user's local day — the client must not guess it. */
   today: string
+  /** Fills the days an account older than `streakDays` has no rows for. */
+  streak: { current: number; lastQualifiedDay: string | null }
   days: ActivityDayDto[]
   repair: { price: number; maxAgeDays: number; perMonth: number; usedThisMonth: number }
+}
+
+/**
+ * Somebody else's map: whether each square is filled and how busy, never the
+ * counts and never which were bought. `visible: false` is a profile that turned
+ * the map off.
+ */
+export interface PublicActivityDto {
+  visible: boolean
+  today?: string
+  streak?: { current: number; lastQualifiedDay: string | null }
+  days: { day: string; intensity: number }[]
+}
+
+export interface PublicSummaryDto {
+  visible: boolean
+  streak?: { current: number; longest: number }
+  corrections?: number
+  tokens?: number
+  week?: { day: string; messages: number; corrections: number }[]
+}
+
+export function usePublicActivity(handle: string, from: string, to: string) {
+  return useQuery({
+    queryKey: ['profileActivity', handle, from, to] as const,
+    queryFn: () => api.get<PublicActivityDto>(`/profiles/${handle}/activity?from=${from}&to=${to}`),
+    enabled: handle.length > 0,
+  })
+}
+
+export function usePublicSummary(handle: string) {
+  return useQuery({
+    queryKey: ['profileSummary', handle] as const,
+    queryFn: () => api.get<PublicSummaryDto>(`/profiles/${handle}/summary`),
+    enabled: handle.length > 0,
+  })
 }
 
 /**
@@ -330,10 +373,13 @@ export interface ActivityDto {
  * day is the profile's timezone and a device set to another one would draw the
  * grid off by a square — and then offer to sell the wrong day.
  */
-export function useActivity(from: string, to: string) {
+export function useActivity(from: string, to: string, enabled = true) {
   return useQuery({
     queryKey: keys.activity(from, to),
     queryFn: () => api.get<ActivityDto>(`/me/activity?from=${from}&to=${to}`),
+    // Off while the same component is drawing somebody else's map: the repair
+    // rules it would fetch are not used there.
+    enabled,
   })
 }
 

--- a/apps/mobile/src/api/types.ts
+++ b/apps/mobile/src/api/types.ts
@@ -38,6 +38,8 @@ export type {
 import type { FollowState, LanguageLevel, PlanTier } from '@langx/shared'
 
 export interface PublicProfileDto {
+  /** Set when the viewer already has a thread with this person. */
+  conversationId?: string
   _id: string
   handle: string
   displayName: string

--- a/apps/mobile/src/components/ActivityMap.tsx
+++ b/apps/mobile/src/components/ActivityMap.tsx
@@ -1,7 +1,7 @@
 import { shiftDayKey } from '@langx/shared'
 import { useMemo, useRef } from 'react'
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native'
-import { useActivity, useRepairDay, useWallet } from '../api/queries'
+import { usePublicActivity, useActivity, useRepairDay, useWallet } from '../api/queries'
 import { activityGrid, repairEffect, type ActivityCell } from '../lib/activityMap'
 import { confirmAlert, showAlert } from '../lib/alert'
 import { dayLabel } from '../lib/messageGroups'
@@ -20,7 +20,16 @@ const WEEKS = 26
  * shading the squares from the latter would slide the whole map by one for
  * anyone far enough east or west. One source, one meaning.
  */
-export function ActivityMap() {
+export interface ActivityMapProps {
+  /**
+   * Somebody else's map. Read-only: no counts behind the shading, no repair —
+   * buying back a day of a stranger's history is not a thing, and the endpoint
+   * would refuse anyway.
+   */
+  handle?: string
+}
+
+export function ActivityMap({ handle }: ActivityMapProps = {}) {
   const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()
@@ -29,30 +38,46 @@ export function ActivityMap() {
   const to = new Date().toISOString().slice(0, 10)
   // Generous: the server clamps the range, and the grid only draws what it needs.
   const from = shiftDayKey(to, -(WEEKS + 1) * 7)
-  const activity = useActivity(from, to)
+  const own = useActivity(from, to, !handle)
+  const theirs = usePublicActivity(handle ?? '', from, to)
   const wallet = useWallet()
   const repair = useRepairDay()
   const scroller = useRef<ScrollView>(null)
 
+  // One shape from two endpoints. The public one carries an intensity rather
+  // than a count — the exact number is the private part — so it is turned back
+  // into the count the shading came from.
+  const source = handle ? theirs : own
   const columns = useMemo(() => {
-    if (!activity.data) return []
+    const data = handle ? theirs.data : own.data
+    if (!data || (handle && theirs.data?.visible === false)) return []
+    const days = handle
+      ? new Map((theirs.data?.days ?? []).map((d) => [d.day, INTENSITY_ACTIONS[d.intensity] ?? 1]))
+      : new Map((own.data?.days ?? []).map((d) => [d.day, d.actions]))
     return activityGrid({
-      today: activity.data.today,
+      today:
+        (handle ? theirs.data?.today : own.data?.today) ?? new Date().toISOString().slice(0, 10),
       weeks: WEEKS,
-      days: new Map(activity.data.days.map((d) => [d.day, d.actions])),
-      maxAgeDays: activity.data.repair.maxAgeDays,
+      days,
+      maxAgeDays: own.data?.repair.maxAgeDays ?? 0,
+      streak: (handle ? theirs.data?.streak : own.data?.streak) ?? undefined,
     })
-  }, [activity.data])
+  }, [handle, own.data, theirs.data])
 
-  if (activity.isPending) return <ActivityIndicator style={styles.loading} />
-  if (!activity.data) return null
+  if (source.isPending) return <ActivityIndicator style={styles.loading} />
+  if (!source.data) return null
+  // A profile that turned the map off says nothing at all, rather than showing
+  // six months of empty squares that look like an inactive person.
+  if (handle && theirs.data?.visible === false) return null
 
-  const { repair: rules, today, days } = activity.data
+  const rules = own.data?.repair ?? { price: 0, maxAgeDays: 0, perMonth: 0, usedThisMonth: 0 }
+  const today = (handle ? theirs.data?.today : own.data?.today) ?? ''
+  const days = handle ? [] : (own.data?.days ?? [])
   const filled = new Set(days.map((d) => d.day))
   const left = Math.max(0, rules.perMonth - rules.usedThisMonth)
 
   async function onPressDay(cell: ActivityCell): Promise<void> {
-    if (cell.state !== 'repairable') return
+    if (handle || cell.state !== 'repairable') return
     if (left === 0) {
       await showAlert(
         t('activity.noRepairsTitle'),
@@ -110,15 +135,20 @@ export function ActivityMap() {
     <View style={styles.wrap}>
       <View style={styles.head}>
         <Text style={styles.title}>{t('chat.activity')}</Text>
-        <Text style={styles.hint}>
-          {left > 0
-            ? t('activity.repairsLeft', {
-                count: left,
-                total: rules.perMonth,
-                price: rules.price,
-              })
-            : t('activity.noRepairsThisMonth')}
-        </Text>
+        {/* Only the owner can buy a day back, so only the owner is told how
+            many are left — and the line wraps rather than running off the
+            card, which is where it went before. */}
+        {handle ? null : (
+          <Text style={styles.hint}>
+            {left > 0
+              ? t('activity.repairsLeft', {
+                  count: left,
+                  total: rules.perMonth,
+                  price: rules.price,
+                })
+              : t('activity.noRepairsThisMonth')}
+          </Text>
+        )}
       </View>
 
       {/*
@@ -145,7 +175,7 @@ export function ActivityMap() {
                     ? t('activity.fillInDay', { day: cell.day })
                     : undefined
                 }
-                disabled={cell.state !== 'repairable'}
+                disabled={Boolean(handle) || cell.state !== 'repairable'}
                 onPress={() => void onPressDay(cell)}
                 style={[
                   styles.cell,
@@ -165,10 +195,28 @@ export function ActivityMap() {
   )
 }
 
+/**
+ * The public map sends a bucket, not a count. Turning it back into the lowest
+ * count in each bucket is enough to reproduce the same shade, and is the only
+ * thing the grid needs from it.
+ */
+const INTENSITY_ACTIONS: Record<number, number> = { 1: 1, 2: 3, 3: 10, 4: 30 }
+
 const useStyles = makeStyles(({ colors, font, spacing }) => ({
   loading: { paddingVertical: spacing.lg },
-  wrap: { gap: spacing.sm },
-  head: { alignItems: 'baseline', flexDirection: 'row', justifyContent: 'space-between' },
+  /**
+   * The card this sits in has no padding of its own — its children bring
+   * theirs. Without this the title sat against the border and the grid ran out
+   * from under the corner radius.
+   */
+  wrap: { gap: spacing.sm, paddingHorizontal: 14, paddingVertical: spacing.md },
+  head: {
+    alignItems: 'baseline',
+    columnGap: spacing.sm,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+  },
   title: { ...font.heading, color: colors.text, fontSize: 15 },
   hint: { ...font.caption, color: colors.textMuted },
   grid: { flexDirection: 'row', gap: 3, paddingVertical: spacing.xs },

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -620,6 +620,7 @@ export const ar: Localized<EnMessages> = {
   },
 
   profile: {
+    openChat: 'افتح المحادثة',
     follow: 'متابعة',
     following: 'تتابعه',
     followers: {
@@ -752,6 +753,8 @@ export const ar: Localized<EnMessages> = {
     codeOfConduct: 'مدونة السلوك',
   },
   settings: {
+    showStats: 'إظهار أرقامي',
+    showStatsBody: 'السلسلة والتصحيحات والتوكنات ورسم هذا الأسبوع على ملفك.',
     legalSection: 'القانونية',
     communitySection: 'المجتمع',
     showInDiscover: 'أظهرني في الاستكشاف',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -533,6 +533,7 @@ export const de: Localized<EnMessages> = {
   },
 
   profile: {
+    openChat: 'Chat öffnen',
     follow: 'Folgen',
     following: 'Folgt',
     followers: { one: '{count} Follower', other: '{count} Follower' },
@@ -641,6 +642,8 @@ export const de: Localized<EnMessages> = {
     codeOfConduct: 'Verhaltenskodex',
   },
   settings: {
+    showStats: 'Meine Zahlen zeigen',
+    showStatsBody: 'Streak, Korrekturen, Tokens und das Wochendiagramm auf deinem Profil.',
     legalSection: 'Rechtliches',
     communitySection: 'Community',
     showInDiscover: 'In Entdecken zeigen',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -567,6 +567,7 @@ export const en = {
   },
 
   profile: {
+    openChat: 'Open your chat',
     follow: 'Follow',
     following: 'Following',
     followers: { one: '{count} follower', other: '{count} followers' },
@@ -674,6 +675,8 @@ export const en = {
     codeOfConduct: 'Code of conduct',
   },
   settings: {
+    showStats: 'Show my numbers',
+    showStatsBody: 'Streak, corrections, tokens and this week’s chart on your profile.',
     legalSection: 'Legal',
     communitySection: 'Community',
     showInDiscover: 'Show me in Discover',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -530,6 +530,7 @@ export const es: Localized<EnMessages> = {
   },
 
   profile: {
+    openChat: 'Abrir el chat',
     follow: 'Seguir',
     following: 'Siguiendo',
     followers: { one: '{count} seguidor', other: '{count} seguidores' },
@@ -637,6 +638,8 @@ export const es: Localized<EnMessages> = {
     codeOfConduct: 'Código de conducta',
   },
   settings: {
+    showStats: 'Mostrar mis números',
+    showStatsBody: 'Racha, correcciones, tokens y el gráfico de la semana en tu perfil.',
     legalSection: 'Legal',
     communitySection: 'Comunidad',
     showInDiscover: 'Mostrarme en Descubrir',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -530,6 +530,7 @@ export const fr: Localized<EnMessages> = {
   },
 
   profile: {
+    openChat: 'Ouvrir la conversation',
     follow: 'Suivre',
     following: 'Suivi',
     followers: { one: '{count} abonné', other: '{count} abonnés' },
@@ -638,6 +639,8 @@ export const fr: Localized<EnMessages> = {
     codeOfConduct: 'Code de conduite',
   },
   settings: {
+    showStats: 'Afficher mes chiffres',
+    showStatsBody: 'Série, corrections, jetons et le graphique de la semaine sur votre profil.',
     legalSection: 'Mentions légales',
     communitySection: 'Communauté',
     showInDiscover: 'M’afficher dans Découvrir',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -526,6 +526,7 @@ export const ptBR: Localized<EnMessages> = {
   },
 
   profile: {
+    openChat: 'Abrir a conversa',
     follow: 'Seguir',
     following: 'Seguindo',
     followers: { one: '{count} seguidor', other: '{count} seguidores' },
@@ -633,6 +634,8 @@ export const ptBR: Localized<EnMessages> = {
     codeOfConduct: 'Código de conduta',
   },
   settings: {
+    showStats: 'Mostrar meus números',
+    showStatsBody: 'Sequência, correções, tokens e o gráfico da semana no seu perfil.',
     legalSection: 'Jurídico',
     communitySection: 'Comunidade',
     showInDiscover: 'Mostrar em Descobrir',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -601,6 +601,7 @@ export const ru: Localized<EnMessages> = {
   },
 
   profile: {
+    openChat: 'Открыть чат',
     follow: 'Подписаться',
     following: 'Вы подписаны',
     followers: {
@@ -725,6 +726,8 @@ export const ru: Localized<EnMessages> = {
     codeOfConduct: 'Кодекс поведения',
   },
   settings: {
+    showStats: 'Показывать мои цифры',
+    showStatsBody: 'Стрик, исправления, токены и график недели в профиле.',
     legalSection: 'Правовые документы',
     communitySection: 'Сообщество',
     showInDiscover: 'Показывать меня в Поиске',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -538,6 +538,7 @@ export const tr: Localized<EnMessages> = {
   },
 
   profile: {
+    openChat: 'Sohbeti aç',
     follow: 'Takip et',
     following: 'Takip ediliyor',
     followers: { one: '{count} takipçi', other: '{count} takipçi' },
@@ -645,6 +646,8 @@ export const tr: Localized<EnMessages> = {
     codeOfConduct: 'Davranış kuralları',
   },
   settings: {
+    showStats: 'Sayılarımı göster',
+    showStatsBody: 'Profilinde streak, düzeltme, token ve bu haftanın grafiği.',
     legalSection: 'Hukuki',
     communitySection: 'Topluluk',
     showInDiscover: 'Keşfet’te görün',

--- a/apps/mobile/src/lib/activityMap.test.ts
+++ b/apps/mobile/src/lib/activityMap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { activityGrid, repairEffect } from './activityMap'
+import { activityGrid, repairEffect, type ActivityCell } from './activityMap'
 
 // A Saturday, so the "today is not the end of the column" case is the default.
 const TODAY = '2026-08-29'
@@ -115,5 +115,46 @@ describe('repairEffect', () => {
     })
     expect(effect.affordable).toBe(false)
     expect(effect.balanceAfter).toBe(-50)
+  })
+})
+
+describe('activityGrid and a streak the collection cannot account for', () => {
+  const BASE = { today: '2026-08-30', weeks: 2, maxAgeDays: 7 }
+  const cellsFor = (grid: ActivityCell[][]): Map<string, ActivityCell> =>
+    new Map(grid.flat().map((cell) => [cell.day, cell]))
+
+  it('fills the run behind a streak that has no rows of its own', () => {
+    const grid = activityGrid({
+      ...BASE,
+      days: new Map(),
+      streak: { current: 3, lastQualifiedDay: '2026-08-30' },
+    })
+    const cells = cellsFor(grid)
+    for (const day of ['2026-08-30', '2026-08-29', '2026-08-28']) {
+      expect(cells.get(day)?.state, day).toBe('filled')
+      expect(cells.get(day)?.intensity, day).toBeGreaterThan(0)
+    }
+    // One day further back is still empty: the streak says three, not four.
+    expect(cells.get('2026-08-27')?.state).toBe('repairable')
+  })
+
+  it('lets a real row outrank the implied one, so shading survives', () => {
+    const grid = activityGrid({
+      ...BASE,
+      days: new Map([['2026-08-30', 40]]),
+      streak: { current: 2, lastQualifiedDay: '2026-08-30' },
+    })
+    const cells = cellsFor(grid)
+    expect(cells.get('2026-08-30')?.intensity).toBe(4)
+    expect(cells.get('2026-08-29')?.intensity).toBe(1)
+  })
+
+  it('does nothing when there is no streak to imply', () => {
+    const grid = activityGrid({
+      ...BASE,
+      days: new Map(),
+      streak: { current: 0, lastQualifiedDay: null },
+    })
+    expect(grid.flat().every((cell) => cell.intensity === 0)).toBe(true)
   })
 })

--- a/apps/mobile/src/lib/activityMap.ts
+++ b/apps/mobile/src/lib/activityMap.ts
@@ -25,8 +25,20 @@ export function activityGrid(input: {
   /** Day → qualifying actions. A bought day is present with zero. */
   days: Map<string, number>
   maxAgeDays: number
+  /**
+   * The streak the profile claims, used to fill days the collection cannot
+   * account for.
+   *
+   * `streakDays` only started existing when this map shipped, so an older
+   * account has a streak counter and no squares behind it — six months of
+   * empty boxes under a "🔥 40", which reads as a bug because it is one. The
+   * run ending at `lastQualifiedDay` is filled at the lowest shade: the days
+   * are known to have happened, only how busy they were is not.
+   */
+  streak?: { current: number; lastQualifiedDay: string | null } | undefined
 }): ActivityCell[][] {
   const { today, weeks, days, maxAgeDays } = input
+  const streakDays = impliedStreakDays(input.streak)
   const oldestRepairable = shiftDayKey(today, -maxAgeDays)
 
   // Wind forward to the Sunday that closes today's week, so the last column is
@@ -40,10 +52,10 @@ export function activityGrid(input: {
     const cells: ActivityCell[] = []
     for (let row = 0; row < 7; row++) {
       const actions = days.get(day)
-      const filled = actions !== undefined
+      const filled = actions !== undefined || streakDays.has(day)
       cells.push({
         day,
-        intensity: filled ? intensityOf(actions) : 0,
+        intensity: filled ? intensityOf(actions ?? 0) : 0,
         state:
           day > today
             ? 'future'
@@ -98,9 +110,33 @@ export function repairEffect(input: {
   }
 }
 
-/** Monday-first weekday index for a `YYYY-MM-DD` key. */
+/**
+ * Monday-first weekday index for a `YYYY-MM-DD` key.
+ *
+ * Parsed as UTC, not as local time. `new Date('2026-08-30T00:00:00')` is
+ * midnight *where the phone is*, and west of UTC that is the previous day —
+ * which slid the whole grid by one weekday for anybody in the Americas, and
+ * put "today" on the wrong row. A day key is a calendar day and carries no
+ * zone; reading it in one is the bug.
+ */
 function mondayIndex(day: string): number {
-  return (new Date(`${day}T00:00:00`).getDay() + 6) % 7
+  return (new Date(`${day}T00:00:00Z`).getUTCDay() + 6) % 7
+}
+
+/**
+ * The days the current streak must have covered, walking back from the last
+ * one that qualified. Empty when there is no streak, which is the common case
+ * and the one where `days` is the whole truth.
+ */
+function impliedStreakDays(
+  streak: { current: number; lastQualifiedDay: string | null } | undefined,
+): Set<string> {
+  const filled = new Set<string>()
+  if (!streak?.lastQualifiedDay || streak.current <= 0) return filled
+  for (let back = 0; back < streak.current; back++) {
+    filled.add(shiftDayKey(streak.lastQualifiedDay, -back))
+  }
+  return filled
 }
 
 /**

--- a/packages/shared/src/profile.ts
+++ b/packages/shared/src/profile.ts
@@ -164,6 +164,13 @@ export const updateProfileSchema = z
          * this one is not a Pro feature, it is a preference.
          */
         activityMapVisible: z.boolean(),
+        /**
+         * The numbers above the map — streak, corrections, tokens — and the
+         * week's chart. Default on for the same reason: they are a record of
+         * teaching people, which is the thing this app is for. Off is for
+         * anyone who would rather not be measured in public.
+         */
+        statsVisible: z.boolean(),
       })
       .partial(),
   })


### PR DESCRIPTION
Four things about looking at somebody else.

**A flag on the discovery card.** The country was already in the payload and only the profile drew it. One glyph, in a row with none to spare, and the one thing on the card that reads the same in every language.

**The message box knows when there is already a chat.** It offered a "send a message" form to somebody you were mid-conversation with, and sending from it failed — `startConversation` refuses a second thread, so the reward for typing a message out was *"a conversation with this user already exists"*. The profile now carries `conversationId` when there is one, computed per viewer exactly like `follow`, and the form becomes a link to the thread.

**Streak, corrections, tokens and this week's chart, on anybody's profile.** New `GET /profiles/:handle/summary` — deliberately smaller than the owner's `/me/summary`: no wallet, no quota, no per-day counters, nothing about what was bought. `privacy.statsVisible` turns it off (default on: a record of teaching people is what this app is for), and off means the fields are **not sent**, not hidden by the client.

**The activity map was wrong twice.**

1. It sat flush against its card's border — the card brings no padding and this child brought none either — and its header ran off the edge instead of wrapping.
2. It drew six months of empty squares under a streak of 40. The squares come from `streakDays`, which only started existing when the map shipped, so every account older than that has a counter with no history behind it (`wallet.ts` already knew this and guarded against it). The map now fills the run the streak implies, at the lowest shade: those days are known to have happened, only how busy they were is not.

`mondayIndex` also parsed the day key in the device's zone, which slid the whole grid by one weekday for anybody west of UTC. A day key is a calendar day and carries no zone.

The same component draws both maps, read-only for somebody else's — a second grid would be a second one to keep in step.

## Checks

`pnpm test` (905), `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` green. Verified against the local stack: profile with stats and map screenshotted, the "Open your chat" path taken, and `scripts/migrate-birthdate.ts` run for real (dry run, then `--apply --set`) on the scratch database.