### PR TITLE
Show your own profile as a preview, and stop it acting like somebody else's

### DIFF
--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -21,6 +21,7 @@ import { LevelBars } from '../../src/components/ui/LevelBars'
 import { ListRow } from '../../src/components/ui/ListRow'
 import { Screen } from '../../src/components/ui/Screen'
 import { StatTile } from '../../src/components/ui/StatTile'
+import { openProfile } from '../../src/lib/navigation'
 import { openPaywall } from '../../src/lib/paywall'
 import { makeStyles, useTheme } from '../../src/lib/theme'
 import { useDisplayNames, useT } from '../../src/i18n'
@@ -169,6 +170,17 @@ export default function MeScreen() {
             {profile.learning[0] ? <LevelBars level={profile.learning[0].level} /> : null}
           </View>
         }
+      />
+
+      {/*
+        Last of the rows, because it is the result of everything above it: this
+        is the profile a stranger — or anyone following your link — actually
+        sees, with your privacy settings already applied.
+      */}
+      <ListRow
+        title={t('me.previewProfile')}
+        subtitle={t('me.previewProfileBody')}
+        onPress={() => openProfile(profile.handle, '/(app)/me')}
       />
 
       {!isPro ? (

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -334,66 +334,79 @@ export default function ProfileScreen() {
       </View>
 
       {/*
-        A conversation that already exists is a link, not a form. The composer
-        below cannot start a second one — `startConversation` refuses, which
-        used to surface as "a conversation with this user already exists" after
-        typing a message out.
+        Everything below is addressed to somebody else, so none of it belongs
+        on your own profile. `isSelf` used to gate only the kebab menu and the
+        Follow button, which left a composer that messaged you and a Block
+        button that blocked you — reachable already through a handle deep
+        link, and now the whole point of "Preview my profile".
       */}
-      {user.conversationId ? (
-        <Button
-          label={t('profile.openChat')}
-          variant="secondary"
-          onPress={() => router.push(`/(app)/chat/${user.conversationId}`)}
-          style={styles.send}
-        />
+      {isSelf ? (
+        <Text style={styles.previewNote}>{t('profile.previewNote')}</Text>
       ) : (
         <>
-          <Text style={styles.sendLabel}>{t('profile.sendMessage')}</Text>
-          <View style={styles.composerRow}>
-            <TextInput
-              value={message}
-              onChangeText={setMessage}
-              placeholder={t('chat.sayHello', { name: user.displayName })}
-              placeholderTextColor={colors.textFaint}
-              style={styles.input}
+          {/*
+            A conversation that already exists is a link, not a form. The
+            composer below cannot start a second one — `startConversation`
+            refuses, which used to surface as "a conversation with this user
+            already exists" after typing a message out.
+          */}
+          {user.conversationId ? (
+            <Button
+              label={t('profile.openChat')}
+              variant="secondary"
+              onPress={() => router.push(`/(app)/chat/${user.conversationId}`)}
+              style={styles.send}
             />
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t('common.send')}
-              accessibilityState={{ disabled: !canSend }}
-              disabled={!canSend}
-              onPress={() => void send()}
-              style={({ pressed }) => [
-                styles.sendCircle,
-                !canSend && styles.sendCircleDisabled,
-                pressed && canSend && styles.iconPressed,
-              ]}
-            >
-              {startConversation.isPending ? (
-                <ActivityIndicator color={colors.bg} />
-              ) : (
-                <Feather name="send" size={17} color={colors.bg} />
-              )}
+          ) : (
+            <>
+              <Text style={styles.sendLabel}>{t('profile.sendMessage')}</Text>
+              <View style={styles.composerRow}>
+                <TextInput
+                  value={message}
+                  onChangeText={setMessage}
+                  placeholder={t('chat.sayHello', { name: user.displayName })}
+                  placeholderTextColor={colors.textFaint}
+                  style={styles.input}
+                />
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={t('common.send')}
+                  accessibilityState={{ disabled: !canSend }}
+                  disabled={!canSend}
+                  onPress={() => void send()}
+                  style={({ pressed }) => [
+                    styles.sendCircle,
+                    !canSend && styles.sendCircleDisabled,
+                    pressed && canSend && styles.iconPressed,
+                  ]}
+                >
+                  {startConversation.isPending ? (
+                    <ActivityIndicator color={colors.bg} />
+                  ) : (
+                    <Feather name="send" size={17} color={colors.bg} />
+                  )}
+                </Pressable>
+              </View>
+              {quota.data ? (
+                <Text style={styles.quotaHint}>
+                  {t('me.newChatsLeft')} {quota.data.initiations.remaining ?? '—'} /{' '}
+                  {quota.data.initiations.limit ?? '∞'}
+                </Text>
+              ) : null}
+              {error ? <Text style={styles.error}>{error}</Text> : null}
+            </>
+          )}
+
+          <View style={styles.danger}>
+            <Pressable onPress={() => void confirmReport()} hitSlop={8}>
+              <Text style={styles.dangerText}>{t('common.report')}</Text>
+            </Pressable>
+            <Pressable onPress={() => void confirmBlock()} hitSlop={8}>
+              <Text style={styles.dangerText}>{t('common.block')}</Text>
             </Pressable>
           </View>
-          {quota.data ? (
-            <Text style={styles.quotaHint}>
-              {t('me.newChatsLeft')} {quota.data.initiations.remaining ?? '—'} /{' '}
-              {quota.data.initiations.limit ?? '∞'}
-            </Text>
-          ) : null}
-          {error ? <Text style={styles.error}>{error}</Text> : null}
         </>
       )}
-
-      <View style={styles.danger}>
-        <Pressable onPress={() => void confirmReport()} hitSlop={8}>
-          <Text style={styles.dangerText}>{t('common.report')}</Text>
-        </Pressable>
-        <Pressable onPress={() => void confirmBlock()} hitSlop={8}>
-          <Text style={styles.dangerText}>{t('common.block')}</Text>
-        </Pressable>
-      </View>
     </Screen>
   )
 }
@@ -475,6 +488,12 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   quotaHint: { color: colors.textFaint, fontSize: 13, marginTop: 10 },
   error: { ...font.caption, color: colors.danger, marginTop: spacing.sm },
   send: { marginTop: spacing.lg },
+  previewNote: {
+    ...font.caption,
+    color: colors.textFaint,
+    lineHeight: 19,
+    marginTop: spacing.xl,
+  },
   danger: {
     borderTopColor: colors.border,
     borderTopWidth: 1,

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -631,6 +631,7 @@ export const ar: Localized<EnMessages> = {
   },
 
   profile: {
+    previewNote: 'هذا هو ملفك الشخصي كما يراه الآخرون — إعدادات الخصوصية مطبَّقة بالفعل.',
     teaches: 'يُعلّم',
     learns: 'يتعلّم',
     openChat: 'افتح المحادثة',
@@ -698,6 +699,8 @@ export const ar: Localized<EnMessages> = {
     settings: 'الإعدادات',
     corrections: 'التصحيحات',
     tokens: 'الرموز',
+    previewProfile: 'معاينة ملفي الشخصي',
+    previewProfileBody: 'شاهد ملفك كما يراه الآخرون',
     badges: 'الشارات',
   },
 

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -545,6 +545,8 @@ export const de: Localized<EnMessages> = {
   },
 
   profile: {
+    previewNote:
+      'So sehen andere dein Profil — deine Privatsphäre-Einstellungen sind bereits angewendet.',
     teaches: 'Lehrt',
     learns: 'Lernt',
     openChat: 'Chat öffnen',
@@ -587,6 +589,8 @@ export const de: Localized<EnMessages> = {
     settings: 'Einstellungen',
     corrections: 'Korrekturen',
     tokens: 'Token',
+    previewProfile: 'Mein Profil ansehen',
+    previewProfileBody: 'Sieh dein Profil so, wie andere es sehen',
     badges: 'Abzeichen',
   },
 

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -578,6 +578,8 @@ export const en = {
   },
 
   profile: {
+    previewNote:
+      'This is your profile as other people see it — your privacy settings are already applied.',
     teaches: 'Teaches',
     learns: 'Learns',
     openChat: 'Open your chat',
@@ -620,6 +622,8 @@ export const en = {
     settings: 'Settings',
     corrections: 'Corrections',
     tokens: 'Tokens',
+    previewProfile: 'Preview my profile',
+    previewProfileBody: 'See your profile the way other people do',
     badges: 'Badges',
   },
 

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -542,6 +542,7 @@ export const es: Localized<EnMessages> = {
   },
 
   profile: {
+    previewNote: 'Así ven los demás tu perfil: tus ajustes de privacidad ya están aplicados.',
     teaches: 'Enseña',
     learns: 'Aprende',
     openChat: 'Abrir el chat',
@@ -584,6 +585,8 @@ export const es: Localized<EnMessages> = {
     settings: 'Ajustes',
     corrections: 'Correcciones',
     tokens: 'Fichas',
+    previewProfile: 'Ver mi perfil',
+    previewProfileBody: 'Mira tu perfil como lo ven los demás',
     badges: 'Insignias',
   },
 

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -542,6 +542,8 @@ export const fr: Localized<EnMessages> = {
   },
 
   profile: {
+    previewNote:
+      'Voici ton profil tel que les autres le voient — tes réglages de confidentialité sont déjà appliqués.',
     teaches: 'Enseigne',
     learns: 'Apprend',
     openChat: 'Ouvrir la conversation',
@@ -585,6 +587,8 @@ export const fr: Localized<EnMessages> = {
     settings: 'Réglages',
     corrections: 'Corrections',
     tokens: 'Jetons',
+    previewProfile: 'Aperçu de mon profil',
+    previewProfileBody: 'Vois ton profil comme les autres le voient',
     badges: 'Badges',
   },
 

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -537,6 +537,8 @@ export const ptBR: Localized<EnMessages> = {
   },
 
   profile: {
+    previewNote:
+      'Este é o seu perfil como as outras pessoas o veem — suas configurações de privacidade já estão aplicadas.',
     teaches: 'Ensina',
     learns: 'Aprende',
     openChat: 'Abrir a conversa',
@@ -579,6 +581,8 @@ export const ptBR: Localized<EnMessages> = {
     settings: 'Configurações',
     corrections: 'Correções',
     tokens: 'Fichas',
+    previewProfile: 'Ver meu perfil',
+    previewProfileBody: 'Veja seu perfil como as outras pessoas veem',
     badges: 'Insígnias',
   },
 

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -612,6 +612,7 @@ export const ru: Localized<EnMessages> = {
   },
 
   profile: {
+    previewNote: 'Так ваш профиль видят другие — настройки приватности уже применены.',
     teaches: 'Преподаёт',
     learns: 'Учит',
     openChat: 'Открыть чат',
@@ -671,6 +672,8 @@ export const ru: Localized<EnMessages> = {
     settings: 'Настройки',
     corrections: 'Исправления',
     tokens: 'Жетоны',
+    previewProfile: 'Посмотреть мой профиль',
+    previewProfileBody: 'Взгляните на профиль глазами других',
     badges: 'Значки',
   },
 

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -549,6 +549,8 @@ export const tr: Localized<EnMessages> = {
   },
 
   profile: {
+    previewNote:
+      'Bu, başkalarının gördüğü haliyle profilin — gizlilik ayarların zaten uygulanmış durumda.',
     teaches: 'Öğretiyor',
     learns: 'Öğreniyor',
     openChat: 'Sohbeti aç',
@@ -591,6 +593,8 @@ export const tr: Localized<EnMessages> = {
     settings: 'Ayarlar',
     corrections: 'Düzeltme',
     tokens: 'Jeton',
+    previewProfile: 'Profilimi önizle',
+    previewProfileBody: 'Profilini başkalarının gördüğü gibi gör',
     badges: 'Rozetler',
   },
 


### PR DESCRIPTION
## What

Me → **Preview my profile** opens your own public profile, so you can see what a stranger — or anyone following your link — actually sees.

## Why the screen needed fixing first

`app/(app)/profile/[handle].tsx` was already reachable for yourself through a handle deep link, and `isSelf` gated only the kebab menu and the Follow button. Two things were left ungated:

- **The composer.** `conversationId` is null for yourself, so the screen took the "start a conversation" branch and its send button called `startConversation({ toUserId: <your own id> })`.
- **The report/block footer.** The same two actions the kebab already hides for yourself. Blocking yourself was one tap away.

One gate now covers both, and in their place the screen states what it is.

## Server

No changes needed. `toPublicProfile` is viewer-independent, and `recordProfileView` already returns early on a self view — previewing does not put you in your own viewers list. The privacy flags that matter (`hideOnlineStatus`, `statsVisible`, `activityMapVisible`) all apply to the *target* profile, so the preview is honest about them.

## Two gaps, deliberately left

- `settings.discoverable` is not reflected — a non-discoverable profile is still fully readable by link, which is exactly what this preview shows.
- Follower counts exclude people *you* blocked; a stranger's view would not. Small, and fixing it would mean an unauthenticated read path.

## Checks

`pnpm --filter @langx/mobile test` — 278 passed (includes `catalogs.test.ts` parity across all 8 locales and `routeLiterals.test.ts`). `pnpm lint` and `pnpm format:check` clean.

`tsc --noEmit` reports three route-literal errors in `settings.tsx`, `languages.tsx` and `index.tsx` — pre-existing on `main`, caused by a stale gitignored `.expo/types/router.d.ts` that predates `(app)/kitchen` and `(onboarding)/levels`. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)