### PR TITLE
Order the feed online-first always, and add a way to search a username

### DIFF
--- a/apps/api/src/modules/discovery/discovery.ts
+++ b/apps/api/src/modules/discovery/discovery.ts
@@ -253,22 +253,55 @@ export async function discoverProfiles(
       : [{ $match: match }]
 
   /**
-   * "Online first" is an *ordering*, not a filter.
+   * "Online first" is an *ordering*, not a filter, and no longer a choice.
    *
-   * It used to be a `$match` on the five-minute window, which emptied the
-   * list whenever nobody was about — the opposite of what a discovery screen
-   * is for. Everyone still comes back; the online ones lead, and the rest
-   * follow by whatever the sort already used.
+   * It was a `$match` on the five-minute window once, which emptied the list
+   * whenever nobody was about — the opposite of what a discovery screen is
+   * for. Then it was a chip. Now it is simply how the recommended feed is
+   * ordered: everyone still comes back, the online ones lead, and the rest
+   * follow by score.
    *
-   * `sort=active` needs none of this: ordering by `lastActiveAt` descending
-   * already puts the window at the top by construction.
+   * It applies to `recommended` **only**, and the other two sorts are the
+   * reason it is not global:
+   *
+   *   - `sort=active` orders by `lastActiveAt` descending, which already puts
+   *     the five-minute window on top by construction. Adding the bucket in
+   *     front would change nothing about the order and break the keyset cursor
+   *     below, which compares `lastActiveAt` and `_id` and knows nothing about
+   *     a bucket.
+   *   - `sort=nearby` is bought to answer "who is near me". Bucketing first
+   *     puts someone online 90 km away ahead of someone offline in the next
+   *     street, which is not a nearby list with a preference — it is a
+   *     recommended list with a radius.
+   *
+   * The cost is real and worth naming: `onlineBucket` is computed, so it can
+   * never be indexed, and this is a blocking in-memory sort. It used to be
+   * paid only by whoever turned the chip on; every default request pays it now.
    */
   const now = new Date()
-  const cursor = query.cursor ? decodeOnlineOffsetCursor(query.cursor, now) : null
-  const onlineOffset = cursor?.offset ?? 0
+
+  /*
+   * Three sorts, three cursor shapes, and each is now decoded only by the sort
+   * that writes it.
+   *
+   * That was a live bug: every cursor went through `decodeOnlineOffsetCursor`,
+   * including `active`'s keyset `<iso>|<userId>`. It contains a `|`, so it took
+   * the pinned-cutoff branch and hit the one-hour expiry check — paging
+   * `sort=active` past anyone whose `lastActiveAt` was over an hour old
+   * returned `400 Cursor has expired`. The existing test missed it because its
+   * fixtures were all active seconds ago.
+   */
+  const recommendedCursor =
+    query.cursor && query.sort === 'recommended'
+      ? decodeOnlineOffsetCursor(query.cursor, now)
+      : null
+  const skipOffset =
+    query.sort === 'nearby' && query.cursor
+      ? decodeOffsetCursor(query.cursor)
+      : (recommendedCursor?.offset ?? 0)
   const onlineCutoff =
-    query.online && query.sort !== 'active'
-      ? (cursor?.cutoff ?? new Date(now.getTime() - ONLINE_WINDOW_MS))
+    query.sort === 'recommended'
+      ? (recommendedCursor?.cutoff ?? new Date(now.getTime() - ONLINE_WINDOW_MS))
       : null
 
   if (onlineCutoff) {
@@ -311,18 +344,16 @@ export async function discoverProfiles(
     }
     pipeline.push({ $sort: { 'stats.lastActiveAt': -1, _id: 1 } })
   } else if (query.sort === 'nearby') {
-    /**
-     * Normally no `$sort`: `$geoNear` already emits nearest-first, and
-     * re-sorting costs a blocking stage and discards that guarantee.
+    /*
+     * No `$sort` at all: `$geoNear` already emits nearest-first, and
+     * re-sorting costs a blocking stage and throws that guarantee away.
      *
-     * With the chip on, discarding it is exactly what was asked for, so one
-     * goes in — bounded by `maxDistance` and Pro+ only, so the blocking sort
-     * runs over a small candidate set.
+     * A chip used to be able to put online-first ahead of distance here. It is
+     * gone rather than made unconditional — this sort is what Pro+ buys to
+     * answer "who is near me", and bucketing first puts someone online 90 km
+     * away ahead of someone offline in the next street.
      */
-    if (onlineCutoff) {
-      pipeline.push({ $sort: { onlineBucket: -1, distanceMeters: 1, _id: 1 } })
-    }
-    if (query.cursor) pipeline.push({ $skip: onlineOffset })
+    if (query.cursor) pipeline.push({ $skip: skipOffset })
   } else {
     // Small, capped arrays (MAX_LANGUAGES=5, MAX_INTERESTS=10) — cheap to
     // score with $setIntersection per candidate rather than needing a
@@ -347,7 +378,7 @@ export async function discoverProfiles(
           : { score: -1, 'stats.lastActiveAt': -1, _id: 1 },
       },
     )
-    if (query.cursor) pipeline.push({ $skip: onlineOffset })
+    if (query.cursor) pipeline.push({ $skip: skipOffset })
   }
 
   // Fetch one extra to know whether a next page exists without a second round-trip.
@@ -390,7 +421,7 @@ export async function discoverProfiles(
   if (hasMore) {
     const last = page.at(-1)
     if (last) {
-      const nextOffset = page.length + onlineOffset
+      const nextOffset = page.length + skipOffset
       nextCursor =
         query.sort === 'active'
           ? encodeActiveCursor(new Date(last.stats.lastActiveAt), last._id)

--- a/apps/api/src/modules/discovery/handleSearch.ts
+++ b/apps/api/src/modules/discovery/handleSearch.ts
@@ -1,0 +1,75 @@
+import { HANDLE_SEARCH_LIMIT, type HandleSearchPage } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { blockedUserIds } from '../moderation/blocks'
+import type { Profile } from '../profiles/profiles'
+
+/**
+ * Escapes a user string before it reaches `$regex`.
+ *
+ * Without it a handle search is a way to hand Mongo a pattern: `.*` scans the
+ * collection, and a nested quantifier is a request the server spends real time
+ * failing to match. `handleSchema` bounds what a stored handle may contain but
+ * says nothing about what somebody may *type*.
+ */
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Find someone by the start of their handle.
+ *
+ * **Anchored, always.** `^term` rides the `handle_unique` btree index; an
+ * unanchored `/term/` cannot, and would turn a search box into a collection
+ * scan per keystroke. Handles are stored lower-cased by `handleSchema`, so the
+ * query lower-cases too rather than asking for a case-insensitive regex, which
+ * would also give up the index.
+ *
+ * The rules it shares with discovery, and the two it does not:
+ *
+ *   - `blockedUserIds` is two-sided and applies here as everywhere else. A
+ *     blocked user is **absent**, never refused — a 403 would confirm the
+ *     account exists, which is what blocking is meant to stop.
+ *   - `settings.discoverable` applies, because searching is browsing. Somebody
+ *     who has opted out of being found is still reachable by their exact link;
+ *     that is `GET /profiles/:handleOrId`, deliberately, and it is a different
+ *     question from this one.
+ *   - Mutual language fit does **not** apply. Discovery requires it because it
+ *     is proposing partners; finding somebody whose name you already know
+ *     cannot depend on whether you happen to be learnable to each other.
+ */
+export async function searchHandles(
+  db: Db,
+  viewerId: string,
+  term: string,
+): Promise<HandleSearchPage> {
+  const excludedIds = [viewerId, ...(await blockedUserIds(db, viewerId))]
+
+  const rows = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .find(
+      {
+        _id: { $nin: excludedIds },
+        handle: { $regex: `^${escapeRegex(term)}` },
+        'settings.discoverable': true,
+        deletedAt: { $exists: false },
+      },
+      {
+        projection: { handle: 1, displayName: 1, avatarUrl: 1 },
+        // Alphabetical, so the shortest match — the one most likely to be the
+        // handle actually being typed — leads.
+        sort: { handle: 1 },
+        limit: HANDLE_SEARCH_LIMIT,
+      },
+    )
+    .toArray()
+
+  return {
+    items: rows.map((row) => ({
+      _id: row._id,
+      handle: row.handle,
+      displayName: row.displayName,
+      ...(row.avatarUrl ? { avatarUrl: row.avatarUrl } : {}),
+    })),
+  }
+}

--- a/apps/api/src/routes/discovery.test.ts
+++ b/apps/api/src/routes/discovery.test.ts
@@ -1,4 +1,9 @@
-import { DISCOVERY_CURSOR_MAX_AGE_MS, DISTANCE_BUCKETS_KM, type DiscoveryPage } from '@langx/shared'
+import {
+  DISCOVERY_CURSOR_MAX_AGE_MS,
+  DISTANCE_BUCKETS_KM,
+  type DiscoveryPage,
+  type HandleSearchPage,
+} from '@langx/shared'
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
 import type { FastifyInstance } from 'fastify'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -241,7 +246,7 @@ describe('Faz 3 — discovery aggregation', () => {
       })
       await setLastActiveAt(staleActive.userId, new Date(Date.now() - 60 * 60 * 1000))
 
-      const response = await discover(viewer, 'online=true')
+      const response = await discover(viewer, '')
       const handles = response.json<{ items: { handle: string }[] }>().items.map((i) => i.handle)
       expect(handles).toContain(recentlyActive.handle)
       expect(handles).toContain(staleActive.handle)
@@ -261,7 +266,7 @@ describe('Faz 3 — discovery aggregation', () => {
       })
       await setLastActiveAt(offline.userId, new Date(Date.now() - 60 * 60 * 1000))
 
-      const response = await discover(viewer, 'online=true')
+      const response = await discover(viewer, '')
       const handles = response.json<{ items: { handle: string }[] }>().items.map((i) => i.handle)
       expect(handles).toEqual([offline.handle])
     })
@@ -291,7 +296,7 @@ describe('Faz 3 — discovery aggregation', () => {
         .updateOne({ _id: hidden.userId }, { $set: { 'privacy.hideOnlineStatus': true } })
       await setLastActiveAt(visible.userId, new Date(Date.now() - 60 * 60 * 1000))
 
-      const response = await discover(viewer, 'online=true')
+      const response = await discover(viewer, '')
       const items = response.json<{ items: { handle: string; isOnline: boolean }[] }>().items
       const handles = items.map((i) => i.handle)
       // Both land in bucket 0 — the hidden one because it is hidden, the
@@ -302,7 +307,7 @@ describe('Faz 3 — discovery aggregation', () => {
       expect(items.find((i) => i.handle === hidden.handle)?.isOnline).toBe(false)
     })
 
-    it('orders online-first ahead of the recommended score, not behind it', async () => {
+    it('orders online-first ahead of the recommended score, always', async () => {
       const viewer = await newUser('bucket-order-viewer@example.com', {
         nativeLanguages: [{ code: 'hu' }],
         learning: [{ code: 'ro', level: 'intermediate', priority: 1 }],
@@ -320,18 +325,11 @@ describe('Faz 3 — discovery aggregation', () => {
       })
       await setLastActiveAt(highScoreOffline.userId, new Date(Date.now() - 60 * 60 * 1000))
 
-      const withChip = await discover(viewer, 'online=true')
-      const chipHandles = withChip
-        .json<{ items: { handle: string }[] }>()
-        .items.map((i) => i.handle)
-      expect(chipHandles[0]).toBe(lowScoreOnline.handle)
-
-      // And without the chip the score still wins, so this is opt-in.
-      const without = await discover(viewer)
-      const plainHandles = without
-        .json<{ items: { handle: string }[] }>()
-        .items.map((i) => i.handle)
-      expect(plainHandles[0]).toBe(highScoreOffline.handle)
+      // No parameter to pass: this used to be a chip and is now the ordering.
+      const response = await discover(viewer)
+      const handles = response.json<{ items: { handle: string }[] }>().items.map((i) => i.handle)
+      expect(handles[0]).toBe(lowScoreOnline.handle)
+      expect(handles).toContain(highScoreOffline.handle)
     })
 
     /**
@@ -340,6 +338,44 @@ describe('Faz 3 — discovery aggregation', () => {
      * under a `$skip` already handed out — one row repeats and another is
      * never shown. Without the pin this test fails, which is why it exists.
      */
+    /**
+     * The pre-existing bug this change had to fix to work at all.
+     *
+     * Every cursor used to go through `decodeOnlineOffsetCursor`, including
+     * `sort=active`'s keyset `<iso>|<userId>`. It contains a `|`, so it took
+     * the pinned-cutoff branch and hit the one-hour expiry check — paging past
+     * anyone last active over an hour ago returned 400. The existing paging
+     * test never caught it because its fixtures were all active seconds ago.
+     */
+    it('pages sort=active past somebody last active long ago', async () => {
+      const viewer = await newUser('active-cursor-viewer@example.com', {
+        nativeLanguages: [{ code: 'da' }],
+        learning: [{ code: 'sv', level: 'intermediate', priority: 1 }],
+      })
+      const olds = []
+      for (const days of [2, 3, 4]) {
+        const candidate = await newUser(`active-cursor-${days}@example.com`, {
+          nativeLanguages: [{ code: 'sv' }],
+          learning: [{ code: 'da', level: 'intermediate', priority: 1 }],
+        })
+        await setLastActiveAt(candidate.userId, new Date(Date.now() - days * 86_400_000))
+        olds.push(candidate)
+      }
+
+      const first = await discover(viewer, 'sort=active&limit=1')
+      expect(first.statusCode, first.body).toBe(200)
+      const cursor = first.json<DiscoveryPage>().nextCursor
+      expect(cursor).not.toBeNull()
+
+      const second = await discover(
+        viewer,
+        `sort=active&limit=1&cursor=${encodeURIComponent(cursor!)}`,
+      )
+      expect(second.statusCode, second.body).toBe(200)
+      expect(second.json<DiscoveryPage>().items).toHaveLength(1)
+      expect(olds).toHaveLength(3)
+    })
+
     it('pages consistently when someone crosses the online boundary mid-scroll', async () => {
       const viewer = await newUser('boundary-viewer@example.com', {
         nativeLanguages: [{ code: 'lt' }],
@@ -360,7 +396,7 @@ describe('Faz 3 — discovery aggregation', () => {
       let flipped = false
       do {
         const suffix: string = cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''
-        const page = await discover(viewer, `online=true&limit=1${suffix}`)
+        const page = await discover(viewer, `limit=1${suffix}`)
         expect(page.statusCode, page.body).toBe(200)
         const body = page.json<{ items: { handle: string }[]; nextCursor: string | null }>()
         seen.push(...body.items.map((i) => i.handle))
@@ -382,10 +418,7 @@ describe('Faz 3 — discovery aggregation', () => {
         learning: [{ code: 'hr', level: 'intermediate', priority: 1 }],
       })
       const old = new Date(Date.now() - DISCOVERY_CURSOR_MAX_AGE_MS - 60_000).toISOString()
-      const response = await discover(
-        viewer,
-        `online=true&cursor=${encodeURIComponent(`${old}|1`)}`,
-      )
+      const response = await discover(viewer, `cursor=${encodeURIComponent(`${old}|1`)}`)
       expect(response.statusCode).toBe(400)
       expect(response.json<{ code: string }>().code).toBe('VALIDATION_FAILED')
     })
@@ -396,7 +429,7 @@ describe('Faz 3 — discovery aggregation', () => {
         nativeLanguages: [{ code: 'bg' }],
         learning: [{ code: 'mk', level: 'intermediate', priority: 1 }],
       })
-      const response = await discover(viewer, 'online=true&cursor=0')
+      const response = await discover(viewer, 'cursor=0')
       expect(response.statusCode, response.body).toBe(200)
     })
 
@@ -677,6 +710,115 @@ describe('Faz 3 — discovery aggregation', () => {
     })
   })
 
+  describe('handle search', () => {
+    async function search(viewer: SignedUpUser, q: string) {
+      return app.inject({
+        method: 'GET',
+        url: `/discovery/handles?q=${encodeURIComponent(q)}`,
+        headers: { cookie: viewer.cookie },
+      })
+    }
+
+    function handlesIn(response: { json: <T>() => T }) {
+      return response.json<HandleSearchPage>().items.map((item) => item.handle)
+    }
+
+    it('finds by the start of a handle, and only by the start', async () => {
+      const viewer = await newUser('search-viewer@example.com')
+      const target = await newUser('search-target@example.com', { handle: 'behicsakar' })
+      await newUser('search-other@example.com', { handle: 'zzunrelated' })
+
+      expect(handlesIn(await search(viewer, 'behic'))).toContain(target.handle)
+      // Unanchored would match, and would also be a collection scan per
+      // keystroke — the anchor is what keeps this on `handle_unique`.
+      expect(handlesIn(await search(viewer, 'sakar'))).not.toContain(target.handle)
+    })
+
+    it('does not care what case the searcher types', async () => {
+      const viewer = await newUser('search-case-viewer@example.com')
+      const target = await newUser('search-case-target@example.com', { handle: 'mixedcase' })
+      for (const term of ['MIXED', 'MiXeD', 'mixed']) {
+        expect(handlesIn(await search(viewer, term)), term).toContain(target.handle)
+      }
+    })
+
+    /**
+     * Discovery requires mutual language fit because it is *proposing*
+     * partners. Finding somebody whose name you already know cannot depend on
+     * whether the two of you happen to be learnable to each other.
+     */
+    it('ignores language fit, unlike the feed', async () => {
+      const viewer = await newUser('search-fit-viewer@example.com', {
+        nativeLanguages: [{ code: 'is' }],
+        learning: [{ code: 'no', level: 'intermediate', priority: 1 }],
+      })
+      const unmatched = await newUser('search-fit-target@example.com', {
+        handle: 'nofitatall',
+        nativeLanguages: [{ code: 'ja' }],
+        learning: [{ code: 'ko', level: 'intermediate', priority: 1 }],
+      })
+      expect(handlesIn(await search(viewer, 'nofit'))).toContain(unmatched.handle)
+    })
+
+    it('leaves out a block in either direction, and says nothing about it', async () => {
+      const viewer = await newUser('search-block-viewer@example.com')
+      const blocked = await newUser('search-blocked@example.com', { handle: 'blockedone' })
+      const blocker = await newUser('search-blocker@example.com', { handle: 'blockerone' })
+
+      await app.inject({
+        method: 'POST',
+        url: '/blocks',
+        headers: { cookie: viewer.cookie },
+        payload: { userId: blocked.userId },
+      })
+      await app.inject({
+        method: 'POST',
+        url: '/blocks',
+        headers: { cookie: blocker.cookie },
+        payload: { userId: viewer.userId },
+      })
+
+      // 200 with an empty list, never 403 — a refusal confirms the account
+      // exists, which is what blocking is meant to stop.
+      const blockedResponse = await search(viewer, 'blocked')
+      expect(blockedResponse.statusCode).toBe(200)
+      expect(handlesIn(blockedResponse)).not.toContain(blocked.handle)
+      expect(handlesIn(await search(viewer, 'blocker'))).not.toContain(blocker.handle)
+    })
+
+    it('leaves out someone who has opted out of being found', async () => {
+      const viewer = await newUser('search-hidden-viewer@example.com')
+      const hidden = await newUser('search-hidden@example.com', { handle: 'hiddenone' })
+      await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .updateOne({ _id: hidden.userId }, { $set: { 'settings.discoverable': false } })
+
+      expect(handlesIn(await search(viewer, 'hidden'))).not.toContain(hidden.handle)
+    })
+
+    it('never returns the searcher themselves', async () => {
+      const viewer = await newUser('search-self@example.com', { handle: 'searchself' })
+      expect(handlesIn(await search(viewer, 'searchself'))).not.toContain(viewer.handle)
+    })
+
+    /**
+     * `handleSchema` bounds what a stored handle may contain; it says nothing
+     * about what somebody may type into a search box.
+     */
+    it('treats regex metacharacters as text, not as a pattern', async () => {
+      const viewer = await newUser('search-regex-viewer@example.com')
+      await newUser('search-regex-target@example.com', { handle: 'patterntest' })
+      const response = await search(viewer, '.*')
+      expect(response.statusCode).toBe(200)
+      expect(handlesIn(response)).toHaveLength(0)
+    })
+
+    it('refuses a term too short to be worth a query', async () => {
+      const viewer = await newUser('search-short-viewer@example.com')
+      expect((await search(viewer, 'a')).statusCode).toBe(400)
+    })
+  })
+
   describe('sort presets and pagination', () => {
     it('sort=active pages through by lastActiveAt with no duplicates or gaps', async () => {
       const viewer = await newUser('active-sort-viewer@example.com', {
@@ -826,6 +968,26 @@ describe('Faz 3 — discovery aggregation', () => {
       for (const km of distances) expect(DISTANCE_BUCKETS_KM).toContain(km)
       // The nearest is about 1.5 km away; the answer must not be finer than a bucket.
       expect(items[0]?.distanceKm).toBeLessThanOrEqual(5)
+    })
+
+    it('orders purely by distance, never promoting whoever happens to be online', async () => {
+      const viewer = await newUser('nearby-online-viewer@example.com')
+      await setTier(viewer.userId, 'pro_plus')
+      await share(viewer, VIEWER)
+
+      const close = await share(await candidate('nearby-close-offline@example.com'), NEXT_DOOR)
+      const far = await share(await candidate('nearby-far-online@example.com'), ANOTHER_CITY)
+      // Close is an hour stale; far is online. Distance still decides.
+      await setLastActiveAt(close.userId, new Date(Date.now() - 60 * 60 * 1000))
+
+      const response = await discover(viewer, 'sort=nearby')
+      expect(response.statusCode, response.body).toBe(200)
+      // Relative, not absolute: earlier tests in this describe have already
+      // seeded candidates around the viewer, and the claim is about these two.
+      const handles = response.json<{ items: { handle: string }[] }>().items.map((i) => i.handle)
+      expect(handles).toContain(close.handle)
+      expect(handles).toContain(far.handle)
+      expect(handles.indexOf(close.handle)).toBeLessThan(handles.indexOf(far.handle))
     })
 
     it('leaves out everyone who has not shared a location, and says so by omission only in this sort', async () => {
@@ -1013,5 +1175,12 @@ describe('Faz 3 — discovery aggregation', () => {
       expect(serialized).toContain('IXSCAN')
       expect(serialized).not.toContain('COLLSCAN')
     })
+    /**
+     * Online-first used to be a chip that applied here too, and it is gone
+     * rather than made unconditional. This sort is what Pro+ buys to answer
+     * "who is near me"; bucketing first puts someone online 90 km away ahead
+     * of someone offline in the next street, which is a recommended list with
+     * a radius rather than a nearby list.
+     */
   })
 })

--- a/apps/api/src/routes/discovery.ts
+++ b/apps/api/src/routes/discovery.ts
@@ -1,7 +1,8 @@
-import { discoveryQuerySchema } from '@langx/shared'
+import { discoveryQuerySchema, handleSearchQuerySchema } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { requireAuth } from '../middleware/requireAuth'
 import { discoverProfiles } from '../modules/discovery/discovery'
+import { searchHandles } from '../modules/discovery/handleSearch'
 
 // eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
 export const discoveryRoutes: FastifyPluginAsyncZod = async (app) => {
@@ -11,6 +12,23 @@ export const discoveryRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request, reply) => {
       const page = await discoverProfiles(app.mongo.db, request.userId, request.query)
       return reply.send(page)
+    },
+  )
+
+  /*
+   * Its own rate limit, tighter than the global 300/minute. A search box is
+   * called per keystroke — the client debounces, but the client is not what
+   * enforces this — and it is the one endpoint here that takes a pattern.
+   */
+  app.get(
+    '/discovery/handles',
+    {
+      preHandler: requireAuth,
+      schema: { querystring: handleSearchQuerySchema },
+      config: { rateLimit: { max: 60, timeWindow: '1 minute' } },
+    },
+    async (request, reply) => {
+      return reply.send(await searchHandles(app.mongo.db, request.userId, request.query.q))
     },
   )
 }

--- a/apps/mobile/app/(app)/discover.tsx
+++ b/apps/mobile/app/(app)/discover.tsx
@@ -9,9 +9,18 @@ import { router, useLocalSearchParams } from 'expo-router'
 import { openProfile } from '../../src/lib/navigation'
 import { useMemo, useState } from 'react'
 import Feather from '@expo/vector-icons/Feather'
-import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from 'react-native'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
 import {
   useDiscovery,
+  useHandleSearch,
   useHasFeature,
   useIsPro,
   useMe,
@@ -33,6 +42,7 @@ import {
   toQuery,
   withoutProFilters,
 } from '../../src/lib/discoveryFilters'
+import { useDebounced } from '../../src/hooks/useDebounced'
 import { showAlert } from '../../src/lib/alert'
 import { captureLocation, LOCATION_FAILURE_KEY } from '../../src/lib/location'
 import { openPaywall } from '../../src/lib/paywall'
@@ -75,6 +85,11 @@ export default function DiscoverScreen() {
   const params = useLocalSearchParams<Record<string, string>>()
   const [sort, setSort] = useState<DiscoverySort>('recommended')
   const [radiusKm, setRadiusKm] = useState<number>(NEARBY_MAX_KM)
+  const [searching, setSearching] = useState(false)
+  const [term, setTerm] = useState('')
+  // The input renders `term` and the query follows the settled value, so
+  // typing stays responsive and "behic" is one request rather than five.
+  const search = useHandleSearch(useDebounced(term))
 
   const isPro = useIsPro()
   const canUseNearby = useHasFeature('nearby')
@@ -163,6 +178,22 @@ export default function DiscoverScreen() {
               the paywall a surprise instead of an offer. Free filters still
               live behind it, which is why a free account opens the filters
               rather than the paywall. */}
+          {/* Beside the filters, not above the list: the two are the same
+              question asked two ways — "narrow this" and "I already know who
+              I am looking for". */}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityState={{ expanded: searching }}
+            accessibilityLabel={t('discover.searchHandles')}
+            onPress={() => {
+              setSearching((on) => !on)
+              if (searching) setTerm('')
+            }}
+            style={({ pressed }) => [styles.filterButton, pressed && styles.pressed]}
+            hitSlop={8}
+          >
+            <Feather name={searching ? 'x' : 'search'} size={22} color={colors.text} />
+          </Pressable>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel={
@@ -180,6 +211,51 @@ export default function DiscoverScreen() {
             {count > 0 ? <Text style={styles.filterCount}>{count}</Text> : null}
           </Pressable>
         </View>
+        {searching ? (
+          <View style={styles.searchRow}>
+            <Feather name="search" size={17} color={colors.textFaint} />
+            <TextInput
+              value={term}
+              onChangeText={setTerm}
+              placeholder={t('discover.searchPlaceholder')}
+              placeholderTextColor={colors.textFaint}
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoFocus
+              style={styles.searchInput}
+            />
+          </View>
+        ) : null}
+
+        {searching ? (
+          <View style={styles.searchResults}>
+            {search.isFetching ? <ActivityIndicator style={styles.searchSpinner} /> : null}
+            {search.data?.items.map((result) => (
+              <Pressable
+                key={result._id}
+                accessibilityRole="button"
+                onPress={() => openProfile(result.handle, '/(app)/discover')}
+                style={({ pressed }) => [styles.searchRow, pressed && styles.pressed]}
+              >
+                <Avatar url={result.avatarUrl} name={result.displayName} size={36} />
+                <View style={styles.searchText}>
+                  <Text style={styles.searchName} numberOfLines={1}>
+                    {result.displayName}
+                  </Text>
+                  <Text style={styles.searchHandle} numberOfLines={1}>
+                    @{result.handle}
+                  </Text>
+                </View>
+              </Pressable>
+            ))}
+            {/* Only once a real search has settled: "no matches" under two
+                letters would be answering a question nobody finished asking. */}
+            {search.data?.items.length === 0 && !search.isFetching ? (
+              <Text style={styles.searchNone}>{t('discover.searchNone')}</Text>
+            ) : null}
+          </View>
+        ) : null}
+
         <View style={styles.segmented}>
           <SegmentedControl
             options={SORTS.map((option) => ({
@@ -193,14 +269,6 @@ export default function DiscoverScreen() {
           />
         </View>
         <View style={styles.chips}>
-          <Chip
-            // "Online first", not "Online": it is a sort modifier now, and a
-            // label promising a filter would be describing the old behaviour.
-            label={t('discover.onlineFirst')}
-            tone="accent"
-            selected={effective.online === true}
-            onPress={() => router.setParams(effective.online ? { online: '' } : { online: '1' })}
-          />
           {/* Only while it applies. A radius control above a list that is not
               sorted by distance would be a control with nothing to control. */}
           {sort === 'nearby'
@@ -239,7 +307,7 @@ export default function DiscoverScreen() {
         />
       ) : (
         <FlatList
-          data={items}
+          data={searching ? [] : items}
           keyExtractor={(item) => item._id}
           contentContainerStyle={styles.list}
           refreshControl={
@@ -253,7 +321,7 @@ export default function DiscoverScreen() {
             if (query.hasNextPage && !query.isFetchingNextPage) void query.fetchNextPage()
           }}
           ListEmptyComponent={
-            sort === 'nearby' ? (
+            searching ? null : sort === 'nearby' ? (
               // Two things narrow this list that narrow no other, and a user
               // who is not told about the second one concludes the feature is
               // broken rather than that the pool is small.
@@ -339,6 +407,28 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
     marginStart: 'auto',
   },
   filterButton: { alignItems: 'center', flexDirection: 'row', gap: spacing.xs },
+  searchRow: {
+    alignItems: 'center',
+    backgroundColor: colors.fill,
+    borderRadius: radius.pill,
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  searchInput: { ...font.body, color: colors.text, flex: 1, padding: 0 },
+  searchResults: { gap: spacing.xs, marginTop: spacing.xs },
+  searchSpinner: { marginTop: spacing.md },
+  searchText: { flex: 1, gap: 1 },
+  searchName: { ...font.label, color: colors.text, fontSize: 15 },
+  searchHandle: { ...font.caption, color: colors.textMuted },
+  searchNone: {
+    ...font.caption,
+    color: colors.textFaint,
+    marginTop: spacing.md,
+    textAlign: 'center',
+  },
   filterCount: {
     backgroundColor: colors.accent,
     borderRadius: radius.pill,

--- a/apps/mobile/app/(app)/filters.tsx
+++ b/apps/mobile/app/(app)/filters.tsx
@@ -194,17 +194,6 @@ export default function FiltersScreen() {
         </View>
 
         <View style={styles.section}>
-          <SectionTitle title={t('filters.availability')} />
-          <View style={styles.row}>
-            <Chip
-              label={t('filters.onlineFirst')}
-              selected={filters.online === true}
-              onPress={() => set({ online: filters.online ? undefined : true })}
-            />
-          </View>
-        </View>
-
-        <View style={styles.section}>
           <SectionTitle title={t('filters.theirLevel')} />
           <Text style={styles.hint}>{t('filters.theirLevelBody')}</Text>
           <View style={styles.levelRow}>

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -10,6 +10,7 @@ import {
   type PlanTier,
 } from '@langx/shared'
 import type {
+  HandleSearchPage,
   DiscoveryResult,
   Leaderboard,
   PeriodType,
@@ -54,6 +55,7 @@ export const keys = {
   me: ['me'] as const,
   profile: (id: string) => ['profile', id] as const,
   discovery: (filters: string) => ['discovery', filters] as const,
+  handleSearch: (term: string) => ['handleSearch', term] as const,
   conversations: ['conversations'] as const,
   messages: (id: string) => ['messages', id] as const,
   /**
@@ -462,6 +464,24 @@ export function useTokens() {
 
 export function useWallet() {
   return useQuery({ queryKey: keys.wallet, queryFn: () => api.get<Wallet>('/me/wallet') })
+}
+
+/**
+ * Handle search. Enabled only past the schema's own two-character minimum, so
+ * the first keystroke does not spend a request on a 400.
+ *
+ * `keepPreviousData` because the alternative is a list that blanks on every
+ * settled keystroke — the results are a jump-to, and a target that disappears
+ * while you reach for it is worse than a slightly stale one.
+ */
+export function useHandleSearch(term: string) {
+  const trimmed = term.trim().toLowerCase()
+  return useQuery({
+    queryKey: keys.handleSearch(trimmed),
+    queryFn: () => api.get<HandleSearchPage>(`/discovery/handles?q=${encodeURIComponent(trimmed)}`),
+    enabled: trimmed.length >= 2,
+    placeholderData: keepPreviousData,
+  })
 }
 
 export function useFeed(filter: FeedFilter) {

--- a/apps/mobile/src/api/types.ts
+++ b/apps/mobile/src/api/types.ts
@@ -92,6 +92,18 @@ export interface DiscoveryResult {
   nextCursor: string | null
 }
 
+/** `GET /discovery/handles` — a jump-to, so no cursor and no counts. */
+export interface HandleSearchResult {
+  _id: string
+  handle: string
+  displayName: string
+  avatarUrl?: string
+}
+
+export interface HandleSearchPage {
+  items: HandleSearchResult[]
+}
+
 /** Body of `POST /auth/login` — see `packages/shared/src/account.ts`. */
 export interface LoginResult {
   /** True when the v1 bridge was what accepted the password. */

--- a/apps/mobile/src/hooks/useDebounced.ts
+++ b/apps/mobile/src/hooks/useDebounced.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * A value that only catches up once it has stopped changing.
+ *
+ * For a search box: the input stays responsive because it renders the raw
+ * value, while the query key follows this one — so typing "behic" is one
+ * request rather than five, and the five would arrive out of order anyway.
+ *
+ * Deliberately not a debounced *callback*. A callback has to be stable or the
+ * timer resets on every render, which is the version of this that silently
+ * never fires.
+ */
+export function useDebounced<T>(value: T, delayMs = 300): T {
+  const [settled, setSettled] = useState(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSettled(value), delayMs)
+    return () => clearTimeout(timer)
+  }, [value, delayMs])
+
+  return settled
+}

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -407,9 +407,11 @@ export const ar: Localized<EnMessages> = {
   },
 
   discover: {
+    searchHandles: 'البحث باسم المستخدم',
+    searchPlaceholder: 'اسم المستخدم',
+    searchNone: 'لا يوجد حساب بهذا الاسم.',
     sortLabel: 'الترتيب',
     forYou: 'لك',
-    onlineFirst: 'المتصلون أولًا',
     title: 'استكشاف',
     active: 'نشطون',
     nearby: 'قريبون',
@@ -430,7 +432,6 @@ export const ar: Localized<EnMessages> = {
   filters: {
     title: 'عوامل التصفية',
     speaks: 'يتكلم',
-    availability: 'التوفر',
     city: 'المدينة',
     cityBody: 'اعثر على أشخاص في المكان نفسه. لا يلزم تطابق الإملاء أو التشكيل أو حالة الأحرف.',
     cityPlaceholder: 'إسطنبول',
@@ -438,7 +439,6 @@ export const ar: Localized<EnMessages> = {
     age: 'العمر',
     country: 'البلد',
     practiseBody: 'أي لغاتك تريد ممارستها. كل من هنا يتكلمها أصلًا كلغة أم.',
-    onlineFirst: 'المتصلون أولًا',
     onlyMyGender: 'جنسي فقط',
     onlyMyGenderBody: 'إظهار من هم {gender} فقط، مثلك.',
     onlyMyGenderMissing: 'أضف جنسك إلى ملفك لاستخدام هذا.',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -346,9 +346,11 @@ export const de: Localized<EnMessages> = {
   },
 
   discover: {
+    searchHandles: 'Nach Benutzername suchen',
+    searchPlaceholder: 'Benutzername',
+    searchNone: 'Kein Konto mit diesem Benutzernamen.',
     sortLabel: 'Sortierung',
     forYou: 'Für dich',
-    onlineFirst: 'Online zuerst',
     title: 'Entdecken',
     active: 'Aktiv',
     nearby: 'In der Nähe',
@@ -371,7 +373,6 @@ export const de: Localized<EnMessages> = {
   filters: {
     title: 'Filter',
     speaks: 'Spricht',
-    availability: 'Verfügbarkeit',
     city: 'Stadt',
     cityBody:
       'Finde Leute an einem Ort. Schreibweise, Akzente und Groß-/Kleinschreibung müssen nicht passen.',
@@ -381,7 +382,6 @@ export const de: Localized<EnMessages> = {
     country: 'Land',
     practiseBody:
       'Welche deiner Sprachen du üben willst. Alle hier sprechen sie bereits muttersprachlich.',
-    onlineFirst: 'Online zuerst',
     onlyMyGender: 'Nur mein Geschlecht',
     onlyMyGenderBody: 'Nur Leute zeigen, die {gender} sind, wie du.',
     onlyMyGenderMissing: 'Trag dein eigenes Geschlecht ins Profil ein, um das zu nutzen.',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -373,9 +373,11 @@ export const en = {
   },
 
   discover: {
+    searchHandles: 'Search by username',
+    searchPlaceholder: 'Username',
+    searchNone: 'No account with that username.',
     sortLabel: 'Sort',
     forYou: 'For you',
-    onlineFirst: 'Online first',
     title: 'Discover',
     active: 'Active',
     nearby: 'Nearby',
@@ -398,7 +400,6 @@ export const en = {
   filters: {
     title: 'Filters',
     speaks: 'Speaks',
-    availability: 'Availability',
     city: 'City',
     cityBody: 'Find people in one place. Spelling, accents and case do not have to match.',
     cityPlaceholder: 'Istanbul',
@@ -407,7 +408,6 @@ export const en = {
     country: 'Country',
     practiseBody:
       'Which of your own languages you want to practise. Everyone here already speaks it natively.',
-    onlineFirst: 'Online first',
     onlyMyGender: 'Only my gender',
     onlyMyGenderBody: 'Show only people who are {gender}, like you.',
     onlyMyGenderMissing: 'Add your own gender to your profile to use this.',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -344,9 +344,11 @@ export const es: Localized<EnMessages> = {
   },
 
   discover: {
+    searchHandles: 'Buscar por nombre de usuario',
+    searchPlaceholder: 'Nombre de usuario',
+    searchNone: 'No hay ninguna cuenta con ese nombre de usuario.',
     sortLabel: 'Ordenar',
     forYou: 'Para ti',
-    onlineFirst: 'En línea primero',
     title: 'Descubrir',
     active: 'Activos',
     nearby: 'Cerca',
@@ -369,7 +371,6 @@ export const es: Localized<EnMessages> = {
   filters: {
     title: 'Filtros',
     speaks: 'Habla',
-    availability: 'Disponibilidad',
     city: 'Ciudad',
     cityBody:
       'Encuentra gente en un mismo lugar. La ortografía, los acentos y las mayúsculas no tienen que coincidir.',
@@ -379,7 +380,6 @@ export const es: Localized<EnMessages> = {
     country: 'País',
     practiseBody:
       'Cuál de tus idiomas quieres practicar. Todo el mundo aquí ya lo habla de forma nativa.',
-    onlineFirst: 'En línea primero',
     onlyMyGender: 'Solo mi género',
     onlyMyGenderBody: 'Mostrar solo personas que son {gender}, como tú.',
     onlyMyGenderMissing: 'Añade tu género a tu perfil para usar esto.',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -344,9 +344,11 @@ export const fr: Localized<EnMessages> = {
   },
 
   discover: {
+    searchHandles: 'Rechercher par nom d’utilisateur',
+    searchPlaceholder: 'Nom d’utilisateur',
+    searchNone: 'Aucun compte avec ce nom d’utilisateur.',
     sortLabel: 'Tri',
     forYou: 'Pour toi',
-    onlineFirst: 'En ligne d’abord',
     title: 'Découvrir',
     active: 'Actifs',
     nearby: 'À proximité',
@@ -369,7 +371,6 @@ export const fr: Localized<EnMessages> = {
   filters: {
     title: 'Filtres',
     speaks: 'Parle',
-    availability: 'Disponibilité',
     city: 'Ville',
     cityBody:
       'Trouve des gens au même endroit. L’orthographe, les accents et la casse n’ont pas à correspondre.',
@@ -379,7 +380,6 @@ export const fr: Localized<EnMessages> = {
     country: 'Pays',
     practiseBody:
       'Laquelle de tes langues tu veux pratiquer. Ici, tout le monde la parle déjà nativement.',
-    onlineFirst: 'En ligne d’abord',
     onlyMyGender: 'Uniquement mon genre',
     onlyMyGenderBody: 'Afficher seulement les personnes {gender}, comme toi.',
     onlyMyGenderMissing: 'Ajoute ton genre à ton profil pour utiliser ceci.',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -339,9 +339,11 @@ export const ptBR: Localized<EnMessages> = {
   },
 
   discover: {
+    searchHandles: 'Buscar por nome de usuário',
+    searchPlaceholder: 'Nome de usuário',
+    searchNone: 'Nenhuma conta com esse nome de usuário.',
     sortLabel: 'Ordenar',
     forYou: 'Para você',
-    onlineFirst: 'On-line primeiro',
     title: 'Descobrir',
     active: 'Ativos',
     nearby: 'Por perto',
@@ -364,7 +366,6 @@ export const ptBR: Localized<EnMessages> = {
   filters: {
     title: 'Filtros',
     speaks: 'Fala',
-    availability: 'Disponibilidade',
     city: 'Cidade',
     cityBody:
       'Encontre pessoas em um mesmo lugar. Grafia, acentos e maiúsculas não precisam coincidir.',
@@ -374,7 +375,6 @@ export const ptBR: Localized<EnMessages> = {
     country: 'País',
     practiseBody:
       'Qual dos seus idiomas você quer praticar. Todo mundo aqui já fala esse idioma como nativo.',
-    onlineFirst: 'On-line primeiro',
     onlyMyGender: 'Só do meu gênero',
     onlyMyGenderBody: 'Mostrar só pessoas que são {gender}, como você.',
     onlyMyGenderMissing: 'Adicione seu gênero ao perfil para usar isso.',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -391,9 +391,11 @@ export const ru: Localized<EnMessages> = {
   },
 
   discover: {
+    searchHandles: 'Поиск по имени пользователя',
+    searchPlaceholder: 'Имя пользователя',
+    searchNone: 'Аккаунта с таким именем пользователя нет.',
     sortLabel: 'Сортировка',
     forYou: 'Для тебя',
-    onlineFirst: 'Сначала онлайн',
     title: 'Поиск',
     active: 'Активные',
     nearby: 'Рядом',
@@ -416,7 +418,6 @@ export const ru: Localized<EnMessages> = {
   filters: {
     title: 'Фильтры',
     speaks: 'Говорит',
-    availability: 'Доступность',
     city: 'Город',
     cityBody: 'Найдите людей в одном городе. Написание, диакритика и регистр совпадать не обязаны.',
     cityPlaceholder: 'Стамбул',
@@ -425,7 +426,6 @@ export const ru: Localized<EnMessages> = {
     country: 'Страна',
     practiseBody:
       'Какой из твоих языков ты хочешь практиковать. Здесь все и так говорят на нём как на родном.',
-    onlineFirst: 'Сначала онлайн',
     onlyMyGender: 'Только мой пол',
     onlyMyGenderBody: 'Показывать только тех, чей пол — {gender}, как у тебя.',
     onlyMyGenderMissing: 'Чтобы использовать это, укажи свой пол в профиле.',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -348,9 +348,11 @@ export const tr: Localized<EnMessages> = {
   },
 
   discover: {
+    searchHandles: 'Kullanıcı adıyla ara',
+    searchPlaceholder: 'Kullanıcı adı',
+    searchNone: 'Bu kullanıcı adında bir hesap yok.',
     sortLabel: 'Sıralama',
     forYou: 'Sana özel',
-    onlineFirst: 'Önce çevrimiçi',
     title: 'Keşfet',
     active: 'Aktif',
     nearby: 'Yakında',
@@ -373,7 +375,6 @@ export const tr: Localized<EnMessages> = {
   filters: {
     title: 'Filtreler',
     speaks: 'Konuşuyor',
-    availability: 'Durum',
     city: 'Şehir',
     cityBody: 'Aynı şehirdekileri bul. Yazım, aksan ve büyük-küçük harf uyuşmak zorunda değil.',
     cityPlaceholder: 'İstanbul',
@@ -382,7 +383,6 @@ export const tr: Localized<EnMessages> = {
     country: 'Ülke',
     practiseBody:
       'Kendi dillerinden hangisini pratik etmek istiyorsun. Buradaki herkes onu zaten ana dili olarak konuşuyor.',
-    onlineFirst: 'Önce çevrimiçi',
     onlyMyGender: 'Sadece kendi cinsiyetim',
     onlyMyGenderBody: 'Sadece senin gibi {gender} olan kişileri göster.',
     onlyMyGenderMissing: 'Bunu kullanmak için profiline kendi cinsiyetini ekle.',

--- a/apps/mobile/src/lib/discoveryFilters.test.ts
+++ b/apps/mobile/src/lib/discoveryFilters.test.ts
@@ -18,7 +18,6 @@ import {
 describe('withoutProFilters', () => {
   const everything: DiscoveryFilters = {
     targetLanguage: 'en',
-    online: true,
     minLevel: 'beginner',
     maxLevel: 'fluent',
     ageMin: 25,
@@ -32,7 +31,6 @@ describe('withoutProFilters', () => {
   it('keeps every free filter', () => {
     expect(withoutProFilters(everything)).toEqual({
       targetLanguage: 'en',
-      online: true,
       minLevel: 'beginner',
       maxLevel: 'fluent',
       ageMin: 25,
@@ -56,9 +54,7 @@ describe('withoutProFilters', () => {
 
 describe('hasProFilters', () => {
   it('is false for a set that is entirely free', () => {
-    expect(
-      hasProFilters({ targetLanguage: 'en', online: true, minLevel: 'beginner', ageMin: 30 }),
-    ).toBe(false)
+    expect(hasProFilters({ targetLanguage: 'en', minLevel: 'beginner', ageMin: 30 })).toBe(false)
   })
 
   it('is true for each paid filter on its own', () => {
@@ -72,7 +68,6 @@ describe('the URL round trip', () => {
   it('survives every filter', () => {
     const filters: DiscoveryFilters = {
       targetLanguage: 'en',
-      online: true,
       minLevel: 'beginner',
       maxLevel: 'fluent',
       ageMin: 25,
@@ -91,8 +86,8 @@ describe('the URL round trip', () => {
 
   /** `'1'` is the URL's spelling of a boolean; `'true'` is the API's. */
   it('sends booleans the way the API coerces them', () => {
-    const query = toQuery({ online: true, onlyMyGender: true, city: 'Istanbul' })
-    expect(query).toMatchObject({ online: 'true', onlyMyGender: 'true', city: 'Istanbul' })
+    const query = toQuery({ onlyMyGender: true, city: 'Istanbul' })
+    expect(query).toMatchObject({ onlyMyGender: 'true', city: 'Istanbul' })
   })
 })
 
@@ -105,7 +100,7 @@ describe('activeCount', () => {
 
   it('counts city as its own filter', () => {
     expect(activeCount({ city: 'Istanbul' })).toBe(1)
-    expect(activeCount({ city: 'Istanbul', online: true })).toBe(2)
+    expect(activeCount({ city: 'Istanbul', country: 'US' })).toBe(2)
   })
 
   it('is zero for no filters', () => {

--- a/apps/mobile/src/lib/discoveryFilters.ts
+++ b/apps/mobile/src/lib/discoveryFilters.ts
@@ -13,8 +13,6 @@ import { DISCOVERY_PRO_FILTER_KEYS, type LanguageLevel, type Gender } from '@lan
 export interface DiscoveryFilters {
   /** Free. One of the viewer's own learning languages. */
   targetLanguage?: string
-  /** Free. */
-  online?: boolean
   /** Free. Their level in my language, as an inclusive band. */
   minLevel?: LanguageLevel
   maxLevel?: LanguageLevel
@@ -59,7 +57,6 @@ export function parseFilters(
   const filters: DiscoveryFilters = {}
   const target = one(params.targetLanguage)
   if (target) filters.targetLanguage = target
-  if (one(params.online) === '1') filters.online = true
 
   const gender = one(params.gender)
   if (gender) filters.gender = gender as Gender
@@ -85,7 +82,6 @@ export function parseFilters(
 export function toParams(filters: DiscoveryFilters): Record<string, string> {
   const params: Record<string, string> = {}
   if (filters.targetLanguage) params.targetLanguage = filters.targetLanguage
-  if (filters.online) params.online = '1'
   if (filters.gender) params.gender = filters.gender
   if (filters.onlyMyGender) params.onlyMyGender = '1'
   if (filters.country) params.country = filters.country
@@ -98,14 +94,13 @@ export function toParams(filters: DiscoveryFilters): Record<string, string> {
 }
 
 /**
- * The API query. `online` and `onlyMyGender` go over the wire as `true`, which
- * is what `z.coerce.boolean()` on the other side reads — `'1'` is the URL's
- * spelling, not the API's.
+ * The API query. `onlyMyGender` goes over the wire as `true`, which is what
+ * `z.coerce.boolean()` on the other side reads — `'1'` is the URL's spelling,
+ * not the API's.
  */
 export function toQuery(filters: DiscoveryFilters): Record<string, string> {
   const query: Record<string, string> = {}
   if (filters.targetLanguage) query.targetLanguage = filters.targetLanguage
-  if (filters.online) query.online = 'true'
   if (filters.gender) query.gender = filters.gender
   if (filters.onlyMyGender) query.onlyMyGender = 'true'
   if (filters.country) query.country = filters.country
@@ -121,7 +116,6 @@ export function toQuery(filters: DiscoveryFilters): Record<string, string> {
 export function activeCount(filters: DiscoveryFilters): number {
   let count = 0
   if (filters.targetLanguage) count++
-  if (filters.online) count++
   if (filters.gender || filters.onlyMyGender) count++
   if (filters.country) count++
   // One level *band*, however many bounds express it.
@@ -145,7 +139,6 @@ export function hasProFilters(filters: DiscoveryFilters): boolean {
 export function withoutProFilters(filters: DiscoveryFilters): DiscoveryFilters {
   const free: DiscoveryFilters = {}
   if (filters.targetLanguage) free.targetLanguage = filters.targetLanguage
-  if (filters.online) free.online = true
   if (filters.minLevel) free.minLevel = filters.minLevel
   if (filters.maxLevel) free.maxLevel = filters.maxLevel
   if (filters.ageMin !== undefined) free.ageMin = filters.ageMin

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -269,17 +269,17 @@ back door around authorisation, quota or token.
 
 ### Free vs Pro vs Pro+
 
-|                            | Free                                 | Pro                            | Pro+          |
-| -------------------------- | ------------------------------------ | ------------------------------ | ------------- |
-| Starting new conversations | **5** per rolling 24h                | Unlimited                      | Unlimited     |
-| Replying                   | **Unlimited**                        | Unlimited                      | Unlimited     |
-| Filters                    | Language, online, country, age, CEFR | + gender, only-my-gender, city | same as Pro   |
-| Sort by distance (Nearby)  | —                                    | —                              | **Yes**       |
-| Translation                | N per day (config)                   | Unlimited                      | Unlimited     |
-| **Message correction**     | **Unlimited**                        | **Unlimited**                  | **Unlimited** |
-| Who viewed me              | Count only                           | Identities                     | Identities    |
-| Incognito                  | —                                    | Yes                            | Yes           |
-| AI copilot                 | —                                    | —                              | **Not built** |
+|                            | Free                         | Pro                            | Pro+          |
+| -------------------------- | ---------------------------- | ------------------------------ | ------------- |
+| Starting new conversations | **5** per rolling 24h        | Unlimited                      | Unlimited     |
+| Replying                   | **Unlimited**                | Unlimited                      | Unlimited     |
+| Filters                    | Language, country, age, CEFR | + gender, only-my-gender, city | same as Pro   |
+| Sort by distance (Nearby)  | —                            | —                              | **Yes**       |
+| Translation                | N per day (config)           | Unlimited                      | Unlimited     |
+| **Message correction**     | **Unlimited**                | **Unlimited**                  | **Unlimited** |
+| Who viewed me              | Count only                   | Identities                     | Identities    |
+| Incognito                  | —                            | Yes                            | Yes           |
+| AI copilot                 | —                            | —                              | **Not built** |
 
 Every threshold lives in `packages/shared/src/limits.ts` → `PLAN_LIMITS`, never
 hard-coded.
@@ -566,9 +566,23 @@ $match:    discoverable, !deleted, !blocked (either direction),
            nativeLanguages.code ∈ my learning,      ← mutual fit
            learning.code ∈ my nativeLanguages
            [if Pro] gender / country / age / CEFR
+$addFields onlineBucket = active in the last 5 min AND not hiding it → 1/0
 $addFields score = language fit + shared interests + activity recency
-$sort:     score desc, lastActiveAt desc  → cursor pagination
+$sort:     onlineBucket desc, score desc, lastActiveAt desc  → cursor pagination
 ```
+
+`onlineBucket` is an **ordering, not a filter** — everyone still comes back,
+the online ones lead. It was a chip once and is now unconditional, but only on
+`recommended`: `sort=active` orders by `lastActiveAt` and so already puts that
+window on top, and bucketing ahead of `sort=nearby` would put someone online
+90 km away in front of someone offline in the next street. The cost is a
+blocking in-memory sort, because a computed field cannot be indexed.
+
+**`GET /discovery/handles?q=`** is the other way in: an anchored `^prefix`
+match on `handle`, riding `handle_unique`, capped at ten. It applies the same
+blocks and `discoverable` rule as the feed and deliberately **not** the mutual
+language fit — finding somebody whose name you already know cannot depend on
+whether you are learnable to each other.
 
 **`sort=nearby` (Pro+)** replaces that leading `$match` with a single
 `$geoNear`, because `$geoNear` must be the pipeline's first stage and cannot

--- a/packages/shared/src/discovery.ts
+++ b/packages/shared/src/discovery.ts
@@ -24,7 +24,7 @@ export const discoverySortSchema = z.enum(DISCOVERY_SORTS)
 export const DISCOVERY_PAGE_SIZE_DEFAULT = 20
 export const DISCOVERY_PAGE_SIZE_MAX = 50
 
-/** A profile counts as "online now" for the free `online` filter within this window. */
+/** A profile counts as "online now" — for the ordering, and for `isOnline` — within this window. */
 export const ONLINE_WINDOW_MS = 5 * 60 * 1000
 
 /**
@@ -91,8 +91,6 @@ export const discoveryQuerySchema = z
       .default(DISCOVERY_PAGE_SIZE_DEFAULT),
     /** Free filter: narrow to one specific language out of the viewer's own learning list. */
     targetLanguage: languageCodeSchema.optional(),
-    /** Free filter: only profiles active within {@link ONLINE_WINDOW_MS}. */
-    online: z.coerce.boolean().optional(),
     /** Free filter: their level in the viewer's language, as an inclusive band.
      *  One bound on its own is still valid — `minLevel` alone means "at least",
      *  which is what the pre-v3 filter offered and what old clients still send. */
@@ -180,3 +178,28 @@ export const discoveryPageSchema = z.object({
   nextCursor: z.string().nullable(),
 })
 export type DiscoveryPage = z.infer<typeof discoveryPageSchema>
+
+/** How many results a handle search returns. Small on purpose: it is a
+ *  jump-to, not a browse — the list below is what browsing is for. */
+export const HANDLE_SEARCH_LIMIT = 10
+
+export const handleSearchQuerySchema = z.object({
+  /**
+   * A handle prefix. Lower-cased to match how handles are stored, and bounded
+   * at the same length one can be, because this reaches a database index and
+   * an unbounded string is a way to make it scan.
+   */
+  q: z.string().trim().toLowerCase().min(2).max(20),
+})
+export type HandleSearchQuery = z.infer<typeof handleSearchQuerySchema>
+
+export const handleSearchResultSchema = z.object({
+  _id: z.string(),
+  handle: z.string(),
+  displayName: z.string(),
+  avatarUrl: z.string().optional(),
+})
+export type HandleSearchResult = z.infer<typeof handleSearchResultSchema>
+
+export const handleSearchPageSchema = z.object({ items: z.array(handleSearchResultSchema) })
+export type HandleSearchPage = z.infer<typeof handleSearchPageSchema>


### PR DESCRIPTION
## Online first, unconditionally — on `recommended` only

It was a chip in two places (Discover and Filters). It is now simply how the recommended feed is ordered.

**Why not all three sorts:**

| Sort | If forced | Decision |
| --- | --- | --- |
| `recommended` | What was asked for | **Unconditional** |
| `active` | Orders by `lastActiveAt` desc, so the 5-minute window is already on top *by construction*. The bucket would change no order and **break the keyset cursor**, which compares `lastActiveAt`/`_id` and knows nothing about a bucket. | Untouched |
| `nearby` | Someone online 90 km away ranks ahead of someone offline in the next street. That is a recommended list with a radius, not the thing Pro+ bought. | Bucket removed entirely |

**The cost, stated:** `onlineBucket` is a computed field and can never be indexed, so this is a blocking in-memory sort. It used to be paid only by whoever turned the chip on; every default request pays it now.

`privacy.hideOnlineStatus` still suppresses the promotion — the existing test at `discovery.test.ts` is the only thing holding that `$cond` and `hidesOnlineStatus` together, and it is unchanged.

## A live bug, fixed on the way

Splitting the three cursor shapes apart was necessary and exposed this: **every** cursor went through `decodeOnlineOffsetCursor`, including `sort=active`'s keyset `<iso>|<userId>`. It contains a `|`, so it took the pinned-cutoff branch and hit the one-hour expiry check.

**Paging `sort=active` past anyone last active over an hour ago returned `400 Cursor has expired`.** The existing paging test never caught it — every fixture was active seconds ago. The new one sets them days back.

## `GET /discovery/handles?q=`

Nothing searched profiles before: no route, no `$regex` in application code, and the one text index in the schema (`displayName`, `bio`) has never been queried by anything.

- **Anchored, always.** `^prefix` rides `handle_unique`; an unanchored `/term/` would make a search box a collection scan per keystroke.
- **Lower-cased, not case-insensitive.** Handles are stored lower-cased by `handleSchema`, so the query matches that — a `$regex` with `i` would also give up the index.
- **Escaped.** `handleSchema` bounds what a handle may *contain*; it says nothing about what somebody may *type*. `.*` returns nothing rather than everything.
- **Its own rate limit** (60/min), tighter than the global 300/min. A search box is called per keystroke and the client's debounce is not what enforces that.

Rules shared with the feed, and the one that is not:

| Rule | Applies? | Why |
| --- | --- | --- |
| Blocks, both directions | Yes | And by **absence**, never 403 — a refusal confirms the account exists |
| `settings.discoverable` | Yes | Searching is browsing. The exact link still resolves; that is a different question |
| Mutual language fit | **No** | Finding somebody whose name you already know cannot depend on whether you are learnable to each other |

Client side: `useDebounced` (the repo's first) so typing "behic" is one request rather than five, and `keepPreviousData` so the list does not blank under a target you are reaching for.

## Removed

`online` from the query schema, both chips, `discover.onlineFirst`, `filters.onlineFirst` and `filters.availability` across all 8 locales.

## Checks

`pnpm test` — shared 140, mobile 278, api 510 (+9). `pnpm lint`, `pnpm format:check` clean; `pnpm -r typecheck` clean apart from the three pre-existing stale-`router.d.ts` errors on `main`.

`docs/architecture.md` updated: the aggregation sketch now shows the bucket, and the search endpoint is documented next to it.

> Note: this touches the same `docs/architecture.md` filter table as #992, so whichever lands second needs a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)