### PR TITLE
Split the token screen into a wallet and the ledger behind it

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -121,7 +121,8 @@ export default function AppLayout() {
         <Tabs.Screen name="viewers" options={FULL_SCREEN} />
         <Tabs.Screen name="filters" options={FULL_SCREEN} />
         <Tabs.Screen name="intro" options={FULL_SCREEN} />
-        <Tabs.Screen name="store" options={FULL_SCREEN} />
+        <Tabs.Screen name="wallet" options={FULL_SCREEN} />
+        <Tabs.Screen name="tokens" options={FULL_SCREEN} />
         <Tabs.Screen name="kitchen" options={FULL_SCREEN} />
       </Tabs>
     </SafeAreaView>

--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -112,13 +112,13 @@ export default function MeScreen() {
           label={t('me.corrections')}
           value={String(summary?.lifetime.corrections ?? 0)}
         />
-        {/* The balance is the way into the store — a number nobody can act on
-            reads as decoration, and the store had nowhere else to be reached
-            from once it left this screen. The "›" is the hint that it opens. */}
+        {/* The balance is the way into the wallet — a number nobody can act
+            on reads as decoration, and the wallet has nowhere else to be
+            reached from. The "›" is the hint that it opens. */}
         <StatTile
-          label={`${t('me.tokens')} ›`}
+          label={`${t('me.wallet')} ›`}
           value={String(balance)}
-          onPress={() => router.push('/(app)/store')}
+          onPress={() => router.push('/(app)/wallet')}
         />
       </View>
 

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -321,7 +321,7 @@ export default function ProfileScreen() {
               label={t('me.corrections')}
               value={String(summary.data.corrections ?? 0)}
             />
-            <StatTile label={t('me.tokens')} value={String(summary.data.tokens ?? 0)} />
+            <StatTile label={t('tokens.title')} value={String(summary.data.tokens ?? 0)} />
           </View>
           {summary.data.week ? <WeeklyChart week={summary.data.week} /> : null}
         </>

--- a/apps/mobile/app/(app)/tokens.tsx
+++ b/apps/mobile/app/(app)/tokens.tsx
@@ -1,54 +1,34 @@
 import { TOKEN_RULES } from '@langx/shared'
 import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { useState } from 'react'
-import { useMe, usePurchase, useTokenHistory, useTokens, useWallet } from '../../src/api/queries'
-import { StoreRow } from '../../src/components/store/StoreRow'
+import { useTokenHistory, useTokens } from '../../src/api/queries'
 import { ProgressBar } from '../../src/components/ui/ProgressBar'
 import { Screen } from '../../src/components/ui/Screen'
 import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
+import { StatTile } from '../../src/components/ui/StatTile'
 import { goBackTo } from '../../src/lib/navigation'
-import { buildStoreOffers } from '../../src/lib/storeOffers'
 import { buildTokenHistory } from '../../src/lib/tokenHistory'
 import { dayLabel } from '../../src/lib/messageGroups'
 import { makeStyles, useTheme } from '../../src/lib/theme'
 import { useLocale, useT } from '../../src/i18n'
 
 /**
- * The token screen, reached by tapping the balance on the profile.
+ * Where the tokens came from: the totals, the pool, and the ledger a day at a
+ * time.
  *
- * A route rather than a sheet: the app has no modal routes and adding one
- * would mean a gesture-handler dependency that does not resolve from this
- * package, for a surface that cannot be linked to or backed out of.
+ * One level below the wallet, reached by pressing the balance. The two used to
+ * be one screen, which meant the shop sat under a list that grows by a row a
+ * day — so the thing you can act on was below the thing you can only read.
  */
-export default function StoreScreen() {
+export default function TokensScreen() {
   const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()
-
-  const me = useMe()
-  const xp = useTokens()
-  const wallet = useWallet()
-  const purchase = usePurchase()
-  const history = useTokenHistory()
   const { locale } = useLocale()
+
+  const xp = useTokens()
+  const history = useTokenHistory()
   const [openDay, setOpenDay] = useState<string | null>(null)
-
-  if (me.isPending || !me.data) {
-    return (
-      <Screen>
-        <ActivityIndicator style={styles.loading} />
-      </Screen>
-    )
-  }
-
-  const restored = me.data.restoredFromV1
-  const offers = buildStoreOffers({
-    t,
-    balance: wallet.data?.balance ?? 0,
-    owned: wallet.data?.owned ?? [],
-    streakFreezes: wallet.data?.streakFreezes ?? 0,
-    restorableStreak: restored && !restored.streakRestoredAt ? restored.frozenStreak : 0,
-  })
 
   const pool = xp.data?.pool
 
@@ -73,67 +53,65 @@ export default function StoreScreen() {
   })
 
   function refresh(): void {
-    void Promise.all([me.refetch(), xp.refetch(), wallet.refetch(), history.refetch()])
+    void Promise.all([xp.refetch(), history.refetch()])
+  }
+
+  if (xp.isPending) {
+    return (
+      <Screen>
+        <ActivityIndicator style={styles.loading} />
+      </Screen>
+    )
   }
 
   return (
-    <Screen scroll onRefresh={refresh} refreshing={wallet.isFetching}>
-      <ScreenHeader title={t('store.title')} onBack={() => goBackTo('/(app)/me')} />
+    <Screen scroll onRefresh={refresh} refreshing={xp.isFetching}>
+      <ScreenHeader title={t('tokens.title')} onBack={() => goBackTo('/(app)/wallet')} />
 
-      <View style={styles.section}>
-        <Text style={styles.kicker}>{t('store.balance')}</Text>
-        <Text style={styles.balanceValue}>{wallet.data?.balance ?? 0}</Text>
-        <Text style={styles.body}>{t('store.intro')}</Text>
+      <View style={styles.tiles}>
+        <StatTile label={t('tokens.thisWeek')} value={String(xp.data?.tokens.week ?? 0)} />
+        <StatTile label={t('tokens.thisMonth')} value={String(xp.data?.tokens.month ?? 0)} />
+        <StatTile label={t('tokens.allTime')} value={String(xp.data?.tokens.all ?? 0)} />
       </View>
+
+      <Text style={styles.body}>{t('tokens.intro')}</Text>
 
       {pool ? (
         <View style={styles.section}>
           <View style={styles.poolHead}>
-            <Text style={styles.poolTitle}>{t('store.todaysPool')}</Text>
-            <Text style={styles.meta}>{t('store.activeToday', { count: pool.activeToday })}</Text>
+            <Text style={styles.poolTitle}>{t('tokens.poolTitle')}</Text>
+            <Text style={styles.meta}>{t('tokens.activeToday', { count: pool.activeToday })}</Text>
           </View>
           {lastPayout ? (
             <>
               <View style={styles.shareRow}>
                 <Text style={styles.shareValue}>
-                  {t('store.shareAmount', { count: lastPayout.amount })}
+                  {t('tokens.shareAmount', { count: lastPayout.amount })}
                 </Text>
                 <Text style={styles.meta}>
-                  {t('store.shareFor', { day: dayLabel(lastPayout.day, { t, locale }) })}
+                  {t('tokens.shareFor', { day: dayLabel(lastPayout.day, { t, locale }) })}
                 </Text>
               </View>
               <ProgressBar
-                accessibilityLabel={t('store.todaysPool')}
+                accessibilityLabel={t('tokens.poolTitle')}
                 color={colors.success}
                 value={shareCap > 0 ? lastPayout.amount / shareCap : 0}
               />
             </>
           ) : (
-            <Text style={styles.meta}>{t('store.noShareYet')}</Text>
+            <Text style={styles.meta}>{t('tokens.noShareYet')}</Text>
           )}
-          <Text style={styles.meta}>{t('store.poolCap', { cap: shareCap })}</Text>
+          <Text style={styles.meta}>{t('tokens.poolCap', { cap: shareCap })}</Text>
           <Text style={styles.meta}>
-            {t('store.poolPaidAt', { hour: TOKEN_RULES.pool.payoutHourUtc })}
+            {t('tokens.poolPaidAt', { hour: TOKEN_RULES.pool.payoutHourUtc })}
           </Text>
         </View>
       ) : null}
 
-      <View style={styles.offers}>
-        {offers.map((offer, index) => (
-          <StoreRow
-            key={offer.id}
-            offer={offer}
-            pending={purchase.isPending}
-            last={index === offers.length - 1}
-            onBuy={(id) => purchase.mutate(id)}
-          />
-        ))}
-      </View>
-
       <View style={styles.section}>
-        <Text style={styles.poolTitle}>{t('store.history')}</Text>
+        <Text style={styles.poolTitle}>{t('tokens.history')}</Text>
         {historyRows.length === 0 ? (
-          <Text style={styles.meta}>{t('store.historyEmpty')}</Text>
+          <Text style={styles.meta}>{t('tokens.historyEmpty')}</Text>
         ) : (
           historyRows.map((row) => {
             const open = openDay === row.day
@@ -150,11 +128,11 @@ export default function StoreScreen() {
                 <View style={styles.historyHead}>
                   <Text style={styles.historyDay}>{row.label}</Text>
                   <Text style={styles.historyEarned}>
-                    {t('store.shareAmount', { count: row.earned })}
+                    {t('tokens.shareAmount', { count: row.earned })}
                   </Text>
                 </View>
                 {row.spent > 0 ? (
-                  <Text style={styles.meta}>{t('store.historySpent', { count: row.spent })}</Text>
+                  <Text style={styles.meta}>{t('tokens.historySpent', { count: row.spent })}</Text>
                 ) : null}
                 {open
                   ? row.entries.map((entry) => (
@@ -175,18 +153,23 @@ export default function StoreScreen() {
             onPress={() => void history.fetchNextPage()}
             style={styles.historyMore}
           >
-            <Text style={styles.historyMoreText}>{t('store.historyMore')}</Text>
+            <Text style={styles.historyMoreText}>{t('tokens.historyMore')}</Text>
           </Pressable>
         ) : null}
       </View>
-
-      <Text style={styles.hint}>{t('store.disclaimer')}</Text>
     </Screen>
   )
 }
-
 const useStyles = makeStyles(({ colors, font, spacing }) => ({
   loading: { marginTop: spacing.xxl },
+  tiles: {
+    borderBottomColor: colors.border,
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    paddingBottom: spacing.lg,
+    paddingTop: spacing.lg,
+  },
+  body: { ...font.body, color: colors.textMuted, lineHeight: 23, marginTop: spacing.lg },
   section: {
     borderBottomColor: colors.border,
     borderBottomWidth: 1,
@@ -194,35 +177,19 @@ const useStyles = makeStyles(({ colors, font, spacing }) => ({
     paddingBottom: spacing.lg + 6,
     paddingTop: spacing.lg,
   },
-  kicker: { color: colors.textFaint, fontSize: 13, fontWeight: '600' },
-  balanceValue: { ...font.title, color: colors.text, fontSize: 56, lineHeight: 60 },
-  body: { ...font.body, color: colors.textMuted, lineHeight: 23 },
-  poolHead: {
-    alignItems: 'baseline',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
+  poolHead: { alignItems: 'baseline', flexDirection: 'row', justifyContent: 'space-between' },
   poolTitle: { ...font.heading, color: colors.text, fontSize: 16 },
   shareRow: { alignItems: 'baseline', flexDirection: 'row', gap: spacing.sm + 1 },
   shareValue: { ...font.heading, color: colors.success, fontSize: 24 },
   meta: { ...font.label, color: colors.textMuted, fontWeight: '400', lineHeight: 19 },
-  historyRow: { gap: 2, paddingVertical: spacing.sm },
-  historyHead: {
-    alignItems: 'baseline',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
+  historyRow: {
+    borderBottomColor: colors.border,
+    borderBottomWidth: 1,
+    paddingVertical: spacing.sm + 2,
   },
+  historyHead: { alignItems: 'baseline', flexDirection: 'row', justifyContent: 'space-between' },
   historyDay: { ...font.label, color: colors.text },
   historyEarned: { ...font.label, color: colors.success },
-  historyMore: { paddingTop: spacing.sm },
-  historyMoreText: { ...font.label, color: colors.textMuted },
-  offers: {},
-  hint: {
-    ...font.caption,
-    color: colors.textFaint,
-    fontSize: 13,
-    lineHeight: 21,
-    marginBottom: spacing.xxl,
-    marginTop: spacing.lg,
-  },
+  historyMore: { alignItems: 'center', paddingVertical: spacing.md },
+  historyMoreText: { ...font.label, color: colors.accent },
 }))

--- a/apps/mobile/app/(app)/wallet.tsx
+++ b/apps/mobile/app/(app)/wallet.tsx
@@ -1,0 +1,145 @@
+import { COSMETICS } from '@langx/shared'
+import { ActivityIndicator, Pressable, Text, View } from 'react-native'
+import { router } from 'expo-router'
+import Feather from '@expo/vector-icons/Feather'
+import { useMe, usePurchase, useWallet } from '../../src/api/queries'
+import { StoreRow } from '../../src/components/store/StoreRow'
+import { Screen } from '../../src/components/ui/Screen'
+import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
+import { StatTile } from '../../src/components/ui/StatTile'
+import { goBackTo } from '../../src/lib/navigation'
+import { buildStoreOffers } from '../../src/lib/storeOffers'
+import { makeStyles, useTheme } from '../../src/lib/theme'
+import { useT } from '../../src/i18n'
+
+/**
+ * The wallet: what you have, and what it buys.
+ *
+ * Split from the screen that used to be all of it. That one answered two
+ * questions at once — "what can I spend" and "where did this come from" — and
+ * the second is a ledger, which grows without bound and pushed the shop below
+ * a scroll nobody reached. The balance is the seam: it is the answer to the
+ * first question and the way into the second, so tapping it opens `/tokens`.
+ *
+ * A route rather than a sheet: the app has no modal routes and adding one
+ * would mean a gesture-handler dependency that does not resolve from this
+ * package, for a surface that cannot be linked to or backed out of.
+ */
+export default function WalletScreen() {
+  const { colors } = useTheme()
+  const styles = useStyles()
+  const t = useT()
+
+  const me = useMe()
+  const wallet = useWallet()
+  const purchase = usePurchase()
+
+  if (me.isPending || !me.data) {
+    return (
+      <Screen>
+        <ActivityIndicator style={styles.loading} />
+      </Screen>
+    )
+  }
+
+  const restored = me.data.restoredFromV1
+  const balance = wallet.data?.balance ?? 0
+  const owned = wallet.data?.owned ?? []
+  const offers = buildStoreOffers({
+    t,
+    balance,
+    owned,
+    streakFreezes: wallet.data?.streakFreezes ?? 0,
+    restorableStreak: restored && !restored.streakRestoredAt ? restored.frozenStreak : 0,
+  })
+
+  function refresh(): void {
+    void Promise.all([me.refetch(), wallet.refetch()])
+  }
+
+  return (
+    <Screen scroll onRefresh={refresh} refreshing={wallet.isFetching}>
+      <ScreenHeader title={t('wallet.title')} onBack={() => goBackTo('/(app)/me')} />
+
+      {/*
+        The balance is the way into the ledger, so it is pressable — and says
+        so. A number that opens something without looking like it does is a
+        number people never press.
+      */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`${t('wallet.balance')}: ${balance}`}
+        onPress={() => router.push('/(app)/tokens')}
+        style={({ pressed }) => [styles.section, pressed && styles.pressed]}
+      >
+        <Text style={styles.kicker}>{t('wallet.balance')}</Text>
+        <Text style={styles.balanceValue}>{balance}</Text>
+        <View style={styles.balanceHint}>
+          <Text style={styles.body}>
+            {t('wallet.earnedSpent', {
+              earned: wallet.data?.earned ?? 0,
+              spent: wallet.data?.spent ?? 0,
+            })}
+          </Text>
+          <Feather name="chevron-right" size={18} color={colors.textFaint} />
+        </View>
+      </Pressable>
+
+      <View style={styles.tiles}>
+        <StatTile
+          label={t('wallet.streakFreezes')}
+          value={String(wallet.data?.streakFreezes ?? 0)}
+        />
+        <StatTile label={t('wallet.itemsOwned')} value={`${owned.length}/${COSMETICS.length}`} />
+      </View>
+
+      <Text style={styles.sectionTitle}>{t('wallet.storeTitle')}</Text>
+      <View style={styles.offers}>
+        {offers.map((offer, index) => (
+          <StoreRow
+            key={offer.id}
+            offer={offer}
+            pending={purchase.isPending}
+            last={index === offers.length - 1}
+            onBuy={(id) => purchase.mutate(id)}
+          />
+        ))}
+      </View>
+
+      <Text style={styles.hint}>{t('wallet.disclaimer')}</Text>
+    </Screen>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, spacing }) => ({
+  loading: { marginTop: spacing.xxl },
+  section: {
+    borderBottomColor: colors.border,
+    borderBottomWidth: 1,
+    gap: spacing.sm + 2,
+    paddingBottom: spacing.lg + 6,
+    paddingTop: spacing.lg,
+  },
+  pressed: { opacity: 0.7 },
+  kicker: { color: colors.textFaint, fontSize: 13, fontWeight: '600' },
+  balanceValue: { ...font.title, color: colors.text, fontSize: 56, lineHeight: 60 },
+  balanceHint: { alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between' },
+  body: { ...font.body, color: colors.textMuted, lineHeight: 23 },
+  tiles: {
+    borderBottomColor: colors.border,
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    paddingBottom: spacing.lg,
+    paddingTop: spacing.lg,
+  },
+  sectionTitle: { ...font.heading, color: colors.text, fontSize: 16, marginTop: spacing.lg },
+  offers: {},
+  hint: {
+    ...font.caption,
+    color: colors.textFaint,
+    fontSize: 13,
+    lineHeight: 21,
+    marginBottom: spacing.xxl,
+    marginTop: spacing.lg,
+  },
+}))

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -703,7 +703,7 @@ export const ar: Localized<EnMessages> = {
     editProfile: 'تعديل الملف',
     settings: 'الإعدادات',
     corrections: 'التصحيحات',
-    tokens: 'الرموز',
+    wallet: 'المحفظة',
     previewProfile: 'معاينة ملفي الشخصي',
     previewProfileBody: 'شاهد ملفك كما يراه الآخرون',
     shareProfile: 'مشاركة ملفي الشخصي',
@@ -839,11 +839,36 @@ export const ar: Localized<EnMessages> = {
   },
 
   store: {
-    intro: 'تُكتسب بالمراسلة وبتصحيح الآخرين. التعليم يزن أكثر من الحديث.',
+    restoreStreak: 'استرجع سلسلتك',
+    restoreStreakBody: 'استعد سلسلة الـ {days} يومًا التي كانت لديك في النسخة الأولى',
+    streakFreeze: 'تجميد السلسلة',
+    streakFreezeBody: 'ينقذ يومًا فائتًا · {banked}/{max} مُدّخر',
+    ownedAccessibility: '{title}، مملوك',
+    buy: 'شراء {title} مقابل {price} رمزًا',
+    owned: 'مملوك',
+    frameKind: 'إطار الملف',
+    titleKind: 'لقب',
     todayCounts: '{messages} · {corrections}',
+  },
+
+  wallet: {
+    title: 'المحفظة',
+    balance: 'الرصيد',
+    earnedSpent: '‏{earned} مكتسب · {spent} منفق',
+    streakFreezes: 'تجميدات السلسلة',
+    itemsOwned: 'العناصر المملوكة',
+    storeTitle: 'المتجر',
     disclaimer:
-      'لا يمكن شراء الرموز أو تداولها أو سحبها أو استخدامها لفتح أي ميزة Pro — فقط لتجميد السلسلة والمظاهر. لا سلسلة كتل ولا محفظة ولا سوق.',
-    todaysPool: 'حصيلة اليوم',
+      'الرموز نقاط داخل التطبيق. لا يمكن شراؤها أو تداولها أو سحبها أو استخدامها لفتح Pro — فقط تجميدات السلسلة والعناصر التجميلية. لا سلسلة ولا عقد ولا سوق.',
+  },
+
+  tokens: {
+    title: 'الرموز',
+    intro: 'تُكتسب بالمراسلة وبتصحيح جمل الآخرين. التعليم يزن أكثر من الحديث.',
+    thisWeek: 'هذا الأسبوع',
+    thisMonth: 'هذا الشهر',
+    allTime: 'كل الأوقات',
+    poolTitle: 'التجمّع اليومي',
     activeToday: {
       zero: 'لا أحد نشط اليوم',
       one: 'شخص واحد نشط اليوم',
@@ -861,17 +886,6 @@ export const ar: Localized<EnMessages> = {
     historyEmpty: 'لا شيء بعد. أرسل رسالة أو صحّح لأحدهم.',
     historySpent: '−{count} أُنفقت',
     historyMore: 'عرض المزيد',
-    restoreStreak: 'استرجع سلسلتك',
-    restoreStreakBody: 'استعد سلسلة الـ {days} يومًا التي كانت لديك في النسخة الأولى',
-    streakFreeze: 'تجميد السلسلة',
-    streakFreezeBody: 'ينقذ يومًا فائتًا · {banked}/{max} مُدّخر',
-    ownedAccessibility: '{title}، مملوك',
-    buy: 'شراء {title} مقابل {price} رمزًا',
-    title: 'الرموز',
-    balance: 'الرصيد',
-    owned: 'مملوك',
-    frameKind: 'إطار الملف',
-    titleKind: 'لقب',
   },
 
   tokenKind: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -594,7 +594,7 @@ export const de: Localized<EnMessages> = {
     editProfile: 'Profil bearbeiten',
     settings: 'Einstellungen',
     corrections: 'Korrekturen',
-    tokens: 'Token',
+    wallet: 'Geldbörse',
     previewProfile: 'Mein Profil ansehen',
     previewProfileBody: 'Sieh dein Profil so, wie andere es sehen',
     shareProfile: 'Mein Profil teilen',
@@ -728,12 +728,37 @@ export const de: Localized<EnMessages> = {
   },
 
   store: {
-    intro:
-      'Verdient durch Schreiben und durch Korrigieren anderer. Unterrichten zählt mehr als Reden.',
+    restoreStreak: 'Serie wiederherstellen',
+    restoreStreakBody: 'Hol dir die {days}-Tage-Serie aus v1 zurück',
+    streakFreeze: 'Serienschutz',
+    streakFreezeBody: 'Rettet einen verpassten Tag · {banked}/{max} auf Vorrat',
+    ownedAccessibility: '{title}, bereits vorhanden',
+    buy: '{title} für {price} Token kaufen',
+    owned: 'Vorhanden',
+    frameKind: 'Profilrahmen',
+    titleKind: 'Titel',
     todayCounts: '{messages} · {corrections}',
+  },
+
+  wallet: {
+    title: 'Geldbörse',
+    balance: 'Guthaben',
+    earnedSpent: '{earned} verdient · {spent} ausgegeben',
+    streakFreezes: 'Serien-Freezes',
+    itemsOwned: 'Besitz',
+    storeTitle: 'Shop',
     disclaimer:
-      'Token lassen sich nicht kaufen, tauschen, auszahlen oder gegen eine Pro-Funktion eintauschen — nur gegen Serienschutz und Kosmetik. Es gibt keine Chain, kein Wallet und keinen Markt.',
-    todaysPool: 'Der heutige Pool',
+      'Token sind In-App-Punkte. Sie lassen sich nicht kaufen, handeln, auszahlen oder gegen Pro eintauschen — nur Serien-Freezes und Kosmetik. Es gibt keine Chain, keinen Vertrag und keinen Markt.',
+  },
+
+  tokens: {
+    title: 'Token',
+    intro:
+      'Verdient durch Nachrichten und durch das Korrigieren anderer. Lehren zählt mehr als Reden.',
+    thisWeek: 'Diese Woche',
+    thisMonth: 'Diesen Monat',
+    allTime: 'Insgesamt',
+    poolTitle: 'Täglicher Pool',
     activeToday: { one: '{count} Person heute aktiv', other: '{count} Personen heute aktiv' },
     shareAmount: '+{count}',
     shareFor: 'dein Anteil für {day}',
@@ -744,17 +769,6 @@ export const de: Localized<EnMessages> = {
     historyEmpty: 'Noch nichts. Schreib eine Nachricht oder korrigiere jemanden.',
     historySpent: '−{count} ausgegeben',
     historyMore: 'Mehr anzeigen',
-    restoreStreak: 'Serie wiederherstellen',
-    restoreStreakBody: 'Hol dir die {days}-Tage-Serie aus v1 zurück',
-    streakFreeze: 'Serienschutz',
-    streakFreezeBody: 'Rettet einen verpassten Tag · {banked}/{max} auf Vorrat',
-    ownedAccessibility: '{title}, bereits vorhanden',
-    buy: '{title} für {price} Token kaufen',
-    title: 'Token',
-    balance: 'Guthaben',
-    owned: 'Vorhanden',
-    frameKind: 'Profilrahmen',
-    titleKind: 'Titel',
   },
 
   tokenKind: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -626,7 +626,7 @@ export const en = {
     editProfile: 'Edit profile',
     settings: 'Settings',
     corrections: 'Corrections',
-    tokens: 'Tokens',
+    wallet: 'Wallet',
     previewProfile: 'Preview my profile',
     previewProfileBody: 'See your profile the way other people do',
     shareProfile: 'Share my profile',
@@ -758,20 +758,37 @@ export const en = {
   },
 
   store: {
-    intro:
-      'Earned by messaging and by correcting other people. Teaching is weighted higher than talking.',
-    todayCounts: '{messages} · {corrections}',
-    disclaimer:
-      'Tokens cannot be bought, traded, withdrawn, or used to unlock any Pro feature — only streak freezes and cosmetics. There is no chain, no wallet and no market.',
     restoreStreak: 'Restore your streak',
     restoreStreakBody: 'Bring back the {days}-day streak you had in v1',
     streakFreeze: 'Streak freeze',
     streakFreezeBody: 'Saves one missed day · {banked}/{max} banked',
     ownedAccessibility: '{title}, owned',
     buy: 'Buy {title} for {price} tokens',
-    title: 'Tokens',
+    owned: 'Owned',
+    frameKind: 'Profile frame',
+    titleKind: 'Title',
+    todayCounts: '{messages} · {corrections}',
+  },
+
+  wallet: {
+    title: 'Wallet',
     balance: 'Balance',
-    todaysPool: "Today's pool",
+    earnedSpent: '{earned} earned · {spent} spent',
+    streakFreezes: 'Streak freezes',
+    itemsOwned: 'Items owned',
+    storeTitle: 'Store',
+    disclaimer:
+      'Tokens are in-app points. They cannot be bought, traded, withdrawn or used to unlock Pro — only streak freezes and cosmetics. There is no chain, no contract and no market.',
+  },
+
+  tokens: {
+    title: 'Tokens',
+    intro:
+      'Earned by messaging and by correcting other people. Teaching is weighted higher than talking.',
+    thisWeek: 'This week',
+    thisMonth: 'This month',
+    allTime: 'All time',
+    poolTitle: 'Daily pool',
     activeToday: { one: '{count} active today', other: '{count} active today' },
     shareAmount: '+{count}',
     shareFor: 'your share for {day}',
@@ -782,9 +799,6 @@ export const en = {
     historyEmpty: 'Nothing yet. Send a message, or correct someone.',
     historySpent: '−{count} spent',
     historyMore: 'Show more',
-    owned: 'Owned',
-    frameKind: 'Profile frame',
-    titleKind: 'Title',
   },
 
   /** One per `TOKEN_KINDS`; `kindKey()` builds the key from the kind itself. */

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -590,7 +590,7 @@ export const es: Localized<EnMessages> = {
     editProfile: 'Editar perfil',
     settings: 'Ajustes',
     corrections: 'Correcciones',
-    tokens: 'Fichas',
+    wallet: 'Cartera',
     previewProfile: 'Ver mi perfil',
     previewProfileBody: 'Mira tu perfil como lo ven los demás',
     shareProfile: 'Compartir mi perfil',
@@ -722,11 +722,37 @@ export const es: Localized<EnMessages> = {
   },
 
   store: {
-    intro: 'Se ganan escribiendo y corrigiendo a otras personas. Enseñar pesa más que hablar.',
+    restoreStreak: 'Recupera tu racha',
+    restoreStreakBody: 'Recupera la racha de {days} días que tenías en la v1',
+    streakFreeze: 'Congelar racha',
+    streakFreezeBody: 'Salva un día perdido · {banked}/{max} guardadas',
+    ownedAccessibility: '{title}, ya lo tienes',
+    buy: 'Comprar {title} por {price} fichas',
+    owned: 'Tuyo',
+    frameKind: 'Marco de perfil',
+    titleKind: 'Título',
     todayCounts: '{messages} · {corrections}',
+  },
+
+  wallet: {
+    title: 'Cartera',
+    balance: 'Saldo',
+    earnedSpent: '{earned} ganadas · {spent} gastadas',
+    streakFreezes: 'Congelaciones de racha',
+    itemsOwned: 'Objetos',
+    storeTitle: 'Tienda',
     disclaimer:
-      'Las fichas no se compran, no se intercambian, no se retiran y no desbloquean ninguna función Pro: solo congelaciones de racha y detalles. No hay cadena, ni monedero, ni mercado.',
-    todaysPool: 'El fondo de hoy',
+      'Las fichas son puntos dentro de la app. No se pueden comprar, intercambiar, retirar ni usar para desbloquear Pro: solo congelaciones de racha y cosméticos. No hay cadena, ni contrato, ni mercado.',
+  },
+
+  tokens: {
+    title: 'Fichas',
+    intro:
+      'Se ganan escribiendo mensajes y corrigiendo a otras personas. Enseñar pesa más que hablar.',
+    thisWeek: 'Esta semana',
+    thisMonth: 'Este mes',
+    allTime: 'Histórico',
+    poolTitle: 'Bote diario',
     activeToday: { one: '{count} persona activa hoy', other: '{count} personas activas hoy' },
     shareAmount: '+{count}',
     shareFor: 'tu parte del {day}',
@@ -737,17 +763,6 @@ export const es: Localized<EnMessages> = {
     historyEmpty: 'Todavía nada. Envía un mensaje o corrige a alguien.',
     historySpent: '−{count} gastado',
     historyMore: 'Ver más',
-    restoreStreak: 'Recupera tu racha',
-    restoreStreakBody: 'Recupera la racha de {days} días que tenías en la v1',
-    streakFreeze: 'Congelar racha',
-    streakFreezeBody: 'Salva un día perdido · {banked}/{max} guardadas',
-    ownedAccessibility: '{title}, ya lo tienes',
-    buy: 'Comprar {title} por {price} fichas',
-    title: 'Fichas',
-    balance: 'Saldo',
-    owned: 'Tuyo',
-    frameKind: 'Marco de perfil',
-    titleKind: 'Título',
   },
 
   tokenKind: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -592,7 +592,7 @@ export const fr: Localized<EnMessages> = {
     editProfile: 'Modifier le profil',
     settings: 'Réglages',
     corrections: 'Corrections',
-    tokens: 'Jetons',
+    wallet: 'Portefeuille',
     previewProfile: 'Aperçu de mon profil',
     previewProfileBody: 'Vois ton profil comme les autres le voient',
     shareProfile: 'Partager mon profil',
@@ -724,11 +724,36 @@ export const fr: Localized<EnMessages> = {
   },
 
   store: {
-    intro: 'Gagnés en écrivant et en corrigeant les autres. Enseigner compte plus que parler.',
+    restoreStreak: 'Restaure ta série',
+    restoreStreakBody: 'Récupère la série de {days} jours que tu avais sur la v1',
+    streakFreeze: 'Gel de série',
+    streakFreezeBody: 'Sauve un jour manqué · {banked}/{max} en réserve',
+    ownedAccessibility: '{title}, déjà acquis',
+    buy: 'Acheter {title} pour {price} jetons',
+    owned: 'Acquis',
+    frameKind: 'Cadre de profil',
+    titleKind: 'Titre',
     todayCounts: '{messages} · {corrections}',
+  },
+
+  wallet: {
+    title: 'Portefeuille',
+    balance: 'Solde',
+    earnedSpent: '{earned} gagnés · {spent} dépensés',
+    streakFreezes: 'Gels de série',
+    itemsOwned: 'Objets possédés',
+    storeTitle: 'Boutique',
     disclaimer:
-      'Les jetons ne s’achètent pas, ne s’échangent pas, ne se retirent pas et ne débloquent aucune fonction Pro — seulement des gels de série et des éléments cosmétiques. Il n’y a ni chaîne, ni portefeuille, ni marché.',
-    todaysPool: 'La cagnotte du jour',
+      'Les jetons sont des points internes à l’app. Ils ne peuvent être achetés, échangés, retirés ni servir à débloquer Pro — seulement des gels de série et des cosmétiques. Pas de chaîne, pas de contrat, pas de marché.',
+  },
+
+  tokens: {
+    title: 'Jetons',
+    intro: 'Gagnés en écrivant et en corrigeant les autres. Enseigner compte plus que parler.',
+    thisWeek: 'Cette semaine',
+    thisMonth: 'Ce mois-ci',
+    allTime: 'Depuis toujours',
+    poolTitle: 'Cagnotte du jour',
     activeToday: {
       one: '{count} personne active aujourd’hui',
       other: '{count} personnes actives aujourd’hui',
@@ -742,17 +767,6 @@ export const fr: Localized<EnMessages> = {
     historyEmpty: 'Rien pour l’instant. Envoyez un message ou corrigez quelqu’un.',
     historySpent: '−{count} dépensé',
     historyMore: 'Afficher plus',
-    restoreStreak: 'Restaure ta série',
-    restoreStreakBody: 'Récupère la série de {days} jours que tu avais sur la v1',
-    streakFreeze: 'Gel de série',
-    streakFreezeBody: 'Sauve un jour manqué · {banked}/{max} en réserve',
-    ownedAccessibility: '{title}, déjà acquis',
-    buy: 'Acheter {title} pour {price} jetons',
-    title: 'Jetons',
-    balance: 'Solde',
-    owned: 'Acquis',
-    frameKind: 'Cadre de profil',
-    titleKind: 'Titre',
   },
 
   tokenKind: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -586,7 +586,7 @@ export const ptBR: Localized<EnMessages> = {
     editProfile: 'Editar perfil',
     settings: 'Configurações',
     corrections: 'Correções',
-    tokens: 'Fichas',
+    wallet: 'Carteira',
     previewProfile: 'Ver meu perfil',
     previewProfileBody: 'Veja seu perfil como as outras pessoas veem',
     shareProfile: 'Compartilhar meu perfil',
@@ -719,11 +719,37 @@ export const ptBR: Localized<EnMessages> = {
   },
 
   store: {
-    intro: 'Ganhas conversando e corrigindo outras pessoas. Ensinar pesa mais do que conversar.',
+    restoreStreak: 'Recupere sua sequência',
+    restoreStreakBody: 'Traga de volta a sequência de {days} dias que você tinha na v1',
+    streakFreeze: 'Congelar sequência',
+    streakFreezeBody: 'Salva um dia perdido · {banked}/{max} guardados',
+    ownedAccessibility: '{title}, você já tem',
+    buy: 'Comprar {title} por {price} fichas',
+    owned: 'Você tem',
+    frameKind: 'Moldura de perfil',
+    titleKind: 'Título',
     todayCounts: '{messages} · {corrections}',
+  },
+
+  wallet: {
+    title: 'Carteira',
+    balance: 'Saldo',
+    earnedSpent: '{earned} ganhas · {spent} gastas',
+    streakFreezes: 'Congelamentos de sequência',
+    itemsOwned: 'Itens',
+    storeTitle: 'Loja',
     disclaimer:
-      'Fichas não podem ser compradas, trocadas, sacadas nem usadas para liberar qualquer recurso Pro — só congelamentos de sequência e itens visuais. Não há blockchain, carteira nem mercado.',
-    todaysPool: 'O fundo de hoje',
+      'As fichas são pontos dentro do app. Não podem ser compradas, trocadas, sacadas nem usadas para desbloquear o Pro — apenas congelamentos de sequência e cosméticos. Não há cadeia, contrato nem mercado.',
+  },
+
+  tokens: {
+    title: 'Fichas',
+    intro:
+      'Ganhas ao enviar mensagens e ao corrigir outras pessoas. Ensinar pesa mais do que conversar.',
+    thisWeek: 'Esta semana',
+    thisMonth: 'Este mês',
+    allTime: 'Desde sempre',
+    poolTitle: 'Bolo diário',
     activeToday: { one: '{count} pessoa ativa hoje', other: '{count} pessoas ativas hoje' },
     shareAmount: '+{count}',
     shareFor: 'sua parte de {day}',
@@ -734,17 +760,6 @@ export const ptBR: Localized<EnMessages> = {
     historyEmpty: 'Nada ainda. Envie uma mensagem ou corrija alguém.',
     historySpent: '−{count} gasto',
     historyMore: 'Mostrar mais',
-    restoreStreak: 'Recupere sua sequência',
-    restoreStreakBody: 'Traga de volta a sequência de {days} dias que você tinha na v1',
-    streakFreeze: 'Congelar sequência',
-    streakFreezeBody: 'Salva um dia perdido · {banked}/{max} guardados',
-    ownedAccessibility: '{title}, você já tem',
-    buy: 'Comprar {title} por {price} fichas',
-    title: 'Fichas',
-    balance: 'Saldo',
-    owned: 'Você tem',
-    frameKind: 'Moldura de perfil',
-    titleKind: 'Título',
   },
 
   tokenKind: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -676,7 +676,7 @@ export const ru: Localized<EnMessages> = {
     editProfile: 'Изменить профиль',
     settings: 'Настройки',
     corrections: 'Исправления',
-    tokens: 'Жетоны',
+    wallet: 'Кошелёк',
     previewProfile: 'Посмотреть мой профиль',
     previewProfileBody: 'Взгляните на профиль глазами других',
     shareProfile: 'Поделиться профилем',
@@ -810,12 +810,36 @@ export const ru: Localized<EnMessages> = {
   },
 
   store: {
-    intro:
-      'Зарабатываются перепиской и исправлениями чужих ошибок. Обучение весит больше, чем разговор.',
+    restoreStreak: 'Восстанови серию',
+    restoreStreakBody: 'Верни серию из {days} дней, которая была у тебя в v1',
+    streakFreeze: 'Заморозка серии',
+    streakFreezeBody: 'Спасает один пропущенный день · накоплено {banked}/{max}',
+    ownedAccessibility: '{title}, уже есть',
+    buy: 'Купить {title} за {price} жетонов',
+    owned: 'Есть',
+    frameKind: 'Рамка профиля',
+    titleKind: 'Титул',
     todayCounts: '{messages} · {corrections}',
+  },
+
+  wallet: {
+    title: 'Кошелёк',
+    balance: 'Баланс',
+    earnedSpent: 'заработано {earned} · потрачено {spent}',
+    streakFreezes: 'Заморозки серии',
+    itemsOwned: 'Предметы',
+    storeTitle: 'Магазин',
     disclaimer:
-      'Жетоны нельзя купить, обменять, вывести или потратить на функции Pro — только на заморозку серии и оформление. Ни блокчейна, ни кошелька, ни рынка.',
-    todaysPool: 'Сегодняшний пул',
+      'Жетоны — это внутренние баллы. Их нельзя купить, обменять, вывести или разблокировать ими Pro — только заморозки серии и косметика. Нет ни цепочки, ни контракта, ни рынка.',
+  },
+
+  tokens: {
+    title: 'Жетоны',
+    intro: 'Начисляются за сообщения и за исправления чужих фраз. Учить важнее, чем говорить.',
+    thisWeek: 'На этой неделе',
+    thisMonth: 'В этом месяце',
+    allTime: 'За всё время',
+    poolTitle: 'Ежедневный пул',
     activeToday: {
       one: 'сегодня активен {count} человек',
       few: 'сегодня активны {count} человека',
@@ -831,17 +855,6 @@ export const ru: Localized<EnMessages> = {
     historyEmpty: 'Пока пусто. Отправьте сообщение или исправьте кого-нибудь.',
     historySpent: '−{count} потрачено',
     historyMore: 'Показать ещё',
-    restoreStreak: 'Восстанови серию',
-    restoreStreakBody: 'Верни серию из {days} дней, которая была у тебя в v1',
-    streakFreeze: 'Заморозка серии',
-    streakFreezeBody: 'Спасает один пропущенный день · накоплено {banked}/{max}',
-    ownedAccessibility: '{title}, уже есть',
-    buy: 'Купить {title} за {price} жетонов',
-    title: 'Жетоны',
-    balance: 'Баланс',
-    owned: 'Есть',
-    frameKind: 'Рамка профиля',
-    titleKind: 'Титул',
   },
 
   tokenKind: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -597,7 +597,7 @@ export const tr: Localized<EnMessages> = {
     editProfile: 'Profili düzenle',
     settings: 'Ayarlar',
     corrections: 'Düzeltme',
-    tokens: 'Jeton',
+    wallet: 'Cüzdan',
     previewProfile: 'Profilimi önizle',
     previewProfileBody: 'Profilini başkalarının gördüğü gibi gör',
     shareProfile: 'Profilimi paylaş',
@@ -729,12 +729,37 @@ export const tr: Localized<EnMessages> = {
   },
 
   store: {
-    intro:
-      'Mesajlaşarak ve başkalarını düzelterek kazanılır. Öğretmek, konuşmaktan daha ağır basar.',
+    restoreStreak: 'Serini geri getir',
+    restoreStreakBody: 'v1’deki {days} günlük serini geri al',
+    streakFreeze: 'Seri dondurma',
+    streakFreezeBody: 'Kaçırılan bir günü kurtarır · {banked}/{max} birikti',
+    ownedAccessibility: '{title}, sende var',
+    buy: '{title} için {price} jeton öde',
+    owned: 'Sende',
+    frameKind: 'Profil çerçevesi',
+    titleKind: 'Unvan',
     todayCounts: '{messages} · {corrections}',
+  },
+
+  wallet: {
+    title: 'Cüzdan',
+    balance: 'Bakiye',
+    earnedSpent: '{earned} kazanıldı · {spent} harcandı',
+    streakFreezes: 'Seri dondurma',
+    itemsOwned: 'Sahip olunan',
+    storeTitle: 'Mağaza',
     disclaimer:
-      'Jetonlar satın alınamaz, takas edilemez, çekilemez ve hiçbir Pro özelliğini açmaz — yalnızca seri dondurma ve görünüm içindir. Zincir, cüzdan ya da piyasa yoktur.',
-    todaysPool: 'Bugünün havuzu',
+      "Jetonlar uygulama içi puandır. Satın alınamaz, takas edilemez, çekilemez ve Pro'yu açamaz — yalnızca seri dondurma ve kozmetikler. Zincir yok, sözleşme yok, piyasa yok.",
+  },
+
+  tokens: {
+    title: 'Jetonlar',
+    intro:
+      'Mesajlaşarak ve başkalarının cümlelerini düzelterek kazanılır. Öğretmek, konuşmaktan daha ağır basar.',
+    thisWeek: 'Bu hafta',
+    thisMonth: 'Bu ay',
+    allTime: 'Tüm zamanlar',
+    poolTitle: 'Günlük havuz',
     activeToday: { one: 'bugün {count} kişi aktif', other: 'bugün {count} kişi aktif' },
     shareAmount: '+{count}',
     shareFor: '{day} için payın',
@@ -745,17 +770,6 @@ export const tr: Localized<EnMessages> = {
     historyEmpty: 'Henüz bir şey yok. Bir mesaj gönder ya da birini düzelt.',
     historySpent: '−{count} harcandı',
     historyMore: 'Daha fazla göster',
-    restoreStreak: 'Serini geri getir',
-    restoreStreakBody: 'v1’deki {days} günlük serini geri al',
-    streakFreeze: 'Seri dondurma',
-    streakFreezeBody: 'Kaçırılan bir günü kurtarır · {banked}/{max} birikti',
-    ownedAccessibility: '{title}, sende var',
-    buy: '{title} için {price} jeton öde',
-    title: 'Jetonlar',
-    balance: 'Bakiye',
-    owned: 'Sende',
-    frameKind: 'Profil çerçevesi',
-    titleKind: 'Unvan',
   },
 
   tokenKind: {

--- a/docs/token-messaging-brief.md
+++ b/docs/token-messaging-brief.md
@@ -21,6 +21,23 @@ it inside the app. That is the entire definition.
 - **Not on a blockchain.** There is no chain, no contract, no wallet address.
 - **It cannot unlock Pro.** LangX Pro is a subscription; tokens buy none of it.
 
+## Words we do and do not use
+
+"Wallet" as the name of the in-app screen holding a point balance is **fine**,
+and it is what that screen is called. What is ruled out is a _crypto_ wallet:
+wallet **addresses**, "connect wallet", coin and chain iconography, and any
+wording that implies custody, transfer or an external holder of value. The
+distinction is not pedantry — `release-runbook.md` cites this document on the
+App Review question (3.1.5(b)), and a reviewer's concern is whether the app is
+crypto-adjacent, not whether a screen has a common English name.
+
+So the in-app disclaimer no longer says "no wallet", which would have
+contradicted the screen it sits on. It says what is actually true and actually
+load-bearing: no chain, no contract, no market, cannot be bought, cannot be
+traded, cannot unlock Pro.
+
+New screens use Feather `award`/`gift`, never a coin.
+
 Call it **"LangX Token"**. Drop "Test Token" — v1 used that because the token
 was framed as a preview of something real, and there is nothing to preview any
 more. Keeping "test" would now be misleading in the opposite direction.

--- a/packages/shared/src/reservedHandles.ts
+++ b/packages/shared/src/reservedHandles.ts
@@ -44,7 +44,9 @@ const ROUTE_RESERVED = [
   'settings',
   'starred',
   'store',
+  'tokens',
   'viewers',
+  'wallet',
 ] as const
 
 /**


### PR DESCRIPTION
## What

`/(app)/store` becomes two screens.

| | `/(app)/wallet` | `/(app)/tokens` |
| --- | --- | --- |
| Answers | "what can I spend" | "where did this come from" |
| Holds | balance, earned·spent, streak freezes, items owned, the shop, the disclaimer | week/month/all-time totals, the daily pool, the day-by-day ledger |

Me's balance tile now reads **Wallet ›** and opens the first. The balance inside it is pressable — with a chevron — and opens the second.

## Why split at all

The ledger grows by a row a day and never shrinks, so the shop — the only thing on that screen anybody can *act* on — sat underneath a list that gets longer forever. The balance is the natural seam: it is the answer to the first question and the entrance to the second.

Nothing appears on both screens.

## The disclaimer

It said *"There is no chain, no wallet and no market"* — on a screen now called Wallet. It now says what is actually load-bearing: no chain, no contract, no market, cannot be bought, cannot be traded, cannot unlock Pro.

`docs/token-messaging-brief.md` gains the distinction that makes that safe:

> "Wallet" as the name of the in-app screen holding a point balance is fine. What is ruled out is a *crypto* wallet: wallet **addresses**, "connect wallet", coin and chain iconography, and any wording that implies custody or transfer.

That document is cited by `release-runbook.md` on **App Review 3.1.5(b)**, so leaving it asserting the opposite of the shipped screen would have read as a compliance miss to whoever checked next.

## i18n

`store.*` splits along the same line. What stays is exactly the shop (`buy`, `owned`, `restoreStreak`, `streakFreeze`, `frameKind`, `titleKind`). The pool and history keys move to `tokens.*` **unchanged** — they were only ever called `store` because that was the screen's name. `me.tokens` → `me.wallet`.

Someone else's profile keeps saying "Tokens" over their count: that tile is a number about them, not a wallet you can open, so it reads `tokens.title`.

## Reserved

`wallet` and `tokens` join `RESERVED_HANDLES`, since every top-level route name is a username nobody may claim. The test that walks `app/` caught both before this commit existed — the second time it has paid for itself (it found `intro` on the first run).

## Checks

`pnpm test` — shared 170, mobile 298, api 529. `pnpm lint`, `pnpm format:check`, `pnpm -r typecheck` clean apart from the three pre-existing stale-`router.d.ts` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)