### PR TITLE
Give new subscribers a welcome pack of items, never of token

### DIFF
--- a/apps/api/src/modules/billing/refresh.ts
+++ b/apps/api/src/modules/billing/refresh.ts
@@ -2,6 +2,7 @@ import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import type { Profile } from '../profiles/profiles'
 import type { RevenueCatClient } from './revenueCatClient'
+import { grantWelcomePack } from './welcomePack'
 
 /**
  * The client-triggered fallback for a webhook that's late or never arrives
@@ -32,6 +33,25 @@ export async function refreshEntitlement(
   await db
     .collection<Profile>(COLLECTIONS.profiles)
     .updateOne({ _id: userId }, { $set: { entitlement: next, updatedAt: now } })
+
+  /*
+   * After the entitlement is written, not before: if the grant threw, a retry
+   * has to find the tier already recorded, and a pack handed out against a
+   * tier that failed to save would be a gift for a subscription nobody has.
+   *
+   * Failure is swallowed for the same reason the v1 loyalty grant's is — the
+   * subscription is the thing the user paid for and it is already active;
+   * losing a cosmetic to a transient write is not worth failing the refresh
+   * that RevenueCat is waiting on. The next refresh picks it up, because the
+   * latch is only written on success.
+   */
+  if (next.tier !== 'free') {
+    try {
+      await grantWelcomePack(db, userId, next.tier)
+    } catch {
+      // Intentionally ignored; see above.
+    }
+  }
 
   return next
 }

--- a/apps/api/src/modules/billing/welcomePack.test.ts
+++ b/apps/api/src/modules/billing/welcomePack.test.ts
@@ -1,0 +1,137 @@
+import { PRO_WELCOME_PACKS } from '@langx/shared'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import type { Profile } from '../profiles/profiles'
+import { grantWelcomePack } from './welcomePack'
+
+function minimalProfile(id: string): Profile {
+  const now = new Date()
+  return {
+    _id: id,
+    handle: id,
+    displayName: id,
+    birthDate: '1995-06-15',
+    gender: 'undisclosed',
+    nativeLanguages: [{ code: 'tr' }],
+    learning: [{ code: 'en', level: 'intermediate', priority: 1 }],
+    interests: [],
+    settings: { discoverable: true, notifications: true },
+    privacy: { incognito: false },
+    entitlement: { tier: 'free', updatedAt: now },
+    quota: { initiations: [], translations: [], media: [] },
+    streak: { current: 0, longest: 0, lastQualifiedDay: null },
+    stats: { lastActiveAt: now, messagesSent: 0 },
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+describe('grantWelcomePack', () => {
+  let server: MongoMemoryServer
+  let handle: DbHandle
+  let seq = 0
+
+  beforeAll(async () => {
+    server = await MongoMemoryServer.create()
+    handle = await connectToDatabase(server.getUri(), 'welcome-pack-test')
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await server.stop()
+  })
+
+  async function seed(overrides: Partial<Profile> = {}): Promise<string> {
+    seq++
+    const id = `packuser${seq}`
+    await handle.db
+      .collection<Profile>(COLLECTIONS.profiles)
+      .insertOne({ ...minimalProfile(id), ...overrides })
+    return id
+  }
+
+  function read(id: string) {
+    return handle.db.collection<Profile>(COLLECTIONS.profiles).findOne({ _id: id })
+  }
+
+  it('hands over what the tier includes', async () => {
+    const id = await seed()
+    const result = await grantWelcomePack(handle.db, id, 'pro')
+
+    expect(result.granted).toBe(true)
+    const profile = await read(id)
+    expect(profile?.cosmetics).toEqual([...PRO_WELCOME_PACKS.pro.cosmetics])
+    expect(profile?.streakFreezes).toBe(PRO_WELCOME_PACKS.pro.streakFreezes)
+  })
+
+  /**
+   * `refreshEntitlement` is the single funnel every tier change passes
+   * through, and it runs on the client's fallback poll as well as the webhook
+   * — so this is called far more often than a subscription starts.
+   */
+  it('is idempotent, because the refresh that calls it is not a one-off', async () => {
+    const id = await seed()
+    await grantWelcomePack(handle.db, id, 'pro')
+    const second = await grantWelcomePack(handle.db, id, 'pro')
+
+    expect(second.granted).toBe(false)
+    const profile = await read(id)
+    expect(profile?.cosmetics).toHaveLength(PRO_WELCOME_PACKS.pro.cosmetics.length)
+    expect(profile?.streakFreezes).toBe(PRO_WELCOME_PACKS.pro.streakFreezes)
+  })
+
+  it('grants only the difference when a pro subscriber upgrades', async () => {
+    const id = await seed()
+    await grantWelcomePack(handle.db, id, 'pro')
+    const upgrade = await grantWelcomePack(handle.db, id, 'pro_plus')
+
+    expect(upgrade.granted).toBe(true)
+    // The bronze frame was already theirs and is not handed over twice.
+    expect(upgrade.cosmetics).not.toContain('frame.bronze')
+    const profile = await read(id)
+    expect(new Set(profile?.cosmetics)).toEqual(new Set(PRO_WELCOME_PACKS.pro_plus.cosmetics))
+  })
+
+  it('gives nothing back to a pro_plus subscriber who drops to pro', async () => {
+    const id = await seed()
+    await grantWelcomePack(handle.db, id, 'pro_plus')
+    const downgrade = await grantWelcomePack(handle.db, id, 'pro')
+
+    expect(downgrade.granted).toBe(false)
+    const profile = await read(id)
+    expect(profile?.streakFreezes).toBe(PRO_WELCOME_PACKS.pro_plus.streakFreezes)
+  })
+
+  /**
+   * The reason the grant is `$addToSet` over unowned items rather than a plain
+   * push: even with the latch lost, a second run cannot duplicate a cosmetic.
+   */
+  it('cannot duplicate a cosmetic somebody already bought with token', async () => {
+    const id = await seed({ cosmetics: ['frame.bronze'] })
+    const result = await grantWelcomePack(handle.db, id, 'pro')
+
+    expect(result.cosmetics).not.toContain('frame.bronze')
+    const profile = await read(id)
+    expect(profile?.cosmetics).toEqual(['frame.bronze'])
+  })
+
+  /**
+   * The whole point of granting items rather than token: a balance is
+   * `tokenAggregates.all` minus spending, and that aggregate is what the
+   * all-time leaderboard ranks. Paying must not move anyone up it.
+   */
+  it('writes no ledger row and no aggregate, so paying buys no rank', async () => {
+    const id = await seed()
+    await grantWelcomePack(handle.db, id, 'pro_plus')
+
+    expect(await handle.db.collection(COLLECTIONS.tokenLedger).countDocuments({ userId: id })).toBe(
+      0,
+    )
+    expect(
+      await handle.db.collection(COLLECTIONS.tokenAggregates).countDocuments({ userId: id }),
+    ).toBe(0)
+    expect((await read(id))?.tokenSpent ?? 0).toBe(0)
+  })
+})

--- a/apps/api/src/modules/billing/welcomePack.ts
+++ b/apps/api/src/modules/billing/welcomePack.ts
@@ -1,0 +1,65 @@
+import { PRO_WELCOME_PACKS, welcomePackDelta, type PaidPlanTier } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import type { Profile } from '../profiles/profiles'
+
+/**
+ * Hands a new subscriber the things token buys, once.
+ *
+ * Deliberately **not** token. Granting token for money is the one thing every
+ * public claim about this economy rules out, and it is not only a wording
+ * problem: a balance is `tokenAggregates.all` minus spending, and that
+ * aggregate is exactly what the all-time leaderboard ranks. There is no way to
+ * credit a balance without moving somebody up a table other people are
+ * climbing by writing corrections.
+ *
+ * Called from `refreshEntitlement`, which is the single funnel every tier
+ * change passes through — both the RevenueCat webhook and the client's
+ * `POST /billing/refresh` fallback — so it runs on **every** refresh and has
+ * to be idempotent under that.
+ *
+ * Idempotency has two layers, and the second is the one that matters.
+ * `welcomePackAt` records which tier's pack has been given, so a plain refresh
+ * does nothing. But the grant itself is `$addToSet` over items the profile
+ * does not already own, so even a lost latch cannot hand out a second copy —
+ * the worst case is a streak freeze, which is capped separately below.
+ *
+ * Upgrading pro → pro_plus grants the difference. Lapsing and re-subscribing
+ * grants nothing, because the items are still owned. Cosmetics are **not**
+ * taken back when a subscription ends: revoking them would change how somebody
+ * looks at the moment they stop paying, which is a support ticket rather than
+ * an incentive.
+ */
+export async function grantWelcomePack(
+  db: Db,
+  userId: string,
+  tier: PaidPlanTier,
+): Promise<{ granted: boolean; cosmetics: readonly string[] }> {
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  const profile = await profiles.findOne(
+    { _id: userId },
+    { projection: { cosmetics: 1, streakFreezes: 1, welcomePackAt: 1 } },
+  )
+  if (!profile) return { granted: false, cosmetics: [] }
+
+  // Already given for this tier, or for the higher one — pro_plus first means
+  // a downgrade does not re-trigger pro's pack.
+  const given = profile.welcomePackAt
+  if (given?.pro_plus || (given?.pro && tier === 'pro')) {
+    return { granted: false, cosmetics: [] }
+  }
+
+  const cosmetics = welcomePackDelta(tier, profile.cosmetics ?? [])
+  const freezes = PRO_WELCOME_PACKS[tier].streakFreezes
+
+  await profiles.updateOne(
+    { _id: userId },
+    {
+      ...(cosmetics.length > 0 ? { $addToSet: { cosmetics: { $each: [...cosmetics] } } } : {}),
+      $inc: { streakFreezes: freezes },
+      $set: { [`welcomePackAt.${tier}`]: new Date() },
+    },
+  )
+
+  return { granted: true, cosmetics }
+}

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -99,6 +99,14 @@ export interface Profile {
   tokenSpent?: number
   /** Cosmetic ids owned (see `COSMETICS`). */
   cosmetics?: string[]
+  /**
+   * When each paid tier's welcome pack was handed over.
+   *
+   * Per tier, not a single flag: upgrading pro → pro_plus grants the
+   * difference, and a single boolean could not tell "already had pro's" from
+   * "already had pro_plus's".
+   */
+  welcomePackAt?: Partial<Record<'pro' | 'pro_plus', Date>>
   /** Set when token earning is suspended pending review (report/block). Clears by unsetting. */
   tokenFrozenAt?: Date
   stats: { lastActiveAt: Date; messagesSent: number }

--- a/apps/mobile/app/(app)/paywall.tsx
+++ b/apps/mobile/app/(app)/paywall.tsx
@@ -100,6 +100,10 @@ const BENEFIT_COPY: Record<ProBenefit, BenefitCopy> = {
     title: 'paywall.hideOnline',
     body: 'paywall.hideOnlineBody',
   },
+  welcomePack: {
+    title: 'paywall.welcomePack',
+    body: 'paywall.welcomePackBody',
+  },
 }
 
 /**

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -1013,6 +1013,8 @@ export const ar: Localized<EnMessages> = {
     partOf: 'جزء من',
     unlimitedChats: 'محادثات جديدة بلا حدود',
     unlimitedChatsBody: '{count} يوميًا في الخطة المجانية.',
+    welcomePack: 'حزمة ترحيب',
+    welcomePackBody: 'إطار للملف الشخصي وتجميدتان للسلسلة للبداية. و‏Pro+ يمنح المجموعة كاملة.',
     advancedFilters: 'عوامل تصفية متقدمة',
     advancedFiltersBody: 'ابحث حسب الجنس والمدينة.',
     unlimitedTranslation: 'ترجمة بلا حدود',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -852,6 +852,9 @@ export const de: Localized<EnMessages> = {
     partOf: 'gehört zu',
     unlimitedChats: 'Unbegrenzt neue Chats',
     unlimitedChatsBody: '{count} am Tag im kostenlosen Tarif.',
+    welcomePack: 'Ein Willkommenspaket',
+    welcomePackBody:
+      'Ein Profilrahmen und zwei Serien-Freezes zum Start. Pro+ bringt das ganze Set.',
     advancedFilters: 'Erweiterte Filter',
     advancedFiltersBody: 'Suche nach Geschlecht und Stadt.',
     unlimitedTranslation: 'Unbegrenzte Übersetzung',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -884,6 +884,9 @@ export const en = {
     partOf: 'is part of',
     unlimitedChats: 'Unlimited new chats',
     unlimitedChatsBody: '{count} a day on the free plan.',
+    welcomePack: 'A welcome pack',
+    welcomePackBody:
+      'A profile frame and two streak freezes to start with. Pro+ brings the full set.',
     advancedFilters: 'Advanced filters',
     advancedFiltersBody: 'Search by gender and city.',
     unlimitedTranslation: 'Unlimited translation',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -844,6 +844,9 @@ export const es: Localized<EnMessages> = {
     partOf: 'forma parte de',
     unlimitedChats: 'Chats nuevos ilimitados',
     unlimitedChatsBody: '{count} al día en el plan gratuito.',
+    welcomePack: 'Un pack de bienvenida',
+    welcomePackBody:
+      'Un marco de perfil y dos congelaciones de racha para empezar. Pro+ trae el set completo.',
     advancedFilters: 'Filtros avanzados',
     advancedFiltersBody: 'Busca por género y ciudad.',
     unlimitedTranslation: 'Traducción ilimitada',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -850,6 +850,9 @@ export const fr: Localized<EnMessages> = {
     partOf: 'fait partie de',
     unlimitedChats: 'Discussions nouvelles illimitées',
     unlimitedChatsBody: '{count} par jour sur le forfait gratuit.',
+    welcomePack: 'Un pack de bienvenue',
+    welcomePackBody:
+      'Un cadre de profil et deux gels de série pour commencer. Pro+ apporte la panoplie complète.',
     advancedFilters: 'Filtres avancés',
     advancedFiltersBody: 'Cherche par genre et par ville.',
     unlimitedTranslation: 'Traduction illimitée',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -842,6 +842,9 @@ export const ptBR: Localized<EnMessages> = {
     partOf: 'faz parte do',
     unlimitedChats: 'Conversas novas ilimitadas',
     unlimitedChatsBody: '{count} por dia no plano gratuito.',
+    welcomePack: 'Um pacote de boas-vindas',
+    welcomePackBody:
+      'Uma moldura de perfil e dois congelamentos de sequência para começar. O Pro+ traz o conjunto completo.',
     advancedFilters: 'Filtros avançados',
     advancedFiltersBody: 'Busque por gênero e cidade.',
     unlimitedTranslation: 'Tradução ilimitada',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -970,6 +970,8 @@ export const ru: Localized<EnMessages> = {
     partOf: '— часть',
     unlimitedChats: 'Безлимитные новые чаты',
     unlimitedChatsBody: '{count} в день на бесплатном тарифе.',
+    welcomePack: 'Приветственный набор',
+    welcomePackBody: 'Рамка профиля и две заморозки серии для начала. Pro+ даёт полный набор.',
     advancedFilters: 'Расширенные фильтры',
     advancedFiltersBody: 'Поиск по полу и городу.',
     unlimitedTranslation: 'Безлимитный перевод',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -849,6 +849,9 @@ export const tr: Localized<EnMessages> = {
     partOf: 'şunun parçası:',
     unlimitedChats: 'Sınırsız yeni sohbet',
     unlimitedChatsBody: 'Ücretsiz planda günde {count} tane.',
+    welcomePack: 'Hoş geldin paketi',
+    welcomePackBody:
+      'Başlangıç için bir profil çerçevesi ve iki seri dondurma. Pro+ setin tamamını getirir.',
     advancedFilters: 'Gelişmiş filtreler',
     advancedFiltersBody: 'Cinsiyete ve şehre göre ara.',
     unlimitedTranslation: 'Sınırsız çeviri',

--- a/docs/token-messaging-brief.md
+++ b/docs/token-messaging-brief.md
@@ -69,6 +69,24 @@ that damages trust.
   on, and it is complete on purpose: if tokens could buy a Pro feature, farming
   tokens would become a substitute for subscribing.
 
+## Subscribing: what Pro includes, and what it cannot
+
+Pro and Pro+ include a one-off **welcome pack** — a profile frame or two, and
+two streak freezes. Items, never token.
+
+That is not a stylistic preference. "There is no way to buy tokens, with money
+or anything else" is the claim above, and a token grant for a subscription
+would make it false. It is also not only wording: a balance is
+`tokenAggregates.all` minus spending, and that aggregate is exactly what the
+all-time leaderboard ranks — so granting token for money would sell rank on a
+table other people climb by writing corrections.
+
+Nothing in the pack is Pro-only. Every item in it is buyable with token by
+anybody; subscribing skips the saving, it does not unlock a shelf. Say it that
+way: **"a head start, not a shortcut"**, never "earn tokens faster".
+
+Cosmetics are not taken back when a subscription lapses.
+
 ## Returning v1 users: what to tell them
 
 **Balances carry over.** Nothing in v1 was ever bought or sold — what looked

--- a/packages/shared/src/cosmetics.test.ts
+++ b/packages/shared/src/cosmetics.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { PAID_PLAN_TIERS } from './limits'
+import { TOKEN_RULES } from './token'
+import { PRO_WELCOME_PACKS, findCosmetic, welcomePackDelta } from './cosmetics'
+
+describe('PRO_WELCOME_PACKS', () => {
+  it('hands out only things that exist in the catalogue', () => {
+    for (const tier of PAID_PLAN_TIERS) {
+      for (const id of PRO_WELCOME_PACKS[tier].cosmetics) {
+        expect(findCosmetic(id), `${tier}: ${id}`).toBeDefined()
+      }
+    }
+  })
+
+  /**
+   * The rule the whole design rests on: paying buys items, never token. A
+   * balance is `tokenAggregates.all` minus spending, and that aggregate is
+   * what the all-time leaderboard ranks — so a token grant would sell rank.
+   * Nothing here can express one, and this asserts the shape stays that way.
+   */
+  it('cannot express a token grant at all', () => {
+    for (const tier of PAID_PLAN_TIERS) {
+      expect(Object.keys(PRO_WELCOME_PACKS[tier]).sort()).toEqual(['cosmetics', 'streakFreezes'])
+    }
+  })
+
+  it('makes Pro+ a superset of Pro, so upgrading never takes something away', () => {
+    const pro = new Set(PRO_WELCOME_PACKS.pro.cosmetics)
+    for (const id of pro) {
+      expect(PRO_WELCOME_PACKS.pro_plus.cosmetics, id).toContain(id)
+    }
+    expect(PRO_WELCOME_PACKS.pro_plus.streakFreezes).toBeGreaterThanOrEqual(
+      PRO_WELCOME_PACKS.pro.streakFreezes,
+    )
+  })
+
+  it('stays inside the banked-freeze cap, so the grant is never partly discarded', () => {
+    for (const tier of PAID_PLAN_TIERS) {
+      expect(PRO_WELCOME_PACKS[tier].streakFreezes, tier).toBeLessThanOrEqual(
+        TOKEN_RULES.sinks.maxBankedStreakFreezes,
+      )
+    }
+  })
+})
+
+describe('welcomePackDelta', () => {
+  it('is the whole pack for somebody who owns nothing', () => {
+    expect(welcomePackDelta('pro', [])).toEqual([...PRO_WELCOME_PACKS.pro.cosmetics])
+  })
+
+  it('is empty once everything in it is owned', () => {
+    expect(welcomePackDelta('pro_plus', [...PRO_WELCOME_PACKS.pro_plus.cosmetics])).toEqual([])
+  })
+
+  /** Somebody who bought the frame with token does not get a second one. */
+  it('skips what was already earned rather than paid for', () => {
+    expect(welcomePackDelta('pro', ['frame.bronze'])).toEqual([])
+  })
+})

--- a/packages/shared/src/cosmetics.ts
+++ b/packages/shared/src/cosmetics.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import type { PaidPlanTier } from './limits'
 
 /**
  * The only things token can buy, besides a streak freeze.
@@ -30,6 +31,51 @@ export const COSMETICS: readonly Cosmetic[] = [
 
 export function findCosmetic(id: string): Cosmetic | undefined {
   return COSMETICS.find((c) => c.id === id)
+}
+
+/**
+ * What subscribing includes, once, per tier.
+ *
+ * **Items, not token.** Granting token for money is the one thing every public
+ * claim about this economy rules out — `token-messaging-brief.md` says "there
+ * is no way to buy tokens, with money or anything else", the in-app disclaimer
+ * says it, and `legal/promise-change.md` says it in a document not yet
+ * published. Handing out the things token buys keeps all three true.
+ *
+ * It also keeps the leaderboard honest, which a token grant could not: a
+ * balance is `tokenAggregates.all` minus spending, and that aggregate is
+ * exactly what the all-time table ranks. There is no way to credit a balance
+ * without moving somebody up a table other people are climbing by writing
+ * corrections.
+ *
+ * Nothing here is Pro-only in itself — every item is buyable with token by
+ * anyone. Subscribing skips the saving, it does not unlock a shelf.
+ */
+export interface WelcomePack {
+  cosmetics: readonly string[]
+  streakFreezes: number
+}
+
+export const PRO_WELCOME_PACKS: Readonly<Record<PaidPlanTier, WelcomePack>> = {
+  pro: { cosmetics: ['frame.bronze'], streakFreezes: 2 },
+  pro_plus: {
+    cosmetics: ['frame.bronze', 'frame.silver', 'frame.gold', 'title.learner'],
+    streakFreezes: 2,
+  },
+}
+
+/**
+ * What a tier's pack adds on top of one already granted.
+ *
+ * Upgrading pro → pro_plus should hand over the difference, not the whole
+ * thing again; downgrading and re-subscribing should hand over nothing. Both
+ * fall out of "grant what this tier includes and you do not already own",
+ * which is also why the caller can be idempotent without a second latch per
+ * item.
+ */
+export function welcomePackDelta(tier: PaidPlanTier, owned: readonly string[]): readonly string[] {
+  const ownedSet = new Set(owned)
+  return PRO_WELCOME_PACKS[tier].cosmetics.filter((id) => !ownedSet.has(id))
 }
 
 /** Everything token can be spent on: the freeze plus the cosmetics catalogue. */

--- a/packages/shared/src/limits.ts
+++ b/packages/shared/src/limits.ts
@@ -221,6 +221,15 @@ export const PRO_BENEFITS = [
   'profileViewerIdentities',
   'incognito',
   'hideOnlineStatus',
+  /**
+   * A one-off welcome pack — cosmetics and streak freezes, never token. See
+   * `PRO_WELCOME_PACKS`, and the note there on why granting token for money is
+   * the one thing this economy cannot do.
+   *
+   * Last in the list on purpose: it is a nice-to-have beside five capabilities,
+   * and leading with it would sell the subscription on a gift.
+   */
+  'welcomePack',
 ] as const
 export type ProBenefit = (typeof PRO_BENEFITS)[number]
 


### PR DESCRIPTION
## What

| Tier | Pack |
| --- | --- |
| Pro | `frame.bronze` + 2 streak freezes |
| Pro+ | `frame.bronze`, `frame.silver`, `frame.gold`, `title.learner` + 2 streak freezes |

One-off, per tier.

## Why items and not token

The original idea was 4,000 token for Pro and 10,000 for Pro+. That cannot ship, for two reasons that are not about taste:

**1. It contradicts every public claim.** `docs/token-messaging-brief.md` says *"there is no way to buy tokens, with money or anything else"*. The in-app disclaimer says it. `docs/legal/promise-change.md` says it — in a document **not yet published**, so we would have been revising a promise before making it.

**2. It would sell leaderboard rank.** A balance is `tokenAggregates.all` minus spending, and that aggregate is *exactly* what the all-time leaderboard ranks. There is no way to credit a balance without moving somebody up a table other people climb by writing corrections. `TOKEN_GRANT_KINDS` already protects the week/month/year buckets for this reason — it cannot protect `all`, because that is where the balance is read from.

Handing over the things token buys keeps all of it true. `PRO_WELCOME_PACKS` cannot express a token grant at all, and a test pins that shape.

Nothing in the pack is Pro-only — every item is buyable with token by anybody. **A head start, not a shortcut**, and the brief now says to describe it in those words rather than "earn tokens faster".

## Idempotency

Granted from `refreshEntitlement`, the single funnel every tier change passes through — both the RevenueCat webhook and the client's `POST /billing/refresh` fallback. So it runs far more often than a subscription starts.

Two layers, and the second is the one that matters:

- `welcomePackAt` records which tier's pack was given (per tier, not a flag — a single boolean could not tell "already had pro's" from "already had pro_plus's").
- The grant is `$addToSet` over items **not already owned**, so even a lost latch cannot hand out a second copy of a frame somebody bought with token.

Upgrading pro → pro_plus grants the difference. Dropping back grants nothing. Lapsing takes nothing away — revoking cosmetics would change how somebody looks at the moment they stop paying, which buys a support ticket rather than a renewal.

The grant runs *after* the entitlement write, and its failure is swallowed the same way the v1 loyalty grant's is: the subscription is what the user paid for and is already active, and the next refresh picks the pack up because the latch is only written on success.

## Tests

6 in `welcomePack.test.ts` — including that a grant writes **no ledger row, no aggregate and no `tokenSpent`**, which is the leaderboard claim made checkable — plus 7 in shared covering the catalogue rules (pack items exist, Pro+ is a superset of Pro, freezes stay inside `maxBankedStreakFreezes` so no part of the grant is silently discarded).

`pnpm test` — shared 177, mobile 298, api 535. Lint, format and typecheck clean apart from the three pre-existing stale-`router.d.ts` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)