### PR TITLE
Give the chat list tabs, pins and an archive — and a view layer to make them safe

### DIFF
--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -130,6 +130,23 @@ export const INDEXES: Partial<IndexSpec> = {
     // have played in a match-gated model.
     { key: { pairKey: 1 }, name: 'pair_key_unique', unique: true },
     { key: { participants: 1, 'lastMessage.createdAt': -1 }, name: 'participants_recent' },
+    /*
+     * There is deliberately **no** index for `pinnedBy` / `archivedBy`, and it
+     * is worth saying why rather than leaving it looking forgotten.
+     *
+     * Both are maps keyed by user id, so the path a query filters on is
+     * `archivedBy.<viewerId>` — a *dynamic* path, which no fixed index key can
+     * name. A wildcard index could, but it cannot be compounded with
+     * `participants`, which is the selective half.
+     *
+     * They are maps rather than arrays because `participants` is already
+     * multikey and MongoDB refuses to compound two array fields ("cannot index
+     * parallel arrays") — the same reason `unread` is shaped this way.
+     *
+     * `participants_recent` above already bounds the scan to one person's
+     * threads, which is tens or hundreds of documents, and the flags are a
+     * cheap filter over that. An index here would buy nothing.
+     */
     // Backs the rolling-24h initiation quota without a separate collection.
     { key: { firstMessageBy: 1, firstMessageAt: -1 }, name: 'first_message_by' },
   ],

--- a/apps/api/src/modules/chat/conversationView.ts
+++ b/apps/api/src/modules/chat/conversationView.ts
@@ -1,0 +1,49 @@
+import type { Conversation } from './conversations'
+
+/**
+ * What one participant is allowed to see of a conversation.
+ *
+ * `listConversations` used to return raw documents, which was fine while every
+ * field on one was mutual — and stopped being fine the moment per-user state
+ * landed on the same document. `unread` has always been a map keyed by user
+ * id, so the list already shipped **the other person's unread count** to both
+ * sides; `pinnedBy` and `archivedBy` would have shipped "they archived you",
+ * which is worse.
+ *
+ * The same reasoning `messageView.ts` records for messages, applied one level
+ * up: one projection, at the single point a conversation leaves the server, is
+ * the only thing that stays true as fields keep being added.
+ */
+export interface ConversationView {
+  _id: string
+  participants: [string, string]
+  lastMessage: { body: string; senderId: string; createdAt: Date; deleted?: boolean }
+  /** This viewer's count, as a number — never the map it is stored in. */
+  unread: number
+  pinned: boolean
+  archived: boolean
+  /** They spoke last, so the next move is the viewer's. */
+  unreplied: boolean
+  bothSpoke: boolean
+  updatedAt: Date
+}
+
+export function toConversationView(conversation: Conversation, viewerId: string): ConversationView {
+  return {
+    _id: conversation._id.toHexString(),
+    participants: conversation.participants,
+    lastMessage: conversation.lastMessage,
+    unread: conversation.unread?.[viewerId] ?? 0,
+    pinned: conversation.pinnedBy?.[viewerId] === true,
+    archived: conversation.archivedBy?.[viewerId] === true,
+    /*
+     * Read off `lastMessage.senderId`, not off the unread count. Opening a
+     * thread clears the unread without answering it, so the two disagree
+     * exactly for the threads somebody read and meant to come back to — which
+     * are the ones this is for.
+     */
+    unreplied: conversation.lastMessage.senderId !== viewerId,
+    bothSpoke: conversation.bothSpoke,
+    updatedAt: conversation.updatedAt,
+  }
+}

--- a/apps/api/src/modules/chat/conversations.ts
+++ b/apps/api/src/modules/chat/conversations.ts
@@ -18,6 +18,19 @@ export interface Conversation {
   participants: [string, string]
   lastMessage: { body: string; senderId: string; createdAt: Date; deleted?: boolean }
   unread: Record<string, number>
+  /**
+   * Per-user, and a **map keyed by user id** rather than an array of ids.
+   *
+   * `participants` is already a multikey field, and MongoDB refuses to compound
+   * two array fields in one index — so `{ participants: 1, archivedBy: 1 }`
+   * cannot exist. A map's dotted path (`archivedBy.<uid>`) is a scalar and can,
+   * which is the same reason `unread` above is shaped this way.
+   *
+   * Not to be confused with `pinned` below, which is a pinned *message* and is
+   * shared by both sides.
+   */
+  pinnedBy?: Record<string, true>
+  archivedBy?: Record<string, true>
   /** One per conversation, replaced rather than appended — see `MAX_PINNED_PER_CONVERSATION`. */
   pinned?: { messageId: ObjectId; byUserId: string; at: Date }
   firstMessageBy: string

--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -1,6 +1,8 @@
 import {
   ERROR_CODES,
+  MAX_PINNED_CONVERSATIONS,
   REPLY_PREVIEW_MAX_LENGTH,
+  type ConversationFilter,
   type SendCorrectionInput,
   type SendMediaMessageInput,
   type SendTextMessageInput,
@@ -15,6 +17,7 @@ import { awardForSend } from '../tokens/awards'
 import { assertConversationAccess } from './access'
 import { toMessageView, type MessageView } from './messageView'
 import type { Conversation, Message } from './conversations'
+import { toConversationView, type ConversationView } from './conversationView'
 
 export interface SendResult {
   message: Message
@@ -497,16 +500,19 @@ export async function markConversationRead(
 }
 
 export interface ConversationPage {
-  items: Conversation[]
+  items: ConversationView[]
+  /** Always the whole set, never paginated — see the note in `listConversations`. */
+  pinned: ConversationView[]
   nextCursor: string | null
 }
 
 export async function listConversations(
   db: Db,
   userId: string,
-  query: { cursor?: string | undefined; limit: number },
+  query: { filter?: ConversationFilter | undefined; cursor?: string | undefined; limit: number },
 ): Promise<ConversationPage> {
   const conversations = db.collection<Conversation>(COLLECTIONS.conversations)
+  const filter = query.filter ?? 'all'
 
   // A blocked counterpart's thread disappears from the list entirely.
   // `assertConversationAccess` already refuses to open it; without this the
@@ -514,28 +520,71 @@ export async function listConversations(
   const hidden = await blockedUserIds(db, userId)
   // On an array field `$nin` means "contains none of these", so this reads as
   //: my threads, minus any whose participant list includes someone hidden.
-  const filter: Document = {
+  const base: Document = {
     participants: hidden.length > 0 ? { $eq: userId, $nin: hidden } : userId,
   }
+
+  /*
+   * Archiving is a per-tab bound, not a flag on a row: the archive tab is the
+   * only place archived threads appear, and every other tab is defined by
+   * their absence. Written as `$ne: true` rather than `$exists: false` so a
+   * document that was archived and then un-archived — which leaves the key
+   * unset — reads the same as one that never was.
+   */
+  const archivedPath = `archivedBy.${userId}`
+  if (filter === 'archived') base[archivedPath] = true
+  else base[archivedPath] = { $ne: true }
+
+  // "They spoke last." See `toConversationView` for why this is not `unread`.
+  if (filter === 'unreplied') base['lastMessage.senderId'] = { $ne: userId }
+
+  const pinnedPath = `pinnedBy.${userId}`
+
+  /*
+   * Pinned threads are fetched whole and separately, and that is a deliberate
+   * limit rather than an oversight.
+   *
+   * Pinning makes the sort compound — pinned first, then recency — and the
+   * cursor is `<lastMessage.createdAt>|<_id>`, which cannot express "and also
+   * this side of the pin boundary". Rather than widen the cursor for a set
+   * that is small by construction, the pins come back in one un-paginated
+   * query and the page below excludes them. `MAX_PINNED_CONVERSATIONS` is what
+   * keeps "small by construction" true.
+   */
+  const pinned =
+    filter === 'archived'
+      ? []
+      : await conversations
+          .find({ ...base, [pinnedPath]: true })
+          .sort({ 'lastMessage.createdAt': -1, _id: -1 })
+          .limit(MAX_PINNED_CONVERSATIONS)
+          .toArray()
+
+  const pageFilter: Document = { ...base }
+  if (filter !== 'archived') pageFilter[pinnedPath] = { $ne: true }
   if (query.cursor) {
     const { date, id } = decodeDateIdCursor(query.cursor)
-    filter.$or = [
+    pageFilter.$or = [
       { 'lastMessage.createdAt': { $lt: date } },
       { 'lastMessage.createdAt': date, _id: { $lt: id } },
     ]
   }
 
   const page = await conversations
-    .find(filter)
+    .find(pageFilter)
     .sort({ 'lastMessage.createdAt': -1, _id: -1 })
     .limit(query.limit + 1)
     .toArray()
 
   const hasMore = page.length > query.limit
-  const items = hasMore ? page.slice(0, query.limit) : page
-  const last = items.at(-1)
+  const rows = hasMore ? page.slice(0, query.limit) : page
+  const last = rows.at(-1)
   const nextCursor =
     hasMore && last ? encodeDateIdCursor(last.lastMessage.createdAt, last._id) : null
 
-  return { items, nextCursor }
+  return {
+    items: rows.map((c) => toConversationView(c, userId)),
+    pinned: pinned.map((c) => toConversationView(c, userId)),
+    nextCursor,
+  }
 }

--- a/apps/api/src/modules/chat/mutations.ts
+++ b/apps/api/src/modules/chat/mutations.ts
@@ -1,5 +1,6 @@
 import {
   canDeleteForEveryone,
+  MAX_PINNED_CONVERSATIONS,
   canEditMessage,
   ERROR_CODES,
   MESSAGE_REACTIONS,
@@ -15,6 +16,7 @@ import { ApiError } from '../../lib/ApiError'
 import { supportsPut, type StorageProvider } from '../../storage/StorageProvider'
 import { assertConversationAccess } from './access'
 import type { Conversation, Message } from './conversations'
+import { toConversationView, type ConversationView } from './conversationView'
 
 export interface MessageMutationResult {
   message: Message
@@ -406,4 +408,62 @@ export async function listStarredMessages(
     .sort({ createdAt: -1 })
     .limit(limit)
     .toArray()
+}
+
+/**
+ * Pin or archive a thread, for one participant only.
+ *
+ * Written as a dotted path into a map keyed by user id — the same shape
+ * `unread` uses, and for the same reason: `participants` is already a multikey
+ * field and MongoDB refuses to compound two arrays in one index, so an
+ * `archivedBy: string[]` could never be part of the index the list rides.
+ *
+ * Un-setting rather than storing `false`, so "never archived" and "archived
+ * then un-archived" are the same document and the list's `$ne: true` reads
+ * both the same way.
+ */
+export async function setConversationFlag(
+  db: Db,
+  conversationId: string,
+  userId: string,
+  flag: 'pinnedBy' | 'archivedBy',
+  on: boolean,
+): Promise<ConversationView> {
+  const conversations = db.collection<Conversation>(COLLECTIONS.conversations)
+  // Mirrors how `messageId` is parsed above: a malformed id is a 404, not a
+  // 500 from the ObjectId constructor.
+  let _id: ObjectId
+  try {
+    _id = new ObjectId(conversationId)
+  } catch {
+    throw new ApiError(ERROR_CODES.NOT_FOUND, 'Conversation not found')
+  }
+  await assertConversationAccess(db, conversationId, userId)
+
+  if (on && flag === 'pinnedBy') {
+    /*
+     * The cap exists because pinned threads are fetched whole rather than
+     * paginated. Counted rather than trusted: the client hides the action at
+     * the limit, and the client is not what enforces it.
+     */
+    const pinned = await conversations.countDocuments({
+      participants: userId,
+      [`pinnedBy.${userId}`]: true,
+    })
+    if (pinned >= MAX_PINNED_CONVERSATIONS) {
+      throw new ApiError(
+        ERROR_CODES.VALIDATION_FAILED,
+        `You can pin at most ${MAX_PINNED_CONVERSATIONS} chats`,
+      )
+    }
+  }
+
+  const path = `${flag}.${userId}`
+  const updated = await conversations.findOneAndUpdate(
+    { _id },
+    on ? { $set: { [path]: true } } : { $unset: { [path]: '' } },
+    { returnDocument: 'after' },
+  )
+  if (!updated) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Conversation not found')
+  return toConversationView(updated, userId)
 }

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -134,6 +134,161 @@ describe('Faz 5 — conversation/message history REST', () => {
     expect(body.items[0]?.participants).toContain(newer.userId) // most recent activity first
   })
 
+  describe('tabs, pins and the view layer', () => {
+    async function list(viewer: SignedUpUser, filter?: string) {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/conversations${filter ? `?filter=${filter}` : ''}`,
+        headers: { cookie: viewer.cookie },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+      return response.json<{
+        items: {
+          _id: string
+          unread: number
+          pinned: boolean
+          archived: boolean
+          unreplied: boolean
+        }[]
+        pinned: { _id: string }[]
+      }>()
+    }
+
+    function setFlags(viewer: SignedUpUser, id: string, body: Record<string, boolean>) {
+      return app.inject({
+        method: 'PATCH',
+        url: `/conversations/${id}/flags`,
+        headers: { cookie: viewer.cookie },
+        payload: body,
+      })
+    }
+
+    /**
+     * The list used to ship raw documents, so `unread` arrived as a map keyed
+     * by user id — meaning both sides received **the other person's** count.
+     * `toConversationView` exists to stop that, and this is what pins it.
+     */
+    it('tells a viewer nothing about the other side', async () => {
+      const viewer = await newUser('view-layer-viewer@example.com')
+      const partner = await newUser('view-layer-partner@example.com')
+      const convo = await startConversation(partner, viewer.userId, 'hello')
+      await setFlags(partner, convo._id, { archived: true })
+
+      const body = await list(viewer)
+      const row = body.items.find((c) => c._id === convo._id)
+
+      expect(typeof row?.unread).toBe('number')
+      expect(row?.unread).toBe(1)
+      // The partner archived it; the viewer must not be able to tell.
+      expect(row?.archived).toBe(false)
+      // `participants` legitimately carries both ids — the client resolves the
+      // counterpart from it. What must not leak is the other side's *state*.
+      expect(Object.keys(row ?? {})).not.toContain('archivedBy')
+      expect(Object.keys(row ?? {})).not.toContain('pinnedBy')
+    })
+
+    /**
+     * "They spoke last", not "I have not read it". Opening a thread clears the
+     * unread without answering it, so a list keyed on unread would silently
+     * drop everything somebody read and meant to come back to.
+     */
+    it('keeps a read-but-unanswered thread in the unreplied tab', async () => {
+      const viewer = await newUser('unreplied-viewer@example.com')
+      const partner = await newUser('unreplied-partner@example.com')
+      const convo = await startConversation(partner, viewer.userId, 'your turn')
+
+      await app.inject({
+        method: 'POST',
+        url: `/conversations/${convo._id}/read`,
+        headers: { cookie: viewer.cookie },
+      })
+
+      const body = await list(viewer, 'unreplied')
+      const row = body.items.find((c) => c._id === convo._id)
+      expect(row, 'read does not mean answered').toBeDefined()
+      expect(row?.unread).toBe(0)
+      expect(row?.unreplied).toBe(true)
+    })
+
+    it('drops a thread out of unreplied once it is answered', async () => {
+      const viewer = await newUser('answered-viewer@example.com')
+      const partner = await newUser('answered-partner@example.com')
+      const convo = await startConversation(partner, viewer.userId, 'your turn')
+
+      expect((await list(viewer, 'unreplied')).items).toHaveLength(1)
+
+      // Messages go over the socket, so the module is what the tests call.
+      const { sendTextMessage } = await import('../modules/chat/messages')
+      await sendTextMessage(handle.db, viewer.userId, {
+        conversationId: convo._id,
+        body: 'answered',
+      })
+
+      expect((await list(viewer, 'unreplied')).items).toHaveLength(0)
+    })
+
+    it('hides an archived thread from every tab but the archive', async () => {
+      const viewer = await newUser('archive-viewer@example.com')
+      const partner = await newUser('archive-partner@example.com')
+      const convo = await startConversation(viewer, partner.userId, 'filed away')
+
+      expect((await setFlags(viewer, convo._id, { archived: true })).statusCode).toBe(200)
+
+      expect((await list(viewer)).items.map((c) => c._id)).not.toContain(convo._id)
+      expect((await list(viewer, 'archived')).items.map((c) => c._id)).toContain(convo._id)
+
+      // Un-archiving unsets the key, so it reads the same as never archived.
+      await setFlags(viewer, convo._id, { archived: false })
+      expect((await list(viewer)).items.map((c) => c._id)).toContain(convo._id)
+      expect((await list(viewer, 'archived')).items).toHaveLength(0)
+    })
+
+    it('returns pins as their own list, out of the paginated one', async () => {
+      const viewer = await newUser('pin-viewer@example.com')
+      const partner = await newUser('pin-partner@example.com')
+      const other = await newUser('pin-other@example.com')
+      const pinned = await startConversation(viewer, partner.userId, 'keep this')
+      await startConversation(viewer, other.userId, 'ordinary')
+
+      await setFlags(viewer, pinned._id, { pinned: true })
+
+      const body = await list(viewer)
+      expect(body.pinned.map((c) => c._id)).toEqual([pinned._id])
+      // And not counted twice.
+      expect(body.items.map((c) => c._id)).not.toContain(pinned._id)
+    })
+
+    /** One side pinning must not pin it for the other. */
+    it('pins for one participant only', async () => {
+      const viewer = await newUser('pin-solo-viewer@example.com')
+      const partner = await newUser('pin-solo-partner@example.com')
+      const convo = await startConversation(viewer, partner.userId, 'mine only')
+
+      await setFlags(viewer, convo._id, { pinned: true })
+
+      expect((await list(viewer)).pinned).toHaveLength(1)
+      expect((await list(partner)).pinned).toHaveLength(0)
+    })
+
+    it('refuses a request that names no flag', async () => {
+      const viewer = await newUser('noflag-viewer@example.com')
+      const partner = await newUser('noflag-partner@example.com')
+      const convo = await startConversation(viewer, partner.userId, 'hi')
+
+      expect((await setFlags(viewer, convo._id, {})).statusCode).toBe(400)
+    })
+
+    it('refuses to flag somebody else conversation', async () => {
+      const a = await newUser('flag-outsider-a@example.com')
+      const b = await newUser('flag-outsider-b@example.com')
+      const outsider = await newUser('flag-outsider-c@example.com')
+      const convo = await startConversation(a, b.userId, 'private')
+
+      const response = await setFlags(outsider, convo._id, { pinned: true })
+      expect(response.statusCode).not.toBe(200)
+    })
+  })
+
   /**
    * The client only started reading `nextCursor` here once the chat list
    * became an infinite query. The server side was already right; this pins it

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -1,10 +1,12 @@
 import {
+  conversationFlagsSchema,
   ERROR_CODES,
   listConversationsQuerySchema,
   listMessagesQuerySchema,
   listStarredQuerySchema,
 } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { z } from 'zod'
 import { ApiError } from '../lib/ApiError'
 import { requireAuth } from '../middleware/requireAuth'
 import {
@@ -14,10 +16,50 @@ import {
   markConversationRead,
 } from '../modules/chat/messages'
 import { toMessageView } from '../modules/chat/messageView'
-import { listStarredMessages } from '../modules/chat/mutations'
+import { listStarredMessages, setConversationFlag } from '../modules/chat/mutations'
 
 // eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
 export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
+  /*
+   * One route for both flags rather than four verbs. Pin and archive are the
+   * same operation — a per-user boolean on a thread — and splitting them into
+   * `POST`/`DELETE` pairs would be four handlers doing one thing.
+   */
+  app.patch(
+    '/conversations/:id/flags',
+    {
+      preHandler: requireAuth,
+      schema: {
+        params: z.object({ id: z.string().trim().min(1) }),
+        body: conversationFlagsSchema,
+      },
+    },
+    async (request, reply) => {
+      const { pinned, archived } = request.body
+      let view = null
+      if (pinned !== undefined) {
+        view = await setConversationFlag(
+          app.mongo.db,
+          request.params.id,
+          request.userId,
+          'pinnedBy',
+          pinned,
+        )
+      }
+      if (archived !== undefined) {
+        view = await setConversationFlag(
+          app.mongo.db,
+          request.params.id,
+          request.userId,
+          'archivedBy',
+          archived,
+        )
+      }
+      if (!view) throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Nothing to change')
+      return reply.send(view)
+    },
+  )
+
   app.get(
     '/conversations',
     { preHandler: requireAuth, schema: { querystring: listConversationsQuerySchema } },

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -22,7 +22,6 @@ import {
   type TextInputKeyPressEventData,
 } from 'react-native'
 import {
-  keys,
   uploadMessageMedia,
   useMe,
   useMessages,
@@ -136,7 +135,7 @@ export default function ChatScreen() {
   useEffect(() => {
     if (!conversationId) return
     void api.post(`/conversations/${conversationId}/read`).then(() => {
-      void queryClient.invalidateQueries({ queryKey: keys.conversations })
+      void queryClient.invalidateQueries({ queryKey: ['conversations'] })
     })
   }, [conversationId, queryClient])
 

--- a/apps/mobile/app/(app)/chats.tsx
+++ b/apps/mobile/app/(app)/chats.tsx
@@ -1,6 +1,7 @@
-import { PLAN_LIMITS } from '@langx/shared'
+import { CONVERSATION_FILTERS, PLAN_LIMITS, type ConversationFilter } from '@langx/shared'
 import Feather from '@expo/vector-icons/Feather'
 import { router } from 'expo-router'
+import { useState } from 'react'
 import {
   ActivityIndicator,
   FlatList,
@@ -10,21 +11,31 @@ import {
   Text,
   View,
 } from 'react-native'
-import { useConversations, useMe } from '../../src/api/queries'
+import { useConversationFlags, useConversations, useMe } from '../../src/api/queries'
 import { ConversationRowSkeleton } from '../../src/components/skeletons/ConversationRowSkeleton'
 import { Avatar } from '../../src/components/ui/Avatar'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
+import { SegmentedControl } from '../../src/components/ui/SegmentedControl'
 import { Skeleton } from '../../src/components/ui/Skeleton'
 import { useProfileCache } from '../../src/hooks/useProfileCache'
+import { chooseAlert } from '../../src/lib/alert'
 import { dedupeById } from '../../src/lib/dedupeById'
 import { listState } from '../../src/lib/listState'
 import { makeStyles, useTheme } from '../../src/lib/theme'
 import { relativeTimeCompact } from '../../src/lib/format'
 import { useLocale, useT } from '../../src/i18n'
+import type { MessageKey } from '../../src/i18n/runtime'
 
 /** v3 draws chat avatars at 52, one step up from the 48 default. */
 const AVATAR_SIZE = 52
+
+/** Per tab, keyed so a missing entry does not compile. */
+const EMPTY_COPY: Record<ConversationFilter, { title: MessageKey; body: MessageKey }> = {
+  all: { title: 'chats.emptyTitle', body: 'chats.emptyBody' },
+  unreplied: { title: 'chats.unrepliedEmptyTitle', body: 'chats.unrepliedEmptyBody' },
+  archived: { title: 'chats.archivedEmptyTitle', body: 'chats.archivedEmptyBody' },
+}
 
 export default function ChatsScreen() {
   const { colors } = useTheme()
@@ -33,11 +44,22 @@ export default function ChatsScreen() {
   const { locale } = useLocale()
 
   const me = useMe()
-  const conversations = useConversations()
+  const [filter, setFilter] = useState<ConversationFilter>('all')
+  const conversations = useConversations(filter)
+  const flags = useConversationFlags()
+
+  /*
+   * Pinned first, then the rest. The server returns them as two lists because
+   * pinning makes the sort compound and the cursor cannot express that — so
+   * the join happens here, where it is one concatenation rather than a widened
+   * cursor format.
+   */
+  const pinned = conversations.data?.pages[0]?.pinned ?? []
   // Deduped on flatten: a keyset cursor over a moving sort key can emit the
   // same row on two pages, and a duplicate `key` in a FlatList is a warning
   // plus a row that never updates.
-  const items = dedupeById(conversations.data?.pages.flatMap((page) => page.items) ?? [])
+  const rest = dedupeById(conversations.data?.pages.flatMap((page) => page.items) ?? [])
+  const items = [...pinned, ...rest]
 
   // One batched lookup for every counterpart, instead of a query per row.
   const partnerIds = items
@@ -66,6 +88,25 @@ export default function ChatsScreen() {
         >
           <Feather name="star" size={21} color={colors.textMuted} />
         </Pressable>
+      </View>
+
+      {/*
+        Three tabs, matching the pattern `feed.tsx` set: the filter lives in
+        `useState`, goes into the query key, and the server does the narrowing.
+        Filtering the loaded pages on the client instead would show whatever
+        happened to be fetched, which is exactly wrong for "who am I keeping
+        waiting" — the answer is usually further down the list.
+      */}
+      <View style={styles.filters}>
+        <SegmentedControl<ConversationFilter>
+          options={CONVERSATION_FILTERS.map((value) => ({
+            value,
+            label: t(`chats.tab_${value}` as MessageKey),
+          }))}
+          selected={[filter]}
+          onToggle={setFilter}
+          accessibilityLabel={t('chats.filterPicker')}
+        />
       </View>
 
       {state === 'skeleton' ? (
@@ -97,21 +138,61 @@ export default function ChatsScreen() {
           ListEmptyComponent={
             <EmptyState
               icon="message-square"
-              title={t('chats.emptyTitle')}
-              body={t('chats.emptyBody', { count: PLAN_LIMITS.free.initiationsPer24h ?? 0 })}
-              actionLabel={t('chats.goToDiscover')}
-              onAction={() => router.push('/(app)/discover')}
+              /*
+                Per tab, because "no chats at all" and "nothing waiting on you"
+                are opposite news and the generic copy makes the second read as
+                the first — with a button offering to go and start one.
+              */
+              title={t(EMPTY_COPY[filter].title)}
+              body={
+                filter === 'all'
+                  ? t('chats.emptyBody', { count: PLAN_LIMITS.free.initiationsPer24h ?? 0 })
+                  : t(EMPTY_COPY[filter].body)
+              }
+              {...(filter === 'all'
+                ? {
+                    actionLabel: t('chats.goToDiscover'),
+                    onAction: () => router.push('/(app)/discover'),
+                  }
+                : {})}
             />
           }
           renderItem={({ item, index }) => {
             const partnerId = item.participants.find((p) => p !== me.data?._id) ?? ''
             const partner = partners[partnerId]
-            const unread = me.data ? (item.unread[me.data._id] ?? 0) : 0
+            const unread = item.unread
             const mine = item.lastMessage.senderId === me.data?._id
 
             return (
               <Pressable
                 onPress={() => router.push(`/(app)/chat/${item._id}`)}
+                /*
+                  Long press rather than a swipe. `react-native-gesture-handler`
+                  is deliberately absent from this package, and the app already
+                  teaches long-press-for-actions on every message bubble — a
+                  second gesture grammar for the same idea is one to learn for
+                  no reason.
+
+                  `chooseAlert` rather than a new menu host: it already draws a
+                  list of choices on every platform, including web, where
+                  react-native's own `Alert` is an empty function.
+                */
+                onLongPress={() => {
+                  void chooseAlert(partner?.displayName ?? '', undefined, [
+                    { label: item.pinned ? t('chats.unpin') : t('chats.pin'), value: 'pin' },
+                    {
+                      label: item.archived ? t('chats.unarchive') : t('chats.archive'),
+                      value: 'archive',
+                    },
+                  ]).then((choice) => {
+                    if (choice === 'pin') {
+                      flags.mutate({ conversationId: item._id, pinned: !item.pinned })
+                    }
+                    if (choice === 'archive') {
+                      flags.mutate({ conversationId: item._id, archived: !item.archived })
+                    }
+                  })
+                }}
                 style={({ pressed }) => [
                   styles.row,
                   index === items.length - 1 && styles.rowLast,
@@ -169,6 +250,7 @@ export default function ChatsScreen() {
 }
 
 const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
+  filters: { paddingBottom: spacing.sm, paddingTop: spacing.md },
   titleRow: { alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between' },
   title: { ...font.title, color: colors.text, fontSize: 34, paddingTop: spacing.md },
   list: { paddingBottom: spacing.xxl, paddingTop: spacing.sm },

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -1,4 +1,5 @@
 import {
+  type ConversationFilter,
   type NotificationPrefs,
   effectivePlanTier,
   hasFeature,
@@ -57,7 +58,13 @@ export const keys = {
   profile: (id: string) => ['profile', id] as const,
   discovery: (filters: string) => ['discovery', filters] as const,
   handleSearch: (term: string) => ['handleSearch', term] as const,
-  conversations: ['conversations'] as const,
+  /**
+   * Parameterised now that the list has tabs. Every writer has to patch with
+   * `setQueriesData` on the `['conversations']` prefix rather than
+   * `setQueryData` on one key — the same reason `messagesAround` is a child of
+   * `messages`.
+   */
+  conversations: (filter: string) => ['conversations', filter] as const,
   messages: (id: string) => ['messages', id] as const,
   /**
    * Deliberately a child of `messages(id)`: a socket patch written with
@@ -248,17 +255,22 @@ export interface ConversationDto {
   _id: string
   participants: string[]
   lastMessage: { body: string; senderId: string; createdAt: string }
-  unread: Record<string, number>
+  /** This viewer's count. Resolved server-side by `toConversationView`. */
+  unread: number
+  pinned: boolean
+  archived: boolean
+  /** They spoke last, so the next move is mine. */
+  unreplied: boolean
   bothSpoke: boolean
   updatedAt: string
 }
 
-export function useConversations() {
+export function useConversations(filter: ConversationFilter = 'all') {
   return useInfiniteQuery({
-    queryKey: keys.conversations,
+    queryKey: keys.conversations(filter),
     queryFn: ({ pageParam }) =>
       api.get<ConversationPageDto>(
-        `/conversations${pageParam ? `?cursor=${encodeURIComponent(pageParam)}` : ''}`,
+        `/conversations?filter=${filter}${pageParam ? `&cursor=${encodeURIComponent(pageParam)}` : ''}`,
       ),
     initialPageParam: '',
     getNextPageParam: (last) => last.nextCursor ?? undefined,
@@ -505,6 +517,31 @@ export function useHandleSearch(term: string) {
   })
 }
 
+/**
+ * Pin or archive a thread.
+ *
+ * Invalidates the whole `['conversations']` prefix rather than patching: the
+ * flags move a thread *between* tabs, so the caches that have to change are
+ * the ones not on screen. Patching one and leaving the others is how the
+ * archive tab ends up showing a thread the list already un-archived.
+ */
+export function useConversationFlags() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      conversationId,
+      ...flags
+    }: {
+      conversationId: string
+      pinned?: boolean
+      archived?: boolean
+    }) => api.patch<ConversationDto>(`/conversations/${conversationId}/flags`, flags),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ['conversations'] })
+    },
+  })
+}
+
 export function useFeed(filter: FeedFilter) {
   return useInfiniteQuery({
     queryKey: keys.feed(filter),
@@ -738,7 +775,7 @@ export function useStartConversation() {
     onSuccess: () => {
       // Starting a conversation spends quota and earns tokens — both visible
       // elsewhere in the UI, so both caches are now stale.
-      void queryClient.invalidateQueries({ queryKey: keys.conversations })
+      void queryClient.invalidateQueries({ queryKey: ['conversations'] })
       void queryClient.invalidateQueries({ queryKey: keys.quota })
       void queryClient.invalidateQueries({ queryKey: keys.tokens })
     },

--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -72,20 +72,29 @@ export function useSocket(): void {
          */
         const meId = queryClient.getQueryData<{ _id: string }>(keys.me)?._id
         let patched = false
-        queryClient.setQueryData<InfiniteData<ConversationPageDto>>(keys.conversations, (old) => {
-          if (!old || !meId) return old
-          const next = applyIncomingMessage(old, {
-            conversationId,
-            body: message.body,
-            senderId: message.senderId,
-            createdAt: message.createdAt,
-            forUserId: meId,
-          })
-          if (!next) return old
-          patched = true
-          return next
-        })
-        if (!patched) void queryClient.invalidateQueries({ queryKey: keys.conversations })
+        /*
+         * `setQueriesData` on the prefix, not `setQueryData` on one key. The
+         * list is tabbed now, so several caches hold the same thread — patching
+         * only the visible one is how the tabs start disagreeing about who
+         * spoke last.
+         */
+        queryClient.setQueriesData<InfiniteData<ConversationPageDto>>(
+          { queryKey: ['conversations'] },
+          (old) => {
+            if (!old || !meId) return old
+            const next = applyIncomingMessage(old, {
+              conversationId,
+              body: message.body,
+              senderId: message.senderId,
+              createdAt: message.createdAt,
+              forUserId: meId,
+            })
+            if (!next) return old
+            patched = true
+            return next
+          },
+        )
+        if (!patched) void queryClient.invalidateQueries({ queryKey: ['conversations'] })
         void queryClient.invalidateQueries({ queryKey: keys.tokens })
       })
 
@@ -112,7 +121,7 @@ export function useSocket(): void {
         // A withdrawal empties the chat list's preview too, and that is the
         // one thing this cannot patch from here.
         if (message.deleted) {
-          void queryClient.invalidateQueries({ queryKey: keys.conversations })
+          void queryClient.invalidateQueries({ queryKey: ['conversations'] })
         }
       })
 
@@ -159,7 +168,7 @@ export function useSocket(): void {
        */
       socket.on('conversation:read', ({ conversationId }: { conversationId: string }) => {
         void queryClient.invalidateQueries({ queryKey: keys.messages(conversationId) })
-        void queryClient.invalidateQueries({ queryKey: keys.conversations })
+        void queryClient.invalidateQueries({ queryKey: ['conversations'] })
       })
     })()
 

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -452,6 +452,19 @@ export const ar: Localized<EnMessages> = {
   },
 
   chats: {
+    tab_all: 'الكل',
+    tab_unreplied: 'بلا رد',
+    tab_archived: 'الأرشيف',
+    filterPicker: 'مرشّح المحادثات',
+    pin: 'تثبيت',
+    unpin: 'إلغاء التثبيت',
+    archive: 'أرشفة',
+    unarchive: 'إلغاء الأرشفة',
+    pinnedSection: 'مثبّتة',
+    unrepliedEmptyTitle: 'لا شيء بانتظارك',
+    unrepliedEmptyBody: 'لقد رددت على كل محادثة.',
+    archivedEmptyTitle: 'لا محادثات مؤرشفة',
+    archivedEmptyBody: 'تبقى المحادثات المؤرشفة هنا حتى تعيدها.',
     emptyTitle: 'لا محادثات بعد',
     emptyBody:
       'راسل أحدًا من الاستكشاف. في الخطة المجانية يمكنك بدء {count} محادثات جديدة يوميًا — أما الرد على ما يصلك فبلا حدود دائمًا.',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -395,6 +395,19 @@ export const de: Localized<EnMessages> = {
   },
 
   chats: {
+    tab_all: 'Alle',
+    tab_unreplied: 'Unbeantwortet',
+    tab_archived: 'Archiv',
+    filterPicker: 'Chat-Filter',
+    pin: 'Anheften',
+    unpin: 'Loslösen',
+    archive: 'Archivieren',
+    unarchive: 'Aus dem Archiv',
+    pinnedSection: 'Angeheftet',
+    unrepliedEmptyTitle: 'Nichts wartet auf dich',
+    unrepliedEmptyBody: 'Auf jeden Chat hast du geantwortet.',
+    archivedEmptyTitle: 'Kein archivierter Chat',
+    archivedEmptyBody: 'Archivierte Chats bleiben hier, bis du sie zurückholst.',
     emptyTitle: 'Noch keine Chats',
     emptyBody:
       'Schreib jemandem aus Entdecken. Im kostenlosen Tarif kannst du {count} neue Chats am Tag beginnen — auf Nachrichten zu antworten ist immer unbegrenzt.',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -421,6 +421,19 @@ export const en = {
   },
 
   chats: {
+    tab_all: 'All',
+    tab_unreplied: 'Unreplied',
+    tab_archived: 'Archived',
+    filterPicker: 'Chat filter',
+    pin: 'Pin',
+    unpin: 'Unpin',
+    archive: 'Archive',
+    unarchive: 'Unarchive',
+    pinnedSection: 'Pinned',
+    unrepliedEmptyTitle: 'Nothing waiting on you',
+    unrepliedEmptyBody: 'Every chat has had your reply.',
+    archivedEmptyTitle: 'No archived chats',
+    archivedEmptyBody: 'Archived chats stay here until you bring them back.',
     emptyTitle: 'No chats yet',
     emptyBody:
       'Message someone from Discover. On the free plan you can start {count} new chats a day — replying to messages you receive is always unlimited.',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -393,6 +393,19 @@ export const es: Localized<EnMessages> = {
   },
 
   chats: {
+    tab_all: 'Todos',
+    tab_unreplied: 'Sin responder',
+    tab_archived: 'Archivados',
+    filterPicker: 'Filtro de chats',
+    pin: 'Fijar',
+    unpin: 'Dejar de fijar',
+    archive: 'Archivar',
+    unarchive: 'Desarchivar',
+    pinnedSection: 'Fijados',
+    unrepliedEmptyTitle: 'Nada te espera',
+    unrepliedEmptyBody: 'Has respondido a todos los chats.',
+    archivedEmptyTitle: 'Sin chats archivados',
+    archivedEmptyBody: 'Los chats archivados se quedan aquí hasta que los recuperes.',
     emptyTitle: 'Aún no hay chats',
     emptyBody:
       'Escribe a alguien desde Descubrir. En el plan gratuito puedes iniciar {count} chats nuevos al día; responder a lo que recibes es siempre ilimitado.',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -393,6 +393,19 @@ export const fr: Localized<EnMessages> = {
   },
 
   chats: {
+    tab_all: 'Tous',
+    tab_unreplied: 'Sans réponse',
+    tab_archived: 'Archivés',
+    filterPicker: 'Filtre de discussions',
+    pin: 'Épingler',
+    unpin: 'Détacher',
+    archive: 'Archiver',
+    unarchive: 'Désarchiver',
+    pinnedSection: 'Épinglés',
+    unrepliedEmptyTitle: 'Rien ne t’attend',
+    unrepliedEmptyBody: 'Tu as répondu à chaque discussion.',
+    archivedEmptyTitle: 'Aucune discussion archivée',
+    archivedEmptyBody: 'Les discussions archivées restent ici jusqu’à ce que tu les récupères.',
     emptyTitle: 'Aucune discussion',
     emptyBody:
       'Écris à quelqu’un depuis Découvrir. Sur le forfait gratuit tu peux lancer {count} nouvelles discussions par jour — répondre à ce que tu reçois est toujours illimité.',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -388,6 +388,19 @@ export const ptBR: Localized<EnMessages> = {
   },
 
   chats: {
+    tab_all: 'Todos',
+    tab_unreplied: 'Sem resposta',
+    tab_archived: 'Arquivados',
+    filterPicker: 'Filtro de conversas',
+    pin: 'Fixar',
+    unpin: 'Desafixar',
+    archive: 'Arquivar',
+    unarchive: 'Desarquivar',
+    pinnedSection: 'Fixados',
+    unrepliedEmptyTitle: 'Nada esperando por você',
+    unrepliedEmptyBody: 'Você respondeu a todas as conversas.',
+    archivedEmptyTitle: 'Nenhuma conversa arquivada',
+    archivedEmptyBody: 'As conversas arquivadas ficam aqui até você trazê-las de volta.',
     emptyTitle: 'Ainda não há conversas',
     emptyBody:
       'Mande mensagem para alguém em Descobrir. No plano gratuito você pode começar {count} conversas novas por dia — responder ao que você recebe é sempre ilimitado.',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -439,6 +439,19 @@ export const ru: Localized<EnMessages> = {
   },
 
   chats: {
+    tab_all: 'Все',
+    tab_unreplied: 'Без ответа',
+    tab_archived: 'Архив',
+    filterPicker: 'Фильтр чатов',
+    pin: 'Закрепить',
+    unpin: 'Открепить',
+    archive: 'В архив',
+    unarchive: 'Из архива',
+    pinnedSection: 'Закреплённые',
+    unrepliedEmptyTitle: 'Никто не ждёт ответа',
+    unrepliedEmptyBody: 'Вы ответили в каждом чате.',
+    archivedEmptyTitle: 'В архиве пусто',
+    archivedEmptyBody: 'Архивные чаты остаются здесь, пока вы их не вернёте.',
     emptyTitle: 'Чатов пока нет',
     emptyBody:
       'Напиши кому-нибудь из Поиска. На бесплатном тарифе можно начинать {count} новых чатов в день — отвечать на входящие всегда без ограничений.',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -396,6 +396,19 @@ export const tr: Localized<EnMessages> = {
   },
 
   chats: {
+    tab_all: 'Tümü',
+    tab_unreplied: 'Cevapsız',
+    tab_archived: 'Arşiv',
+    filterPicker: 'Sohbet filtresi',
+    pin: 'Sabitle',
+    unpin: 'Sabitlemeyi kaldır',
+    archive: 'Arşivle',
+    unarchive: 'Arşivden çıkar',
+    pinnedSection: 'Sabitlenmiş',
+    unrepliedEmptyTitle: 'Sıra sende olan yok',
+    unrepliedEmptyBody: 'Her sohbete cevap vermişsin.',
+    archivedEmptyTitle: 'Arşivde sohbet yok',
+    archivedEmptyBody: 'Arşivlediğin sohbetler geri alana kadar burada durur.',
     emptyTitle: 'Henüz sohbet yok',
     emptyBody:
       'Keşfet’ten birine yaz. Ücretsiz planda günde {count} yeni sohbet başlatabilirsin — sana gelen mesaplara cevap vermek her zaman sınırsız.',

--- a/apps/mobile/src/lib/conversationCache.test.ts
+++ b/apps/mobile/src/lib/conversationCache.test.ts
@@ -11,15 +11,28 @@ function conversation(id: string, unreadForMe = 0): ConversationDto {
     _id: id,
     participants: [ME, THEM],
     lastMessage: { body: `old ${id}`, senderId: THEM, createdAt: '2026-08-01T00:00:00.000Z' },
-    unread: { [ME]: unreadForMe, [THEM]: 0 },
+    // A number, not a map: `toConversationView` resolves it server-side so the
+    // other person's count never reaches the client.
+    unread: unreadForMe,
+    pinned: false,
+    archived: false,
+    unreplied: true,
     bothSpoke: true,
     updatedAt: '2026-08-01T00:00:00.000Z',
   }
 }
 
-function pages(...groups: ConversationDto[][]): InfiniteData<ConversationPageDto> {
+function pages(
+  groups: ConversationDto[][],
+  pinned: ConversationDto[] = [],
+): InfiniteData<ConversationPageDto> {
   return {
-    pages: groups.map((items, i) => ({ items, nextCursor: i === groups.length - 1 ? null : 'c' })),
+    pages: groups.map((items, i) => ({
+      items,
+      // The whole pinned set rides on every page, so only page one is read.
+      pinned: i === 0 ? pinned : [],
+      nextCursor: i === groups.length - 1 ? null : 'c',
+    })),
     pageParams: groups.map((_, i) => (i === 0 ? '' : 'c')),
   }
 }
@@ -34,7 +47,7 @@ const incoming = {
 
 describe('applyIncomingMessage', () => {
   it('moves the conversation to the head, even from a later page', () => {
-    const data = pages([conversation('c1'), conversation('c2')], [conversation('c3')])
+    const data = pages([[conversation('c1'), conversation('c2')], [conversation('c3')]])
     const next = applyIncomingMessage(data, incoming)
 
     expect(next?.pages[0]?.items.map((c) => c._id)).toEqual(['c3', 'c1', 'c2'])
@@ -42,7 +55,7 @@ describe('applyIncomingMessage', () => {
   })
 
   it('carries the new last message', () => {
-    const next = applyIncomingMessage(pages([conversation('c3')]), incoming)
+    const next = applyIncomingMessage(pages([[conversation('c3')]]), incoming)
     expect(next?.pages[0]?.items[0]?.lastMessage).toEqual({
       body: 'hello',
       senderId: THEM,
@@ -51,17 +64,17 @@ describe('applyIncomingMessage', () => {
   })
 
   it('increments my unread count when someone else wrote', () => {
-    const next = applyIncomingMessage(pages([conversation('c3', 2)]), incoming)
-    expect(next?.pages[0]?.items[0]?.unread[ME]).toBe(3)
+    const next = applyIncomingMessage(pages([[conversation('c3', 2)]]), incoming)
+    expect(next?.pages[0]?.items[0]?.unread).toBe(3)
   })
 
   /** The echo reaches the sender too; their own message is not unread. */
   it('leaves the count alone when the message is mine', () => {
-    const next = applyIncomingMessage(pages([conversation('c3', 2)]), {
+    const next = applyIncomingMessage(pages([[conversation('c3', 2)]]), {
       ...incoming,
       senderId: ME,
     })
-    expect(next?.pages[0]?.items[0]?.unread[ME]).toBe(2)
+    expect(next?.pages[0]?.items[0]?.unread).toBe(2)
   })
 
   /**
@@ -70,17 +83,58 @@ describe('applyIncomingMessage', () => {
    * refetches away.
    */
   it('does not guess bothSpoke', () => {
-    const data = pages([{ ...conversation('c3'), bothSpoke: false }])
+    const data = pages([[{ ...conversation('c3'), bothSpoke: false }]])
     const next = applyIncomingMessage(data, incoming)
     expect(next?.pages[0]?.items[0]?.bothSpoke).toBe(false)
   })
 
   /** The caller's signal to fall back to invalidating. */
   it('returns undefined for a conversation outside the loaded pages', () => {
-    expect(applyIncomingMessage(pages([conversation('c1')]), incoming)).toBeUndefined()
+    expect(applyIncomingMessage(pages([[conversation('c1')]]), incoming)).toBeUndefined()
   })
 
   it('passes an empty cache straight through', () => {
     expect(applyIncomingMessage(undefined, incoming)).toBeUndefined()
+  })
+})
+
+describe('pinned threads', () => {
+  /**
+   * The regression this exists to stop. `moveToHead` was unconditional, so a
+   * message in an *unpinned* thread put it above every pin — undoing the one
+   * thing pinning does.
+   */
+  it('does not float an unpinned thread above the pins', () => {
+    const pin = { ...conversation('p1'), pinned: true }
+    const data = pages([[conversation('c3')]], [pin])
+
+    const next = applyIncomingMessage(data, incoming)
+
+    expect(next?.pages[0]?.pinned.map((c) => c._id)).toEqual(['p1'])
+    expect(next?.pages[0]?.items.map((c) => c._id)).toEqual(['c3'])
+  })
+
+  it('re-sorts a pinned thread within the pins, not out of them', () => {
+    const first = { ...conversation('p1'), pinned: true }
+    const second = { ...conversation('p2'), pinned: true }
+    const data = pages([[conversation('c1')]], [first, second])
+
+    const next = applyIncomingMessage(data, { ...incoming, conversationId: 'p2' })
+
+    expect(next?.pages[0]?.pinned.map((c) => c._id)).toEqual(['p2', 'p1'])
+    // And it does not appear in the unpinned list as well.
+    expect(next?.pages[0]?.items.map((c) => c._id)).toEqual(['c1'])
+  })
+
+  it('flips `unreplied` by who sent it, not by the unread count', () => {
+    const data = pages([[conversation('c3')]])
+
+    const theirs = applyIncomingMessage(data, incoming)
+    expect(theirs?.pages[0]?.items[0]?.unreplied).toBe(true)
+
+    const mine = applyIncomingMessage(data, { ...incoming, senderId: ME })
+    expect(mine?.pages[0]?.items[0]?.unreplied).toBe(false)
+    // Mine does not bump my own unread either.
+    expect(mine?.pages[0]?.items[0]?.unread).toBe(0)
   })
 })

--- a/apps/mobile/src/lib/conversationCache.ts
+++ b/apps/mobile/src/lib/conversationCache.ts
@@ -3,6 +3,8 @@ import type { ConversationDto } from '../api/queries'
 
 export interface ConversationPageDto {
   items: ConversationDto[]
+  /** Never paginated — the whole set, on every page. */
+  pinned: ConversationDto[]
   nextCursor: string | null
 }
 
@@ -40,13 +42,14 @@ export function applyIncomingMessage(
       senderId: input.senderId,
       createdAt: input.createdAt,
     },
+    // A number now, not the map it is stored in — `toConversationView`
+    // resolves it server-side, so the other person's count never arrives here.
     unread:
       input.senderId === input.forUserId
         ? found.conversation.unread
-        : {
-            ...found.conversation.unread,
-            [input.forUserId]: (found.conversation.unread[input.forUserId] ?? 0) + 1,
-          },
+        : found.conversation.unread + 1,
+    // The next move is theirs if they sent it, mine if I did.
+    unreplied: input.senderId !== input.forUserId,
     // `bothSpoke` is deliberately left alone. It means "both participants
     // have sent at least one message ever", which one socket event cannot
     // establish — the sender may well have spoken before. Guessing it here
@@ -54,16 +57,18 @@ export function applyIncomingMessage(
     updatedAt: input.createdAt,
   }
 
-  return moveToHead(data, input.conversationId, patched)
+  return moveToHead(data, input.conversationId, patched, found.pinned)
 }
 
 function findConversation(
   data: InfiniteData<ConversationPageDto>,
   conversationId: string,
-): { conversation: ConversationDto } | null {
+): { conversation: ConversationDto; pinned: boolean } | null {
   for (const page of data.pages) {
+    const pinned = page.pinned.find((c) => c._id === conversationId)
+    if (pinned) return { conversation: pinned, pinned: true }
     const conversation = page.items.find((c) => c._id === conversationId)
-    if (conversation) return { conversation }
+    if (conversation) return { conversation, pinned: false }
   }
   return null
 }
@@ -72,12 +77,28 @@ function findConversation(
  * The server sorts by `lastMessage.createdAt` descending, so a conversation
  * that just received a message belongs at the very top — whichever page it
  * was sitting on.
+ *
+ * **Unless it is pinned.** Pinned threads are a separate list that sits above
+ * the rest, and this used to move unconditionally: a message in an unpinned
+ * thread would jump it above every pin, which is the one thing pinning is for.
+ * A pinned thread is re-sorted within its own list instead.
  */
 function moveToHead(
   data: InfiniteData<ConversationPageDto>,
   conversationId: string,
   patched: ConversationDto,
+  isPinned: boolean,
 ): InfiniteData<ConversationPageDto> {
+  if (isPinned) {
+    const pages = data.pages.map((page, index) => ({
+      ...page,
+      pinned:
+        index === 0
+          ? [patched, ...page.pinned.filter((c) => c._id !== conversationId)]
+          : page.pinned.filter((c) => c._id !== conversationId),
+    }))
+    return { ...data, pages }
+  }
   const pages = data.pages.map((page) => ({
     ...page,
     items: page.items.filter((c) => c._id !== conversationId),

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -251,7 +251,29 @@ export const CONVERSATION_PAGE_SIZE_DEFAULT = 20
 export const CONVERSATION_PAGE_SIZE_MAX = 50
 
 /** `GET /conversations` — the chat list, sorted by most recent activity. */
+/**
+ * Which slice of the list to return.
+ *
+ * `unreplied` is "they spoke last", read off `lastMessage.senderId` rather
+ * than off the unread count. The two disagree, and the disagreement matters:
+ * opening a thread clears the unread and does not answer it, so a list keyed
+ * on unread would quietly drop everything somebody had read and meant to come
+ * back to — which is exactly the list this tab is for.
+ */
+/**
+ * How many threads one person may pin.
+ *
+ * A cap, because pinned threads are fetched whole rather than paginated — the
+ * cursor cannot express a compound sort, and the simple answer is only simple
+ * while the set stays small.
+ */
+export const MAX_PINNED_CONVERSATIONS = 20
+
+export const CONVERSATION_FILTERS = ['all', 'unreplied', 'archived'] as const
+export type ConversationFilter = (typeof CONVERSATION_FILTERS)[number]
+
 export const listConversationsQuerySchema = z.object({
+  filter: z.enum(CONVERSATION_FILTERS).default('all'),
   cursor: z.string().optional(),
   limit: z.coerce
     .number()
@@ -261,6 +283,18 @@ export const listConversationsQuerySchema = z.object({
     .default(CONVERSATION_PAGE_SIZE_DEFAULT),
 })
 export type ListConversationsQuery = z.infer<typeof listConversationsQuerySchema>
+
+/**
+ * At least one flag has to be named — `{}` is a request that means nothing,
+ * and answering 200 to it would hide a client bug rather than surface one.
+ */
+export const conversationFlagsSchema = z
+  .object({ pinned: z.boolean(), archived: z.boolean() })
+  .partial()
+  .refine((body) => body.pinned !== undefined || body.archived !== undefined, {
+    message: 'Name pinned, archived, or both',
+  })
+export type ConversationFlagsInput = z.infer<typeof conversationFlagsSchema>
 
 export const mediaUploadUrlSchema = z.object({
   conversationId: z.string().trim().min(1),


### PR DESCRIPTION
## What

Three tabs — **All**, **Unreplied**, **Archived** — and a long press on a row to pin or archive it.

## The part that had to come first

`listConversations` returned **raw documents with no projection**. That was fine while every field on a conversation was mutual, and stopped being fine the moment one was not: `unread` has always been a map keyed by user id, so **the list already shipped the other person's unread count to both sides**.

Adding `pinnedBy` and `archivedBy` the same way would have shipped *"they archived you"*.

So `toConversationView` exists now, for the same reason `toMessageView` does one level down: one projection, at the single point a conversation leaves the server, is the only thing that stays true as fields keep being added. `unread` reaches the client as a number. There is a test asserting the viewer learns nothing about the other side.

## Maps, not arrays

Both flags are `Record<string, true>` keyed by user id.

`participants` is already a multikey field, and MongoDB refuses to compound two array fields in one index (*"cannot index parallel arrays"*) — so `archivedBy: string[]` could never sit in the index this list rides. `unread` was shaped this way years before it mattered; this follows it.

There is deliberately **no index on the flags**, and a comment now says why rather than leaving it looking forgotten: the filtered path is `archivedBy.<viewerId>`, which is *dynamic* and no fixed index key can name. `participants_recent` already bounds the scan to one person's threads.

## "Unreplied" is not "unread"

It reads `lastMessage.senderId`. The two disagree exactly for the threads somebody **read and meant to come back to** — which are the ones the tab is for — so a list keyed on unread would drop them the moment the thread was opened. Its own test.

## Pins are a separate list

Pinning makes the sort compound, and the cursor is `<createdAt>|<_id>`, which cannot express "and also this side of the pin boundary". Rather than widen the cursor format for a set that is small by construction, pins come back un-paginated alongside the page, and `MAX_PINNED_CONVERSATIONS` (20, enforced server-side) keeps "small" true.

## Two client-side consequences

- **`moveToHead` was unconditional** — a message in an unpinned thread floated it above every pin, undoing the one thing pinning does. Sort-aware now, with a regression test.
- **`keys.conversations` was a flat constant**, which cannot survive tabs. It takes the filter, and every writer moved to `setQueriesData` on the `['conversations']` prefix — otherwise the tabs start disagreeing about who spoke last.

The row menu is `chooseAlert`, not a new host: it already draws a list of choices on every platform including web, where react-native's own `Alert` is an empty function. Long press rather than swipe, because gesture-handler is deliberately absent from this package and the app already teaches long-press-for-actions on every message bubble.

## Tests

8 on the API (the leak, read-but-unanswered staying in Unreplied, leaving it once answered, archive hidden everywhere else, un-archive restoring, pins out of the paginated list, pinning for one side only, and an outsider refused) and 3 more in `conversationCache.test.ts` for the pin ordering.

`pnpm test` — mobile 301, api 548. Lint, format and typecheck clean apart from the three pre-existing stale-`router.d.ts` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)