### PR TITLE
Stop indexing Better Auth's collection out from under it

### DIFF
--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -10,7 +10,8 @@ export const COLLECTIONS = {
   verification: 'verification',
   /**
    * The device flow's codes, written by Better Auth's `device-authorization`
-   * plugin. Ours only to index — see `indexes.ts` for why that matters here.
+   * plugin — which also owns their lookup indexes. Named here only so the TTL
+   * in `indexes.ts` has something to hang on; see the note there.
    */
   deviceCode: 'deviceCode',
 

--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -48,24 +48,25 @@ export const INDEXES: Partial<IndexSpec> = {
   // Email verification and password reset both look a token up by identifier.
   [COLLECTIONS.verification]: [{ key: { identifier: 1 }, name: 'verification_identifier_idx' }],
   /**
-   * QR sign-in's codes. Better Auth's Mongo adapter creates almost no indexes,
-   * and this collection is looked up on every poll — once every five seconds
-   * per waiting browser — so the absence of one is not a slow query, it is a
-   * collection scan on a loop.
+   * QR sign-in's codes — a Better Auth collection, like `user` and
+   * `verification`, and the lookup indexes are **its** to create.
    *
-   * `userCode` is unique because the whole flow rests on it: two live codes
-   * colliding would let one person approve another's sign-in. The plugin
-   * generates them randomly and does not enforce that itself.
+   * They were declared here first, and that broke the endpoint outright: the
+   * plugin creates its own unique index on `deviceCode` at first use, Mongo
+   * refused it with "Index already exists with a different name", and every
+   * `POST /device/code` answered 500. An index on somebody else's collection
+   * is not a free optimisation — it is a name collision waiting for the owner
+   * to reach for the same key.
    *
-   * The TTL sweeps expired rows an hour after they die rather than at the
-   * instant — the plugin checks `expiresAt` on every read, so nothing depends
-   * on the deletion being prompt, and a short grace period keeps a
-   * just-expired code answering "expired" instead of "never existed".
+   * The TTL stays because the plugin does not create one, and without it a
+   * collection that gains a row per sign-in attempt only ever grows. It sweeps
+   * an hour after expiry rather than at the instant: the plugin checks
+   * `expiresAt` on every read, so nothing depends on prompt deletion, and the
+   * grace period keeps a just-expired code answering "expired" instead of
+   * "never existed".
    */
   [COLLECTIONS.deviceCode]: [
-    { key: { deviceCode: 1 }, name: 'device_code_unique', unique: true },
-    { key: { userCode: 1 }, name: 'user_code_unique', unique: true },
-    { key: { expiresAt: 1 }, name: 'ttl', expireAfterSeconds: 3600 },
+    { key: { expiresAt: 1 }, name: 'device_code_ttl', expireAfterSeconds: 3600 },
   ],
 
   [COLLECTIONS.profiles]: [


### PR DESCRIPTION
## The bug

`POST /api/auth/device/code` answered **500 in production** the moment QR sign-in shipped:

```
MongoServerError: Index already exists with a different name: device_code_unique
```

The `device-authorization` plugin creates its own unique index on `deviceCode` at first use. `ensureIndexes` had already made one on the same key under a different name at boot, so Mongo refused the plugin's — and the endpoint failed outright.

## The fix, and the lesson

`deviceCode` is a **Better Auth collection**, like `user`, `session`, `account` and `verification`. `collections.ts` already says we never change the shape of those; I treated this one as ours because it was new.

Declaring lookup indexes on somebody else's collection is not a free optimisation — it is a name collision waiting for the owner to reach for the same key. Both unique indexes are removed; the plugin makes its own.

The TTL stays, because the plugin does **not** create one and the collection gains a row per sign-in attempt. Renamed `device_code_ttl` so it cannot be confused with the entries just removed.

The two stale indexes are dropped from production separately — `ensureIndexes` only creates.

## Checks

Lint, format and typecheck clean. Verified against production after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)