### PR TITLE
Read the code parameter Better Auth actually sends

### DIFF
--- a/apps/api/src/routes/qr.ts
+++ b/apps/api/src/routes/qr.ts
@@ -70,7 +70,12 @@ export const qrRoutes: FastifyPluginAsyncZod = async (app) => {
       config: { rateLimit: { max: 60, timeWindow: '1 minute' } },
     },
     async (request, reply) => {
-      const target = `https://${WEB_HOST}/link-device?code=${encodeURIComponent(request.params.code)}`
+      // `user_code`, because that is the name Better Auth puts in its own
+      // `verification_uri_complete` — a QR that used a different one would
+      // send people to the same page with the field left empty.
+      const target = `https://${WEB_HOST}/link-device?user_code=${encodeURIComponent(
+        request.params.code,
+      )}`
       const svg = await QRCode.toString(target, {
         type: 'svg',
         errorCorrectionLevel: 'M',

--- a/apps/mobile/app/(app)/link-device.tsx
+++ b/apps/mobile/app/(app)/link-device.tsx
@@ -24,7 +24,14 @@ import { useT } from '../../src/i18n'
  * button rather than a silent redirect after a scan.
  */
 export default function LinkDeviceScreen() {
-  const { code } = useLocalSearchParams<{ code?: string }>()
+  /*
+   * Two names for one thing, and both are read. Better Auth's own
+   * `verification_uri_complete` uses `user_code`; `code` is what a hand-typed
+   * or older link may carry. Accepting either costs nothing and means a link
+   * that looks right cannot land on an empty field.
+   */
+  const params = useLocalSearchParams<{ user_code?: string; code?: string }>()
+  const code = params.user_code ?? params.code
   const styles = useStyles()
   const { colors } = useTheme()
   const t = useT()


### PR DESCRIPTION
## The mismatch

Verified against production after deploying the device flow:

```
"verification_uri_complete":"https://app2.langx.io/link-device?user_code=2RTL9C2E"
```

The QR encoded `?code=` and the approval screen read `?code=`. Better Auth's own link — the one anybody following the flow by hand receives — uses `?user_code=`. Two links to the same page, one of which arrived with the field empty.

The QR now uses `user_code`, and the screen reads **either**. Accepting both costs nothing, and the alternative is a link that looks correct and silently does half of what it should.

## Checks

`pnpm test` — mobile 301, api profiles 49. Lint, format and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)