### PR TITLE
Give the QR a size it can actually be drawn at

### DIFF
--- a/apps/mobile/app/(app)/share-profile.tsx
+++ b/apps/mobile/app/(app)/share-profile.tsx
@@ -100,7 +100,21 @@ const useStyles = makeStyles(({ colors, font, radius, spacing }) => ({
     marginTop: spacing.xl,
     padding: spacing.xl,
   },
-  qr: { aspectRatio: 1, backgroundColor: '#ffffff', borderRadius: radius.sm, width: '100%' },
+  /*
+   * A fixed size, not `width: '100%'`.
+   *
+   * The card centres its children, so on the cross axis "100%" has nothing to
+   * be a percentage *of* — the image resolved to zero width, painted nothing,
+   * and never even fetched. A QR wants a known size anyway: too small and a
+   * camera cannot resolve the modules, and it does not benefit from being
+   * bigger than a phone screen held at arm's length.
+   */
+  qr: {
+    backgroundColor: '#ffffff',
+    borderRadius: radius.sm,
+    height: 220,
+    width: 220,
+  },
   handle: { ...font.heading, color: colors.text, fontSize: 20, marginTop: spacing.md },
   url: { ...font.caption, color: colors.textMuted },
   body: {

--- a/apps/mobile/app/(auth)/qr.tsx
+++ b/apps/mobile/app/(auth)/qr.tsx
@@ -135,7 +135,21 @@ const useStyles = makeStyles(({ colors, font, radius, spacing }) => ({
     marginTop: spacing.xl,
     padding: spacing.xl,
   },
-  qr: { aspectRatio: 1, backgroundColor: '#ffffff', borderRadius: radius.sm, width: '100%' },
+  /*
+   * A fixed size, not `width: '100%'`.
+   *
+   * The card centres its children, so on the cross axis "100%" has nothing to
+   * be a percentage *of* — the image resolved to zero width, painted nothing,
+   * and never even fetched. A QR wants a known size anyway: too small and a
+   * camera cannot resolve the modules, and it does not benefit from being
+   * bigger than a phone screen held at arm's length.
+   */
+  qr: {
+    backgroundColor: '#ffffff',
+    borderRadius: radius.sm,
+    height: 220,
+    width: 220,
+  },
   code: { ...font.title, color: colors.text, fontSize: 32, letterSpacing: 6 },
   body: {
     ...font.body,


### PR DESCRIPTION
## The bug

Neither QR rendered — not on the share screen, not on the sign-in screen.

Not a broken URL and not a failed request: **no request at all**. The card centres its children, so on the cross axis `width: '100%'` had nothing to be a percentage *of*. The image resolved to zero width, and `expo-image` had no reason to fetch something with no size to paint it in.

## How it was found

By driving the deployed page, not by reading the code. Playwright against `app2.langx.io/qr`:

```
BODY: Sign in with your phone S89ES4HV Open LangX on your phone and enter this code, or scan it.
QR requests: NONE
has qr url in dom: false
```

The screen looked right, the code appeared, and the picture beside it was a div of zero width.

## The fix

A fixed 220×220 rather than `alignSelf: 'stretch'`, because a QR wants a known size anyway: too small and a camera cannot resolve the modules, and it gains nothing from being wider than a phone held at arm's length.

## Checks

`pnpm test` — mobile 301. Lint, format and typecheck clean. Will re-verify against the deployed page after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)