### PR TITLE
Let the QR images be embedded by the web app

### DIFF
--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -413,6 +413,13 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
       expect(response.headers['content-type']).toContain('image/svg+xml')
       expect(response.headers['cache-control']).toContain('max-age=')
       expect(response.body).toContain('<svg')
+      /*
+       * The header that made this endpoint useless in production. Helmet sets
+       * `same-origin` for everything, which is right for an API and wrong for
+       * a picture: the web build is on another host, so the browser blocked
+       * the image outright with nothing logged server-side.
+       */
+      expect(response.headers['cross-origin-resource-policy']).toBe('cross-origin')
     })
 
     /**
@@ -429,6 +436,14 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
 
     it('refuses something that could not be a handle at all', async () => {
       expect((await app.inject({ method: 'GET', url: '/public/qr/a' })).statusCode).toBe(400)
+    })
+
+    it('lets the device link code be embedded too', async () => {
+      const response = await app.inject({ method: 'GET', url: '/public/qr/link/ABCD1234' })
+      expect(response.statusCode, response.body).toBe(200)
+      expect(response.headers['cross-origin-resource-policy']).toBe('cross-origin')
+      // Two minutes of life; caching the picture past that serves the dead.
+      expect(response.headers['cache-control']).toBe('no-store')
     })
   })
 

--- a/apps/api/src/routes/qr.ts
+++ b/apps/api/src/routes/qr.ts
@@ -30,6 +30,24 @@ const CACHE_SECONDS = 86_400
  * for pictures, and a code that resolves to a 404 page is a harmless thing to
  * have drawn.
  */
+/**
+ * These are the only responses meant to be embedded by another origin.
+ *
+ * Helmet sets `Cross-Origin-Resource-Policy: same-origin` for everything,
+ * which is right for an API and wrong for a picture: the web build lives on
+ * `app2.langx.io` and the image on `api2.langx.io`, so the browser blocked it
+ * outright — `ERR_BLOCKED_BY_RESPONSE.NotSameOrigin`, with no request logged
+ * server-side and nothing on screen.
+ *
+ * Relaxed per route rather than globally. CORP is what stops another site
+ * reading responses it should not, and every other endpoint here answers with
+ * somebody's data; these two answer with a QR of a public link.
+ *
+ * `image/svg+xml` is safe in an `<img>` — scripts inside an SVG do not execute
+ * in that context — and `nosniff` stays on.
+ */
+const EMBEDDABLE = { 'cross-origin-resource-policy': 'cross-origin' } as const
+
 export const qrRoutes: FastifyPluginAsyncZod = async (app) => {
   app.get(
     '/public/qr/:handle',
@@ -51,6 +69,7 @@ export const qrRoutes: FastifyPluginAsyncZod = async (app) => {
       return reply
         .header('content-type', 'image/svg+xml')
         .header('cache-control', `public, max-age=${CACHE_SECONDS}`)
+        .headers(EMBEDDABLE)
         .send(svg)
     },
   )
@@ -87,6 +106,7 @@ export const qrRoutes: FastifyPluginAsyncZod = async (app) => {
           // A device code lives two minutes; caching its picture past that would
           // only ever serve something already dead.
           .header('cache-control', 'no-store')
+          .headers(EMBEDDABLE)
           .send(svg)
       )
     },


### PR DESCRIPTION
## The bug

Neither QR appeared. The browser said why:

```
Failed to load resource: net::ERR_BLOCKED_BY_RESPONSE.NotSameOrigin
```

Helmet sets `Cross-Origin-Resource-Policy: same-origin` on **everything**. That is right for an API and wrong for a picture: the web build is served from `app2.langx.io` and the image from `api2.langx.io`, so the request never left the browser — **nothing was logged server-side**, and `curl` against the endpoint returned a perfectly correct 200.

## The fix

Relaxed on the two QR routes only, not globally. CORP is what stops another site reading responses it should not, and every other endpoint here answers with somebody's data; these two answer with a QR of a public link.

`nosniff` stays on, and `image/svg+xml` in an `<img>` does not execute scripts.

## Tests

Both headers are asserted now, because this failure is **invisible from the server's side** — a correct status, a correct body, and the only evidence in a browser console. The kind of thing a test exists to remember.

`pnpm test` — api profiles 50. Lint, format and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)