### PR TITLE
Size the activity squares to the card instead of assuming a phone

### DIFF
--- a/apps/mobile/src/components/ActivityMap.tsx
+++ b/apps/mobile/src/components/ActivityMap.tsx
@@ -1,8 +1,14 @@
 import { shiftDayKey } from '@langx/shared'
-import { useMemo, useRef } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native'
 import { usePublicActivity, useActivity, useRepairDay, useWallet } from '../api/queries'
-import { activityGrid, repairEffect, type ActivityCell } from '../lib/activityMap'
+import {
+  ACTIVITY_CELL_GAP,
+  activityCellSize,
+  activityGrid,
+  repairEffect,
+  type ActivityCell,
+} from '../lib/activityMap'
 import { confirmAlert, showAlert } from '../lib/alert'
 import { dayLabel } from '../lib/messageGroups'
 import { makeStyles, useTheme } from '../lib/theme'
@@ -43,6 +49,10 @@ export function ActivityMap({ handle }: ActivityMapProps = {}) {
   const wallet = useWallet()
   const repair = useRepairDay()
   const scroller = useRef<ScrollView>(null)
+  // Measured rather than assumed: the squares are sized to fill whatever width
+  // the card actually has. See `activityCellSize` for why that is the knob.
+  const [width, setWidth] = useState(0)
+  const cell = activityCellSize(width, WEEKS)
 
   // One shape from two endpoints. The public one carries an intensity rather
   // than a count — the exact number is the private part — so it is turned back
@@ -162,28 +172,30 @@ export function ActivityMap({ handle }: ActivityMapProps = {}) {
         horizontal
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.grid}
+        onLayout={(event) => setWidth(event.nativeEvent.layout.width)}
         onContentSizeChange={() => scroller.current?.scrollToEnd({ animated: false })}
       >
         {columns.map((column) => (
           <View key={column[0]?.day} style={styles.column}>
-            {column.map((cell) => (
+            {column.map((square) => (
               <Pressable
-                key={cell.day}
-                accessibilityRole={cell.state === 'repairable' ? 'button' : undefined}
+                key={square.day}
+                accessibilityRole={square.state === 'repairable' ? 'button' : undefined}
                 accessibilityLabel={
-                  cell.state === 'repairable'
-                    ? t('activity.fillInDay', { day: cell.day })
+                  square.state === 'repairable'
+                    ? t('activity.fillInDay', { day: square.day })
                     : undefined
                 }
-                disabled={Boolean(handle) || cell.state !== 'repairable'}
-                onPress={() => void onPressDay(cell)}
+                disabled={Boolean(handle) || square.state !== 'repairable'}
+                onPress={() => void onPressDay(square)}
                 style={[
                   styles.cell,
-                  cell.state === 'future' && styles.future,
-                  cell.state === 'repairable' && styles.repairable,
-                  cell.intensity > 0 && {
+                  { height: cell, width: cell },
+                  square.state === 'future' && styles.future,
+                  square.state === 'repairable' && styles.repairable,
+                  square.intensity > 0 && {
                     backgroundColor: colors.streak,
-                    opacity: 0.25 + cell.intensity * 0.1875,
+                    opacity: 0.25 + square.intensity * 0.1875,
                   },
                 ]}
               />
@@ -223,14 +235,25 @@ const useStyles = makeStyles(({ colors, font, spacing }) => ({
   },
   title: { ...font.heading, color: colors.text, fontSize: 16 },
   hint: { ...font.caption, color: colors.textMuted },
-  grid: { flexDirection: 'row', gap: 3, paddingVertical: spacing.xs },
-  column: { gap: 3 },
+  /**
+   * `flexGrow` so the container fills the viewport when the grid is narrower
+   * than it, which is what lets `justifyContent` centre the leftover. A grid
+   * wider than the viewport is not shrunk by either, so a phone still scrolls.
+   */
+  grid: {
+    flexDirection: 'row',
+    flexGrow: 1,
+    gap: ACTIVITY_CELL_GAP,
+    justifyContent: 'center',
+    paddingVertical: spacing.xs,
+  },
+  column: { gap: ACTIVITY_CELL_GAP },
   /**
    * `fill`, the one grey v3 lets be a box: an empty day must still be a
    * visible square on the white ground — a calendar whose empty days are
    * invisible is not a calendar, it is a scatter of dots.
    */
-  cell: { backgroundColor: colors.fill, borderRadius: 3, height: 13, width: 13 },
+  cell: { backgroundColor: colors.fill, borderRadius: 3 },
   // Drawn as a gap rather than a square: a day that has not happened is not an
   // empty day.
   future: { backgroundColor: 'transparent' },

--- a/apps/mobile/src/lib/activityMap.test.ts
+++ b/apps/mobile/src/lib/activityMap.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { activityGrid, repairEffect, type ActivityCell } from './activityMap'
+import {
+  ACTIVITY_CELL_GAP,
+  ACTIVITY_CELL_MAX,
+  ACTIVITY_CELL_MIN,
+  activityCellSize,
+  activityGrid,
+  repairEffect,
+  type ActivityCell,
+} from './activityMap'
 
 // A Saturday, so the "today is not the end of the column" case is the default.
 const TODAY = '2026-08-29'
@@ -156,5 +164,41 @@ describe('activityGrid and a streak the collection cannot account for', () => {
       streak: { current: 0, lastQualifiedDay: null },
     })
     expect(grid.flat().every((cell) => cell.intensity === 0)).toBe(true)
+  })
+})
+
+describe('activityCellSize', () => {
+  const total = (cell: number, weeks: number) => weeks * cell + (weeks - 1) * ACTIVITY_CELL_GAP
+
+  it('grows the square to fill a container the old fixed size left empty', () => {
+    // 688px is the web build's content box: layout.maxWidth 720 less two 16px
+    // gutters. The old fixed 13px square drew 413px into it.
+    expect(total(ACTIVITY_CELL_MIN, 26)).toBe(413)
+    const cell = activityCellSize(688, 26)
+    expect(cell).toBeGreaterThan(ACTIVITY_CELL_MIN)
+    expect(total(cell, 26)).toBeGreaterThan(500)
+  })
+
+  it('never draws wider than the container it was given', () => {
+    for (const width of [320, 358, 500, 688, 720, 1200]) {
+      expect(total(activityCellSize(width, 26), 26)).toBeLessThanOrEqual(
+        Math.max(width, total(ACTIVITY_CELL_MIN, 26)),
+      )
+    }
+  })
+
+  it('keeps the old size on a narrow phone, where the grid scrolls instead', () => {
+    // 390px handset less the screen's two 16px gutters.
+    expect(activityCellSize(358, 26)).toBe(ACTIVITY_CELL_MIN)
+  })
+
+  it('caps the square so a wide window is a heatmap, not a chessboard', () => {
+    expect(activityCellSize(4000, 26)).toBe(ACTIVITY_CELL_MAX)
+  })
+
+  it('falls back to the old size before the container has been measured', () => {
+    expect(activityCellSize(0, 26)).toBe(ACTIVITY_CELL_MIN)
+    expect(activityCellSize(Number.NaN, 26)).toBe(ACTIVITY_CELL_MIN)
+    expect(activityCellSize(688, 0)).toBe(ACTIVITY_CELL_MIN)
   })
 })

--- a/apps/mobile/src/lib/activityMap.ts
+++ b/apps/mobile/src/lib/activityMap.ts
@@ -110,6 +110,36 @@ export function repairEffect(input: {
   }
 }
 
+/** The gutter between squares, in both directions. */
+export const ACTIVITY_CELL_GAP = 3
+/** What the squares were before they could grow; nothing gets smaller than this. */
+export const ACTIVITY_CELL_MIN = 13
+/** A ceiling, so a desktop window gets a heatmap rather than a chessboard. */
+export const ACTIVITY_CELL_MAX = 20
+
+/**
+ * The square size that makes `weeks` columns fill `width`.
+ *
+ * The grid was a fixed 13px square: 26 of them plus their gutters is 413px of
+ * content inside a container that is 688px wide on the web build, so a third of
+ * the card was dead space on every desktop screen — while a narrow phone
+ * overflowed and scrolled correctly, which is why it never showed up on a
+ * handset.
+ *
+ * Growing the *square* rather than the number of weeks is deliberate: the
+ * window stays half a year on every device, so two people's maps still mean the
+ * same thing. Widening it instead would show a desktop reader more history than
+ * a phone reader and quietly make the two incomparable.
+ *
+ * Returns the floor for a width that has not been measured yet, so the first
+ * frame draws the old size rather than collapsing to nothing.
+ */
+export function activityCellSize(width: number, weeks: number): number {
+  if (!Number.isFinite(width) || width <= 0 || weeks <= 0) return ACTIVITY_CELL_MIN
+  const fitted = Math.floor((width - (weeks - 1) * ACTIVITY_CELL_GAP) / weeks)
+  return Math.min(ACTIVITY_CELL_MAX, Math.max(ACTIVITY_CELL_MIN, fitted))
+}
+
 /**
  * Monday-first weekday index for a `YYYY-MM-DD` key.
  *


### PR DESCRIPTION
The activity grid was 26 fixed 13px squares. That is `26×13 + 25×3 = 413px` of
content inside a container that is `720 − 2×16 = 688px` wide on the web build,
so a third of the card was dead space on every desktop screen.

It never showed up on a handset because there the same numbers *overflow* — a
390px phone has 358px of content, the grid is wider than that, and the
horizontal `ScrollView` does exactly what it should.

## What changed

`activityCellSize(width, weeks)` derives the square from the measured width:
floored at the old 13px so nothing gets smaller than it is today, capped at 20px
so a wide window gets a heatmap rather than a chessboard, and the leftover is
centred by `flexGrow` + `justifyContent` on the scroll container. A grid wider
than the viewport is unaffected by either, so narrow screens still scroll.

Growing the **square** rather than the number of weeks is the deliberate half.
The window stays half a year on every device, so two people's maps still mean
the same thing. Widening it would show a desktop reader more history than a
phone reader and quietly make the two incomparable.

The sizing is a pure function in `src/lib/activityMap.ts` because that is what
`vitest.config.ts` sees — the component itself is not reachable from a test.

## Tests

Five new cases, including the two that pin the intent rather than the arithmetic:
the 688px web container must produce something larger than the old fixed size,
and a 358px phone must still get exactly the old 13px.

`pnpm test` 1047 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)