### PR TITLE
Make a bought streak day survive the next message

### DIFF
--- a/apps/api/src/modules/tokens/streakDays.ts
+++ b/apps/api/src/modules/tokens/streakDays.ts
@@ -2,7 +2,10 @@ import { localDayKey, shiftDayKey, TOKEN_RULES } from '@langx/shared'
 
 // Re-exported so callers here keep one import; the walk itself lives in shared,
 // because the client has to predict the same number before a repair is bought.
-export { streakFromDays } from '@langx/shared'
+// `streakHeadDay` travels with it: they share the rule about where an
+// unfinished today starts from, and splitting them across two imports is how
+// one of them ends up being reimplemented.
+export { streakFromDays, streakHeadDay } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 

--- a/apps/api/src/modules/tokens/wallet.ts
+++ b/apps/api/src/modules/tokens/wallet.ts
@@ -23,6 +23,7 @@ import {
   repairsInMonth,
   streakDayId,
   streakFromDays,
+  streakHeadDay,
   type StreakDay,
 } from './streakDays'
 import { countCorrectionsWritten } from './corrections'
@@ -343,30 +344,63 @@ export async function repairDay(db: Db, userId: string, day: string): Promise<Re
    * to know the new length is to walk them.
    */
   const window = await listStreakDays(db, userId, shiftDayKey(today, -400), today)
-  const walked = streakFromDays(new Set(window.map((d) => d.day)), today)
+  const filled = new Set(window.map((d) => d.day))
+  const walked = streakFromDays(filled, today)
 
   /**
-   * Never below what they already had.
+   * `lastQualifiedDay` has to move with the streak, and forgetting it made the
+   * purchase worthless.
    *
-   * `streakDays` only starts existing when this ships, so every account that
-   * predates it has a history of nothing — and the walk above would price a
-   * two-hundred-day streak at zero. Buying a repair must not be able to take a
-   * streak away, which is what the max guarantees whatever the history looks
-   * like. As the collection fills in, the walk becomes the larger of the two on
-   * its own and this stops doing anything.
+   * `recordQualifyingAction` reads this field twice: `nextStreak` uses it to
+   * decide whether today continues the run, and `missedExactlyOne` uses it to
+   * decide whether a banked freeze is owed. Leaving it on the day *before* the
+   * gap meant the next message after a repair saw a day it had already been
+   * paid to fill still missing — so `nextStreak` found no adjacency and reset
+   * the streak to 1, and a user holding a freeze spent that too, bridging a day
+   * they had just bought. Three hundred tokens for nothing, twice over.
    */
-  const current = Math.max(profile.streak.current, walked)
-  const longest = Math.max(profile.streak.longest, current)
+  const head = streakHeadDay(filled, today)
+
+  /**
+   * `$max`, not `$set`, and it is doing two jobs.
+   *
+   * The race: `walked` was computed from a read three awaits ago, so a message
+   * that landed in between would be rolled back by a plain `$set`. `$max` can
+   * only move a value forward, so the later write wins whichever order they
+   * arrive in.
+   *
+   * The floor: `streakDays` only started existing when the map shipped, so an
+   * older account has a streak counter and no history behind it, and the walk
+   * would price a two-hundred-day run at zero. Buying a repair must never be
+   * able to take a streak away. `$max` says exactly that, in the database,
+   * instead of a `Math.max` over a value that may already be stale.
+   *
+   * `longest` takes the same floor: it is `>= current` by invariant, and maxing
+   * both by the same number keeps it that way.
+   */
   const after = await profiles.findOneAndUpdate(
     { _id: userId },
-    { $set: { 'streak.current': current, 'streak.longest': longest, updatedAt: now } },
+    {
+      $max: {
+        'streak.current': walked,
+        'streak.longest': walked,
+        // Day keys are `YYYY-MM-DD`, so BSON's string comparison is
+        // chronological — and `null` sorts below any string, so a profile that
+        // has never qualified still moves forward.
+        ...(head === null ? {} : { 'streak.lastQualifiedDay': head }),
+      },
+      $set: { updatedAt: now },
+    },
     { returnDocument: 'after' },
   )
 
+  const streak = after?.streak ?? profile.streak
   return {
     day,
     price,
-    streak: { current, longest },
+    // Read back rather than reported from the local walk, since `$max` is what
+    // decided the answer and a concurrent message may have raised it further.
+    streak: { current: streak.current, longest: streak.longest },
     wallet: walletOf(after ?? charged, earned),
     repairsLeftThisMonth: TOKEN_RULES.sinks.dayRepairPerMonth - used - 1,
   }

--- a/apps/api/src/routes/tokens.test.ts
+++ b/apps/api/src/routes/tokens.test.ts
@@ -556,6 +556,110 @@ describe('Faz 8 — streak, token ledger and direct awards', () => {
       expect(profile?.streak.current).toBe(200)
     })
 
+    /**
+     * The bug that made a repair worthless, and the reason it was invisible:
+     * every test here asserted the streak right after the purchase, and none
+     * of them sent a message afterwards.
+     *
+     * `repairDay` recomputed `streak.current` but never moved
+     * `streak.lastQualifiedDay`, so the next qualifying action still read the
+     * day *before* the gap. `nextStreak` found no adjacency to today and reset
+     * the run to 1 — three hundred token for a square and nothing else.
+     */
+    it('keeps the repaired streak when the next message lands', async () => {
+      const user = await funded('repair-then-send@example.com', 1000)
+      const partner = await newUser('repair-then-send-partner@example.com')
+      const days = handle.db.collection<StreakDay>(COLLECTIONS.streakDays)
+      const profiles = handle.db.collection<Profile>(COLLECTIONS.profiles)
+
+      // A run of two ending the day before yesterday, then a gap at yesterday.
+      for (const offset of [3, 2]) {
+        await days.insertOne({
+          _id: `${user.userId}:${dayKey(offset)}`,
+          userId: user.userId,
+          day: dayKey(offset),
+          source: 'activity',
+          actions: 1,
+        })
+      }
+      await profiles.updateOne(
+        { _id: user.userId },
+        {
+          $set: {
+            'streak.current': 2,
+            'streak.longest': 2,
+            'streak.lastQualifiedDay': dayKey(2),
+          },
+        },
+      )
+
+      const repair = await app.inject({
+        method: 'POST',
+        url: '/me/activity/repair',
+        headers: { cookie: user.cookie },
+        payload: { day: dayKey(1) },
+      })
+      expect(repair.statusCode, repair.body).toBe(200)
+      expect(repair.json<{ streak: { current: number } }>().streak.current).toBe(3)
+
+      // The whole point: the bought day is now the last one that qualified,
+      // so today is adjacent to it.
+      const repaired = await profiles.findOne({ _id: user.userId })
+      expect(repaired?.streak.lastQualifiedDay).toBe(dayKey(1))
+
+      await startConversation(user, partner.userId)
+
+      const after = await profiles.findOne({ _id: user.userId })
+      expect(after?.streak.current).toBe(4)
+      expect(after?.streak.lastQualifiedDay).toBe(dayKey(0))
+    })
+
+    /**
+     * The same stale read cost a second thing. `missedExactlyOne` is
+     * `lastQualifiedDay + 2 === today`, which a day-before-the-gap value
+     * satisfies exactly — so a user holding a freeze spent it bridging the day
+     * they had just paid to repair. Two charges for one gap.
+     */
+    it('does not spend a banked freeze on a day that was just bought', async () => {
+      const user = await funded('repair-then-freeze@example.com', 1000)
+      const partner = await newUser('repair-then-freeze-partner@example.com')
+      const days = handle.db.collection<StreakDay>(COLLECTIONS.streakDays)
+      const profiles = handle.db.collection<Profile>(COLLECTIONS.profiles)
+
+      await days.insertOne({
+        _id: `${user.userId}:${dayKey(2)}`,
+        userId: user.userId,
+        day: dayKey(2),
+        source: 'activity',
+        actions: 1,
+      })
+      await profiles.updateOne(
+        { _id: user.userId },
+        {
+          $set: {
+            'streak.current': 1,
+            'streak.longest': 1,
+            'streak.lastQualifiedDay': dayKey(2),
+            streakFreezes: 1,
+          },
+        },
+      )
+
+      const repair = await app.inject({
+        method: 'POST',
+        url: '/me/activity/repair',
+        headers: { cookie: user.cookie },
+        payload: { day: dayKey(1) },
+      })
+      expect(repair.statusCode, repair.body).toBe(200)
+
+      await startConversation(user, partner.userId)
+
+      const after = await profiles.findOne({ _id: user.userId })
+      expect(after?.streakFreezes).toBe(1)
+      expect(after?.streak.current).toBe(3)
+    })
+
     /** The leaderboard ranks token earned. Spending must not move anyone. */
     it('does not touch the leaderboard aggregates', async () => {
       const user = await funded('repair-rank@example.com', 1000)

--- a/packages/shared/src/token.test.ts
+++ b/packages/shared/src/token.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { streakFromDays, streakHeadDay } from './token'
+
+const days = (...list: string[]) => new Set(list)
+
+describe('streakHeadDay', () => {
+  it('is today when today has already qualified', () => {
+    expect(streakHeadDay(days('2026-08-30', '2026-08-31'), '2026-08-31')).toBe('2026-08-31')
+  })
+
+  /** An unfinished today still has the run that ended yesterday. */
+  it('falls back to yesterday when today has not qualified yet', () => {
+    expect(streakHeadDay(days('2026-08-29', '2026-08-30'), '2026-08-31')).toBe('2026-08-30')
+  })
+
+  it('is null when neither today nor yesterday is filled', () => {
+    expect(streakHeadDay(days('2026-08-20'), '2026-08-31')).toBeNull()
+    expect(streakHeadDay(days(), '2026-08-31')).toBeNull()
+  })
+
+  /**
+   * The two have to agree, because `repairDay` writes the streak length from
+   * one and `streak.lastQualifiedDay` from the other. A head with no length, or
+   * a length with no head, is the shape of the bug that let a bought day reset
+   * the streak on the very next message.
+   */
+  it('is non-null exactly when the walk finds a run', () => {
+    const cases: [string[], string][] = [
+      [['2026-08-31'], '2026-08-31'],
+      [['2026-08-30'], '2026-08-31'],
+      [['2026-08-29'], '2026-08-31'],
+      [[], '2026-08-31'],
+      [['2026-08-29', '2026-08-30', '2026-08-31'], '2026-08-31'],
+    ]
+    for (const [list, today] of cases) {
+      const set = days(...list)
+      expect(streakHeadDay(set, today) === null).toBe(streakFromDays(set, today) === 0)
+    }
+  })
+
+  /**
+   * The head is what the next qualifying action reads to decide whether today
+   * continues the run, so it must be the *newest* filled day, never the oldest.
+   */
+  it('names the newest day of the run, not the start of it', () => {
+    const set = days('2026-08-27', '2026-08-28', '2026-08-29', '2026-08-30')
+    expect(streakHeadDay(set, '2026-08-31')).toBe('2026-08-30')
+    expect(streakFromDays(set, '2026-08-31')).toBe(4)
+  })
+})

--- a/packages/shared/src/token.ts
+++ b/packages/shared/src/token.ts
@@ -492,12 +492,28 @@ export const repairDaySchema = z.object({
  * anything yet today still has the run that ended yesterday.
  */
 export function streakFromDays(days: Set<string>, today: string): number {
-  let cursor = days.has(today) ? today : shiftDayKey(today, -1)
-  if (!days.has(cursor)) return 0
+  let cursor = streakHeadDay(days, today)
+  if (cursor === null) return 0
   let length = 0
   while (days.has(cursor)) {
     length++
     cursor = shiftDayKey(cursor, -1)
   }
   return length
+}
+
+/**
+ * The newest day of the run `streakFromDays` counts, or `null` when there is no
+ * run at all.
+ *
+ * This is what `streak.lastQualifiedDay` has to become after a repair, and it
+ * shares the "yesterday is where an unfinished today starts from" rule above by
+ * construction rather than by being written out twice. Getting the two out of
+ * step is not a cosmetic bug: `recordQualifyingAction` reads
+ * `lastQualifiedDay` to decide both whether the streak continues and whether a
+ * banked freeze is owed, so a stale value silently undoes a purchase.
+ */
+export function streakHeadDay(days: Set<string>, today: string): string | null {
+  const head = days.has(today) ? today : shiftDayKey(today, -1)
+  return days.has(head) ? head : null
 }


### PR DESCRIPTION
A paid streak repair was silently undone by the user's very next message.

## What happens today

`repairDay` recomputes `streak.current` from the filled days, but never moves
`streak.lastQualifiedDay` — and that is the field `recordQualifyingAction`
actually reads.

Concretely, with today 08-31 and a run that ended 08-29:

| step | `streak.current` | `lastQualifiedDay` |
|---|---|---|
| before | 3 | `2026-08-29` |
| pay 300, repair `08-30` | **4** ✅ | `2026-08-29` ❌ |
| send one message | **1** 💥 | `2026-08-31` |

`nextStreak(4, '2026-08-29', '2026-08-31')` finds no adjacency and resets to 1.
The purchase bought a square and nothing else.

The same stale read costs a second thing. `missedExactlyOne` is
`lastQualifiedDay + 2 === today`, which a day-before-the-gap value satisfies
*exactly* — so a user holding a banked freeze spends that too, bridging the day
they have just paid to repair. **Two charges for one gap.**

## The fix

`streakHeadDay(days, today)` names the newest day of the run `streakFromDays`
counts. It sits in `packages/shared` next to the walk and shares its "yesterday
is where an unfinished today starts from" rule by construction rather than by
being written out twice — the client predicts the same value before a repair is
bought, so two implementations would be two different promises.

The write also becomes `$max` instead of `$set`, doing two jobs:

- **the race** — `walked` comes from a read three `await`s earlier, so a message
  landing in between would be rolled back by a plain `$set`;
- **the floor** — "never lower a streak that predates the day records" is now
  stated in the database, rather than as a `Math.max` over a value that may
  already be stale. `longest` takes the same max, which preserves
  `longest >= current`.

`repairDay` still pays no `streakMilestoneBonus`. That is left alone
deliberately: whether buying your way to day 7 should also pay the 50-token
milestone is a product call, not a defect, and it belongs in its own change.

## Why no test caught it

Every existing repair test asserts the streak immediately after the purchase,
and **not one of them sends a message afterwards**. Both new tests fail on
`main` and pass here — verified by reverting the one-line `$max` entry and
watching exactly those two go red.

`pnpm test` 1044 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)