### PR TITLE
Rename the plans to Fluent and Polyglot, from one table

### DIFF
--- a/apps/mobile/app/(app)/filters.tsx
+++ b/apps/mobile/app/(app)/filters.tsx
@@ -3,6 +3,8 @@ import {
   GENDERS,
   LANGUAGE_LEVELS,
   levelRank,
+  TIER_BADGES,
+  tierUnlocking,
   type LanguageLevel,
 } from '@langx/shared'
 import { router, useLocalSearchParams } from 'expo-router'
@@ -40,11 +42,15 @@ type FilterPatch = { [K in keyof DiscoveryFilters]?: DiscoveryFilters[K] | undef
  */
 function SectionTitle({ title, locked }: { title: string; locked?: boolean }) {
   const styles = useStyles()
+  // Names the plan that actually unlocks this row rather than a fixed word, so
+  // moving a filter between tiers moves the tag with it. `tierUnlocking` reads
+  // the real table, which is why it can be trusted to stay right.
+  const badge = TIER_BADGES[tierUnlocking('advancedFilters') ?? 'free']
 
   return (
     <View style={styles.sectionHead}>
       <Text style={styles.sectionTitle}>{title}</Text>
-      {locked ? <Text style={styles.proTag}>PRO</Text> : null}
+      {locked && badge ? <Text style={styles.proTag}>{badge}</Text> : null}
     </View>
   )
 }

--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -1,5 +1,13 @@
 import { ActivityMap } from '../../src/components/ActivityMap'
-import { countryFlag, getCountry, profileUrl, wornCosmetic } from '@langx/shared'
+import {
+  countryFlag,
+  getCountry,
+  profileUrl,
+  wornCosmetic,
+  TIER_BADGES,
+  TIER_NAMES,
+  tierUnlocking,
+} from '@langx/shared'
 import Feather from '@expo/vector-icons/Feather'
 import { router } from 'expo-router'
 import { ActivityIndicator, Pressable, Text, View } from 'react-native'
@@ -65,11 +73,12 @@ export default function MeScreen() {
   const summary = xp.data
   const viewerPage = viewers.data?.pages[0]
 
-  // "PRO" / "PRO+" are brand marks, not copy — the same literals TierBadge
-  // draws in its chip, folded into the meta line the way v3 writes it.
+  // The same mark TierBadge draws in its chip, folded into the meta line the
+  // way v3 writes it — read from the shared table rather than re-typed, which
+  // is how this line and the chip came to disagree about a renamed plan.
   const meta = [
     `@${profile.handle}`,
-    tier === 'free' ? null : tier === 'pro_plus' ? 'PRO+' : 'PRO',
+    TIER_BADGES[tier],
     profile.country ? countryLabel(profile.country) : null,
   ]
     .filter(Boolean)
@@ -151,7 +160,10 @@ export default function MeScreen() {
           /* `total` and `locked` describe the whole list, so page one is
              the authority on both. */
           viewerPage?.locked
-            ? t('me.viewersLocked', { count: viewerPage.total })
+            ? t('me.viewersLocked', {
+                count: viewerPage.total,
+                plan: TIER_NAMES[tierUnlocking('profileViewerIdentities') ?? 'pro'],
+              })
             : t('me.viewersCount', { count: viewerPage?.total ?? 0 })
         }
         onPress={() => router.push('/(app)/viewers')}

--- a/apps/mobile/app/(app)/paywall.tsx
+++ b/apps/mobile/app/(app)/paywall.tsx
@@ -11,6 +11,7 @@ import {
   type PlanFeature,
   type ProBenefit,
   type ProPlusBenefit,
+  TIER_NAMES,
 } from '@langx/shared'
 import { useLocalSearchParams } from 'expo-router'
 import { useEffect, useState } from 'react'
@@ -47,15 +48,6 @@ const PERIOD_LABEL: Record<BillingPeriod, MessageKey> = {
 }
 
 /**
- * `name` is a brand — "Pro" and "Pro+" are the same words in every locale, and
- * they are what the store listing and the receipt say.
- */
-const TIER_NAME: Record<PaidPlanTier, string> = {
-  pro: 'Pro',
-  pro_plus: 'Pro+',
-}
-
-/**
  * Copy for every benefit in `PRO_BENEFITS`, keyed by it.
  *
  * `Record<ProBenefit, ...>` is the enforcement: add a benefit to the shared
@@ -67,17 +59,23 @@ const TIER_NAME: Record<PaidPlanTier, string> = {
 interface BenefitCopy {
   title: MessageKey
   body: MessageKey
-  /** Interpolated into `body`. The free-tier numbers come from `PLAN_LIMITS`
-   *  rather than being typed out, because a paywall quoting a limit the server
-   *  no longer enforces is the worst kind of wrong. */
-  count?: number
+  /**
+   * Interpolated into `body`. Free-tier numbers come from `PLAN_LIMITS` rather
+   * than being typed out, because a paywall quoting a limit the server no
+   * longer enforces is the worst kind of wrong; plan names come from
+   * `TIER_NAMES` for the same reason, one rename later.
+   *
+   * A bag rather than a bare `count` because a benefit can need both, and a
+   * second optional field per placeholder is how the two drift apart.
+   */
+  vars?: Record<string, string | number>
 }
 
 const BENEFIT_COPY: Record<ProBenefit, BenefitCopy> = {
   unlimitedInitiations: {
     title: 'paywall.unlimitedChats',
     body: 'paywall.unlimitedChatsBody',
-    count: PLAN_LIMITS.free.initiationsPer24h ?? 0,
+    vars: { count: PLAN_LIMITS.free.initiationsPer24h ?? 0 },
   },
   advancedFilters: {
     title: 'paywall.advancedFilters',
@@ -86,7 +84,7 @@ const BENEFIT_COPY: Record<ProBenefit, BenefitCopy> = {
   unlimitedTranslation: {
     title: 'paywall.unlimitedTranslation',
     body: 'paywall.unlimitedTranslationBody',
-    count: PLAN_LIMITS.free.translationsPer24h ?? 0,
+    vars: { count: PLAN_LIMITS.free.translationsPer24h ?? 0 },
   },
   profileViewerIdentities: {
     title: 'paywall.whoViewed',
@@ -99,6 +97,7 @@ const BENEFIT_COPY: Record<ProBenefit, BenefitCopy> = {
   welcomePack: {
     title: 'paywall.welcomePack',
     body: 'paywall.welcomePackBody',
+    vars: { plan: TIER_NAMES.pro_plus },
   },
 }
 
@@ -222,8 +221,12 @@ export default function PaywallScreen() {
 
   return (
     <Screen scroll>
-      {/* "LangX Pro" is a brand, like the tier names — the same words in every locale. */}
-      <ScreenHeader title="LangX Pro" onBack={() => goBackTo('/(app)/me', from)} />
+      {/*
+        Translated, unlike the plan names below it. "LangX Pro" named one of the
+        two things this screen sells and would have read wrong above a Fluent
+        and a Polyglot column. A screen heading is copy, not a brand mark.
+      */}
+      <ScreenHeader title={t('paywall.screenTitle')} onBack={() => goBackTo('/(app)/me', from)} />
 
       {/*
         Says why this screen opened, when the caller knew. Someone who just
@@ -236,7 +239,7 @@ export default function PaywallScreen() {
           {feature && highlightTier ? (
             <Text style={styles.contextText}>
               <Text style={styles.contextFeature}>{t(FEATURE_TITLE[feature])}</Text>{' '}
-              {t('paywall.partOf')} {TIER_NAME[highlightTier]}.
+              {t('paywall.partOf')} {TIER_NAMES[highlightTier]}.
             </Text>
           ) : null}
           {remaining === 0 ? (
@@ -246,7 +249,7 @@ export default function PaywallScreen() {
           ) : null}
           {tier !== 'free' ? (
             <Text style={styles.contextText}>
-              {t('paywall.manageNotice', { plan: TIER_NAME[tier] })}
+              {t('paywall.manageNotice', { plan: TIER_NAMES[tier] })}
             </Text>
           ) : null}
         </View>
@@ -330,11 +333,13 @@ function TierSection({ tier, offers, currentTier, busyOfferId, onBuy }: TierSect
   return (
     <View style={[styles.section, tier === 'pro_plus' && styles.sectionLast]}>
       {tier === 'pro' ? (
-        <Text style={styles.tierName}>{TIER_NAME.pro}</Text>
+        <Text style={styles.tierName}>{TIER_NAMES.pro}</Text>
       ) : (
         <View style={styles.plusHead}>
-          <Text style={styles.tierName}>{TIER_NAME.pro_plus}</Text>
-          <Text style={styles.plusTagline}>{t('paywall.everythingInPro')}</Text>
+          <Text style={styles.tierName}>{TIER_NAMES.pro_plus}</Text>
+          <Text style={styles.plusTagline}>
+            {t('paywall.everythingInPro', { plan: TIER_NAMES.pro })}
+          </Text>
         </View>
       )}
 
@@ -446,7 +451,7 @@ function BenefitRow({ copy, pending = false }: { copy: BenefitCopy; pending?: bo
         </Text>
         <Text style={styles.benefitBody}>
           {' — '}
-          {t(copy.body, copy.count === undefined ? undefined : { count: copy.count })}
+          {t(copy.body, copy.vars)}
         </Text>
         {pending ? <Text style={styles.pendingTag}> · {t('common.comingSoon')}</Text> : null}
       </Text>

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -1,5 +1,5 @@
 import Feather from '@expo/vector-icons/Feather'
-import { ACCOUNT_DELETION_GRACE_DAYS } from '@langx/shared'
+import { ACCOUNT_DELETION_GRACE_DAYS, TIER_BADGES, tierUnlocking } from '@langx/shared'
 import { router } from 'expo-router'
 import { useState } from 'react'
 import { Image, Linking, Platform, Pressable, Text, View } from 'react-native'
@@ -86,6 +86,12 @@ export default function SettingsScreen() {
 
   const profile = me.data
   const isPro = useIsPro()
+  // Each tag names the plan that unlocks *that* row. Incognito reads the real
+  // table through `tierUnlocking`, so moving it between tiers moves the tag.
+  // The app icon is not in `PLAN_LIMITS` at all — it is a local cosmetic gated
+  // on "any paid plan" — so it takes the cheapest paid badge instead.
+  const incognitoBadge = TIER_BADGES[tierUnlocking('incognito') ?? 'free']
+  const paidBadge = TIER_BADGES.pro
   const shareLocation = useShareLocation()
   const stopSharingLocation = useStopSharingLocation()
 
@@ -251,7 +257,7 @@ export default function SettingsScreen() {
           subtitle={t('settings.incognitoBody')}
           accessory={
             <View style={styles.gated}>
-              {isPro ? null : <Text style={styles.proTag}>PRO</Text>}
+              {isPro ? null : <Text style={styles.proTag}>{incognitoBadge}</Text>}
               <Toggle
                 accessibilityLabel={t('settings.incognito')}
                 disabled={!isPro}
@@ -421,7 +427,7 @@ export default function SettingsScreen() {
               last
               accessory={
                 <View style={styles.gated}>
-                  {isPro ? null : <Text style={styles.proTag}>PRO</Text>}
+                  {isPro ? null : <Text style={styles.proTag}>{paidBadge}</Text>}
                   {APP_ICONS.map((name) => (
                     <Pressable
                       key={name}

--- a/apps/mobile/app/(onboarding)/welcome-back.tsx
+++ b/apps/mobile/app/(onboarding)/welcome-back.tsx
@@ -1,4 +1,4 @@
-import { TOKEN_RULES } from '@langx/shared'
+import { TIER_NAMES, TOKEN_RULES } from '@langx/shared'
 import { useQueryClient } from '@tanstack/react-query'
 import { router } from 'expo-router'
 import { useState } from 'react'
@@ -154,11 +154,7 @@ export default function WelcomeBackScreen() {
         {lifetimeGranted ? (
           <Line
             icon="✨"
-            title={t(
-              lifetimeGranted === 'pro_plus'
-                ? 'welcomeBack.proPlusForLife'
-                : 'welcomeBack.proForLife',
-            )}
+            title={t('welcomeBack.tierForLife', { plan: TIER_NAMES[lifetimeGranted] })}
             body={t('welcomeBack.proBody')}
           />
         ) : null}

--- a/apps/mobile/src/components/TierBadge.tsx
+++ b/apps/mobile/src/components/TierBadge.tsx
@@ -1,8 +1,8 @@
-import type { PlanTier } from '@langx/shared'
+import { TIER_BADGES, type PlanTier } from '@langx/shared'
 import { Chip } from './ui/Chip'
 
 /**
- * The PRO / PRO+ badge, in one place.
+ * The plan badge, in one place.
  *
  * Two screens rendered this inline and disagreed about how to decide it — the
  * profile screen compared `tier === 'pro'` while `me` used `useIsPro()` — so
@@ -18,7 +18,10 @@ import { Chip } from './ui/Chip'
  * reading "FREE" is an insult, not information.
  */
 export function TierBadge({ tier }: { tier: PlanTier }) {
-  if (tier === 'free') return null
-  const isPlus = tier === 'pro_plus'
-  return <Chip label={isPlus ? 'PRO+' : 'PRO'} tone={isPlus ? 'proPlus' : 'pro'} />
+  const label = TIER_BADGES[tier]
+  if (label === null) return null
+  // `tone` stays keyed on the tier, not the label: 'pro' and 'proPlus' are
+  // theme token names, and renaming them because the plan was renamed would be
+  // unrelated churn in the palette.
+  return <Chip label={label} tone={tier === 'pro_plus' ? 'proPlus' : 'pro'} />
 }

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -30,7 +30,6 @@ export const ar: Localized<EnMessages> = {
     oneMoment: 'لحظة…',
     skip: 'ليس الآن',
     you: '(أنت)',
-    pro: '✦ Pro',
     comingSoon: 'قريبًا',
     continue: 'متابعة',
     next: 'التالي',
@@ -384,8 +383,7 @@ export const ar: Localized<EnMessages> = {
     tokensBonusBody: 'هدية عودة للبداية. اكسب المزيد بالحديث والتصحيح.',
     streak: 'أفضل سلسلة: {days}',
     streakBody: 'محفوظة كرقمك القياسي. سلسلتك الحالية تبدأ من جديد اليوم.',
-    proForLife: 'LangX Pro مدى الحياة',
-    proPlusForLife: 'LangX Pro+ مدى الحياة',
+    tierForLife: '{plan} مدى الحياة',
     proBody:
       'مقابل ما بنيته في النسخة الأولى. لا تنتهي صلاحيته ولا شيء عليك دفعه — شكرًا لوجودك هنا أولًا.',
   },
@@ -498,7 +496,7 @@ export const ar: Localized<EnMessages> = {
     photosPermission: 'يحتاج LangX إلى إذن لفتح مكتبة صورك.',
     microphoneTitle: 'الميكروفون',
     translationUnavailable: 'الترجمة غير متاحة',
-    translationQuota: 'استخدمت ترجماتك المجانية لهذا اليوم. Pro يرفع الحد.',
+    translationQuota: 'لقد استخدمت ترجمات اليوم المجانية. الخطة المدفوعة تزيل الحد.',
     translationFailed: 'تعذّرت ترجمة هذه الرسالة الآن.',
     sayHello: 'ألقِ التحية على {name}…',
     pinnedMessage: 'رسالة مثبّتة',
@@ -694,12 +692,12 @@ export const ar: Localized<EnMessages> = {
     dayStreak: 'سلسلة الأيام',
     viewersTitle: 'من زار ملفك',
     viewersLocked: {
-      zero: 'زارك {count} شخص — اعرف من هم مع Pro',
-      one: 'زارك شخص واحد — اعرف من هو مع Pro',
-      two: 'زارك شخصان — اعرف من هما مع Pro',
-      few: 'زارك {count} أشخاص — اعرف من هم مع Pro',
-      many: 'زارك {count} شخصًا — اعرف من هم مع Pro',
-      other: 'زارك {count} شخص — اعرف من هم مع Pro',
+      zero: 'زارك {count} شخص — اعرف من هم مع {plan}',
+      one: 'زارك شخص واحد — اعرف من هو مع {plan}',
+      two: 'زارك شخصان — اعرف من هما مع {plan}',
+      few: 'زارك {count} أشخاص — اعرف من هم مع {plan}',
+      many: 'زارك {count} شخصًا — اعرف من هم مع {plan}',
+      other: 'زارك {count} شخص — اعرف من هم مع {plan}',
     },
     viewersCount: {
       zero: '{count} شخص',
@@ -710,7 +708,7 @@ export const ar: Localized<EnMessages> = {
       other: '{count} شخص',
     },
     leaderboardSubtitle: 'السلاسل والتصحيحات وكل ما حققته',
-    proTitle: '✦ LangX Pro',
+    proTitle: '✦ اذهب أبعد',
     proBody: 'محادثات جديدة بلا حدود، عوامل تصفية متقدمة، ترجمة وتصفح خفي.',
     newChatsLeft: 'المحادثات الجديدة المتبقية اليوم:',
     editProfile: 'تعديل الملف',
@@ -880,7 +878,7 @@ export const ar: Localized<EnMessages> = {
     itemsOwned: 'العناصر المملوكة',
     storeTitle: 'المتجر',
     disclaimer:
-      'الرموز نقاط داخل التطبيق. لا يمكن شراؤها أو تداولها أو سحبها أو استخدامها لفتح Pro — فقط تجميدات السلسلة والعناصر التجميلية. لا سلسلة ولا عقد ولا سوق.',
+      'الرموز نقاط داخل التطبيق. لا يمكن شراؤها أو تداولها أو سحبها أو استخدامها لفتح خطة مدفوعة — فقط تجميدات السلسلة والعناصر التجميلية. لا سلسلة ولا عقد ولا سوق.',
   },
 
   tokens: {
@@ -1088,7 +1086,8 @@ export const ar: Localized<EnMessages> = {
   },
 
   paywall: {
-    everythingInPro: 'كل ما في Pro',
+    screenTitle: 'الخطط',
+    everythingInPro: 'كل ما في {plan}',
     restorePurchases: 'استعادة المشتريات',
     title: 'تحدّث أكثر، تعلّم أسرع',
     proTagline: 'كل ما يجعل الخطة المجانية تبدو ضيقة.',
@@ -1096,7 +1095,7 @@ export const ar: Localized<EnMessages> = {
     unlimitedChats: 'محادثات جديدة بلا حدود',
     unlimitedChatsBody: '{count} يوميًا في الخطة المجانية.',
     welcomePack: 'حزمة ترحيب',
-    welcomePackBody: 'إطار للملف الشخصي وتجميدتان للسلسلة للبداية. و‏Pro+ يمنح المجموعة كاملة.',
+    welcomePackBody: 'إطار للملف الشخصي وتجميدتان للسلسلة للبداية. و‏{plan} يمنح المجموعة كاملة.',
     advancedFilters: 'عوامل تصفية متقدمة',
     advancedFiltersBody: 'ابحث حسب الجنس والمدينة.',
     unlimitedTranslation: 'ترجمة بلا حدود',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -17,7 +17,6 @@ export const de: Localized<EnMessages> = {
     oneMoment: 'Einen Moment…',
     skip: 'Später',
     you: '(du)',
-    pro: '✦ Pro',
     comingSoon: 'BALD',
     continue: 'Weiter',
     next: 'Weiter',
@@ -323,8 +322,7 @@ export const de: Localized<EnMessages> = {
       'Ein Willkommensbonus für den Anfang. Mehr gibt es fürs Reden und Korrigieren.',
     streak: 'Beste Serie: {days}',
     streakBody: 'Bleibt als dein Rekord stehen. Deine laufende Serie fängt heute neu an.',
-    proForLife: 'LangX Pro, auf Lebenszeit',
-    proPlusForLife: 'LangX Pro+, auf Lebenszeit',
+    tierForLife: '{plan}, auf Lebenszeit',
     proBody:
       'Für das, was du in v1 aufgebaut hast. Es läuft nie ab und kostet nichts — danke, dass du von Anfang an dabei warst.',
   },
@@ -442,7 +440,7 @@ export const de: Localized<EnMessages> = {
     microphoneTitle: 'Mikrofon',
     translationUnavailable: 'Übersetzung nicht verfügbar',
     translationQuota:
-      'Du hast deine kostenlosen Übersetzungen für heute aufgebraucht. Pro hebt das Limit auf.',
+      'Du hast die kostenlosen Übersetzungen für heute aufgebraucht. Ein bezahlter Tarif hebt das Limit auf.',
     translationFailed: 'Diese Nachricht konnte gerade nicht übersetzt werden.',
     sayHello: 'Sag {name} Hallo…',
     pinnedMessage: 'Angeheftete Nachricht',
@@ -596,12 +594,12 @@ export const de: Localized<EnMessages> = {
     dayStreak: 'Tagesserie',
     viewersTitle: 'Wer dein Profil angesehen hat',
     viewersLocked: {
-      one: '{count} Person hat geschaut — mit Pro siehst du, wer',
-      other: '{count} Leute haben geschaut — mit Pro siehst du, wer',
+      one: '{count} Person hat geschaut — mit {plan} sehen, wer',
+      other: '{count} Personen haben geschaut — mit {plan} sehen, wer',
     },
     viewersCount: { one: '{count} Person', other: '{count} Leute' },
     leaderboardSubtitle: 'Serien, Korrekturen und alles andere, was du verdient hast',
-    proTitle: '✦ LangX Pro',
+    proTitle: '✦ Mehr erreichen',
     proBody: 'Unbegrenzt neue Chats, erweiterte Filter, Übersetzung und Inkognito-Modus.',
     newChatsLeft: 'Heute noch neue Chats:',
     editProfile: 'Profil bearbeiten',
@@ -769,7 +767,7 @@ export const de: Localized<EnMessages> = {
     itemsOwned: 'Besitz',
     storeTitle: 'Shop',
     disclaimer:
-      'Token sind In-App-Punkte. Sie lassen sich nicht kaufen, handeln, auszahlen oder gegen Pro eintauschen — nur Serien-Freezes und Kosmetik. Es gibt keine Chain, keinen Vertrag und keinen Markt.',
+      'Token sind In-App-Punkte. Sie lassen sich nicht kaufen, handeln, auszahlen oder gegen einen bezahlten Tarif eintauschen — nur Serien-Freezes und Kosmetik. Es gibt keine Chain, keinen Vertrag und keinen Markt.',
   },
 
   tokens: {
@@ -928,7 +926,8 @@ export const de: Localized<EnMessages> = {
   },
 
   paywall: {
-    everythingInPro: 'Alles aus Pro',
+    screenTitle: 'Tarife',
+    everythingInPro: 'Alles aus {plan}',
     restorePurchases: 'Käufe wiederherstellen',
     title: 'Mehr reden, schneller lernen',
     proTagline: 'Alles, was den kostenlosen Tarif klein wirken lässt.',
@@ -937,7 +936,7 @@ export const de: Localized<EnMessages> = {
     unlimitedChatsBody: '{count} am Tag im kostenlosen Tarif.',
     welcomePack: 'Ein Willkommenspaket',
     welcomePackBody:
-      'Ein Profilrahmen und zwei Serien-Freezes zum Start. Pro+ bringt das ganze Set.',
+      'Ein Profilrahmen und zwei Serien-Freezes zum Start. {plan} bringt das ganze Set.',
     advancedFilters: 'Erweiterte Filter',
     advancedFiltersBody: 'Suche nach Geschlecht und Stadt.',
     unlimitedTranslation: 'Unbegrenzte Übersetzung',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -36,7 +36,6 @@ export const en = {
     oneMoment: 'One moment…',
     skip: 'Skip for now',
     you: '(you)',
-    pro: '✦ Pro',
     comingSoon: 'COMING SOON',
     continue: 'Continue',
     next: 'Next',
@@ -350,8 +349,7 @@ export const en = {
     tokensBonusBody: 'A welcome-back bonus to start with. Earn more by talking and by correcting.',
     streak: '{days} best streak',
     streakBody: 'Kept as your record. Your live streak starts fresh from today.',
-    proForLife: 'LangX Pro, for life',
-    proPlusForLife: 'LangX Pro+, for life',
+    tierForLife: '{plan}, for life',
     proBody:
       'For what you built in v1. It never expires and there is nothing to pay — thank you for being here first.',
   },
@@ -467,7 +465,7 @@ export const en = {
     photosPermission: 'LangX needs permission to open your photo library.',
     microphoneTitle: 'Microphone',
     translationUnavailable: 'Translation unavailable',
-    translationQuota: 'You’ve used today’s free translations. Pro removes the limit.',
+    translationQuota: 'You’ve used today’s free translations. A paid plan removes the limit.',
     translationFailed: 'Could not translate that message right now.',
     sayHello: 'Say hello to {name}…',
     pinnedMessage: 'Pinned message',
@@ -628,12 +626,12 @@ export const en = {
     dayStreak: 'Day streak',
     viewersTitle: 'Who viewed your profile',
     viewersLocked: {
-      one: '{count} person looked — see who with Pro',
-      other: '{count} people looked — see who with Pro',
+      one: '{count} person looked — see who with {plan}',
+      other: '{count} people looked — see who with {plan}',
     },
     viewersCount: { one: '{count} person', other: '{count} people' },
     leaderboardSubtitle: 'Streaks, corrections and everything else you have earned',
-    proTitle: '✦ LangX Pro',
+    proTitle: '✦ Go further',
     proBody: 'Unlimited new chats, advanced filters, translation and incognito browsing.',
     newChatsLeft: 'New chats left today:',
     editProfile: 'Edit profile',
@@ -799,7 +797,7 @@ export const en = {
     itemsOwned: 'Items owned',
     storeTitle: 'Store',
     disclaimer:
-      'Tokens are in-app points. They cannot be bought, traded, withdrawn or used to unlock Pro — only streak freezes and cosmetics. There is no chain, no contract and no market.',
+      'Tokens are in-app points. They cannot be bought, traded, withdrawn or used to unlock a paid plan — only streak freezes and cosmetics. There is no chain, no contract and no market.',
   },
 
   tokens: {
@@ -960,16 +958,17 @@ export const en = {
   },
 
   paywall: {
+    screenTitle: 'Plans',
     title: 'Talk more, learn faster',
     proTagline: 'Everything that makes the free plan feel small.',
-    everythingInPro: 'Everything in Pro',
+    everythingInPro: 'Everything in {plan}',
     restorePurchases: 'Restore purchases',
     partOf: 'is part of',
     unlimitedChats: 'Unlimited new chats',
     unlimitedChatsBody: '{count} a day on the free plan.',
     welcomePack: 'A welcome pack',
     welcomePackBody:
-      'A profile frame and two streak freezes to start with. Pro+ brings the full set.',
+      'A profile frame and two streak freezes to start with. {plan} brings the full set.',
     advancedFilters: 'Advanced filters',
     advancedFiltersBody: 'Search by gender and city.',
     unlimitedTranslation: 'Unlimited translation',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -20,7 +20,6 @@ export const es: Localized<EnMessages> = {
     oneMoment: 'Un momento…',
     skip: 'Ahora no',
     you: '(tú)',
-    pro: '✦ Pro',
     comingSoon: 'PRÓXIMAMENTE',
     continue: 'Continuar',
     next: 'Siguiente',
@@ -321,8 +320,7 @@ export const es: Localized<EnMessages> = {
     tokensBonusBody: 'Un regalo de bienvenida para empezar. Gana más hablando y corrigiendo.',
     streak: 'Mejor racha: {days}',
     streakBody: 'Se guarda como tu récord. Tu racha en curso empieza hoy de cero.',
-    proForLife: 'LangX Pro, de por vida',
-    proPlusForLife: 'LangX Pro+, de por vida',
+    tierForLife: '{plan}, de por vida',
     proBody:
       'Por lo que construiste en la v1. No caduca y no hay nada que pagar: gracias por estar aquí desde el principio.',
   },
@@ -439,7 +437,8 @@ export const es: Localized<EnMessages> = {
     photosPermission: 'LangX necesita permiso para abrir tu galería.',
     microphoneTitle: 'Micrófono',
     translationUnavailable: 'Traducción no disponible',
-    translationQuota: 'Has usado las traducciones gratuitas de hoy. Pro quita el límite.',
+    translationQuota:
+      'Has usado las traducciones gratuitas de hoy. Un plan de pago quita el límite.',
     translationFailed: 'No se pudo traducir ese mensaje ahora mismo.',
     sayHello: 'Saluda a {name}…',
     pinnedMessage: 'Mensaje fijado',
@@ -592,12 +591,12 @@ export const es: Localized<EnMessages> = {
     dayStreak: 'Racha diaria',
     viewersTitle: 'Quién ha visto tu perfil',
     viewersLocked: {
-      one: '{count} persona lo ha visto: descubre quién con Pro',
-      other: '{count} personas lo han visto: descubre quiénes con Pro',
+      one: '{count} persona te vio — descubre quién con {plan}',
+      other: '{count} personas te vieron — descubre quién con {plan}',
     },
     viewersCount: { one: '{count} persona', other: '{count} personas' },
     leaderboardSubtitle: 'Rachas, correcciones y todo lo que has ganado',
-    proTitle: '✦ LangX Pro',
+    proTitle: '✦ Ve más lejos',
     proBody: 'Chats nuevos ilimitados, filtros avanzados, traducción y modo incógnito.',
     newChatsLeft: 'Chats nuevos que te quedan hoy:',
     editProfile: 'Editar perfil',
@@ -763,7 +762,7 @@ export const es: Localized<EnMessages> = {
     itemsOwned: 'Objetos',
     storeTitle: 'Tienda',
     disclaimer:
-      'Las fichas son puntos dentro de la app. No se pueden comprar, intercambiar, retirar ni usar para desbloquear Pro: solo congelaciones de racha y cosméticos. No hay cadena, ni contrato, ni mercado.',
+      'Las fichas son puntos dentro de la app. No se pueden comprar, intercambiar, retirar ni usar para desbloquear un plan de pago: solo congelaciones de racha y cosméticos. No hay cadena, ni contrato, ni mercado.',
   },
 
   tokens: {
@@ -921,7 +920,8 @@ export const es: Localized<EnMessages> = {
   },
 
   paywall: {
-    everythingInPro: 'Todo lo de Pro',
+    screenTitle: 'Planes',
+    everythingInPro: 'Todo lo de {plan}',
     restorePurchases: 'Restaurar compras',
     title: 'Habla más, aprende más rápido',
     proTagline: 'Todo lo que hace que el plan gratuito se quede pequeño.',
@@ -930,7 +930,7 @@ export const es: Localized<EnMessages> = {
     unlimitedChatsBody: '{count} al día en el plan gratuito.',
     welcomePack: 'Un pack de bienvenida',
     welcomePackBody:
-      'Un marco de perfil y dos congelaciones de racha para empezar. Pro+ trae el set completo.',
+      'Un marco de perfil y dos congelaciones de racha para empezar. {plan} trae el set completo.',
     advancedFilters: 'Filtros avanzados',
     advancedFiltersBody: 'Busca por género y ciudad.',
     unlimitedTranslation: 'Traducción ilimitada',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -17,7 +17,6 @@ export const fr: Localized<EnMessages> = {
     oneMoment: 'Un instant…',
     skip: 'Plus tard',
     you: '(toi)',
-    pro: '✦ Pro',
     comingSoon: 'BIENTÔT',
     continue: 'Continuer',
     next: 'Suivant',
@@ -321,8 +320,7 @@ export const fr: Localized<EnMessages> = {
       'Un cadeau de bienvenue pour démarrer. Gagnes-en plus en parlant et en corrigeant.',
     streak: 'Meilleure série : {days}',
     streakBody: 'Gardée comme record. Ta série en cours repart de zéro aujourd’hui.',
-    proForLife: 'LangX Pro, à vie',
-    proPlusForLife: 'LangX Pro+, à vie',
+    tierForLife: '{plan}, à vie',
     proBody:
       'Pour ce que tu as construit sur la v1. Cela n’expire jamais et il n’y a rien à payer — merci d’avoir été là en premier.',
   },
@@ -439,7 +437,8 @@ export const fr: Localized<EnMessages> = {
     photosPermission: 'LangX a besoin d’une autorisation pour ouvrir ta photothèque.',
     microphoneTitle: 'Micro',
     translationUnavailable: 'Traduction indisponible',
-    translationQuota: 'Tu as utilisé tes traductions gratuites du jour. Pro enlève la limite.',
+    translationQuota:
+      'Tu as utilisé les traductions gratuites du jour. Une formule payante lève la limite.',
     translationFailed: 'Impossible de traduire ce message pour le moment.',
     sayHello: 'Dis bonjour à {name}…',
     pinnedMessage: 'Message épinglé',
@@ -593,12 +592,12 @@ export const fr: Localized<EnMessages> = {
     dayStreak: 'Série de jours',
     viewersTitle: 'Qui a vu ton profil',
     viewersLocked: {
-      one: '{count} personne a regardé — vois qui avec Pro',
-      other: '{count} personnes ont regardé — vois qui avec Pro',
+      one: '{count} personne a regardé — voir qui avec {plan}',
+      other: '{count} personnes ont regardé — voir qui avec {plan}',
     },
     viewersCount: { one: '{count} personne', other: '{count} personnes' },
     leaderboardSubtitle: 'Séries, corrections et tout ce que tu as gagné',
-    proTitle: '✦ LangX Pro',
+    proTitle: '✦ Aller plus loin',
     proBody:
       'Discussions nouvelles illimitées, filtres avancés, traduction et navigation incognito.',
     newChatsLeft: 'Nouvelles discussions restantes aujourd’hui :',
@@ -765,7 +764,7 @@ export const fr: Localized<EnMessages> = {
     itemsOwned: 'Objets possédés',
     storeTitle: 'Boutique',
     disclaimer:
-      'Les jetons sont des points internes à l’app. Ils ne peuvent être achetés, échangés, retirés ni servir à débloquer Pro — seulement des gels de série et des cosmétiques. Pas de chaîne, pas de contrat, pas de marché.',
+      'Les jetons sont des points internes à l’app. Ils ne peuvent être achetés, échangés, retirés ni servir à débloquer une formule payante — seulement des gels de série et des cosmétiques. Pas de chaîne, pas de contrat, pas de marché.',
   },
 
   tokens: {
@@ -926,7 +925,8 @@ export const fr: Localized<EnMessages> = {
   },
 
   paywall: {
-    everythingInPro: 'Tout ce que Pro inclut',
+    screenTitle: 'Formules',
+    everythingInPro: 'Tout ce que {plan} inclut',
     restorePurchases: 'Restaurer les achats',
     title: 'Parle plus, apprends plus vite',
     proTagline: 'Tout ce qui fait paraître le forfait gratuit étroit.',
@@ -935,7 +935,7 @@ export const fr: Localized<EnMessages> = {
     unlimitedChatsBody: '{count} par jour sur le forfait gratuit.',
     welcomePack: 'Un pack de bienvenue',
     welcomePackBody:
-      'Un cadre de profil et deux gels de série pour commencer. Pro+ apporte la panoplie complète.',
+      'Un cadre de profil et deux gels de série pour commencer. {plan} apporte la panoplie complète.',
     advancedFilters: 'Filtres avancés',
     advancedFiltersBody: 'Cherche par genre et par ville.',
     unlimitedTranslation: 'Traduction illimitée',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -17,7 +17,6 @@ export const ptBR: Localized<EnMessages> = {
     oneMoment: 'Um instante…',
     skip: 'Agora não',
     you: '(você)',
-    pro: '✦ Pro',
     comingSoon: 'EM BREVE',
     continue: 'Continuar',
     next: 'Avançar',
@@ -316,8 +315,7 @@ export const ptBR: Localized<EnMessages> = {
     tokensBonusBody: 'Um bônus de boas-vindas para começar. Ganhe mais conversando e corrigindo.',
     streak: 'Melhor sequência: {days}',
     streakBody: 'Fica guardada como seu recorde. Sua sequência atual começa do zero hoje.',
-    proForLife: 'LangX Pro, para sempre',
-    proPlusForLife: 'LangX Pro+, para sempre',
+    tierForLife: '{plan}, para sempre',
     proBody:
       'Pelo que você construiu na v1. Nunca expira e não há nada a pagar — obrigado por estar aqui desde o começo.',
   },
@@ -434,7 +432,7 @@ export const ptBR: Localized<EnMessages> = {
     photosPermission: 'O LangX precisa de permissão para abrir sua galeria.',
     microphoneTitle: 'Microfone',
     translationUnavailable: 'Tradução indisponível',
-    translationQuota: 'Você usou as traduções gratuitas de hoje. O Pro tira o limite.',
+    translationQuota: 'Você usou as traduções gratuitas de hoje. Um plano pago remove o limite.',
     translationFailed: 'Não deu para traduzir essa mensagem agora.',
     sayHello: 'Dê um oi para {name}…',
     pinnedMessage: 'Mensagem fixada',
@@ -588,12 +586,12 @@ export const ptBR: Localized<EnMessages> = {
     dayStreak: 'Sequência de dias',
     viewersTitle: 'Quem viu seu perfil',
     viewersLocked: {
-      one: '{count} pessoa olhou — veja quem com o Pro',
-      other: '{count} pessoas olharam — veja quem com o Pro',
+      one: '{count} pessoa viu — veja quem com {plan}',
+      other: '{count} pessoas viram — veja quem com {plan}',
     },
     viewersCount: { one: '{count} pessoa', other: '{count} pessoas' },
     leaderboardSubtitle: 'Sequências, correções e tudo o que você conquistou',
-    proTitle: '✦ LangX Pro',
+    proTitle: '✦ Vá além',
     proBody: 'Conversas novas ilimitadas, filtros avançados, tradução e navegação anônima.',
     newChatsLeft: 'Conversas novas restantes hoje:',
     editProfile: 'Editar perfil',
@@ -760,7 +758,7 @@ export const ptBR: Localized<EnMessages> = {
     itemsOwned: 'Itens',
     storeTitle: 'Loja',
     disclaimer:
-      'As fichas são pontos dentro do app. Não podem ser compradas, trocadas, sacadas nem usadas para desbloquear o Pro — apenas congelamentos de sequência e cosméticos. Não há cadeia, contrato nem mercado.',
+      'As fichas são pontos dentro do app. Não podem ser compradas, trocadas, sacadas nem usadas para desbloquear um plano pago — apenas congelamentos de sequência e cosméticos. Não há cadeia, contrato nem mercado.',
   },
 
   tokens: {
@@ -919,7 +917,8 @@ export const ptBR: Localized<EnMessages> = {
   },
 
   paywall: {
-    everythingInPro: 'Tudo do Pro',
+    screenTitle: 'Planos',
+    everythingInPro: 'Tudo do {plan}',
     restorePurchases: 'Restaurar compras',
     title: 'Converse mais, aprenda mais rápido',
     proTagline: 'Tudo o que faz o plano gratuito parecer pequeno.',
@@ -928,7 +927,7 @@ export const ptBR: Localized<EnMessages> = {
     unlimitedChatsBody: '{count} por dia no plano gratuito.',
     welcomePack: 'Um pacote de boas-vindas',
     welcomePackBody:
-      'Uma moldura de perfil e dois congelamentos de sequência para começar. O Pro+ traz o conjunto completo.',
+      'Uma moldura de perfil e dois congelamentos de sequência para começar. O {plan} traz o conjunto completo.',
     advancedFilters: 'Filtros avançados',
     advancedFiltersBody: 'Busque por gênero e cidade.',
     unlimitedTranslation: 'Tradução ilimitada',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -27,7 +27,6 @@ export const ru: Localized<EnMessages> = {
     oneMoment: 'Минуту…',
     skip: 'Пока пропустить',
     you: '(ты)',
-    pro: '✦ Pro',
     comingSoon: 'СКОРО',
     continue: 'Далее',
     next: 'Далее',
@@ -368,8 +367,7 @@ export const ru: Localized<EnMessages> = {
       'Подарок за возвращение, чтобы начать. Остальное зарабатывается общением и исправлениями.',
     streak: 'Лучшая серия: {days}',
     streakBody: 'Осталась как твой рекорд. Текущая серия начинается сегодня с нуля.',
-    proForLife: 'LangX Pro навсегда',
-    proPlusForLife: 'LangX Pro+ навсегда',
+    tierForLife: '{plan} навсегда',
     proBody:
       'За то, что ты построил в v1. Срок не истекает и платить ничего не нужно — спасибо, что был здесь первым.',
   },
@@ -485,7 +483,7 @@ export const ru: Localized<EnMessages> = {
     photosPermission: 'LangX нужен доступ, чтобы открыть галерею.',
     microphoneTitle: 'Микрофон',
     translationUnavailable: 'Перевод недоступен',
-    translationQuota: 'Бесплатные переводы на сегодня закончились. Pro снимает лимит.',
+    translationQuota: 'Бесплатные переводы на сегодня закончились. Платный тариф снимает лимит.',
     translationFailed: 'Сейчас не удалось перевести это сообщение.',
     sayHello: 'Поздоровайся с {name}…',
     pinnedMessage: 'Закреплённое сообщение',
@@ -671,10 +669,10 @@ export const ru: Localized<EnMessages> = {
     dayStreak: 'Серия дней',
     viewersTitle: 'Кто смотрел твой профиль',
     viewersLocked: {
-      one: 'Смотрел {count} человек — узнай кто с Pro',
-      few: 'Смотрели {count} человека — узнай кто с Pro',
-      many: 'Смотрели {count} человек — узнай кто с Pro',
-      other: 'Смотрели {count} человека — узнай кто с Pro',
+      one: 'Смотрел {count} человек — узнай кто с {plan}',
+      few: 'Смотрели {count} человека — узнай кто с {plan}',
+      many: 'Смотрели {count} человек — узнай кто с {plan}',
+      other: 'Смотрели {count} человека — узнай кто с {plan}',
     },
     viewersCount: {
       one: '{count} человек',
@@ -683,7 +681,7 @@ export const ru: Localized<EnMessages> = {
       other: '{count} человека',
     },
     leaderboardSubtitle: 'Серии, исправления и всё остальное, что вы заработали',
-    proTitle: '✦ LangX Pro',
+    proTitle: '✦ Больше возможностей',
     proBody: 'Безлимитные новые чаты, расширенные фильтры, перевод и невидимый просмотр.',
     newChatsLeft: 'Новых чатов осталось сегодня:',
     editProfile: 'Изменить профиль',
@@ -851,7 +849,7 @@ export const ru: Localized<EnMessages> = {
     itemsOwned: 'Предметы',
     storeTitle: 'Магазин',
     disclaimer:
-      'Жетоны — это внутренние баллы. Их нельзя купить, обменять, вывести или разблокировать ими Pro — только заморозки серии и косметика. Нет ни цепочки, ни контракта, ни рынка.',
+      'Жетоны — это внутренние баллы. Их нельзя купить, обменять, вывести или разблокировать ими платный тариф — только заморозки серии и косметика. Нет ни цепочки, ни контракта, ни рынка.',
   },
 
   tokens: {
@@ -1045,7 +1043,8 @@ export const ru: Localized<EnMessages> = {
   },
 
   paywall: {
-    everythingInPro: 'Всё из Pro',
+    screenTitle: 'Тарифы',
+    everythingInPro: 'Всё из {plan}',
     restorePurchases: 'Восстановить покупки',
     title: 'Больше общения — быстрее прогресс',
     proTagline: 'Всё, из-за чего бесплатный тариф кажется тесным.',
@@ -1053,7 +1052,7 @@ export const ru: Localized<EnMessages> = {
     unlimitedChats: 'Безлимитные новые чаты',
     unlimitedChatsBody: '{count} в день на бесплатном тарифе.',
     welcomePack: 'Приветственный набор',
-    welcomePackBody: 'Рамка профиля и две заморозки серии для начала. Pro+ даёт полный набор.',
+    welcomePackBody: 'Рамка профиля и две заморозки серии для начала. {plan} даёт полный набор.',
     advancedFilters: 'Расширенные фильтры',
     advancedFiltersBody: 'Поиск по полу и городу.',
     unlimitedTranslation: 'Безлимитный перевод',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -26,7 +26,6 @@ export const tr: Localized<EnMessages> = {
     oneMoment: 'Bir saniye…',
     skip: 'Şimdilik geç',
     you: '(sen)',
-    pro: '✦ Pro',
     comingSoon: 'YAKINDA',
     continue: 'Devam',
     next: 'İleri',
@@ -325,8 +324,7 @@ export const tr: Localized<EnMessages> = {
       'Başlangıç için bir dönüş hediyesi. Konuşarak ve düzelterek daha fazlasını kazan.',
     streak: 'En iyi seri: {days}',
     streakBody: 'Rekorun olarak duruyor. Yaşayan serin bugünden sıfırdan başlıyor.',
-    proForLife: 'Ömür boyu LangX Pro',
-    proPlusForLife: 'Ömür boyu LangX Pro+',
+    tierForLife: 'Ömür boyu {plan}',
     proBody:
       'v1’de kurduğun şey için. Süresi hiç dolmaz, ödenecek bir şey de yok — ilk günden burada olduğun için teşekkürler.',
   },
@@ -442,7 +440,8 @@ export const tr: Localized<EnMessages> = {
     photosPermission: 'LangX’in fotoğraf kitaplığını açmak için izne ihtiyacı var.',
     microphoneTitle: 'Mikrofon',
     translationUnavailable: 'Çeviri kullanılamıyor',
-    translationQuota: 'Bugünkü ücretsiz çevirilerini kullandın. Pro sınırı kaldırıyor.',
+    translationQuota:
+      'Bugünkü ücretsiz çevirilerini kullandın. Ücretli bir plan bu sınırı kaldırır.',
     translationFailed: 'Bu mesaj şu anda çevrilemedi.',
     sayHello: '{name} adlı kişiye merhaba de…',
     pinnedMessage: 'Sabitlenmiş mesaj',
@@ -599,12 +598,12 @@ export const tr: Localized<EnMessages> = {
     dayStreak: 'Günlük seri',
     viewersTitle: 'Profiline kim baktı',
     viewersLocked: {
-      one: '{count} kişi baktı — kim olduklarını Pro ile gör',
-      other: '{count} kişi baktı — kim olduklarını Pro ile gör',
+      one: '{count} kişi baktı — kimler olduğunu {plan} ile gör',
+      other: '{count} kişi baktı — kimler olduğunu {plan} ile gör',
     },
     viewersCount: { one: '{count} kişi', other: '{count} kişi' },
     leaderboardSubtitle: 'Seriler, düzeltmeler ve kazandığın her şey',
-    proTitle: '✦ LangX Pro',
+    proTitle: '✦ Daha ileri git',
     proBody: 'Sınırsız yeni sohbet, gelişmiş filtreler, çeviri ve gizli gezinme.',
     newChatsLeft: 'Bugün kalan yeni sohbet:',
     editProfile: 'Profili düzenle',
@@ -770,7 +769,7 @@ export const tr: Localized<EnMessages> = {
     itemsOwned: 'Sahip olunan',
     storeTitle: 'Mağaza',
     disclaimer:
-      "Jetonlar uygulama içi puandır. Satın alınamaz, takas edilemez, çekilemez ve Pro'yu açamaz — yalnızca seri dondurma ve kozmetikler. Zincir yok, sözleşme yok, piyasa yok.",
+      'Jetonlar uygulama içi puandır. Satın alınamaz, takas edilemez, çekilemez ve ücretli bir planı açamaz — yalnızca seri dondurma ve kozmetikler. Zincir yok, sözleşme yok, piyasa yok.',
   },
 
   tokens: {
@@ -925,7 +924,8 @@ export const tr: Localized<EnMessages> = {
   },
 
   paywall: {
-    everythingInPro: "Pro'daki her şey",
+    screenTitle: 'Planlar',
+    everythingInPro: '{plan} planındaki her şey',
     restorePurchases: 'Satın alımları geri yükle',
     title: 'Daha çok konuş, daha hızlı öğren',
     proTagline: 'Ücretsiz planı küçük gösteren her şey.',
@@ -934,7 +934,7 @@ export const tr: Localized<EnMessages> = {
     unlimitedChatsBody: 'Ücretsiz planda günde {count} tane.',
     welcomePack: 'Hoş geldin paketi',
     welcomePackBody:
-      'Başlangıç için bir profil çerçevesi ve iki seri dondurma. Pro+ setin tamamını getirir.',
+      'Başlangıç için bir profil çerçevesi ve iki seri dondurma. {plan} setin tamamını getirir.',
     advancedFilters: 'Gelişmiş filtreler',
     advancedFiltersBody: 'Cinsiyete ve şehre göre ara.',
     unlimitedTranslation: 'Sınırsız çeviri',

--- a/packages/shared/src/limits.ts
+++ b/packages/shared/src/limits.ts
@@ -163,6 +163,37 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
   },
 }
 
+/**
+ * What the plans are called, in one place.
+ *
+ * Brand marks, not copy: the same words in every locale, and what the store
+ * listing and the receipt say. They lived as literals in six places — the
+ * paywall, `TierBadge`, `me`, three rows of Settings and the filters header —
+ * which is five opportunities for a rename to be half-applied.
+ *
+ * These are **display only**. The RevenueCat entitlement ids and the `PACKAGES`
+ * keys stay `pro` / `pro_plus` forever: an entitlement identifier cannot be
+ * renamed after creation, and fixing one was free exactly once, before there
+ * were customers.
+ */
+export const TIER_NAMES: Record<PlanTier, string> = {
+  free: 'Free',
+  pro: 'Fluent',
+  pro_plus: 'Polyglot',
+}
+
+/**
+ * The short form for a chip, or `null` where there should be no chip at all.
+ *
+ * Free is `null` rather than `'FREE'`: an absent badge is the free state, and a
+ * chip reading "FREE" is an insult, not information.
+ */
+export const TIER_BADGES: Record<PlanTier, string | null> = {
+  free: null,
+  pro: 'FLUENT',
+  pro_plus: 'POLYGLOT',
+}
+
 /** Quota buckets that are enforced with a rolling 24h timestamp array. */
 export const QUOTA_KINDS = ['initiations', 'translations', 'corrections', 'media'] as const
 export type QuotaKind = (typeof QUOTA_KINDS)[number]


### PR DESCRIPTION
"Pro" and "Pro+" were literals in **six** places — `paywall.tsx`, `TierBadge`,
the meta line on Me, three rows of Settings and the filters header — and baked
into the middle of **seven sentences across eight catalogues**. Five chances for
a rename to be half-applied, seven for a translation to keep selling a plan that
no longer exists.

## One table

`TIER_NAMES` and `TIER_BADGES` live in `packages/shared/src/limits.ts` and are
now the only place a plan is named. Shared rather than mobile because the API
will eventually word an email or a push with the same names.

The badge tags in Settings and Filters no longer say a fixed word — they read
`TIER_BADGES[tierUnlocking(feature)]`, so **a capability moved between tiers
moves its tag with it**. `tierUnlocking` already existed for exactly this and
reads the real table. The app-icon tag is the one exception and says so in a
comment: it is a local cosmetic, not in `PLAN_LIMITS`, gated on "any paid plan".

## Copy with a plan name inside a sentence

Now takes `{plan}`: `me.viewersLocked`, `paywall.everythingInPro`,
`paywall.welcomePackBody`, and the token-economy disclaimer, in all eight
locales. Russian and Arabic keep every plural category they had — only the brand
word moved out of the sentence.

- `welcomeBack.proForLife` + `proPlusForLife` → one `tierForLife` with `{plan}`
- `me.proTitle` drops the plan entirely. It opens a paywall selling two of them,
  so naming one was always going to be wrong.
- `ScreenHeader title="LangX Pro"` → translated `paywall.screenTitle`. A screen
  heading is copy, not a brand mark, and it sat above a Fluent and a Polyglot
  column.
- `common.pro` was dead — nothing rendered it — so it is gone, not renamed.

`BenefitCopy.count` becomes a `vars` bag: a benefit can need both a number and a
plan name, and a second optional field per placeholder is how the two drift.

## Not touched, on purpose

The RevenueCat entitlement ids and the `PACKAGES` keys stay `pro` / `pro_plus`.
An entitlement identifier **cannot be renamed after creation**, and `decisions.md`
records that fixing one was free exactly once, before there were customers. These
tables are display-only and must stay that way.

## Verified in the running app

Paywall loaded on a local stack and scanned: `Fluent` present, `Polyglot`
present, **zero remaining `Pro` / `Pro+` matches** in the rendered text.

`pnpm test` 1054 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)