### PR TITLE
Put the way out of search inside the search field

### DIFF
--- a/apps/mobile/app/(app)/discover.tsx
+++ b/apps/mobile/app/(app)/discover.tsx
@@ -91,6 +91,13 @@ export default function DiscoverScreen() {
   // typing stays responsive and "behic" is one request rather than five.
   const search = useHandleSearch(useDebounced(term))
 
+  // Both the arrow and any future caller mean the same two things by it, and
+  // forgetting the second one leaves a stale query behind the next open.
+  function closeSearch(): void {
+    setSearching(false)
+    setTerm('')
+  }
+
   const isPro = useIsPro()
   const canUseNearby = useHasFeature('nearby')
   const me = useMe()
@@ -181,19 +188,25 @@ export default function DiscoverScreen() {
           {/* Beside the filters, not above the list: the two are the same
               question asked two ways — "narrow this" and "I already know who
               I am looking for". */}
-          <Pressable
-            accessibilityRole="button"
-            accessibilityState={{ expanded: searching }}
-            accessibilityLabel={t('discover.searchHandles')}
-            onPress={() => {
-              setSearching((on) => !on)
-              if (searching) setTerm('')
-            }}
-            style={({ pressed }) => [styles.filterButton, pressed && styles.pressed]}
-            hitSlop={8}
-          >
-            <Feather name={searching ? 'x' : 'search'} size={22} color={colors.text} />
-          </Pressable>
+          {/*
+            Opens search and nothing else. It used to toggle, which put the way
+            *out* of search up here in the header: a 22px glyph beside an
+            identical-looking filters icon, diagonally opposite the caret, and
+            announced to a screen reader as "Search by username" even while it
+            meant close. Leaving is now the arrow inside the field, at the
+            geometry every other back control in the app uses.
+          */}
+          {searching ? null : (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t('discover.searchHandles')}
+              onPress={() => setSearching(true)}
+              style={({ pressed }) => [styles.filterButton, pressed && styles.pressed]}
+              hitSlop={8}
+            >
+              <Feather name="search" size={22} color={colors.text} />
+            </Pressable>
+          )}
           <Pressable
             accessibilityRole="button"
             accessibilityLabel={
@@ -212,8 +225,21 @@ export default function DiscoverScreen() {
           </Pressable>
         </View>
         {searching ? (
-          <View style={styles.searchRow}>
-            <Feather name="search" size={17} color={colors.textFaint} />
+          <View style={styles.searchField}>
+            {/*
+              Leaving search is local state, never navigation. Discover is a tab
+              root, so `router.back()` would drop the reader on the first tab —
+              see `backHref` for why `canGoBack()` does not save you there.
+            */}
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t('common.backPlain')}
+              onPress={closeSearch}
+              hitSlop={12}
+              style={({ pressed }) => [styles.searchLeave, pressed && styles.pressed]}
+            >
+              <Feather name="arrow-left" size={22} color={colors.text} />
+            </Pressable>
             <TextInput
               value={term}
               onChangeText={setTerm}
@@ -222,8 +248,25 @@ export default function DiscoverScreen() {
               autoCapitalize="none"
               autoCorrect={false}
               autoFocus
+              returnKeyType="search"
               style={styles.searchInput}
             />
+            {/*
+              Clears the text without leaving search — a different intent from
+              the arrow, which is why it is a different control rather than one
+              button meaning two things. Only while there is something to clear.
+            */}
+            {term.length > 0 ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t('common.clear')}
+                onPress={() => setTerm('')}
+                hitSlop={10}
+                style={({ pressed }) => pressed && styles.pressed}
+              >
+                <Feather name="x" size={18} color={colors.textMuted} />
+              </Pressable>
+            ) : null}
           </View>
         ) : null}
 
@@ -235,7 +278,7 @@ export default function DiscoverScreen() {
                 key={result._id}
                 accessibilityRole="button"
                 onPress={() => openProfile(result.handle, '/(app)/discover')}
-                style={({ pressed }) => [styles.searchRow, pressed && styles.pressed]}
+                style={({ pressed }) => [styles.resultRow, pressed && styles.pressed]}
               >
                 <Avatar url={result.avatarUrl} name={result.displayName} size={36} />
                 <View style={styles.searchText}>
@@ -407,14 +450,30 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
     marginStart: 'auto',
   },
   filterButton: { alignItems: 'center', flexDirection: 'row', gap: spacing.xs },
-  searchRow: {
+  /**
+   * The input, and only the input. Both this and every result row used to be
+   * `searchRow`, so each result wore the field's fill, its pill radius and its
+   * top margin — the thing you type into and the things you tap looked like the
+   * same object stacked five deep. Splitting them is also what makes it safe to
+   * pad this one for the two controls inside it.
+   */
+  searchField: {
     alignItems: 'center',
     backgroundColor: colors.fill,
     borderRadius: radius.pill,
     flexDirection: 'row',
     gap: spacing.sm,
     marginTop: spacing.md,
-    paddingHorizontal: spacing.md,
+    paddingEnd: spacing.md,
+    paddingStart: spacing.sm,
+    paddingVertical: spacing.sm,
+  },
+  // Matches every other back control in the app: a 30x30 box, hitSlop 12.
+  searchLeave: { alignItems: 'center', height: 30, justifyContent: 'center', width: 30 },
+  resultRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: spacing.sm,
     paddingVertical: spacing.sm,
   },
   searchInput: { ...font.body, color: colors.text, flex: 1, padding: 0 },

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -21,6 +21,7 @@ export const ar: Localized<EnMessages> = {
     hidePassword: 'إخفاء كلمة المرور',
     back: '‹ رجوع',
     backPlain: 'رجوع',
+    clear: 'مسح',
     cancel: 'إلغاء',
     ok: 'حسنًا',
     save: 'حفظ',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -8,6 +8,7 @@ export const de: Localized<EnMessages> = {
     hidePassword: 'Passwort verbergen',
     back: '‹ Zurück',
     backPlain: 'Zurück',
+    clear: 'Löschen',
     cancel: 'Abbrechen',
     ok: 'OK',
     save: 'Speichern',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -27,6 +27,7 @@ export const en = {
     back: '‹ Back',
     /** Without it, for anywhere an icon is already beside the word. */
     backPlain: 'Back',
+    clear: 'Clear',
     cancel: 'Cancel',
     ok: 'OK',
     save: 'Save',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -11,6 +11,7 @@ export const es: Localized<EnMessages> = {
     hidePassword: 'Ocultar contraseña',
     back: '‹ Atrás',
     backPlain: 'Atrás',
+    clear: 'Borrar',
     cancel: 'Cancelar',
     ok: 'Aceptar',
     save: 'Guardar',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -8,6 +8,7 @@ export const fr: Localized<EnMessages> = {
     hidePassword: 'Masquer le mot de passe',
     back: '‹ Retour',
     backPlain: 'Retour',
+    clear: 'Effacer',
     cancel: 'Annuler',
     ok: 'OK',
     save: 'Enregistrer',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -8,6 +8,7 @@ export const ptBR: Localized<EnMessages> = {
     hidePassword: 'Ocultar senha',
     back: '‹ Voltar',
     backPlain: 'Voltar',
+    clear: 'Limpar',
     cancel: 'Cancelar',
     ok: 'OK',
     save: 'Salvar',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -18,6 +18,7 @@ export const ru: Localized<EnMessages> = {
     hidePassword: 'Скрыть пароль',
     back: '‹ Назад',
     backPlain: 'Назад',
+    clear: 'Очистить',
     cancel: 'Отмена',
     ok: 'ОК',
     save: 'Сохранить',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -17,6 +17,7 @@ export const tr: Localized<EnMessages> = {
     hidePassword: 'Parolayı gizle',
     back: '‹ Geri',
     backPlain: 'Geri',
+    clear: 'Temizle',
     cancel: 'Vazgeç',
     ok: 'Tamam',
     save: 'Kaydet',


### PR DESCRIPTION
Reported as: after you tap search, the close button is very hard to find.

It is, and the reasons are measurable rather than taste.

- **The smallest dismiss control in the app.** A bare 22px glyph with
  `hitSlop={8}` — about 38×38. Every back arrow in the app is a 30×30 box with
  `hitSlop={12}`, about 54×54.
- **The interior of a two-icon cluster.** It sat immediately left of the filters
  icon: same size, same colour, same style. The way out and an unrelated
  navigation action were neighbours that looked alike.
- **Its position was not stable.** The language-pair badge carries
  `marginStart: 'auto'`, which is what pushes the icons right. A user with no
  pair set renders no badge, so both icons slid back against the title.
- **It lied to screen readers.** `accessibilityLabel` was hard-wired to
  `discover.searchHandles`, so the ✕ announced itself as "Search by username".
- And it was a row above, hard right, while the reader was looking at the caret.

## What changed

One button meant two things — leaving search and clearing the text. Those are
different intents, so they are now different controls:

| | where | means |
|---|---|---|
| `arrow-left` | leading edge of the field | leave search |
| `x` | trailing edge, only when there is text | clear it, stay in search |
| header magnifier | unchanged, hidden while searching | enter search |

The arrow reuses `common.backPlain` and the exact geometry of every other back
control in the app, so the only new string is `common.clear` (×8).

**The arrow is local state, never navigation.** Discover is a tab root;
`router.back()` would drop the reader on the first tab, and `backHref` already
records that `canGoBack()` returns `true` while doing it.

## A bug found on the way

`styles.searchRow` was applied both to the input container **and to every result
row**, so each result inherited the field's fill, pill radius and 12px top
margin — the thing you type into and the things you tap rendered as the same
object stacked five deep. Split into `searchField` and `resultRow`, which is
also what makes it safe to pad the field for the two controls now inside it.

## Verified in the running app

Driven with Playwright on a local stack: back button present in the field; clear
button absent before typing and present after; clear empties the input **without
leaving search**; back closes search.

`pnpm test` 1061 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)