### PR TITLE
Stop recording every cancelled subscription as renewing

### DIFF
--- a/apps/api/src/modules/billing/fakeRevenueCat.ts
+++ b/apps/api/src/modules/billing/fakeRevenueCat.ts
@@ -178,6 +178,9 @@ export function createFakeRevenueCat(): FakeRevenueCat {
         expiresAt: subscription.expiresAt,
         productId: subscription.productId,
         store: FAKE_STORE,
+        // The harness has tracked this since it was written; it simply was not
+        // reported, because `refreshEntitlement` overwrote it with `true`.
+        willRenew: subscription.willRenew,
       })
     },
 

--- a/apps/api/src/modules/billing/refresh.ts
+++ b/apps/api/src/modules/billing/refresh.ts
@@ -26,7 +26,15 @@ export async function refreshEntitlement(
   const now = new Date()
 
   const next: Profile['entitlement'] = entitlement
-    ? { tier: entitlement.tier, willRenew: true, store: entitlement.store, updatedAt: now }
+    ? {
+        tier: entitlement.tier,
+        // Was hardcoded `true`. With no webhook endpoint configured this is the
+        // only path that writes an entitlement, so every subscriber who had
+        // cancelled was still recorded as renewing.
+        willRenew: entitlement.willRenew,
+        store: entitlement.store,
+        updatedAt: now,
+      }
     : { tier: 'free', willRenew: false, updatedAt: now }
   if (entitlement?.expiresAt) next.expiresAt = entitlement.expiresAt
 

--- a/apps/api/src/modules/billing/revenueCatClient.ts
+++ b/apps/api/src/modules/billing/revenueCatClient.ts
@@ -13,6 +13,19 @@ export interface SubscriberEntitlement {
   expiresAt: Date | null
   productId: string
   store: string
+  /**
+   * Whether it renews at `expiresAt`, or simply ends there.
+   *
+   * Read from the purchase rather than assumed. `refreshEntitlement` used to
+   * hardcode `true`, and with no webhook endpoint configured the refresh path
+   * is the *only* path — so every subscriber who had cancelled was still
+   * recorded as renewing, and any UI showing a renewal date would have shown a
+   * cancelled subscriber a date it will not happen on.
+   *
+   * Always `false` for a lifetime grant: there is nothing to renew. Paired with
+   * `expiresAt: null`, that is what says "lifetime" rather than "ending".
+   */
+  willRenew: boolean
 }
 
 export interface RevenueCatClient {
@@ -54,7 +67,7 @@ export interface RevenueCatClient {
 interface RevenueCatSubscriberResponse {
   subscriber: {
     entitlements: Record<string, { expires_date: string | null; product_identifier: string }>
-    subscriptions?: Record<string, { store?: string }>
+    subscriptions?: Record<string, { store?: string; unsubscribe_detected_at?: string | null }>
     non_subscriptions?: Record<string, { store?: string }[]>
   }
 }
@@ -72,6 +85,28 @@ function storeForProduct(
     oneTime?.[oneTime.length - 1]?.store ??
     'unknown'
   )
+}
+
+/**
+ * Whether the purchase behind a product is still set to renew.
+ *
+ * `unsubscribe_detected_at` is RevenueCat's record that the subscriber turned
+ * auto-renew off in the store; access continues to `expires_date` either way,
+ * which is exactly the distinction between "Renews on" and "Ends on".
+ *
+ * A product with no `subscriptions` entry is a one-time purchase — a lifetime —
+ * and renews by definition never. `billing_issues_detected_at` is deliberately
+ * *not* consulted: a failed card is usually transient and retried by the store,
+ * and telling someone their plan ends because one charge bounced would be
+ * alarming and, most of the time, wrong.
+ */
+function willRenewProduct(
+  subscriber: RevenueCatSubscriberResponse['subscriber'],
+  productId: string,
+): boolean {
+  const subscription = subscriber.subscriptions?.[productId]
+  if (!subscription) return false
+  return !subscription.unsubscribe_detected_at
 }
 
 /** `null` expiry is a lifetime (or not-yet-elapsed non-renewing) grant, not a missing one. */
@@ -107,6 +142,7 @@ export function createRevenueCatClient(secretApiKey: string): RevenueCatClient {
           expiresAt,
           productId: entitlement.product_identifier,
           store: storeForProduct(body.subscriber, entitlement.product_identifier),
+          willRenew: willRenewProduct(body.subscriber, entitlement.product_identifier),
         }
       }
       return null

--- a/apps/api/src/routes/billing.test.ts
+++ b/apps/api/src/routes/billing.test.ts
@@ -4,8 +4,10 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { buildApp } from '../app'
 import { createAuth } from '../auth'
 import { connectToDatabase, type DbHandle } from '../db/client'
+import { COLLECTIONS } from '../db/collections'
 import { ensureIndexes } from '../db/indexes'
 import { loadEnv } from '../env'
+import type { Profile } from '../modules/profiles/profiles'
 import type { RevenueCatClient, SubscriberEntitlement } from '../modules/billing/revenueCatClient'
 import { createStorageProvider } from '../storage/createStorageProvider'
 import { CapturingEmailSender, signUpAndSignIn, type SignedUpUser } from '../testSupport/authFlow'
@@ -245,6 +247,7 @@ describe('Faz 7 — billing', () => {
         expiresAt: new Date(Date.now() + 1_000_000),
         productId: 'monthly',
         store: 'app_store',
+        willRenew: true,
       }
 
       await app.inject({
@@ -283,6 +286,7 @@ describe('Faz 7 — billing', () => {
         expiresAt: new Date(Date.now() + 1_000_000),
         productId: 'pro_plus_monthly',
         store: 'app_store',
+        willRenew: true,
       }
 
       const response = await app.inject({
@@ -413,6 +417,7 @@ describe('Faz 7 — billing', () => {
         expiresAt: new Date(Date.now() + 1_000_000),
         productId: 'monthly',
         store: 'play_store',
+        willRenew: true,
       }
 
       const response = await app.inject({
@@ -432,6 +437,7 @@ describe('Faz 7 — billing', () => {
         expiresAt: new Date(Date.now() + 1_000_000),
         productId: 'pro_plus_yearly',
         store: 'play_store',
+        willRenew: true,
       }
 
       const response = await app.inject({
@@ -441,6 +447,40 @@ describe('Faz 7 — billing', () => {
       })
       expect(response.statusCode, response.body).toBe(200)
       expect(response.json()).toMatchObject({ tier: 'pro_plus' })
+    })
+
+    /**
+     * `refreshEntitlement` wrote `willRenew: true` unconditionally, and with no
+     * webhook endpoint configured this is the only path that writes an
+     * entitlement — so every subscriber who had cancelled in the store was
+     * still recorded as renewing. Any UI showing a renewal date would have
+     * shown them a date that will not happen.
+     */
+    it('records a cancelled subscription as ending, not renewing', async () => {
+      const user = await newUser('refresh-cancelled@example.com')
+      fakeRevenueCat.unavailable = false
+      fakeRevenueCat.next = {
+        tier: 'pro',
+        expiresAt: new Date(Date.now() + 1_000_000),
+        productId: 'monthly',
+        store: 'app_store',
+        willRenew: false,
+      }
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/billing/refresh',
+        headers: { cookie: user.cookie },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+      expect(response.json()).toMatchObject({ tier: 'pro', willRenew: false })
+
+      const profile = await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .findOne({ _id: user.userId })
+      expect(profile?.entitlement.willRenew).toBe(false)
+      // Access survives a cancellation; only the renewal stops.
+      expect(profile?.entitlement.tier).toBe('pro')
     })
 
     it('reconciles to free when RevenueCat reports no active entitlement', async () => {


### PR DESCRIPTION
`refreshEntitlement` wrote `willRenew: true` unconditionally:

```ts
const next = entitlement
  ? { tier: entitlement.tier, willRenew: true, store: entitlement.store, updatedAt: now }
  : { tier: 'free', willRenew: false, updatedAt: now }
```

`decisions.md` records that **no webhook endpoint is configured**, which makes
the refresh path the *only* path that writes an entitlement. So every subscriber
who had cancelled in the store was recorded as renewing, and the field was
simply never true-to-life.

Nothing renders it today, which is why it went unnoticed — and it is exactly why
this lands **before** the Settings subscription section, which will show a
renewal date.

## The fix

RevenueCat's subscriber record carries `unsubscribe_detected_at` on the
purchase. That is precisely the "Renews on {date}" versus "Ends on {date}"
distinction: access continues to `expires_date` either way, only the next charge
stops.

A product with no `subscriptions` entry is a one-time purchase — a lifetime — so
it renews never. Paired with a null expiry, that is what lets a UI say
"Lifetime" rather than "Ends on".

**`billing_issues_detected_at` is deliberately not consulted.** A failed card is
usually transient and retried by the store; telling someone their plan is ending
because one charge bounced would be alarming and, most of the time, wrong.

## The fake store already knew

`fakeRevenueCat` has tracked `willRenew` on its internal record since it was
written — `cancel()` sets it to `false` — and `getEntitlement` simply never
returned it. So the harness was producing the correct state and nothing
downstream could observe it. Returning it means the fake now exercises the real
path rather than a shape that only looks like it.

Adding the field to `SubscriberEntitlement` is what found the four test fixtures
that needed it.

## Tests

New: a cancelled subscription refreshes to `willRenew: false` while keeping
`tier: 'pro'` — access survives a cancellation, only the renewal stops.

`pnpm test` 1062 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)