### PR TITLE
Give the app language and the legal links a screen each

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -126,6 +126,8 @@ export default function AppLayout() {
         <Tabs.Screen name="wallet" options={FULL_SCREEN} />
         <Tabs.Screen name="tokens" options={FULL_SCREEN} />
         <Tabs.Screen name="kitchen" options={FULL_SCREEN} />
+        <Tabs.Screen name="app-language" options={FULL_SCREEN} />
+        <Tabs.Screen name="legal" options={FULL_SCREEN} />
       </Tabs>
     </SafeAreaView>
   )

--- a/apps/mobile/app/(app)/app-language.tsx
+++ b/apps/mobile/app/(app)/app-language.tsx
@@ -1,0 +1,62 @@
+import Feather from '@expo/vector-icons/Feather'
+import { LOCALE_NAMES, SUPPORTED_LOCALES } from '@langx/shared'
+import { View } from 'react-native'
+import { useLocalePreference, useT } from '../../src/i18n'
+import { ListRow } from '../../src/components/ui/ListRow'
+import { Screen } from '../../src/components/ui/Screen'
+import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
+import { goBackTo } from '../../src/lib/navigation'
+import { useTheme } from '../../src/lib/theme'
+
+/**
+ * `auto` leads because it is what almost everyone wants and what nobody has to
+ * think about — the override exists for the people this app is full of, who
+ * read a language their phone is not set to.
+ */
+const LOCALE_OPTIONS = ['auto', ...SUPPORTED_LOCALES] as const
+
+/**
+ * The app language, on its own screen.
+ *
+ * Nine rows stacked inside Settings made the list read as nine settings rather
+ * than one with nine values, and pushed everything after it below the fold.
+ * A screen rather than a modal because that is what this app already does with
+ * settings-adjacent lists (`blocked`, `starred`), and because it earns a real
+ * URL on the web build.
+ *
+ * Still a device preference, not an account one — a shared tablet should not
+ * change language when somebody else signs in. See `I18nProvider`.
+ */
+export default function AppLanguageScreen() {
+  const t = useT()
+  const { colors } = useTheme()
+  const { preference, setPreference, deviceLocale } = useLocalePreference()
+
+  return (
+    <Screen scroll>
+      <ScreenHeader
+        title={t('settings.languageSection')}
+        onBack={() => goBackTo('/(app)/settings')}
+      />
+      <View>
+        {LOCALE_OPTIONS.map((option, index) => (
+          <ListRow
+            key={option}
+            title={
+              option === 'auto'
+                ? t('settings.languageAuto', { name: LOCALE_NAMES[deviceLocale] })
+                : LOCALE_NAMES[option]
+            }
+            last={index === LOCALE_OPTIONS.length - 1}
+            onPress={() => setPreference(option)}
+            accessory={
+              preference === option ? (
+                <Feather name="check" size={18} color={colors.accent} />
+              ) : undefined
+            }
+          />
+        ))}
+      </View>
+    </Screen>
+  )
+}

--- a/apps/mobile/app/(app)/legal.tsx
+++ b/apps/mobile/app/(app)/legal.tsx
@@ -1,0 +1,35 @@
+import { View } from 'react-native'
+import { ListRow } from '../../src/components/ui/ListRow'
+import { Screen } from '../../src/components/ui/Screen'
+import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
+import { useT } from '../../src/i18n'
+import { LEGAL_LINKS } from '../../src/lib/externalLinks'
+import { goBackTo } from '../../src/lib/navigation'
+import { openExternal } from '../../src/lib/openExternal'
+
+/**
+ * The legal links, on their own screen.
+ *
+ * Five rows that every reader scrolls past to reach Community and Account. They
+ * have to be reachable — two stores require it — but they do not have to be in
+ * the way, and one row that says what is behind it is as findable as five.
+ */
+export default function LegalScreen() {
+  const t = useT()
+
+  return (
+    <Screen scroll>
+      <ScreenHeader title={t('settings.legalSection')} onBack={() => goBackTo('/(app)/settings')} />
+      <View>
+        {LEGAL_LINKS.map((link, index) => (
+          <ListRow
+            key={link.url}
+            title={t(link.labelKey as never)}
+            onPress={() => void openExternal(link.url)}
+            last={index === LEGAL_LINKS.length - 1}
+          />
+        ))}
+      </View>
+    </Screen>
+  )
+}

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -1,4 +1,3 @@
-import Feather from '@expo/vector-icons/Feather'
 import { ACCOUNT_DELETION_GRACE_DAYS, TIER_BADGES, tierUnlocking } from '@langx/shared'
 import { router } from 'expo-router'
 import { useState } from 'react'
@@ -34,33 +33,17 @@ import {
   setAppIcon,
   type AppIcon,
 } from '../../src/lib/appIcon'
-import { LEGAL_LINKS } from '../../src/lib/externalLinks'
 import { FLAG_KEYS, readBoolFlag } from '../../src/lib/localFlags'
-import { openExternal } from '../../src/lib/openExternal'
 import { captureLocation, LOCATION_FAILURE_KEY } from '../../src/lib/location'
-import { useLocalePreference, useT, type LocalePreference, type MessageKey } from '../../src/i18n'
-import {
-  LOCALE_NAMES,
-  NOTIFICATION_TYPES,
-  notificationsAllowed,
-  SUPPORTED_LOCALES,
-} from '@langx/shared'
+import { useLocalePreference, useT, type MessageKey } from '../../src/i18n'
+import { LOCALE_NAMES, NOTIFICATION_TYPES, notificationsAllowed } from '@langx/shared'
 import { unregisterPushToken } from '../../src/hooks/usePushRegistration'
 import {
   makeStyles,
-  useTheme,
   useThemePreference,
   THEME_PREFERENCES,
   type ThemePreference,
 } from '../../src/lib/theme'
-
-/**
- * `auto` first, then the eight in the order `SUPPORTED_LOCALES` declares them —
- * English, then the rest. Not sorted alphabetically: alphabetical order is
- * itself locale-dependent, so the list would reshuffle underneath someone
- * switching between two languages.
- */
-const LOCALE_OPTIONS: readonly LocalePreference[] = ['auto', ...SUPPORTED_LOCALES]
 
 /** Keys, not words: a module constant is fixed at import time. */
 const THEME_LABELS: Record<ThemePreference, MessageKey> = {
@@ -70,10 +53,9 @@ const THEME_LABELS: Record<ThemePreference, MessageKey> = {
 }
 
 export default function SettingsScreen() {
-  const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()
-  const { preference: locale, setPreference: setLocale, deviceLocale } = useLocalePreference()
+  const { preference: locale, deviceLocale } = useLocalePreference()
   const { preference, setPreference } = useThemePreference()
 
   const me = useMe()
@@ -377,23 +359,21 @@ export default function SettingsScreen() {
       */}
       <Text style={styles.section}>{t('settings.languageSection')}</Text>
       <View>
-        {LOCALE_OPTIONS.map((option, index) => (
-          <ListRow
-            key={option}
-            title={
-              option === 'auto'
-                ? t('settings.languageAuto', { name: LOCALE_NAMES[deviceLocale] })
-                : LOCALE_NAMES[option]
-            }
-            last={index === LOCALE_OPTIONS.length - 1}
-            onPress={() => setLocale(option)}
-            accessory={
-              locale === option ? (
-                <Feather name="check" size={18} color={colors.accent} />
-              ) : undefined
-            }
-          />
-        ))}
+        {/*
+          One row showing the current value, not nine rows showing every value.
+          Stacked, the list read as nine settings rather than one with nine
+          options, and pushed Theme, Legal and Account below the fold.
+        */}
+        <ListRow
+          title={t('settings.appLanguage')}
+          value={
+            locale === 'auto'
+              ? t('settings.languageAuto', { name: LOCALE_NAMES[deviceLocale] })
+              : LOCALE_NAMES[locale]
+          }
+          last
+          onPress={() => router.push('/(app)/app-language')}
+        />
       </View>
 
       <Text style={styles.section}>{t('theme.section')}</Text>
@@ -449,14 +429,16 @@ export default function SettingsScreen() {
 
       <Text style={styles.section}>{t('settings.legalSection')}</Text>
       <View>
-        {LEGAL_LINKS.map((link, index) => (
-          <ListRow
-            key={link.url}
-            title={t(link.labelKey as never)}
-            onPress={() => void openExternal(link.url)}
-            last={index === LEGAL_LINKS.length - 1}
-          />
-        ))}
+        {/*
+          Five links every reader scrolls past to reach Community and Account.
+          They have to be reachable — two stores require it — but not in the
+          way, and one row naming what is behind it is as findable as five.
+        */}
+        <ListRow
+          title={t('settings.legalSection')}
+          last
+          onPress={() => router.push('/(app)/legal')}
+        />
       </View>
 
       <Text style={styles.section}>{t('settings.communitySection')}</Text>

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -857,6 +857,7 @@ export const ar: Localized<EnMessages> = {
     updateLocation: 'تحديث موقعي',
     updating: 'جارٍ التحديث…',
     languageSection: 'اللغة',
+    appLanguage: 'لغة التطبيق',
     languageAuto: 'الجهاز ({name})',
     blockedPeople: 'المحظورون',
     showIntro: 'إظهار المقدمة مجددًا',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -730,6 +730,7 @@ export const de: Localized<EnMessages> = {
     updateLocation: 'Meinen Standort aktualisieren',
     updating: 'Wird aktualisiert…',
     languageSection: 'Sprache',
+    appLanguage: 'App-Sprache',
     languageAuto: 'Gerät ({name})',
     blockedPeople: 'Blockierte Personen',
     showIntro: 'Einführung noch einmal zeigen',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -748,6 +748,7 @@ export const en = {
     updateLocation: 'Update my location',
     updating: 'Updating…',
     languageSection: 'Language',
+    appLanguage: 'App language',
     languageAuto: 'Device ({name})',
     blockedPeople: 'Blocked people',
     showIntro: 'Show intro again',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -714,6 +714,7 @@ export const es: Localized<EnMessages> = {
     updateLocation: 'Actualizar mi ubicación',
     updating: 'Actualizando…',
     languageSection: 'Idioma',
+    appLanguage: 'Idioma de la app',
     languageAuto: 'Dispositivo ({name})',
     blockedPeople: 'Personas bloqueadas',
     showIntro: 'Ver la introducción otra vez',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -712,6 +712,7 @@ export const fr: Localized<EnMessages> = {
     updateLocation: 'Mettre à jour ma position',
     updating: 'Mise à jour…',
     languageSection: 'Langue',
+    appLanguage: 'Langue de l’app',
     languageAuto: 'Appareil ({name})',
     blockedPeople: 'Personnes bloquées',
     showIntro: 'Revoir l’introduction',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -707,6 +707,7 @@ export const ptBR: Localized<EnMessages> = {
     updateLocation: 'Atualizar minha localização',
     updating: 'Atualizando…',
     languageSection: 'Idioma',
+    appLanguage: 'Idioma do app',
     languageAuto: 'Aparelho ({name})',
     blockedPeople: 'Pessoas bloqueadas',
     showIntro: 'Ver a introdução de novo',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -821,6 +821,7 @@ export const ru: Localized<EnMessages> = {
     updateLocation: 'Обновить местоположение',
     updating: 'Обновляем…',
     languageSection: 'Язык',
+    appLanguage: 'Язык приложения',
     languageAuto: 'Устройство ({name})',
     blockedPeople: 'Заблокированные',
     showIntro: 'Показать вступление снова',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -721,6 +721,7 @@ export const tr: Localized<EnMessages> = {
     updateLocation: 'Konumumu güncelle',
     updating: 'Güncelleniyor…',
     languageSection: 'Dil',
+    appLanguage: 'Uygulama dili',
     languageAuto: 'Cihaz ({name})',
     blockedPeople: 'Engellenenler',
     showIntro: 'Tanıtımı tekrar göster',


### PR DESCRIPTION
Settings listed **nine languages and five legal links as fourteen rows** in the
middle of the screen. Stacked like that, the language block reads as nine
settings rather than one setting with nine values, and between them they pushed
Theme, Community and Account below the fold on a phone.

Each collapses to one row naming its current value, opening a screen.

## Why a screen, not a modal

1. There is **no Modal or BottomSheet primitive** in `src/components/ui/`.
   Adding one for two pickers is a bigger and riskier change than two screens.
2. The pattern already exists and is used seven times — `(app)/_layout.tsx`
   registers `blocked`, `starred`, `filters`, `viewers` and others as
   `href: null` full-screen routes. `blocked` and `starred` are the exact
   analogues: settings-adjacent lists.
3. It earns a real URL on the web build, which is what this repo values.
4. `routeLiterals.test.ts` validates the route string; nothing validates a
   modal's existence.

## Reserved handles

Neither segment needs an entry. `app-language` contains a hyphen, which
`HANDLE_PATTERN` forbids, so it can never collide with a username — and `legal`
is already in `INFRASTRUCTURE_RESERVED`. The reserved-handles test confirms it.

The language list moves across unchanged, including `auto` leading and the
deliberately non-alphabetical order: alphabetical order is itself
locale-dependent, so the list would reshuffle underneath someone switching
between two languages.

## Verified in the running app

Settings now shows a single **App language** row carrying the current value;
tapping it opens `/app-language` with all nine options and the check on the
active one.

`pnpm test` 1061 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)