### PR TITLE
Draw a message that is only emoji as itself

### DIFF
--- a/apps/mobile/src/components/MessageBubble.tsx
+++ b/apps/mobile/src/components/MessageBubble.tsx
@@ -1,5 +1,5 @@
 import Feather from '@expo/vector-icons/Feather'
-import { memo, useMemo, useRef, type ReactNode } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react'
 import {
   Animated,
   PanResponder,
@@ -12,6 +12,7 @@ import {
 } from 'react-native'
 import type { MessageDto } from '../api/queries'
 import { diffCorrection } from '../lib/correctionDiff'
+import { isBigEmoji } from '../lib/singleEmoji'
 import type { AnchorRect } from '../lib/messageMenu'
 import {
   SWIPE_ACTIVATE_PX,
@@ -136,6 +137,34 @@ export const MessageBubble = memo(function MessageBubble({
    * than per render — the memo is the reason this bubble can stay `memo`'d at
    * all while the screen re-renders on every keystroke in the composer.
    */
+  /**
+   * A bounce on arrival that a tap can replay.
+   *
+   * RN's `Animated`, not Reanimated: Reanimated 4 is a dependency that nothing
+   * imports, and pulling it in for one spring would put its worklets bundle
+   * into the shipped web build. `Button` already does exactly this shape.
+   *
+   * A tap is free to take: every `Pressable` in this file has only
+   * `onLongPress`, and the shell's `PanResponder` returns false from
+   * `onStartShouldSetPanResponder` precisely so a tap and a long press survive.
+   */
+  const heroScale = useRef(new Animated.Value(1)).current
+  const replay = useCallback(() => {
+    heroScale.setValue(0.6)
+    Animated.spring(heroScale, {
+      toValue: 1,
+      useNativeDriver: true,
+      speed: 12,
+      bounciness: 14,
+    }).start()
+  }, [heroScale])
+
+  useEffect(() => {
+    if (isBigEmoji(message.body)) replay()
+    // Once, when the message appears. Re-running on every render would make the
+    // thread jump every time the composer takes a keystroke.
+  }, [message.body, replay])
+
   const correction = message.correction
   const diff = useMemo(
     () => (correction ? diffCorrection(correction.original, message.body) : null),
@@ -303,6 +332,33 @@ export const MessageBubble = memo(function MessageBubble({
     )
   }
 
+  /**
+   * A message that is nothing but a couple of emoji, drawn as itself.
+   *
+   * No bubble: chrome sized for a sentence around a single glyph is what made
+   * these read as small rather than emphatic. It still goes through `shell`, so
+   * swipe-to-reply and the long-press menu keep working, and it keeps its quote
+   * and meta — a reaction to a specific message is still a reply, and the read
+   * receipt is still the thing people check.
+   */
+  if (isBigEmoji(message.body) && !message.deleted) {
+    return shell(
+      <Pressable
+        onPress={replay}
+        onLongPress={press}
+        style={[styles.hero, mine ? styles.heroMine : styles.heroTheirs]}
+      >
+        {quote}
+        <Animated.Text style={[styles.heroText, { transform: [{ scale: heroScale }] }]}>
+          {message.body}
+        </Animated.Text>
+        {translating ? <Text style={styles.translateLink}>{t('chat.translating')}</Text> : null}
+        <MessageMeta message={message} mine={mine} />
+        {badge}
+      </Pressable>,
+    )
+  }
+
   return shell(
     <Pressable
       onLongPress={press}
@@ -432,6 +488,16 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
   reaction: { alignItems: 'center', flexDirection: 'row', gap: 2 },
   reactionGlyph: { fontSize: 13, lineHeight: 18 },
   reactionCount: { ...font.caption, color: colors.textMuted, fontWeight: '700' },
+  /**
+   * No background and no padding: the glyph is the message. `alignSelf` still
+   * picks a side, because who sent it is the one thing the shape no longer says.
+   */
+  hero: { gap: spacing.xs, paddingVertical: 2 },
+  heroMine: { alignSelf: 'flex-end', alignItems: 'flex-end' },
+  heroTheirs: { alignSelf: 'flex-start', alignItems: 'flex-start' },
+  // 48 is the house size for a hero glyph — `AppGate` uses it, `IntroCarousel`
+  // 64. Bubble text is 16, so this reads as deliberate rather than as a font bug.
+  heroText: { fontSize: 48, lineHeight: 58 },
   bubbleText: { ...font.body, color: colors.text, fontSize: 16, lineHeight: 24 },
   bubbleTextMine: { color: colors.text },
   caption: { marginTop: spacing.xs },

--- a/apps/mobile/src/components/MessageMenuHost.tsx
+++ b/apps/mobile/src/components/MessageMenuHost.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from '@expo/vector-icons'
+import { isBigEmoji } from '../lib/singleEmoji'
 import { useEffect, useState } from 'react'
 import {
   Modal,
@@ -197,7 +198,20 @@ export function MessageMenuHost() {
               },
             ]}
           >
-            <Text style={[styles.copyText, request.mine && styles.copyTextMine]} numberOfLines={6}>
+            {/*
+              The menu draws its own copy of the bubble, so a message the thread
+              shows as a hero has to look like one here too — otherwise holding
+              an emoji shrinks it, which reads as the menu having replaced the
+              message rather than lifted it.
+            */}
+            <Text
+              style={[
+                styles.copyText,
+                request.mine && styles.copyTextMine,
+                isBigEmoji(request.preview) && styles.copyHero,
+              ]}
+              numberOfLines={6}
+            >
               {request.preview}
             </Text>
           </View>
@@ -268,6 +282,7 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
   anchoredBackdrop: { backgroundColor: colors.scrim, flex: 1 },
   destructive: { color: colors.danger },
   label: { ...font.body, color: colors.text },
+  copyHero: { fontSize: 48, lineHeight: 58 },
   preview: {
     ...font.caption,
     borderBottomColor: colors.border,

--- a/apps/mobile/src/lib/singleEmoji.test.ts
+++ b/apps/mobile/src/lib/singleEmoji.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { bigEmojiCount, isBigEmoji, MAX_BIG_EMOJI } from './singleEmoji'
+
+describe('bigEmojiCount', () => {
+  it('counts plain emoji', () => {
+    expect(bigEmojiCount('😀')).toBe(1)
+    expect(bigEmojiCount('😀😀')).toBe(2)
+    expect(bigEmojiCount('😀 😀 😀')).toBe(3)
+  })
+
+  /** One emoji, four code points. Counting code points would call this four. */
+  it('treats a ZWJ sequence as one', () => {
+    expect(bigEmojiCount('👨‍👩‍👧‍👦')).toBe(1)
+    expect(bigEmojiCount('👨‍👩‍👧‍👦👨‍👩‍👧‍👦')).toBe(2)
+  })
+
+  it('treats a skin-tone modifier and a variation selector as part of the emoji', () => {
+    expect(bigEmojiCount('👍🏽')).toBe(1)
+    expect(bigEmojiCount('❤️')).toBe(1)
+    expect(bigEmojiCount('👍🏽❤️')).toBe(2)
+  })
+
+  it('treats a flag as one, and a lone regional indicator as not an emoji', () => {
+    expect(bigEmojiCount('🇹🇷')).toBe(1)
+    expect(bigEmojiCount('🇹🇷🇷🇺')).toBe(2)
+    expect(bigEmojiCount('\u{1F1F9}')).toBe(0)
+  })
+
+  /**
+   * The trap `\p{Emoji}` walks into: the digits carry the property, so "7"
+   * would have rendered as a 64px hero.
+   */
+  it('does not treat bare digits, # or * as emoji', () => {
+    expect(bigEmojiCount('7')).toBe(0)
+    expect(bigEmojiCount('2026')).toBe(0)
+    expect(bigEmojiCount('#')).toBe(0)
+    expect(bigEmojiCount('*')).toBe(0)
+    expect(bigEmojiCount('7️⃣')).toBe(1)
+  })
+
+  it('is zero for anything with words in it', () => {
+    expect(bigEmojiCount('')).toBe(0)
+    expect(bigEmojiCount('   ')).toBe(0)
+    expect(bigEmojiCount('ok 😀')).toBe(0)
+    expect(bigEmojiCount('😀 nice')).toBe(0)
+    expect(bigEmojiCount('merhaba')).toBe(0)
+    // Punctuation is words too — "!" is not a hero.
+    expect(bigEmojiCount('😀!')).toBe(0)
+  })
+})
+
+describe('isBigEmoji', () => {
+  it('is true up to the cap and false past it', () => {
+    expect(isBigEmoji('😀')).toBe(true)
+    expect(isBigEmoji('😀'.repeat(MAX_BIG_EMOJI))).toBe(true)
+    // Past the cap it is a sentence in emoji, which reads better at body size.
+    expect(isBigEmoji('😀'.repeat(MAX_BIG_EMOJI + 1))).toBe(false)
+    expect(isBigEmoji('hello')).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/singleEmoji.ts
+++ b/apps/mobile/src/lib/singleEmoji.ts
@@ -1,0 +1,111 @@
+/**
+ * Whether a message is nothing but a couple of emoji, and how many.
+ *
+ * Harder than `/\p{Emoji}/` suggests, in three ways that all produce visible
+ * bugs:
+ *
+ * - **`\p{Emoji}` matches the digits.** `0`–`9`, `#` and `*` carry the property,
+ *   so "7" would render as a 64px hero. Only a keycap sequence (`7️⃣`) counts.
+ * - **One emoji is often many code points.** `👨‍👩‍👧‍👦` is four pictographs joined
+ *   by zero-width joiners, `👍🏽` is a thumb plus a skin-tone modifier, and `❤️`
+ *   is a heart plus a variation selector. Counting code points would call a
+ *   single family emoji four, and drop it out of the "at most three" rule that
+ *   makes this readable.
+ * - **Flags are pairs of regional indicators**, which are not pictographic at
+ *   all.
+ *
+ * `Intl.Segmenter` would do the clustering, but Hermes does not reliably ship
+ * it, so the grouping is done here. Property escapes are compiled once inside a
+ * `try` for the same reason: an engine without them must make every message
+ * ordinary, never crash the bundle at import.
+ */
+
+/** More than this and it is a sentence in emoji, which reads better at body size. */
+export const MAX_BIG_EMOJI = 3
+
+const PICTOGRAPHIC = compile('\\p{Extended_Pictographic}')
+const REGIONAL = compile('[\\u{1F1E6}-\\u{1F1FF}]')
+const SKIN_TONE = compile('[\\u{1F3FB}-\\u{1F3FF}]')
+
+function compile(source: string): RegExp | null {
+  try {
+    return new RegExp(`^${source}$`, 'u')
+  } catch {
+    // An engine without Unicode property escapes. Every message stays ordinary,
+    // which is the correct degradation for a decoration.
+    return null
+  }
+}
+
+const ZWJ = '‍'
+const VARIATION_SELECTOR_16 = '️'
+const KEYCAP = '⃣'
+
+function is(pattern: RegExp | null, codePoint: string): boolean {
+  return pattern !== null && pattern.test(codePoint)
+}
+
+/**
+ * The number of emoji, when the message is *only* emoji and whitespace.
+ * Zero for anything else — including an empty string, and including a message
+ * that mixes emoji with words.
+ */
+export function bigEmojiCount(body: string): number {
+  const points = [...body.trim()]
+  if (points.length === 0) return 0
+
+  let count = 0
+  let i = 0
+  while (i < points.length) {
+    const point = points[i]!
+
+    if (/\s/u.test(point)) {
+      i++
+      continue
+    }
+
+    // A flag: exactly two regional indicators. A lone one is not an emoji.
+    if (is(REGIONAL, point)) {
+      if (!is(REGIONAL, points[i + 1] ?? '')) return 0
+      count++
+      i += 2
+      continue
+    }
+
+    // A keycap: the digit is only an emoji with the enclosing mark after it.
+    if (/^[0-9#*]$/u.test(point)) {
+      const next = points[i + 1]
+      const after = next === VARIATION_SELECTOR_16 ? points[i + 2] : next
+      if (after !== KEYCAP) return 0
+      count++
+      i += next === VARIATION_SELECTOR_16 ? 3 : 2
+      continue
+    }
+
+    if (!is(PICTOGRAPHIC, point)) return 0
+
+    // One pictograph, then everything that modifies or joins to it.
+    i++
+    for (;;) {
+      const next = points[i]
+      if (next === VARIATION_SELECTOR_16 || is(SKIN_TONE, next ?? '')) {
+        i++
+        continue
+      }
+      if (next === ZWJ && is(PICTOGRAPHIC, points[i + 1] ?? '')) {
+        i += 2
+        continue
+      }
+      break
+    }
+    count++
+  }
+
+  return count
+}
+
+/** Whether the message should be drawn as a hero rather than in a bubble. */
+export function isBigEmoji(body: string): boolean {
+  const count = bigEmojiCount(body)
+  return count > 0 && count <= MAX_BIG_EMOJI
+}


### PR DESCRIPTION
A single emoji arrived in a bubble sized for a sentence, at the same 16px as the
words around it — the one case where chrome makes a message quieter instead of
clearer.

Up to three emoji now render at **48px with no bubble**, and a tap replays the
spring they arrive with.

## Detection is the hard part

`/\p{Emoji}/` is the obvious answer and wrong three ways, each of which produces
something a user would see:

| trap | what breaks |
|---|---|
| **`\p{Emoji}` matches the digits.** `0`–`9`, `#`, `*` all carry it | `7` renders as a 48px hero. Only a keycap (`7️⃣`) should count |
| **One emoji is often many code points.** `👨‍👩‍👧‍👦` is four pictographs joined by ZWJ; `👍🏽` is a thumb plus a modifier; `❤️` is a heart plus a variation selector | counting code points calls a family emoji *four*, pushing it past the three-emoji cap |
| **Flags are pairs of regional indicators** | not pictographic at all, so they never match |

`Intl.Segmenter` would do the clustering, but Hermes does not reliably ship it,
so the grouping is done by hand in `src/lib/singleEmoji.ts` — pure, no
`react-native` in its import graph, which is what makes it reachable by vitest.
The property escapes are compiled inside a `try`: an engine without them must
make every message ordinary, never fail the bundle at import.

## The rest

- **RN `Animated`, not Reanimated.** Reanimated 4 is a dependency nothing
  imports, and `ui/Skeleton.tsx` already records why reaching for it puts its
  worklets bundle into the shipped web build. `Button`'s spring is the precedent.
- **A tap was free to take.** Every `Pressable` in `MessageBubble` had only
  `onLongPress`, and the shell's `PanResponder` returns `false` from
  `onStartShouldSetPanResponder` precisely so a tap and a long press survive the
  swipe gesture.
- Still goes through `shell()`, so swipe-to-reply and menu anchoring keep
  working, and keeps its quote and `MessageMeta`.
- `MessageMenuHost` draws its own copy of the held message, so it matches —
  otherwise holding an emoji shrinks it, which reads as the menu having
  replaced the message rather than lifted it.

## Verified in the running app

Four messages through the real send path, then the rendered font size measured
in the browser:

```
😀                        48px
👨‍👩‍👧‍👦 (ZWJ family)          48px
🇹🇷🎉 (flag + pictograph)  48px
sadece yazı, büyümemeli   16px
```

`pnpm test` 1069 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)