### PR TITLE
Stop losing a chat message when the send fails

### DIFF
--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -242,6 +242,35 @@ export const INDEXES: Partial<IndexSpec> = {
      * index would let exactly one of them exist.
      */
     { key: { legacyId: 1 }, name: 'legacy_id_unique', unique: true, sparse: true },
+    /**
+     * Idempotency for a resent message, by index rather than by the handler
+     * remembering to check — the same shape as `legacy_id_unique` above, and
+     * the doctrine `decisions.md` already records for retried writes.
+     *
+     * A send whose ack is lost is indistinguishable from one that never
+     * arrived, so the client retries; without this, the message it already
+     * delivered is posted twice.
+     *
+     * Keyed on the sender as well as the id. The id is minted on a device from
+     * a clock and a random number, which is unique enough among one person's
+     * own attempts and nothing more — a global unique index would let one
+     * user's collision refuse another user's message. Sparse because a build
+     * that predates this sends no `clientId`.
+     */
+    {
+      key: { senderId: 1, clientId: 1 },
+      name: 'sender_client_id_unique',
+      unique: true,
+      /**
+       * `partialFilterExpression`, **not** `sparse`. A compound sparse index is
+       * only sparse when *every* indexed field is missing, and `senderId` is
+       * always there — so a sparse version indexes every message with a null
+       * `clientId` and the unique constraint then allows exactly one message
+       * per sender. Which is to say: it silently breaks sending, and it breaks
+       * it for everyone, on the second message.
+       */
+      partialFilterExpression: { clientId: { $exists: true } },
+    },
   ],
 
   [COLLECTIONS.blocks]: [

--- a/apps/api/src/modules/chat/conversations.ts
+++ b/apps/api/src/modules/chat/conversations.ts
@@ -82,6 +82,11 @@ export interface Message {
   deletedAt?: Date
   deletedBy?: string
   /** Private to each user — projected away, never shipped as a list. */
+  /**
+   * The client's id for the attempt that created this message, when it sent
+   * one. Only ever read to refuse a duplicate — see `sender_client_id_unique`.
+   */
+  clientId?: string
   starredBy?: string[]
   editedAt?: Date
   /**

--- a/apps/api/src/modules/chat/messageView.ts
+++ b/apps/api/src/modules/chat/messageView.ts
@@ -46,6 +46,12 @@ export interface MessageView {
   deliveredAt?: string
   readAt?: string
   createdAt: string
+  /**
+   * Echoed back only to the sender, so a client holding a "not sent" row can
+   * retire it when the message it gave up on turns out to have arrived. Nobody
+   * else's client has any use for it.
+   */
+  clientId?: string
 }
 
 export function toMessageView(message: Message, viewerId: string): MessageView {
@@ -69,6 +75,9 @@ export function toMessageView(message: Message, viewerId: string): MessageView {
   if (deleted) view.deleted = true
   if (hidden) view.hidden = true
   if (message.starredBy?.includes(viewerId)) view.starred = true
+  // Only to its author: it is their retry key, and it says nothing to anyone
+  // else. `toMessageView` builds by naming fields, so this is the only way in.
+  if (message.clientId && message.senderId === viewerId) view.clientId = message.clientId
   if (!deleted && message.editedAt) view.editedAt = message.editedAt.toISOString()
   if (!deleted && message.correctedAt) view.corrected = true
   if (!deleted && message.media) view.media = message.media

--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -123,12 +123,26 @@ export async function sendTextMessage(
   const conversation = await assertConversationAccess(db, input.conversationId, senderId)
   const replyTo = await resolveReplyTo(db, conversation, input.replyToMessageId)
 
+  /**
+   * A send whose ack was lost looks exactly like one that never arrived, so the
+   * client retries it. `sender_client_id_unique` is what makes that safe: the
+   * second write is refused by the index rather than by a prior read, which is
+   * the only version that holds under a race.
+   */
+  if (input.clientId) {
+    const already = await db
+      .collection<Message>(COLLECTIONS.messages)
+      .findOne({ senderId, clientId: input.clientId })
+    if (already) return { message: already, conversation }
+  }
+
   const message: Message = {
     _id: new ObjectId(),
     conversationId: conversation._id,
     senderId,
     type: 'text',
     body: input.body,
+    ...(input.clientId ? { clientId: input.clientId } : {}),
     ...(replyTo ? { replyTo } : {}),
     createdAt: new Date(),
   }

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -115,6 +115,59 @@ describe('Faz 5 — conversation/message history REST', () => {
     await replSet?.stop()
   })
 
+  /**
+   * A send whose ack is lost is indistinguishable from one that never arrived,
+   * so the client retries it. Without the index behind this, the message it
+   * already delivered would be posted a second time.
+   */
+  it('does not post a resent message twice', async () => {
+    const a = await newUser('idem-a@example.com')
+    const b = await newUser('idem-b@example.com')
+    const conversationId = (await startConversation(a, b.userId))._id
+    const { sendTextMessage } = await import('../modules/chat/messages')
+
+    const first = await sendTextMessage(handle.db, a.userId, {
+      conversationId,
+      body: 'only once',
+      clientId: 'attempt-1',
+    })
+    const retry = await sendTextMessage(handle.db, a.userId, {
+      conversationId,
+      body: 'only once',
+      clientId: 'attempt-1',
+    })
+
+    expect(String(retry.message._id)).toBe(String(first.message._id))
+    const count = await handle.db
+      .collection(COLLECTIONS.messages)
+      .countDocuments({ senderId: a.userId, body: 'only once' })
+    expect(count).toBe(1)
+  })
+
+  /** A different attempt at the same words is a different message. */
+  it('still allows the same text sent deliberately twice', async () => {
+    const a = await newUser('idem-twice-a@example.com')
+    const b = await newUser('idem-twice-b@example.com')
+    const conversationId = (await startConversation(a, b.userId))._id
+    const { sendTextMessage } = await import('../modules/chat/messages')
+
+    await sendTextMessage(handle.db, a.userId, {
+      conversationId,
+      body: 'ha',
+      clientId: 'attempt-1',
+    })
+    await sendTextMessage(handle.db, a.userId, {
+      conversationId,
+      body: 'ha',
+      clientId: 'attempt-2',
+    })
+
+    const count = await handle.db
+      .collection(COLLECTIONS.messages)
+      .countDocuments({ senderId: a.userId, body: 'ha' })
+    expect(count).toBe(2)
+  })
+
   it('lists a user own conversations, most recent first', async () => {
     const viewer = await newUser('list-convos-viewer@example.com')
     const older = await newUser('list-convos-older@example.com')

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -41,6 +41,13 @@ import { useProfileCache } from '../../../src/hooks/useProfileCache'
 import { useVoiceRecorder } from '../../../src/hooks/useVoiceRecorder'
 import { chooseAlert, showAlert } from '../../../src/lib/alert'
 import { emitWithAck, getSocket } from '../../../src/lib/socket'
+import {
+  addUnsent,
+  newClientId,
+  removeUnsent,
+  retireDelivered,
+  type UnsentMessage,
+} from '../../../src/lib/unsentMessages'
 import { errorCodeOf } from '../../../src/lib/errors'
 import { listState } from '../../../src/lib/listState'
 import { shouldSubmitOnEnter } from '../../../src/lib/submitOnEnter'
@@ -72,6 +79,7 @@ export default function ChatScreen() {
 
   const [draft, setDraft] = useState('')
   const [sending, setSending] = useState(false)
+  const [unsent, setUnsent] = useState<UnsentMessage[]>([])
   const [correcting, setCorrecting] = useState<MessageDto | null>(null)
   const [partnerTyping, setPartnerTyping] = useState(false)
   // Keyed by message id: a translation replaces nothing, it sits under the
@@ -109,6 +117,20 @@ export default function ChatScreen() {
 
   const items = useMemo(() => messagesNewestFirst(thread.data), [thread.data])
   const rows = useMemo(() => messageRows(items), [items])
+
+  /**
+   * A send whose ack was lost still left an unsent row, and the message may
+   * have arrived anyway — the thread would then show the same sentence twice.
+   * The server echoes `clientId` back to its author so the duplicate can go.
+   */
+  useEffect(() => {
+    setUnsent((list) =>
+      retireDelivered(
+        list,
+        items.map((message) => message.clientId),
+      ),
+    )
+  }, [items])
   // Newest first, so the anchor's index *is* how many arrived while away.
   const missed = awayFrom
     ? Math.max(
@@ -223,6 +245,47 @@ export default function ChatScreen() {
     await sendMedia('audio', recording)
   }
 
+  /**
+   * Sends `body`, and on failure keeps it as a visible row rather than losing
+   * it.
+   *
+   * `clientId` is passed in on a retry so the row updates itself instead of
+   * stacking a second copy of the same sentence.
+   */
+  async function deliver(body: string, clientId: string): Promise<void> {
+    try {
+      const socket = await getSocket()
+      await emitWithAck(socket, 'message:send', {
+        conversationId,
+        body,
+        clientId,
+        ...(replyingTo ? { replyToMessageId: replyingTo._id } : {}),
+      })
+      setUnsent((list) => removeUnsent(list, clientId))
+      setReplyingTo(null)
+    } catch {
+      /*
+       * Swallowed on purpose, and this is the whole change: it used to be
+       * swallowed by *nothing* — `send()` had a `try/finally` with no `catch`,
+       * both call sites were `void send()`, and there is no global rejection
+       * handler, so the reader was shown nothing whatsoever. The row below is
+       * the report.
+       */
+      setUnsent((list) =>
+        addUnsent(list, {
+          clientId,
+          body,
+          ...(replyingTo ? { replyToMessageId: replyingTo._id } : {}),
+          failedAt: new Date().toISOString(),
+        }),
+      )
+    }
+  }
+
+  async function retry(message: UnsentMessage): Promise<void> {
+    await deliver(message.body, message.clientId)
+  }
+
   async function send(): Promise<void> {
     const body = draft.trim()
     if (!body || sending) return
@@ -247,12 +310,10 @@ export default function ChatScreen() {
         })
         setCorrecting(null)
       } else {
-        await emitWithAck(socket, 'message:send', {
-          conversationId,
-          body,
-          ...(replyingTo ? { replyToMessageId: replyingTo._id } : {}),
-        })
-        setReplyingTo(null)
+        // `deliver` never rejects — a failure becomes an unsent row — so the
+        // composer clears either way. The text is not lost, it has moved into
+        // the thread where the reader can see it did not go.
+        await deliver(body, newClientId(Date.now(), Math.random()))
       }
       setDraft('')
       notifyTyping(false)
@@ -617,6 +678,31 @@ export default function ChatScreen() {
               }
             }}
             onEndReachedThreshold={0.4}
+            /**
+             * Header, not footer: inverted, the header is what sits at the
+             * bottom — under the newest message and directly above the
+             * composer, which is where something that failed to send belongs.
+             */
+            ListHeaderComponent={
+              unsent.length > 0 ? (
+                <View style={styles.unsentBlock}>
+                  {unsent.map((message) => (
+                    <Pressable
+                      key={message.clientId}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('chat.notSentRetry')}
+                      onPress={() => void retry(message)}
+                      style={({ pressed }) => [styles.unsent, pressed && styles.unsentPressed]}
+                    >
+                      <Text style={styles.unsentBody}>{message.body}</Text>
+                      <Text style={styles.unsentNote}>
+                        <Feather name="alert-circle" size={12} /> {t('chat.notSentRetry')}
+                      </Text>
+                    </Pressable>
+                  ))}
+                </View>
+              ) : null
+            }
             /** Footer, not header: inverted, the footer is what sits on top. */
             ListFooterComponent={
               thread.isFetchingNextPage ? <ActivityIndicator style={styles.older} /> : null
@@ -915,6 +1001,27 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
   headerName: { ...font.heading, color: colors.text, fontSize: 16 },
   typing: { ...font.caption, color: colors.accent, fontSize: 13, fontWeight: '600' },
   presence: { ...font.caption, color: colors.success, fontSize: 13, fontWeight: '600' },
+  /** Under the newest message, above the composer. */
+  unsentBlock: { gap: spacing.xs, paddingTop: spacing.xs },
+  /**
+   * Shaped like one of your own bubbles but drained of it: same side, same
+   * radius, an `error` outline instead of the accent fill. It has to read as
+   * "this is your message and it did not go", which a toast cannot say because
+   * a toast does not sit next to the sentence.
+   */
+  unsent: {
+    alignSelf: 'flex-end',
+    borderColor: colors.danger,
+    borderRadius: 20,
+    borderWidth: 1,
+    gap: 2,
+    maxWidth: '82%',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  unsentPressed: { opacity: 0.6 },
+  unsentBody: { ...font.body, color: colors.text, fontSize: 16, lineHeight: 24 },
+  unsentNote: { ...font.caption, color: colors.danger, fontSize: 12 },
   listWrap: { flex: 1 },
   list: { gap: spacing.md, paddingHorizontal: spacing.lg, paddingVertical: spacing.lg },
   skeletonFill: { flex: 1 },

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -307,6 +307,12 @@ export interface MessageDto {
   /** Starred by me alone; who else did never leaves the server. */
   starred?: boolean
   editedAt?: string
+  /**
+   * Present only on your own messages, and only when the client that sent it
+   * supplied one. Used to retire a "not sent" row whose message turns out to
+   * have arrived.
+   */
+  clientId?: string
   /** Somebody corrected this sentence, so it can no longer be edited. */
   corrected?: boolean
   deliveredAt?: string

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -522,6 +522,7 @@ export const ar: Localized<EnMessages> = {
   chat: {
     title: 'محادثة',
     typing: 'يكتب…',
+    notSentRetry: 'لم يُرسل — اضغط للمحاولة مرة أخرى',
     editing: 'تعديل',
     correcting: 'تصحيح',
     activity: 'النشاط',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -445,6 +445,7 @@ export const de: Localized<EnMessages> = {
   chat: {
     title: 'Chat',
     typing: 'schreibt…',
+    notSentRetry: 'Nicht gesendet — zum Wiederholen tippen',
     editing: 'Bearbeiten',
     correcting: 'Korrigieren',
     activity: 'Aktivität',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -459,6 +459,7 @@ export const en = {
   chat: {
     title: 'Chat',
     typing: 'typing…',
+    notSentRetry: 'Not sent — tap to try again',
     editing: 'Editing',
     correcting: 'Correcting',
     activity: 'Activity',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -431,6 +431,7 @@ export const es: Localized<EnMessages> = {
   chat: {
     title: 'Chat',
     typing: 'escribiendo…',
+    notSentRetry: 'No enviado: toca para reintentar',
     editing: 'Editando',
     correcting: 'Corrigiendo',
     activity: 'Actividad',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -428,6 +428,7 @@ export const fr: Localized<EnMessages> = {
   chat: {
     title: 'Discussion',
     typing: 'écrit…',
+    notSentRetry: 'Non envoyé — touche pour réessayer',
     editing: 'Modification',
     correcting: 'Correction',
     activity: 'Activité',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -423,6 +423,7 @@ export const ptBR: Localized<EnMessages> = {
   chat: {
     title: 'Conversa',
     typing: 'digitando…',
+    notSentRetry: 'Não enviado — toque para tentar de novo',
     editing: 'Editando',
     correcting: 'Corrigindo',
     activity: 'Atividade',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -499,6 +499,7 @@ export const ru: Localized<EnMessages> = {
   chat: {
     title: 'Чат',
     typing: 'печатает…',
+    notSentRetry: 'Не отправлено — нажми, чтобы повторить',
     editing: 'Редактирование',
     correcting: 'Исправление',
     activity: 'Активность',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -434,6 +434,7 @@ export const tr: Localized<EnMessages> = {
   chat: {
     title: 'Sohbet',
     typing: 'yazıyor…',
+    notSentRetry: 'Gönderilmedi — tekrar denemek için dokun',
     editing: 'Düzenleniyor',
     correcting: 'Düzeltiliyor',
     activity: 'Etkinlik',

--- a/apps/mobile/src/lib/socket.ts
+++ b/apps/mobile/src/lib/socket.ts
@@ -1,4 +1,4 @@
-import { APP_SCHEME } from '@langx/shared'
+import { APP_SCHEME, SOCKET_ACK_TIMEOUT_MS } from '@langx/shared'
 import { Platform } from 'react-native'
 import { io, type Socket } from 'socket.io-client'
 import { API_URL } from './apiUrl'
@@ -40,13 +40,29 @@ export function closeSocket(): void {
   socket = null
 }
 
-/** Promise wrapper over socket.io's ack callback, with the API's error shape. */
+/**
+ * Promise wrapper over socket.io's ack callback, with the API's error shape.
+ *
+ * `.timeout()` is not optional decoration. Without it socket.io registers the
+ * ack with no timer, and `_clearAcks` on close only invokes handlers that were
+ * created with one — so a connection dying after the frame is sent but before
+ * the ack returns left this promise unsettled *forever*. The caller's
+ * `finally` never ran, `sending` stayed true, and the send button was disabled
+ * until the reader left the screen.
+ */
 export function emitWithAck<T>(s: Socket, event: string, payload: unknown): Promise<T> {
   return new Promise((resolve, reject) => {
-    s.emit(
+    s.timeout(SOCKET_ACK_TIMEOUT_MS).emit(
       event,
       payload,
-      (response: { ok: boolean; data?: T; error?: { code: string; message: string } }) => {
+      (
+        timeout: Error | null,
+        response?: { ok: boolean; data?: T; error?: { code: string; message: string } },
+      ) => {
+        if (timeout || !response) {
+          reject(Object.assign(new Error('ack timed out'), { code: ACK_TIMEOUT }))
+          return
+        }
         if (response.ok) resolve(response.data as T)
         else
           reject(
@@ -58,5 +74,8 @@ export function emitWithAck<T>(s: Socket, event: string, payload: unknown): Prom
     )
   })
 }
+
+/** The code an ack timeout rejects with, so callers can word it as "not sent". */
+export const ACK_TIMEOUT = 'ACK_TIMEOUT'
 
 export { APP_SCHEME }

--- a/apps/mobile/src/lib/unsentMessages.test.ts
+++ b/apps/mobile/src/lib/unsentMessages.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { addUnsent, MAX_UNSENT, newClientId, removeUnsent, retireDelivered } from './unsentMessages'
+
+const at = (clientId: string, body = 'hi') => ({ clientId, body, failedAt: '2026-08-31T12:00:00Z' })
+
+describe('addUnsent', () => {
+  it('puts the newest first, matching the inverted thread', () => {
+    const list = addUnsent(addUnsent([], at('a')), at('b'))
+    expect(list.map((m) => m.clientId)).toEqual(['b', 'a'])
+  })
+
+  /** A retry that fails again must update its own row, not stack a copy. */
+  it('replaces by clientId rather than appending', () => {
+    const list = addUnsent(addUnsent([], at('a', 'first')), at('a', 'second'))
+    expect(list).toHaveLength(1)
+    expect(list[0]?.body).toBe('second')
+  })
+
+  it('caps the list so a long offline stretch cannot grow the thread', () => {
+    let list = [] as ReturnType<typeof addUnsent>
+    for (let i = 0; i < MAX_UNSENT + 5; i++) list = addUnsent(list, at(`m${i}`))
+    expect(list).toHaveLength(MAX_UNSENT)
+    // The oldest are the ones dropped.
+    expect(list[0]?.clientId).toBe(`m${MAX_UNSENT + 4}`)
+  })
+})
+
+describe('removeUnsent', () => {
+  it('drops only the one that finally sent', () => {
+    const list = removeUnsent(addUnsent(addUnsent([], at('a')), at('b')), 'a')
+    expect(list.map((m) => m.clientId)).toEqual(['b'])
+  })
+
+  it('is a no-op for an id that is not there', () => {
+    const list = addUnsent([], at('a'))
+    expect(removeUnsent(list, 'zzz')).toHaveLength(1)
+  })
+})
+
+describe('newClientId', () => {
+  it('differs for the same instant with different randomness', () => {
+    expect(newClientId(1, 0.1)).not.toBe(newClientId(1, 0.2))
+  })
+})
+
+describe('retireDelivered', () => {
+  const list = [at('a'), at('b')]
+
+  /**
+   * The case that showed up on screen before this existed: the ack timed out,
+   * the message had actually arrived, and the thread showed the same sentence
+   * twice — once delivered, once as "not sent".
+   */
+  it('drops a row whose message did arrive', () => {
+    expect(retireDelivered(list, ['a']).map((m) => m.clientId)).toEqual(['b'])
+  })
+
+  it('ignores messages with no clientId, which is every older one', () => {
+    expect(retireDelivered(list, [undefined, undefined])).toHaveLength(2)
+  })
+
+  it('returns the same list when nothing matches', () => {
+    expect(retireDelivered(list, ['zzz'])).toHaveLength(2)
+  })
+})

--- a/apps/mobile/src/lib/unsentMessages.ts
+++ b/apps/mobile/src/lib/unsentMessages.ts
@@ -1,0 +1,75 @@
+/**
+ * Messages typed into the composer that never reached the server.
+ *
+ * Kept because the alternative is what the app did before: `send()` had a
+ * `try/finally` with no `catch`, both call sites were `void send()`, and there
+ * is no global rejection handler — so a failed send became an unhandled promise
+ * rejection and the reader was shown nothing at all. The text survived only in
+ * React state, and only until they left the screen.
+ *
+ * A pure module so the queue is reachable by vitest, which only sees
+ * `src/lib/**` and `src/i18n/**`. The same logic inside the chat screen would
+ * never be tested.
+ *
+ * Not persisted yet, deliberately. Surviving an app kill needs a real store —
+ * `localFlags` swallows its own write failures by design, which is exactly the
+ * wrong contract for a queue — and a server-side `clientId` so a retry cannot
+ * double-post. Both are their own change; this one stops the silent loss.
+ */
+
+export interface UnsentMessage {
+  /** Client-minted, so a row exists before the server has given it an id. */
+  clientId: string
+  body: string
+  replyToMessageId?: string
+  /** For ordering, and so a retry can report how long it has been waiting. */
+  failedAt: string
+}
+
+/**
+ * A ceiling, so a long offline stretch cannot grow the thread without bound.
+ * Well above any realistic run of failures — this is a guard, not a quota.
+ */
+export const MAX_UNSENT = 20
+
+/**
+ * Newest first, matching the inverted thread it is rendered into.
+ *
+ * Replaces by `clientId` rather than appending, so a retry that fails again
+ * updates the row it came from instead of stacking a second copy of the same
+ * sentence.
+ */
+export function addUnsent(list: readonly UnsentMessage[], message: UnsentMessage): UnsentMessage[] {
+  const withoutSelf = list.filter((entry) => entry.clientId !== message.clientId)
+  return [message, ...withoutSelf].slice(0, MAX_UNSENT)
+}
+
+export function removeUnsent(list: readonly UnsentMessage[], clientId: string): UnsentMessage[] {
+  return list.filter((entry) => entry.clientId !== clientId)
+}
+
+/**
+ * Drops rows whose message turns out to have arrived after all.
+ *
+ * A send whose ack is lost is indistinguishable from one that never left, so
+ * the row appears either way — and a message that *did* land then sits in the
+ * thread twice, once as delivered and once as "not sent". The server echoes the
+ * `clientId` back to its author precisely so the second one can be retired.
+ */
+export function retireDelivered(
+  list: readonly UnsentMessage[],
+  deliveredClientIds: readonly (string | undefined)[],
+): UnsentMessage[] {
+  const delivered = new Set(deliveredClientIds.filter((id): id is string => Boolean(id)))
+  if (delivered.size === 0) return list as UnsentMessage[]
+  return list.filter((entry) => !delivered.has(entry.clientId))
+}
+
+/**
+ * A client id that does not need `crypto.randomUUID`, which Hermes does not
+ * ship. Only ever compared against other ids in this list, so it needs to be
+ * unique on one device and nothing more.
+ */
+export function newClientId(now: number, random: number): string {
+  return `${now.toString(36)}-${Math.floor(random * 1e9).toString(36)}`
+}

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -64,10 +64,20 @@ export type MessageType = (typeof MESSAGE_TYPES)[number]
  */
 export const REPLY_PREVIEW_MAX_LENGTH = 140
 
+/**
+ * A client-minted id for one attempt to send, so a retry cannot double-post.
+ *
+ * Bounded and opaque: the server only ever compares it against this sender's
+ * other ids, never parses it. Optional because an older build sends none — such
+ * a message simply gets no protection, which is what it had before.
+ */
+export const clientMessageIdSchema = z.string().trim().min(1).max(64)
+
 export const sendTextMessageSchema = z.object({
   conversationId: z.string().trim().min(1),
   body: messageBodySchema,
   replyToMessageId: z.string().trim().min(1).optional(),
+  clientId: clientMessageIdSchema.optional(),
 })
 export type SendTextMessageInput = z.infer<typeof sendTextMessageSchema>
 
@@ -94,6 +104,21 @@ export type SendCorrectionInput = z.infer<typeof sendCorrectionSchema>
  * decision. Plain 🔥 rather than WhatsApp's ❤️‍🔥: the flame is already the
  * streak's symbol in this app and reusing it here keeps one meaning per glyph.
  */
+/**
+ * How long to wait for a socket ack before treating a send as failed.
+ *
+ * Without one, socket.io registers the ack with **no timer at all** and only
+ * invokes it on close if it was created with a timeout — so a connection that
+ * dies after the frame goes out but before the ack returns leaves the promise
+ * unsettled forever. In the app that meant `finally { setSending(false) }` never
+ * ran and the send button stayed disabled until the screen was left.
+ *
+ * Comfortably longer than a round trip on a bad connection and comfortably
+ * shorter than the ~45s it takes the server's default ping timeout to notice a
+ * dead socket, which is the window this is closing.
+ */
+export const SOCKET_ACK_TIMEOUT_MS = 12_000
+
 export const MESSAGE_REACTIONS = ['👍', '❤️', '😂', '😮', '😢', '🙏', '🔥'] as const
 export type MessageReaction = (typeof MESSAGE_REACTIONS)[number]
 


### PR DESCRIPTION
Two defects in the same twenty lines, and together the worst data loss in the
app.

## 1. `emitWithAck` had no ack timeout

socket.io registers an ack with **no timer at all** unless `.timeout()` is used,
and `_clearAcks` on close only invokes handlers that were created with one. So a
connection dying *after* the frame went out but *before* the ack came back left
the promise **unsettled forever**:

- `finally { setSending(false) }` never ran
- `sending` stayed `true`
- the send button was disabled until the reader left the screen

The server sets no `pingTimeout` either, so that window ran to roughly 45
seconds of a dead radio while `socket.connected` was still `true`.

## 2. `send()` had no `catch`

`try/finally`, both call sites `void send()`, no global rejection handler. **A
failed text send showed the reader nothing whatsoever.** Its own siblings in the
same file already did better — `emit()` and `sendMedia()` both catch. Text send
was the one path that did not.

## What it does now

A failed send becomes a row in the thread: sender's side, `danger` outline,
*"Not sent — tap to try again"*. A toast could not do this job — a toast does not
sit next to the sentence it is about.

## Which surfaced the next problem, on screen

A send whose ack is lost is indistinguishable from one that never arrived. So a
message that **did** land appeared twice: once delivered with a tick, once as
"not sent". I caught this in the running app before writing it up.

The fix is the idempotency this write path never had:

- `clientId`, minted per attempt, sent with the message
- stored, and a repeat refused by a **unique index rather than a prior read** —
  the doctrine `decisions.md` already records and `legacy_id_unique` already
  follows
- echoed back **to its author only**, so a stale "not sent" row retires itself

### The index is partial, not sparse — and that distinction is load-bearing

A compound **sparse** index is sparse only when *every* indexed field is missing.
`senderId` is always present, so the sparse version indexes every message with a
null `clientId`, and `unique` then permits **one message per sender, forever**.

It broke fifty tests in a single run. In production it would have broken sending
itself, on the second message, for everybody. `partialFilterExpression:
{ clientId: { $exists: true } }` is the correct form, and it matches what
`deleted_at` and the ledger's `refId` index already do in this file.

## Verified against a real failure

Not DevTools "offline" — that closes the socket cleanly, which is the easy path.
The API process is `SIGSTOP`ed mid-send, so the socket stays open and simply
stops answering:

| | |
|---|---|
| while paused | "Not sent" row shown, text preserved, **composer still usable** (the wedge is gone) |
| after `SIGCONT` | row retires itself, message present **exactly once** |

Not persisted across an app kill. That needs a store `localFlags` cannot be — it
swallows its own write failures by design, which is the wrong contract for a
queue — and is its own change. This one stops the silent loss.

`pnpm test` 1074 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)