### PR TITLE
Raise the price of filling in a missed day

### DIFF
--- a/packages/shared/src/token.ts
+++ b/packages/shared/src/token.ts
@@ -142,6 +142,12 @@ export interface TokenRules {
      * ahead of a day you might miss and costs you the foresight; a repair is
      * bought after one you did miss and costs nothing but tokens. Pricing the
      * retrospective one lower would make the freeze pointless.
+     *
+     * Read it against what a day is worth rather than against the freeze alone.
+     * `messagesPerDay` caps a day's earning at 200, so this is roughly three
+     * days of committed use to buy one day back — which is the ratio that keeps
+     * the foresight discount worth having. At 300 it was a day and a half, and
+     * a freeze at 200 was barely cheaper than simply not bothering.
      */
     dayRepair: number
     /** How far back a day can still be repaired. */
@@ -239,7 +245,7 @@ export const TOKEN_RULES: TokenRules = {
     maxBankedStreakFreezes: 2,
     streakRestorePerDay: 20,
     streakRestoreMax: 2000,
-    dayRepair: 300,
+    dayRepair: 600,
     dayRepairMaxAgeDays: 14,
     dayRepairPerMonth: 2,
   },


### PR DESCRIPTION
300 tokens was **a day and a half** of committed use, measuring a day at the
`messagesPerDay` cap of 100 × 2 tokens. That made a freeze at 200 barely cheaper
than not bothering — and the pair only works if thinking ahead is visibly the
better deal.

600 is about **three days of use to buy one day back**.

The cap of two a month is still what stops a large balance manufacturing a
streak nobody lived — that was never the price's job, and the doc comment on
`dayRepairPerMonth` already says so. The price's job is to stop a repair being
the default habit.

One line: every consumer already reads `TOKEN_RULES.sinks.dayRepair`, and `300`
appears as a literal nowhere else in the repo.

## The mirror

The number is also published in `docs/token/utility.md`, which nothing keeps in
sync — `REPO_MAP.md` lists it as hand-kept. Updated in the same breath, along
with the ratio it now claims, in the `docs` repo.

Easy to tune if 600 is the wrong call: it is a single constant, and the paywall
and the confirm dialog both read it.

`pnpm test` 1070 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)