### PR TITLE
Put a history behind the streak number

### DIFF
--- a/apps/api/src/modules/tokens/streak.ts
+++ b/apps/api/src/modules/tokens/streak.ts
@@ -70,7 +70,7 @@ export async function recordQualifyingAction(
    * leave every day looking equally busy — and the set of filled days is what
    * a repair later has to recompute a streak length from.
    */
-  await recordStreakDay(db, profile._id, today)
+  await recordStreakDay(db, profile._id, today, at)
 
   if (profile.streak.lastQualifiedDay === today) return held
 

--- a/apps/api/src/modules/tokens/streakDays.ts
+++ b/apps/api/src/modules/tokens/streakDays.ts
@@ -30,6 +30,12 @@ export interface StreakDay {
   day: string
   /** How the square came to be filled. `purchase` is the only one that cost anything. */
   source: 'activity' | 'purchase'
+  /**
+   * When the first qualifying action of the day happened. Absent on days
+   * recorded before this field existed, and on a bought day — which has no
+   * check-in by definition, and must not be given a fabricated one.
+   */
+  firstAt?: Date
   /** Qualifying actions that day — the map's shading, not its fill. */
   actions: number
 }
@@ -51,13 +57,23 @@ export async function recordStreakDay(
   db: Db,
   userId: string,
   day: string,
+  at: Date,
   source: StreakDay['source'] = 'activity',
 ): Promise<void> {
   await db.collection<StreakDay>(COLLECTIONS.streakDays).updateOne(
     { _id: streakDayId(userId, day) },
     {
       $inc: { actions: 1 },
-      $setOnInsert: { userId, day, source },
+      /**
+       * `firstAt` under `$setOnInsert` is what makes it the *check-in* time:
+       * only the first qualifying action of the day writes it, and every later
+       * one leaves it alone. `$set` would turn it into "most recent action",
+       * which is a different fact and not the one worth showing.
+       *
+       * Days recorded before this field existed simply have none, and the
+       * history screen says the time is unknown rather than inventing one.
+       */
+      $setOnInsert: { userId, day, source, firstAt: at },
     },
     { upsert: true },
   )

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -4,6 +4,8 @@ import {
   localDayKey,
   repairDaySchema,
   TOKEN_RULES,
+  ACTIVITY_MAX_RANGE_DAYS,
+  shiftDayKey,
 } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { ApiError } from '../lib/ApiError'
@@ -32,7 +34,15 @@ export const activityRoutes: FastifyPluginAsyncZod = async (app) => {
 
       const { from, to } = request.query
       const today = localDayKey(new Date(), profile.timezone ?? 'UTC')
-      const days = await listStreakDays(app.mongo.db, request.userId, from, to)
+      /**
+       * Clamped, at last. `activityRangeSchema` validates the *shape* of the
+       * two keys and nothing else — no span, no ordering — while the client has
+       * carried a comment claiming "the server clamps the range" since the map
+       * shipped. Anyone could ask for a decade.
+       */
+      const oldest = shiftDayKey(today, -ACTIVITY_MAX_RANGE_DAYS)
+      const start = from < oldest ? oldest : from
+      const days = await listStreakDays(app.mongo.db, request.userId, start, to)
 
       return reply.send({
         today,
@@ -49,7 +59,17 @@ export const activityRoutes: FastifyPluginAsyncZod = async (app) => {
           current: profile.streak.current,
           lastQualifiedDay: profile.streak.lastQualifiedDay,
         },
-        days: days.map((d) => ({ day: d.day, actions: d.actions, source: d.source })),
+        days: days.map((d) => ({
+          day: d.day,
+          actions: d.actions,
+          source: d.source,
+          /**
+           * Absent on days recorded before the field existed, and on a bought
+           * day, which has no check-in. The client says so rather than
+           * inventing a time.
+           */
+          ...(d.firstAt ? { firstAt: d.firstAt.toISOString() } : {}),
+        })),
         repair: {
           price: TOKEN_RULES.sinks.dayRepair,
           maxAgeDays: TOKEN_RULES.sinks.dayRepairMaxAgeDays,

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -128,6 +128,7 @@ export default function AppLayout() {
         <Tabs.Screen name="kitchen" options={FULL_SCREEN} />
         <Tabs.Screen name="app-language" options={FULL_SCREEN} />
         <Tabs.Screen name="legal" options={FULL_SCREEN} />
+        <Tabs.Screen name="streak" options={FULL_SCREEN} />
       </Tabs>
     </SafeAreaView>
   )

--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -127,7 +127,13 @@ export default function MeScreen() {
       </View>
 
       <View style={styles.tiles}>
-        <StatTile label={t('me.dayStreak')} value={`🔥 ${summary?.streak.current ?? 0}`} />
+        {/* Same affordance as the wallet tile beside it: a number nobody can
+            act on reads as decoration. */}
+        <StatTile
+          label={`${t('me.dayStreak')} ›`}
+          value={`🔥 ${summary?.streak.current ?? 0}`}
+          onPress={() => router.push('/(app)/streak')}
+        />
         <StatTile
           tone="success"
           label={t('me.corrections')}

--- a/apps/mobile/app/(app)/streak.tsx
+++ b/apps/mobile/app/(app)/streak.tsx
@@ -1,0 +1,139 @@
+import Feather from '@expo/vector-icons/Feather'
+import { shiftDayKey } from '@langx/shared'
+import { useMemo } from 'react'
+import { ActivityIndicator, Text, View } from 'react-native'
+import { useActivity, useTokens } from '../../src/api/queries'
+import { EmptyState } from '../../src/components/ui/EmptyState'
+import { Screen } from '../../src/components/ui/Screen'
+import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
+import { StatTile } from '../../src/components/ui/StatTile'
+import { useLocale, useT } from '../../src/i18n'
+import type { TranslateFn } from '../../src/i18n/runtime'
+import { dayLabel } from '../../src/lib/messageGroups'
+import { goBackTo } from '../../src/lib/navigation'
+import { streakHistory, type StreakHistoryRow } from '../../src/lib/streakHistory'
+import { makeStyles, useTheme } from '../../src/lib/theme'
+
+/** Enough to read as a history without becoming a year of scrolling. */
+const DAYS = 60
+
+/**
+ * The days behind the number on the profile.
+ *
+ * The activity map answers "how consistent, roughly" in a shape you take in at
+ * a glance. This answers what the squares cannot: which day that was, when the
+ * check-in happened, and which of them were bought. Same endpoint, same data —
+ * a calendar and a list are not substitutes for one another.
+ */
+export default function StreakScreen() {
+  const t = useT()
+  const { locale } = useLocale()
+  const styles = useStyles()
+  const { colors } = useTheme()
+  const tokens = useTokens()
+
+  const to = new Date().toISOString().slice(0, 10)
+  const from = shiftDayKey(to, -DAYS)
+  const activity = useActivity(from, to)
+
+  const rows = useMemo(
+    () =>
+      activity.data
+        ? streakHistory({ today: activity.data.today, from, days: activity.data.days })
+        : [],
+    [activity.data, from],
+  )
+
+  if (activity.isPending) return <ActivityIndicator style={styles.loading} />
+
+  const streak = tokens.data?.streak
+  const now = new Date(`${activity.data?.today ?? to}T12:00:00`)
+
+  return (
+    <Screen scroll>
+      <ScreenHeader title={t('streak.title')} onBack={() => goBackTo('/(app)/me')} />
+
+      <View style={styles.tiles}>
+        <StatTile label={t('me.dayStreak')} value={`🔥 ${streak?.current ?? 0}`} />
+        <StatTile label={t('streak.longest')} value={String(streak?.longest ?? 0)} />
+      </View>
+
+      {rows.length === 0 ? (
+        <EmptyState icon="calendar" title={t('streak.emptyTitle')} body={t('streak.emptyBody')} />
+      ) : (
+        <View>
+          {rows.map((row) => (
+            <View key={row.day} style={styles.row}>
+              <Feather
+                name={
+                  row.kind === 'missed'
+                    ? 'circle'
+                    : row.kind === 'bought'
+                      ? 'shopping-bag'
+                      : 'check-circle'
+                }
+                size={18}
+                color={
+                  row.kind === 'missed'
+                    ? colors.textFaint
+                    : row.kind === 'bought'
+                      ? colors.streak
+                      : colors.success
+                }
+              />
+              <View style={styles.text}>
+                <Text style={row.kind === 'missed' ? styles.dayMissed : styles.day}>
+                  {dayLabel(row.day, { t, locale, now })}
+                </Text>
+                <Text style={styles.detail}>{detail(t, locale, row)}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+      )}
+    </Screen>
+  )
+}
+
+/**
+ * The one line under each date.
+ *
+ * A bought day says so and shows no time, because it has none — stamping one
+ * would be the screen inventing a check-in that never happened. A day recorded
+ * before the field existed says the time is unknown for the same reason.
+ */
+function detail(t: TranslateFn, locale: string, row: StreakHistoryRow): string {
+  if (row.kind === 'missed') return t('streak.missed')
+  if (row.kind === 'bought') return t('streak.bought')
+  if (!row.firstAt) return t('streak.checkedInUnknownTime')
+  const at = new Date(row.firstAt)
+  if (Number.isNaN(at.getTime())) return t('streak.checkedInUnknownTime')
+  return t('streak.checkedInAt', {
+    time: at.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' }),
+    count: row.actions,
+  })
+}
+
+const useStyles = makeStyles(({ colors, font, spacing }) => ({
+  loading: { paddingVertical: spacing.xl },
+  tiles: {
+    borderBottomColor: colors.border,
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    paddingBottom: 18,
+    paddingTop: spacing.sm,
+  },
+  row: {
+    alignItems: 'center',
+    borderBottomColor: colors.border,
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    gap: spacing.md,
+    paddingVertical: 14,
+  },
+  text: { flex: 1, gap: 2 },
+  day: { ...font.label, color: colors.text, fontSize: 15 },
+  // A missed day is still a row, but it is not news.
+  dayMissed: { ...font.label, color: colors.textMuted, fontSize: 15 },
+  detail: { ...font.caption, color: colors.textMuted },
+}))

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -342,6 +342,12 @@ export interface ActivityDayDto {
   day: string
   actions: number
   source: 'activity' | 'purchase'
+  /**
+   * When the first qualifying action of that day happened. Absent on days
+   * recorded before the field existed, and on a bought day — which has no
+   * check-in, and must not be shown one.
+   */
+  firstAt?: string
 }
 
 export interface ActivityDto {

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -835,6 +835,23 @@ export const ar: Localized<EnMessages> = {
     licenses: 'التراخيص',
     codeOfConduct: 'مدونة السلوك',
   },
+  streak: {
+    title: 'سلسلتك',
+    longest: 'الأطول',
+    missed: 'فائت',
+    bought: 'مُلئ بالنقاط',
+    checkedInUnknownTime: 'كنت نشطًا',
+    checkedInAt: {
+      zero: 'في {time} · {count} إجراء',
+      one: 'في {time} · إجراء واحد',
+      two: 'في {time} · إجراءان',
+      few: 'في {time} · {count} إجراءات',
+      many: 'في {time} · {count} إجراءً',
+      other: 'في {time} · {count} إجراء',
+    },
+    emptyTitle: 'لا شيء هنا بعد',
+    emptyBody: 'أرسل رسالة أو اكتب تصحيحًا، ويصبح اليوم أول أيامك.',
+  },
   settings: {
     appIconSection: 'أيقونة التطبيق',
     appIcon: 'الأيقونة على الشاشة الرئيسية',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -707,6 +707,19 @@ export const de: Localized<EnMessages> = {
     licenses: 'Lizenzen',
     codeOfConduct: 'Verhaltenskodex',
   },
+  streak: {
+    title: 'Deine Serie',
+    longest: 'Am längsten',
+    missed: 'Verpasst',
+    bought: 'Mit Token aufgefüllt',
+    checkedInUnknownTime: 'Aktiv gewesen',
+    checkedInAt: {
+      one: 'Um {time} · {count} Aktion',
+      other: 'Um {time} · {count} Aktionen',
+    },
+    emptyTitle: 'Hier ist noch nichts',
+    emptyBody: 'Schreib eine Nachricht oder eine Korrektur — heute wird dein erster Tag.',
+  },
   settings: {
     appIconSection: 'App-Symbol',
     appIcon: 'Symbol auf dem Homescreen',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -726,6 +726,19 @@ export const en = {
     licenses: 'Licenses',
     codeOfConduct: 'Code of conduct',
   },
+  streak: {
+    title: 'Your streak',
+    longest: 'Longest',
+    missed: 'Missed',
+    bought: 'Filled in with tokens',
+    checkedInUnknownTime: 'Checked in',
+    checkedInAt: {
+      one: 'Checked in at {time} · {count} action',
+      other: 'Checked in at {time} · {count} actions',
+    },
+    emptyTitle: 'Nothing here yet',
+    emptyBody: 'Send a message or write a correction, and today becomes your first day.',
+  },
   settings: {
     appIconSection: 'App icon',
     appIcon: 'Home screen icon',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -691,6 +691,19 @@ export const es: Localized<EnMessages> = {
     licenses: 'Licencias',
     codeOfConduct: 'Código de conducta',
   },
+  streak: {
+    title: 'Tu racha',
+    longest: 'La más larga',
+    missed: 'Perdido',
+    bought: 'Rellenado con tokens',
+    checkedInUnknownTime: 'Activo',
+    checkedInAt: {
+      one: 'A las {time} · {count} acción',
+      other: 'A las {time} · {count} acciones',
+    },
+    emptyTitle: 'Aquí todavía no hay nada',
+    emptyBody: 'Envía un mensaje o escribe una corrección y hoy será tu primer día.',
+  },
   settings: {
     appIconSection: 'Icono de la app',
     appIcon: 'Icono en la pantalla de inicio',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -690,6 +690,19 @@ export const fr: Localized<EnMessages> = {
     licenses: 'Licences',
     codeOfConduct: 'Code de conduite',
   },
+  streak: {
+    title: 'Ta série',
+    longest: 'La plus longue',
+    missed: 'Manqué',
+    bought: 'Rempli avec des jetons',
+    checkedInUnknownTime: 'Actif',
+    checkedInAt: {
+      one: 'À {time} · {count} action',
+      other: 'À {time} · {count} actions',
+    },
+    emptyTitle: 'Rien ici pour l’instant',
+    emptyBody: 'Envoie un message ou écris une correction, et aujourd’hui sera ton premier jour.',
+  },
   settings: {
     appIconSection: 'Icône de l’app',
     appIcon: 'Icône sur l’écran d’accueil',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -683,6 +683,19 @@ export const ptBR: Localized<EnMessages> = {
     licenses: 'Licenças',
     codeOfConduct: 'Código de conduta',
   },
+  streak: {
+    title: 'Sua sequência',
+    longest: 'A maior',
+    missed: 'Perdido',
+    bought: 'Preenchido com fichas',
+    checkedInUnknownTime: 'Ativo',
+    checkedInAt: {
+      one: 'Às {time} · {count} ação',
+      other: 'Às {time} · {count} ações',
+    },
+    emptyTitle: 'Ainda não há nada aqui',
+    emptyBody: 'Mande uma mensagem ou escreva uma correção, e hoje vira seu primeiro dia.',
+  },
   settings: {
     appIconSection: 'Ícone do app',
     appIcon: 'Ícone na tela inicial',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -798,6 +798,21 @@ export const ru: Localized<EnMessages> = {
     licenses: 'Лицензии',
     codeOfConduct: 'Кодекс поведения',
   },
+  streak: {
+    title: 'Твоя серия',
+    longest: 'Рекорд',
+    missed: 'Пропущено',
+    bought: 'Заполнено жетонами',
+    checkedInUnknownTime: 'Был(а) активен',
+    checkedInAt: {
+      one: 'В {time} · {count} действие',
+      few: 'В {time} · {count} действия',
+      many: 'В {time} · {count} действий',
+      other: 'В {time} · {count} действия',
+    },
+    emptyTitle: 'Здесь пока пусто',
+    emptyBody: 'Отправь сообщение или напиши исправление — и сегодня станет первым днём.',
+  },
   settings: {
     appIconSection: 'Иконка приложения',
     appIcon: 'Иконка на экране',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -698,6 +698,19 @@ export const tr: Localized<EnMessages> = {
     licenses: 'Lisanslar',
     codeOfConduct: 'Davranış kuralları',
   },
+  streak: {
+    title: 'Serin',
+    longest: 'En uzun',
+    missed: 'Kaçırıldı',
+    bought: 'Jetonla dolduruldu',
+    checkedInUnknownTime: 'Giriş yapıldı',
+    checkedInAt: {
+      one: '{time} · {count} işlem',
+      other: '{time} · {count} işlem',
+    },
+    emptyTitle: 'Burada henüz bir şey yok',
+    emptyBody: 'Bir mesaj gönder ya da bir düzeltme yaz; bugün ilk günün olsun.',
+  },
   settings: {
     appIconSection: 'Uygulama ikonu',
     appIcon: 'Ana ekran ikonu',

--- a/apps/mobile/src/lib/streakHistory.test.ts
+++ b/apps/mobile/src/lib/streakHistory.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { streakHistory } from './streakHistory'
+
+const day = (
+  d: string,
+  over: Partial<{ actions: number; source: 'activity' | 'purchase'; firstAt: string }> = {},
+) => ({
+  day: d,
+  actions: over.actions ?? 1,
+  source: over.source ?? ('activity' as const),
+  ...(over.firstAt ? { firstAt: over.firstAt } : {}),
+})
+
+describe('streakHistory', () => {
+  it('is newest first', () => {
+    const rows = streakHistory({
+      today: '2026-08-31',
+      from: '2026-08-01',
+      days: [day('2026-08-29'), day('2026-08-31')],
+    })
+    expect(rows[0]?.day).toBe('2026-08-31')
+    expect(rows.at(-1)?.day).toBe('2026-08-29')
+  })
+
+  /** The gaps are the point; a list of only the good days is a trophy cabinet. */
+  it('includes the days nothing happened', () => {
+    const rows = streakHistory({
+      today: '2026-08-31',
+      from: '2026-08-01',
+      days: [day('2026-08-29'), day('2026-08-31')],
+    })
+    expect(rows.map((r) => r.kind)).toEqual(['checkedIn', 'missed', 'checkedIn'])
+  })
+
+  /**
+   * An account made yesterday has not *missed* the fifty-nine days before it
+   * existed, and saying so would be both wrong and discouraging.
+   */
+  it('stops at the oldest day on record rather than filling the window', () => {
+    const rows = streakHistory({
+      today: '2026-08-31',
+      from: '2026-01-01',
+      days: [day('2026-08-30')],
+    })
+    expect(rows).toHaveLength(2)
+    expect(rows.map((r) => r.day)).toEqual(['2026-08-31', '2026-08-30'])
+  })
+
+  it('is empty when there is nothing on record', () => {
+    expect(streakHistory({ today: '2026-08-31', from: '2026-08-01', days: [] })).toEqual([])
+  })
+
+  it('marks a bought day as bought and carries no check-in time for it', () => {
+    const rows = streakHistory({
+      today: '2026-08-31',
+      from: '2026-08-30',
+      days: [day('2026-08-31', { source: 'purchase', actions: 0 })],
+    })
+    expect(rows[0]).toEqual({ day: '2026-08-31', kind: 'bought', actions: 0 })
+  })
+
+  it('carries the check-in time when there is one', () => {
+    const rows = streakHistory({
+      today: '2026-08-31',
+      from: '2026-08-31',
+      days: [day('2026-08-31', { firstAt: '2026-08-31T07:15:00Z', actions: 4 })],
+    })
+    expect(rows[0]).toMatchObject({
+      kind: 'checkedIn',
+      actions: 4,
+      firstAt: '2026-08-31T07:15:00Z',
+    })
+  })
+
+  /** Older rows than the caller asked for must not widen the list. */
+  it('never goes further back than the requested window', () => {
+    const rows = streakHistory({
+      today: '2026-08-31',
+      from: '2026-08-30',
+      days: [day('2026-01-01'), day('2026-08-31')],
+    })
+    expect(rows.map((r) => r.day)).toEqual(['2026-08-31', '2026-08-30'])
+  })
+})

--- a/apps/mobile/src/lib/streakHistory.ts
+++ b/apps/mobile/src/lib/streakHistory.ts
@@ -1,0 +1,62 @@
+import { shiftDayKey } from '@langx/shared'
+
+/** What happened on one day, as the history reads it. */
+export type StreakDayKind = 'checkedIn' | 'bought' | 'missed'
+
+export interface StreakHistoryRow {
+  day: string
+  kind: StreakDayKind
+  /** Qualifying actions that day. Zero on a bought day, by construction. */
+  actions: number
+  /** When the first one happened. Absent on a bought day and on old records. */
+  firstAt?: string
+}
+
+interface HistoryDay {
+  day: string
+  actions: number
+  source: 'activity' | 'purchase'
+  firstAt?: string
+}
+
+/**
+ * One row per day, newest first, including the days nothing happened.
+ *
+ * The activity map answers "how consistent, roughly" in a shape you take in at
+ * a glance. This answers what the squares cannot: which day that was, when the
+ * check-in happened, and which of them were bought. The missed days are the
+ * point — a list of only the good days is a trophy cabinet, not a history.
+ *
+ * It stops at the oldest day on record rather than filling the whole window.
+ * An account made yesterday has not *missed* the fifty-nine days before it
+ * existed, and saying it did would be both wrong and discouraging.
+ */
+export function streakHistory(input: {
+  today: string
+  from: string
+  days: readonly HistoryDay[]
+}): StreakHistoryRow[] {
+  const byDay = new Map(input.days.map((entry) => [entry.day, entry]))
+  const oldest = input.days.reduce<string | null>(
+    (found, entry) => (found === null || entry.day < found ? entry.day : found),
+    null,
+  )
+  if (oldest === null) return []
+
+  const floor = oldest < input.from ? input.from : oldest
+  const rows: StreakHistoryRow[] = []
+  for (let day = input.today; day >= floor; day = shiftDayKey(day, -1)) {
+    const entry = byDay.get(day)
+    if (!entry) {
+      rows.push({ day, kind: 'missed', actions: 0 })
+      continue
+    }
+    rows.push({
+      day,
+      kind: entry.source === 'purchase' ? 'bought' : 'checkedIn',
+      actions: entry.actions,
+      ...(entry.firstAt ? { firstAt: entry.firstAt } : {}),
+    })
+  }
+  return rows
+}

--- a/packages/shared/src/reservedHandles.ts
+++ b/packages/shared/src/reservedHandles.ts
@@ -44,6 +44,7 @@ const ROUTE_RESERVED = [
   'profile',
   'settings',
   'starred',
+  'streak',
   'store',
   'tokens',
   'viewers',

--- a/packages/shared/src/token.ts
+++ b/packages/shared/src/token.ts
@@ -464,6 +464,15 @@ export const tokenHistoryQuerySchema = z.object({
     .optional(),
 })
 
+/**
+ * The furthest back `GET /me/activity` will look.
+ *
+ * The range is caller-supplied and was never bounded, while the client carried
+ * a comment saying the server clamped it. A little over the half-year the map
+ * draws, so the map keeps working and a request for a decade does not.
+ */
+export const ACTIVITY_MAX_RANGE_DAYS = 400
+
 export const activityRangeSchema = z.object({
   from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),


### PR DESCRIPTION
The 🔥 on the profile was a number nobody could act on. The activity map beside
it answers "how consistent, roughly" — a shape you take in at a glance and
cannot interrogate. It cannot tell you *which* day that square was, when you
checked in, or which of them you bought.

Tapping the tile now opens a list that can. Same endpoint, same data: a calendar
and a list are not substitutes for one another.

## The check-in time did not exist

`streakDays` held `{ day, source, actions }` and nothing with a clock.
`recordStreakDay` did not even take a `Date` — while `recordQualifyingAction`,
its only caller, had one in hand and was throwing it away.

It now writes `firstAt` under **`$setOnInsert`**, which is what makes it the
*check-in* rather than the most recent action: only the first qualifying action
of a day writes it, every later one leaves it alone. `$set` would have recorded
something else entirely.

Two honest absences, both rendered rather than papered over:

- **Days recorded before the field existed** say the time is unknown. No
  backfill: `tokenLedger.createdAt` could reconstruct some of them, but it is
  bucketed by UTC day while a streak day is local, and it writes no row at all
  for a user earning zero — so it would be a guess dressed as a fact.
- **A bought day shows no time**, because it has none. Stamping one would be the
  screen inventing a check-in that never happened, which is the same reason
  `repairDay` does not set the field either.

## The missed days are in the list on purpose

A history of only the good days is a trophy cabinet. It does stop at the oldest
day on record rather than filling the window: an account made yesterday has not
*missed* the fifty-nine days before it existed, and saying so would be both
wrong and discouraging.

## Also: the activity range is finally clamped

`activityRangeSchema` validated the shape of the two date keys and nothing else
— no span, no ordering — while `ActivityMap.tsx` has carried a comment saying
*"the server clamps the range"* since the map shipped. Anyone could ask for a
decade. Now the comment is true.

## Verified in the running app

Seeded a run, a gap, a bought day and a pre-field row, then opened it from the
profile tile:

```
Today        ✓ Checked in at 06:15 AM · 4 actions
Yesterday    ✓ Checked in at 06:15 AM · 12 actions
August 29    ○ Missed
August 28    🛍 Filled in with tokens
August 27    ✓ Checked in                 ← time unknown, not invented
August 26    ✓ Checked in at 06:15 AM · 7 actions
```

`pnpm test` 1088 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)