### PR TITLE
Put the corrections you wrote behind the count

### DIFF
--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -198,6 +198,24 @@ export const INDEXES: Partial<IndexSpec> = {
      */
     { key: { senderId: 1, type: 1 }, name: 'sender_type' },
     /**
+     * "Everything this person has corrected, newest first" — the corrections
+     * history screen, paged.
+     *
+     * `sender_type` above gives the exact filter and carries no `createdAt`, so
+     * ordering through it is an in-memory sort of every correction the user has
+     * ever written. Fine for the `countDocuments` it was built for; wrong for a
+     * list. `_id` is on the end for the same reason `conversation_created_id`
+     * has it: a keyset cursor tie-breaks on it, and without it the sort falls
+     * back to memory anyway.
+     *
+     * A new name rather than widening `sender_type`, because changing the keys
+     * of a live index is an `IndexOptionsConflict` at boot, not an upgrade.
+     */
+    {
+      key: { senderId: 1, type: 1, createdAt: -1, _id: -1 },
+      name: 'sender_type_created',
+    },
+    /**
      * The starred screen, which is a `find` by one user across every
      * conversation they are in — without this it is a scan of the whole
      * messages collection, and it grows with the app rather than with the

--- a/apps/api/src/modules/chat/corrections.ts
+++ b/apps/api/src/modules/chat/corrections.ts
@@ -1,0 +1,64 @@
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { decodeDateIdCursor, encodeDateIdCursor } from '../../lib/dateIdCursor'
+import type { Message } from './conversations'
+
+export interface CorrectionsPage {
+  items: Message[]
+  nextCursor: string | null
+}
+
+/**
+ * Every chat correction one person has written, newest first.
+ *
+ * A sibling of `listStarredMessages` — the other read in the chat area that is
+ * not scoped to a thread — but **paged**, which starred deliberately is not. A
+ * bookmark list people actually keep is tens of items and the server caps it; a
+ * correction history is the number on somebody's profile, which is meant to
+ * grow without bound. Capping it would quietly hide the older half of the thing
+ * the screen exists to show.
+ *
+ * Chat only. Post corrections live in a different collection with a different
+ * shape — no `original` of their own, because the original is the post's body —
+ * and merging the two in one Mongo query is not possible. The screen shows the
+ * chat half and says so; the feed already has its own per-post list.
+ *
+ * Rides `sender_type_created`. `sender_type` gives the same filter with no
+ * `createdAt`, which sorts every correction the user ever wrote in memory.
+ */
+export async function listCorrectionsWritten(
+  db: Db,
+  userId: string,
+  limit: number,
+  cursor?: string,
+): Promise<CorrectionsPage> {
+  const filter: Record<string, unknown> = {
+    senderId: userId,
+    type: 'correction',
+    deletedAt: { $exists: false },
+  }
+
+  if (cursor) {
+    const { date, id } = decodeDateIdCursor(cursor)
+    // Keyset, not skip: an offset shifts under a correction written while the
+    // reader is paging, which repeats or drops a row.
+    filter.$or = [{ createdAt: { $lt: date } }, { createdAt: date, _id: { $lt: id } }]
+  }
+
+  // One over, so "is there another page" is answered without a second count.
+  const rows = await db
+    .collection<Message>(COLLECTIONS.messages)
+    .find(filter)
+    .sort({ createdAt: -1, _id: -1 })
+    .limit(limit + 1)
+    .toArray()
+
+  const hasMore = rows.length > limit
+  const items = hasMore ? rows.slice(0, limit) : rows
+  const last = items.at(-1)
+
+  return {
+    items,
+    nextCursor: hasMore && last ? encodeDateIdCursor(last.createdAt, last._id) : null,
+  }
+}

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -120,6 +120,69 @@ describe('Faz 5 — conversation/message history REST', () => {
    * so the client retries it. Without the index behind this, the message it
    * already delivered would be posted a second time.
    */
+  describe('the corrections you have written', () => {
+    it('lists them newest first, and pages without repeating or skipping', async () => {
+      const a = await newUser('corr-list-a@example.com')
+      const b = await newUser('corr-list-b@example.com')
+      const conversationId = (await startConversation(a, b.userId))._id
+      const { sendTextMessage, sendCorrection } = await import('../modules/chat/messages')
+
+      const targets: string[] = []
+      for (let i = 0; i < 5; i++) {
+        const sent = await sendTextMessage(handle.db, b.userId, {
+          conversationId,
+          body: `i writed ${i}`,
+        })
+        targets.push(String(sent.message._id))
+      }
+      for (const [i, targetMessageId] of targets.entries()) {
+        await sendCorrection(handle.db, a.userId, {
+          conversationId,
+          targetMessageId,
+          corrected: `I wrote ${i}`,
+        })
+      }
+
+      const seen: string[] = []
+      let cursor: string | null | undefined
+      for (let guard = 0; guard < 5; guard++) {
+        const url = `/me/corrections?limit=2${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`
+        const response = await app.inject({ method: 'GET', url, headers: { cookie: a.cookie } })
+        expect(response.statusCode, response.body).toBe(200)
+        const body = response.json<{ items: { _id: string }[]; nextCursor: string | null }>()
+        seen.push(...body.items.map((m) => m._id))
+        cursor = body.nextCursor
+        if (!cursor) break
+      }
+
+      expect(seen).toHaveLength(5)
+      expect(new Set(seen).size).toBe(5)
+    })
+
+    /** The other side's corrections are theirs, not yours. */
+    it('lists only your own', async () => {
+      const a = await newUser('corr-mine-a@example.com')
+      const b = await newUser('corr-mine-b@example.com')
+      const conversationId = (await startConversation(a, b.userId))._id
+      const { sendTextMessage, sendCorrection } = await import('../modules/chat/messages')
+
+      const fromB = await sendTextMessage(handle.db, b.userId, { conversationId, body: 'i writed' })
+      await sendCorrection(handle.db, a.userId, {
+        conversationId,
+        targetMessageId: String(fromB.message._id),
+        corrected: 'I wrote',
+      })
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/me/corrections',
+        headers: { cookie: b.cookie },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+      expect(response.json<{ items: unknown[] }>().items).toHaveLength(0)
+    })
+  })
+
   it('does not post a resent message twice', async () => {
     const a = await newUser('idem-a@example.com')
     const b = await newUser('idem-b@example.com')

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -4,6 +4,7 @@ import {
   listConversationsQuerySchema,
   listMessagesQuerySchema,
   listStarredQuerySchema,
+  listCorrectionsQuerySchema,
 } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { z } from 'zod'
@@ -16,6 +17,7 @@ import {
   markConversationRead,
 } from '../modules/chat/messages'
 import { toMessageView } from '../modules/chat/messageView'
+import { listCorrectionsWritten } from '../modules/chat/corrections'
 import { listStarredMessages, setConversationFlag } from '../modules/chat/mutations'
 
 // eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
@@ -111,6 +113,31 @@ export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request, reply) => {
       const messages = await listStarredMessages(app.mongo.db, request.userId, request.query.limit)
       return reply.send({ items: messages.map((m) => toMessageView(m, request.userId)) })
+    },
+  )
+
+  /**
+   * The list behind the corrections count on the profile.
+   *
+   * Hangs off `/me` for the same reason `/me/starred` does — it is a read
+   * across every conversation rather than within one — but paged, because a
+   * correction history is meant to grow and a capped list would hide the older
+   * half of the thing the screen exists to show.
+   */
+  app.get(
+    '/me/corrections',
+    { preHandler: requireAuth, schema: { querystring: listCorrectionsQuerySchema } },
+    async (request, reply) => {
+      const page = await listCorrectionsWritten(
+        app.mongo.db,
+        request.userId,
+        request.query.limit,
+        request.query.cursor,
+      )
+      return reply.send({
+        items: page.items.map((m) => toMessageView(m, request.userId)),
+        nextCursor: page.nextCursor,
+      })
     },
   )
 

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -129,6 +129,7 @@ export default function AppLayout() {
         <Tabs.Screen name="app-language" options={FULL_SCREEN} />
         <Tabs.Screen name="legal" options={FULL_SCREEN} />
         <Tabs.Screen name="streak" options={FULL_SCREEN} />
+        <Tabs.Screen name="corrections" options={FULL_SCREEN} />
       </Tabs>
     </SafeAreaView>
   )

--- a/apps/mobile/app/(app)/corrections.tsx
+++ b/apps/mobile/app/(app)/corrections.tsx
@@ -1,0 +1,150 @@
+import { useMemo } from 'react'
+import { ActivityIndicator, FlatList, Pressable, Text } from 'react-native'
+import { router } from 'expo-router'
+import { useCorrectionsWritten, type MessageDto } from '../../src/api/queries'
+import { EmptyState } from '../../src/components/ui/EmptyState'
+import { Screen } from '../../src/components/ui/Screen'
+import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
+import { useLocale, useT } from '../../src/i18n'
+import type { Locale } from '@langx/shared'
+import { dedupeById } from '../../src/lib/dedupeById'
+import { foldCorrection } from '../../src/lib/feedCache'
+import { dayLabel } from '../../src/lib/messageGroups'
+import { goBackTo } from '../../src/lib/navigation'
+import { listState } from '../../src/lib/listState'
+import { makeStyles } from '../../src/lib/theme'
+
+/**
+ * Every correction you have written, newest first.
+ *
+ * The count on the profile was a number with nothing behind it, and the
+ * corrections themselves were scattered one per conversation — findable only by
+ * remembering who you had helped.
+ *
+ * Chat corrections only. Post corrections live in another collection with a
+ * different shape (no `original` of their own — the original is the post's
+ * body), the feed already lists them per post, and merging the two in one query
+ * is not possible. The count on the profile includes both, so this screen says
+ * which half it is showing rather than quietly disagreeing with the tile.
+ */
+export default function CorrectionsScreen() {
+  const t = useT()
+  const { locale } = useLocale()
+  const styles = useStyles()
+  const page = useCorrectionsWritten()
+
+  const items = useMemo(
+    () => dedupeById(page.data?.pages.flatMap((p) => p.items) ?? []),
+    [page.data],
+  )
+  const state = listState({
+    isPending: page.isPending,
+    isError: page.isError,
+    itemCount: items.length,
+  })
+
+  return (
+    <Screen fluid>
+      <ScreenHeader title={t('corrections.title')} onBack={() => goBackTo('/(app)/me')} />
+      {state === 'skeleton' ? (
+        <ActivityIndicator style={styles.loading} />
+      ) : state === 'empty' ? (
+        <EmptyState
+          icon="edit-3"
+          title={t('corrections.emptyTitle')}
+          body={t('corrections.emptyBody')}
+        />
+      ) : (
+        <FlatList
+          data={items}
+          keyExtractor={(item) => String(item._id)}
+          onEndReached={() => {
+            if (page.hasNextPage && !page.isFetchingNextPage) void page.fetchNextPage()
+          }}
+          onEndReachedThreshold={0.4}
+          ListFooterComponent={
+            page.isFetchingNextPage ? <ActivityIndicator style={styles.loading} /> : null
+          }
+          renderItem={({ item }) => <Row message={item} t={t} locale={locale} styles={styles} />}
+        />
+      )}
+    </Screen>
+  )
+}
+
+function Row({
+  message,
+  t,
+  locale,
+  styles,
+}: {
+  message: MessageDto
+  t: ReturnType<typeof useT>
+  locale: Locale
+  styles: ReturnType<typeof useStyles>
+}) {
+  const correction = message.correction
+  /**
+   * The folded diff — the corrected sentence with the removals struck through
+   * in place — not the two-line before/after the chat bubble draws. A row does
+   * not have space for two lines, which is exactly why `foldCorrection` exists
+   * and why the feed's correction panel already uses it.
+   */
+  const runs = correction ? foldCorrection(correction.original, message.body) : null
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={() =>
+        router.push(
+          `/(app)/chat/${String(message.conversationId)}?at=${encodeURIComponent(String(message._id))}`,
+        )
+      }
+      style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+    >
+      <Text style={styles.fold} numberOfLines={3}>
+        {runs
+          ? runs.map((run, index) => (
+              <Text
+                key={index}
+                style={
+                  run.kind === 'removed'
+                    ? styles.removed
+                    : run.kind === 'added'
+                      ? styles.added
+                      : undefined
+                }
+              >
+                {run.text}
+              </Text>
+            ))
+          : message.body}
+      </Text>
+      {correction?.note ? (
+        <Text style={styles.note} numberOfLines={2}>
+          {correction.note}
+        </Text>
+      ) : null}
+      <Text style={styles.when}>{dayLabel(message.createdAt.slice(0, 10), { t, locale })}</Text>
+    </Pressable>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, spacing }) => ({
+  loading: { paddingVertical: spacing.lg },
+  row: {
+    borderBottomColor: colors.border,
+    borderBottomWidth: 1,
+    gap: 4,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: 14,
+  },
+  pressed: { opacity: 0.6 },
+  fold: { ...font.body, color: colors.text, fontSize: 15, lineHeight: 22 },
+  // Not colour alone: the strike-through is what carries the meaning for a
+  // reader who cannot tell the two hues apart.
+  removed: { color: colors.textMuted, textDecorationLine: 'line-through' },
+  added: { color: colors.success, fontWeight: '600' },
+  note: { ...font.caption, color: colors.textMuted },
+  when: { ...font.caption, color: colors.textFaint },
+}))

--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -134,10 +134,14 @@ export default function MeScreen() {
           value={`🔥 ${summary?.streak.current ?? 0}`}
           onPress={() => router.push('/(app)/streak')}
         />
+        {/* The number was already "corrections I wrote, chat and posts, for
+            life" — exactly the list behind it, so the tile and the screen
+            cannot disagree about what they are counting. */}
         <StatTile
           tone="success"
-          label={t('me.corrections')}
+          label={`${t('me.corrections')} ›`}
           value={String(summary?.lifetime.corrections ?? 0)}
+          onPress={() => router.push('/(app)/corrections')}
         />
         {/* The balance is the way into the wallet — a number nobody can act
             on reads as decoration, and the wallet has nowhere else to be

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -73,6 +73,7 @@ export const keys = {
    */
   messagesAround: (id: string, anchorId: string) => ['messages', id, 'around', anchorId] as const,
   starred: ['starred'] as const,
+  corrections: ['corrections'] as const,
   activity: (from: string, to: string) => ['activity', from, to] as const,
   tokens: ['tokens'] as const,
   tokenHistory: ['tokens', 'history'] as const,
@@ -437,6 +438,22 @@ export function useStarred() {
   return useQuery({
     queryKey: keys.starred,
     queryFn: () => api.get<{ items: MessageDto[] }>('/me/starred'),
+  })
+}
+
+/**
+ * Paged, unlike `useStarred`. A correction history is the number on the
+ * profile, so it grows; a bookmark list is tens of items and capped.
+ */
+export function useCorrectionsWritten() {
+  return useInfiniteQuery({
+    queryKey: keys.corrections,
+    queryFn: ({ pageParam }) =>
+      api.get<{ items: MessageDto[]; nextCursor: string | null }>(
+        `/me/corrections${pageParam ? `?cursor=${encodeURIComponent(pageParam)}` : ''}`,
+      ),
+    initialPageParam: '',
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
   })
 }
 

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -408,6 +408,11 @@ export const ar: Localized<EnMessages> = {
     microphonePermission: 'يحتاج LangX إلى إذن الميكروفون لتسجيل رسالة صوتية.',
   },
 
+  corrections: {
+    title: 'تصحيحاتك',
+    emptyTitle: 'لا تصحيحات بعد',
+    emptyBody: 'اضغط مطولًا على رسالة واختر «صحّح» — أنفع ما يمكنك فعله هنا.',
+  },
   discover: {
     searchHandles: 'البحث باسم المستخدم',
     searchPlaceholder: 'اسم المستخدم',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -347,6 +347,12 @@ export const de: Localized<EnMessages> = {
     microphonePermission: 'LangX braucht Mikrofonzugriff, um eine Sprachnachricht aufzunehmen.',
   },
 
+  corrections: {
+    title: 'Deine Korrekturen',
+    emptyTitle: 'Noch keine Korrekturen',
+    emptyBody:
+      'Halte eine Nachricht gedrückt und wähle Korrigieren — das Nützlichste, was du hier tun kannst.',
+  },
   discover: {
     searchHandles: 'Nach Benutzername suchen',
     searchPlaceholder: 'Benutzername',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -374,6 +374,12 @@ export const en = {
     microphonePermission: 'LangX needs microphone access to record a voice message.',
   },
 
+  corrections: {
+    title: 'Corrections you wrote',
+    emptyTitle: 'No corrections yet',
+    emptyBody:
+      'Hold a message in a chat and choose Correct — it is the most useful thing you can do here.',
+  },
   discover: {
     searchHandles: 'Search by username',
     searchPlaceholder: 'Username',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -345,6 +345,11 @@ export const es: Localized<EnMessages> = {
     microphonePermission: 'LangX necesita acceso al micrófono para grabar un mensaje de voz.',
   },
 
+  corrections: {
+    title: 'Correcciones que escribiste',
+    emptyTitle: 'Aún no hay correcciones',
+    emptyBody: 'Mantén pulsado un mensaje y elige Corregir: es lo más útil que puedes hacer aquí.',
+  },
   discover: {
     searchHandles: 'Buscar por nombre de usuario',
     searchPlaceholder: 'Nombre de usuario',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -345,6 +345,11 @@ export const fr: Localized<EnMessages> = {
     microphonePermission: 'LangX a besoin du micro pour enregistrer un message vocal.',
   },
 
+  corrections: {
+    title: 'Tes corrections',
+    emptyTitle: 'Pas encore de corrections',
+    emptyBody: 'Appuie longuement sur un message et choisis Corriger — c’est le plus utile ici.',
+  },
   discover: {
     searchHandles: 'Rechercher par nom d’utilisateur',
     searchPlaceholder: 'Nom d’utilisateur',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -340,6 +340,12 @@ export const ptBR: Localized<EnMessages> = {
     microphonePermission: 'O LangX precisa do microfone para gravar uma mensagem de voz.',
   },
 
+  corrections: {
+    title: 'Correções que você escreveu',
+    emptyTitle: 'Ainda sem correções',
+    emptyBody:
+      'Segure uma mensagem e escolha Corrigir — é a coisa mais útil que você pode fazer aqui.',
+  },
   discover: {
     searchHandles: 'Buscar por nome de usuário',
     searchPlaceholder: 'Nome de usuário',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -392,6 +392,12 @@ export const ru: Localized<EnMessages> = {
     microphonePermission: 'Чтобы записать голосовое, LangX нужен доступ к микрофону.',
   },
 
+  corrections: {
+    title: 'Твои исправления',
+    emptyTitle: 'Исправлений пока нет',
+    emptyBody:
+      'Задержи палец на сообщении и выбери «Исправить» — это самое полезное, что тут можно сделать.',
+  },
   discover: {
     searchHandles: 'Поиск по имени пользователя',
     searchPlaceholder: 'Имя пользователя',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -349,6 +349,12 @@ export const tr: Localized<EnMessages> = {
     microphonePermission: 'Sesli mesaj kaydetmek için LangX’in mikrofon iznine ihtiyacı var.',
   },
 
+  corrections: {
+    title: 'Yazdığın düzeltmeler',
+    emptyTitle: 'Henüz düzeltme yok',
+    emptyBody:
+      'Bir sohbette mesaja basılı tut ve Düzelt’i seç — burada yapabileceğin en faydalı şey bu.',
+  },
   discover: {
     searchHandles: 'Kullanıcı adıyla ara',
     searchPlaceholder: 'Kullanıcı adı',

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -239,6 +239,19 @@ export function canDeleteForEveryone(
 export const STARRED_PAGE_SIZE_MAX = 100
 
 /** `GET /me/starred` — a flat list, newest first, across every conversation. */
+/**
+ * Paged, unlike the starred list beside it. A bookmark list is tens of items
+ * and capped; a correction history is the number on somebody's profile, and it
+ * is meant to grow.
+ */
+export const CORRECTIONS_PAGE_SIZE_MAX = 50
+
+export const listCorrectionsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(CORRECTIONS_PAGE_SIZE_MAX).default(20),
+  cursor: z.string().trim().min(1).optional(),
+})
+export type ListCorrectionsQuery = z.infer<typeof listCorrectionsQuerySchema>
+
 export const listStarredQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(STARRED_PAGE_SIZE_MAX).default(50),
 })

--- a/packages/shared/src/reservedHandles.ts
+++ b/packages/shared/src/reservedHandles.ts
@@ -22,6 +22,8 @@ const ROUTE_RESERVED = [
   'blocked',
   'chat',
   'chats',
+  'corrections',
+  'corrections',
   'discover',
   'done',
   'feed',


### PR DESCRIPTION
The corrections tile on the profile was a number with nothing behind it, and the
corrections themselves were scattered one per conversation — findable only by
remembering who you had helped.

The number already meant *"corrections I wrote, chat and posts, for life"*
(`countCorrectionsWritten`), which is exactly this list — so the tile and the
screen cannot disagree about what they are counting.

## Paged, unlike `/me/starred` beside it

`/me/starred` is a flat capped list on purpose: a bookmark list people actually
keep is tens of items. A correction history is the number on a profile and is
meant to grow, so a cap would quietly hide the older half of the thing the
screen exists to show.

Keyset rather than offset, following `listPostCorrections`: an offset shifts
under a correction written while the reader is paging, which repeats or drops a
row.

## A new index, not a widened one

`sender_type` — `{ senderId, type }` — gives the exact filter and carries **no
`createdAt`**, so ordering through it is an in-memory sort of every correction
the user has ever written. Fine for the `countDocuments` it was built for, wrong
for a list.

`sender_type_created` is `{ senderId, type, createdAt: -1, _id: -1 }`. A new
name rather than widening the old one, because changing the keys of a live index
is an `IndexOptionsConflict` at boot, not an upgrade — the same reason
`conversation_created_id` sits beside `conversation_created`.

## Chat corrections only, and it says so

Post corrections are a different collection with a different shape — no
`original` of their own, since the original is the post's body — the feed
already lists them per post, and the two cannot be merged in one Mongo query.
The screen is titled "Corrections you wrote" rather than implying completeness.

Rows use **`foldCorrection`**, the one-line folded diff the feed's correction
panel already draws, not the chat bubble's two-line before/after. A row has no
space for two lines, which is precisely why that helper exists. Removals are
struck through as well as coloured, so the meaning survives for a reader who
cannot separate the hues.

## Caught while verifying

The screen initially appeared **as a fifth tab** in the tab bar — the
`Tabs.Screen … FULL_SCREEN` registration had silently not been applied. Fixed,
and worth noting that `href: null` alone is not enough; `_layout.tsx`'s comment
already explains why the hidden tab bar is the other half of it.

`pnpm test` 1083 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)