### PR TITLE
Refresh a shared location when the app comes back

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -7,6 +7,7 @@ import { useTheme } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
 import { useNotificationRouting } from '../../src/hooks/useNotificationRouting'
 import { usePushRegistration } from '../../src/hooks/usePushRegistration'
+import { useLocationRefresh } from '../../src/hooks/useLocationRefresh'
 import { useSocket } from '../../src/hooks/useSocket'
 
 /** Not a tab, and no tab bar under it either. */
@@ -32,6 +33,7 @@ export default function AppLayout() {
   const { colors } = useTheme()
   const t = useT()
   useSocket()
+  useLocationRefresh()
   usePushRegistration()
   // Here rather than in the root layout: every destination a notification has
   // is behind the sign-in gate, so routing from one before there is a session

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -27,6 +27,7 @@ import { authLandingHref } from '../../src/lib/authLanding'
 import darkIcon from '../../assets/icons/dark.png'
 import defaultIcon from '../../assets/icons/default.png'
 import { openPaywall } from '../../src/lib/paywall'
+import { relativeTime } from '../../src/lib/format'
 import { manageSubscriptionUrl } from '../../src/lib/manageSubscription'
 import { openExternal } from '../../src/lib/openExternal'
 import {
@@ -358,6 +359,17 @@ export default function SettingsScreen() {
         {sharingLocation ? (
           <ListRow
             title={t('settings.updateLocation')}
+            /* `locationUpdatedAt` has been stored and returned to its owner
+               since sharing shipped, and rendered nowhere — which is what the
+               field's own doc comment asks for: sharing a location should not
+               be a thing you turned on once and can never see the state of. */
+            subtitle={
+              profile?.locationUpdatedAt
+                ? t('settings.locationUpdated', {
+                    time: relativeTime(profile.locationUpdatedAt, { t, locale: activeLocale }),
+                  })
+                : undefined
+            }
             value={shareLocation.isPending ? t('settings.updating') : undefined}
             onPress={() => void toggleLocation(true)}
             last

--- a/apps/mobile/src/hooks/useLocationRefresh.ts
+++ b/apps/mobile/src/hooks/useLocationRefresh.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react'
+import { AppState } from 'react-native'
+import { useMe, useShareLocation } from '../api/queries'
+import { captureLocation } from '../lib/location'
+import { shouldRefreshLocation } from '../lib/locationRefresh'
+
+/**
+ * Keeps a shared location from going stale, on foreground.
+ *
+ * `AppState`, not `setInterval`, and the reason is in `app.config.ts`: there is
+ * no background location permission on either platform, and adding one would
+ * change what both stores' privacy forms have to say. A timer therefore only
+ * ever fires while the app is open — which is precisely what this listener
+ * says, without pretending to be a schedule. `useAppConfig` already makes the
+ * same argument: polling in the background spends battery to learn nothing.
+ *
+ * It is also the moment that matters. Somebody who opens the app after landing
+ * in a new city gets a fresh position on their first foreground, which is
+ * exactly when they would look at who is nearby.
+ *
+ * Silent throughout. This is not something the user asked for right now, so a
+ * denied permission or a failed fix must not raise anything — they will find
+ * out when they next use the feature deliberately.
+ */
+export function useLocationRefresh(): void {
+  const me = useMe()
+  const share = useShareLocation()
+  // Guards against a second run while one is in flight — foregrounding twice
+  // in quick succession is ordinary, and two fixes would be two writes.
+  const busy = useRef(false)
+
+  const hasLocation = me.data?.location !== undefined
+  const updatedAt = me.data?.locationUpdatedAt
+
+  useEffect(() => {
+    async function refresh(): Promise<void> {
+      if (busy.current) return
+      if (!shouldRefreshLocation({ hasLocation, locationUpdatedAt: updatedAt })) return
+      busy.current = true
+      try {
+        // `promptIfNeeded: false` is the whole safety of this: without it a
+        // permission dialog could appear on returning to the app, unconnected
+        // to anything the person tapped.
+        const fix = await captureLocation({ promptIfNeeded: false })
+        if (fix.ok) share.mutate({ lat: fix.lat, lng: fix.lng })
+      } finally {
+        busy.current = false
+      }
+    }
+
+    const subscription = AppState.addEventListener('change', (next) => {
+      if (next === 'active') void refresh()
+    })
+    // Once on mount too: the app is already foreground when this first runs,
+    // so waiting for a change event would skip the launch that opened it.
+    void refresh()
+    return () => subscription.remove()
+    // Keyed on the two values the decision actually reads, plus the mutation
+    // object react-query keeps stable across renders.
+  }, [hasLocation, updatedAt, share])
+}

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -881,6 +881,7 @@ export const ar: Localized<EnMessages> = {
     activityMap: 'إظهار خريطة نشاطي',
     activityMapBody: 'المربعات في ملفك. تبقى سلسلتك ظاهرة في الحالتين.',
     updateLocation: 'تحديث موقعي',
+    locationUpdated: 'حُدّث قبل {time}',
     updating: 'جارٍ التحديث…',
     languageSection: 'اللغة',
     appLanguage: 'لغة التطبيق',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -751,6 +751,7 @@ export const de: Localized<EnMessages> = {
     activityMap: 'Meine Aktivitätskarte zeigen',
     activityMapBody: 'Die Kästchen auf deinem Profil. Deine Serie bleibt so oder so sichtbar.',
     updateLocation: 'Meinen Standort aktualisieren',
+    locationUpdated: 'Vor {time} aktualisiert',
     updating: 'Wird aktualisiert…',
     languageSection: 'Sprache',
     appLanguage: 'App-Sprache',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -769,6 +769,7 @@ export const en = {
     activityMap: 'Show my activity map',
     activityMapBody: 'The squares on your profile. Your streak stays visible either way.',
     updateLocation: 'Update my location',
+    locationUpdated: 'Last updated {time} ago',
     updating: 'Updating…',
     languageSection: 'Language',
     appLanguage: 'App language',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -734,6 +734,7 @@ export const es: Localized<EnMessages> = {
     activityMap: 'Mostrar mi mapa de actividad',
     activityMapBody: 'Los cuadrados de tu perfil. Tu racha se ve igualmente.',
     updateLocation: 'Actualizar mi ubicación',
+    locationUpdated: 'Actualizado hace {time}',
     updating: 'Actualizando…',
     languageSection: 'Idioma',
     appLanguage: 'Idioma de la app',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -732,6 +732,7 @@ export const fr: Localized<EnMessages> = {
     activityMap: 'Afficher ma carte d’activité',
     activityMapBody: 'Les carrés sur ton profil. Ta série reste visible dans tous les cas.',
     updateLocation: 'Mettre à jour ma position',
+    locationUpdated: 'Mis à jour il y a {time}',
     updating: 'Mise à jour…',
     languageSection: 'Langue',
     appLanguage: 'Langue de l’app',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -728,6 +728,7 @@ export const ptBR: Localized<EnMessages> = {
     activityMapBody:
       'Os quadradinhos do seu perfil. Sua sequência continua visível de qualquer jeito.',
     updateLocation: 'Atualizar minha localização',
+    locationUpdated: 'Atualizado há {time}',
     updating: 'Atualizando…',
     languageSection: 'Idioma',
     appLanguage: 'Idioma do app',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -844,6 +844,7 @@ export const ru: Localized<EnMessages> = {
     activityMap: 'Показывать карту активности',
     activityMapBody: 'Квадратики в твоём профиле. Серия остаётся видна в любом случае.',
     updateLocation: 'Обновить местоположение',
+    locationUpdated: 'Обновлено {time} назад',
     updating: 'Обновляем…',
     languageSection: 'Язык',
     appLanguage: 'Язык приложения',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -742,6 +742,7 @@ export const tr: Localized<EnMessages> = {
     activityMap: 'Etkinlik haritamı göster',
     activityMapBody: 'Profilindeki kareler. Serin her hâlükârda görünür kalır.',
     updateLocation: 'Konumumu güncelle',
+    locationUpdated: '{time} önce güncellendi',
     updating: 'Güncelleniyor…',
     languageSection: 'Dil',
     appLanguage: 'Uygulama dili',

--- a/apps/mobile/src/lib/location.ts
+++ b/apps/mobile/src/lib/location.ts
@@ -24,11 +24,25 @@ export type LocationResult =
   | { ok: true; lat: number; lng: number }
   | { ok: false; reason: 'denied' | 'disabled' | 'unavailable' }
 
-export async function captureLocation(): Promise<LocationResult> {
+export interface CaptureOptions {
+  /**
+   * Whether an unprompted user may be asked.
+   *
+   * `false` for anything the app decides to do on its own. A background
+   * refresh that can raise the OS permission dialog is a dialog appearing on a
+   * timer, at a moment the person did not choose and cannot connect to
+   * anything they tapped — which is how a feature teaches people to say no.
+   */
+  promptIfNeeded?: boolean
+}
+
+export async function captureLocation({
+  promptIfNeeded = true,
+}: CaptureOptions = {}): Promise<LocationResult> {
   // `getForegroundPermissionsAsync` first, so a user who has already granted
   // it is never re-prompted; `request` only runs the first time.
   let permission = await Location.getForegroundPermissionsAsync()
-  if (!permission.granted && permission.canAskAgain) {
+  if (!permission.granted && permission.canAskAgain && promptIfNeeded) {
     permission = await Location.requestForegroundPermissionsAsync()
   }
   if (!permission.granted) return { ok: false, reason: 'denied' }

--- a/apps/mobile/src/lib/locationRefresh.test.ts
+++ b/apps/mobile/src/lib/locationRefresh.test.ts
@@ -1,0 +1,47 @@
+import { LOCATION_REFRESH_MIN_GAP_MS } from '@langx/shared'
+import { describe, expect, it } from 'vitest'
+import { shouldRefreshLocation } from './locationRefresh'
+
+const NOW = new Date('2026-08-31T12:00:00Z')
+const ago = (ms: number) => new Date(NOW.getTime() - ms).toISOString()
+
+describe('shouldRefreshLocation', () => {
+  it('does nothing for somebody who is not sharing', () => {
+    expect(shouldRefreshLocation({ hasLocation: false, now: NOW })).toBe(false)
+    expect(
+      shouldRefreshLocation({ hasLocation: false, locationUpdatedAt: ago(1e12), now: NOW }),
+    ).toBe(false)
+  })
+
+  it('waits out the gap', () => {
+    expect(
+      shouldRefreshLocation({
+        hasLocation: true,
+        locationUpdatedAt: ago(LOCATION_REFRESH_MIN_GAP_MS - 60_000),
+        now: NOW,
+      }),
+    ).toBe(false)
+    expect(
+      shouldRefreshLocation({
+        hasLocation: true,
+        locationUpdatedAt: ago(LOCATION_REFRESH_MIN_GAP_MS),
+        now: NOW,
+      }),
+    ).toBe(true)
+  })
+
+  /** A point written before the field existed has no timestamp to compare. */
+  it('refreshes a point that has no timestamp', () => {
+    expect(shouldRefreshLocation({ hasLocation: true, now: NOW })).toBe(true)
+    expect(
+      shouldRefreshLocation({ hasLocation: true, locationUpdatedAt: 'nonsense', now: NOW }),
+    ).toBe(true)
+  })
+
+  /** A phone whose clock is fast is not a stale location. */
+  it('does not refresh on a future timestamp', () => {
+    expect(
+      shouldRefreshLocation({ hasLocation: true, locationUpdatedAt: ago(-60_000), now: NOW }),
+    ).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/locationRefresh.ts
+++ b/apps/mobile/src/lib/locationRefresh.ts
@@ -1,0 +1,31 @@
+import { LOCATION_REFRESH_MIN_GAP_MS } from '@langx/shared'
+
+/**
+ * Whether a shared location is stale enough to be worth refreshing.
+ *
+ * Pure, and separate from the hook, because this is the decision — the hook is
+ * only the wiring, and `vitest.config.ts` cannot see hooks.
+ */
+export function shouldRefreshLocation(input: {
+  /** Absent means the person is not sharing at all; nothing to refresh. */
+  hasLocation: boolean
+  /** When it was last written. Absent on a point stored before the field existed. */
+  locationUpdatedAt?: string | undefined
+  now?: Date
+}): boolean {
+  if (!input.hasLocation) return false
+  // A point with no timestamp predates `locationUpdatedAt`. Refreshing it once
+  // is how it acquires one, and it is by definition older than the gap.
+  if (!input.locationUpdatedAt) return true
+
+  const at = Date.parse(input.locationUpdatedAt)
+  // An unparseable date is not evidence of staleness, but it is not evidence of
+  // freshness either — and one silent refresh is cheaper than a location that
+  // can never update again.
+  if (Number.isNaN(at)) return true
+
+  const now = (input.now ?? new Date()).getTime()
+  // A timestamp in the future is a clock skew, not a reason to refresh.
+  if (at > now) return false
+  return now - at >= LOCATION_REFRESH_MIN_GAP_MS
+}

--- a/packages/shared/src/location.ts
+++ b/packages/shared/src/location.ts
@@ -36,6 +36,19 @@ export const LOCATION_PRECISION_DECIMALS = 2
  * is not "nearby", it is just the nearest, and showing it would make the sort
  * look broken rather than empty.
  */
+/**
+ * How stale a shared location may get before the app quietly refreshes it.
+ *
+ * Six hours, and the number follows from `LOCATION_PRECISION_DECIMALS`: the
+ * stored point is rounded to about a kilometre, so anything finer than a few
+ * hours mostly writes the same cell back and spends a GPS wake-up to do it.
+ *
+ * There is no background permission — `app.config.ts` disables it on both
+ * platforms and says why — so this is a floor on how often a *foreground*
+ * refresh may happen, not a schedule.
+ */
+export const LOCATION_REFRESH_MIN_GAP_MS = 6 * 60 * 60 * 1000
+
 export const NEARBY_MAX_KM = 500
 
 /** Radii the UI offers. Any value up to {@link NEARBY_MAX_KM} is accepted. */


### PR DESCRIPTION
A location was written **once**, when somebody turned sharing on, and never
again. Move city and the distance bucket other people see is wherever you were
the day you enabled it.

## `AppState`, not `setInterval`

`app.config.ts` sets `isAndroidBackgroundLocationEnabled: false` and
`isIosBackgroundLocationEnabled: false`, with a comment that adding background
permission changes what both stores' privacy forms have to say.

So a timer would **only ever fire while the app is open anyway** — the
foreground listener says exactly that without pretending to be a schedule.
`useAppConfig` already makes the same argument in its doc comment: polling in
the background spends battery to find out nothing almost every time.

It is also the moment that matters. Somebody who opens the app after landing
somewhere new gets a fresh position on their first foreground, which is when
they would look at who is nearby.

## The trap this had to avoid

`captureLocation` calls `requestForegroundPermissionsAsync()` when permission
has not been granted. A foreground-driven refresh would therefore **raise the OS
permission dialog on returning to the app** — at a moment the person did not
choose and cannot connect to anything they tapped, which is how a feature
teaches people to say no.

It now takes `promptIfNeeded`, and the refresh passes `false`. Asking is only
ever the consequence of a deliberate tap. Failures are silent for the same
reason: this is not something they asked for right now.

## Throttle

`locationUpdatedAt` was already stored and already returned to its owner, so
there is no new state. Six hours, and the number follows from
`LOCATION_PRECISION_DECIMALS`: the point is rounded to about a kilometre, so
anything finer mostly writes the same cell back and spends a GPS wake-up doing
it.

The decision is a pure function so `vitest.config.ts` reaches it — including the
two cases that are easy to get wrong: a point with **no** timestamp (written
before the field existed) refreshes once, and a **future** timestamp is clock
skew rather than staleness.

## While in there

`locationUpdatedAt` was rendered nowhere, which the field's own doc comment
argues against — sharing a location should not be something you turned on once
and can never see the state of. The Settings row now says when it last changed.

`pnpm test` 1097 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)