### PR TITLE
Let people find each other from the Chats tab too

### DIFF
--- a/apps/mobile/app/(app)/chats.tsx
+++ b/apps/mobile/app/(app)/chats.tsx
@@ -12,6 +12,7 @@ import {
   View,
 } from 'react-native'
 import { useConversationFlags, useConversations, useMe } from '../../src/api/queries'
+import { PeopleSearch } from '../../src/components/PeopleSearch'
 import { ConversationRowSkeleton } from '../../src/components/skeletons/ConversationRowSkeleton'
 import { Avatar } from '../../src/components/ui/Avatar'
 import { EmptyState } from '../../src/components/ui/EmptyState'
@@ -45,6 +46,9 @@ export default function ChatsScreen() {
 
   const me = useMe()
   const [filter, setFilter] = useState<ConversationFilter>('all')
+  // Blanks the thread list while a search is open, so the results are not
+  // competing with a list of unrelated conversations underneath them.
+  const [searching, setSearching] = useState(false)
   const conversations = useConversations(filter)
   const flags = useConversationFlags()
 
@@ -80,6 +84,12 @@ export default function ChatsScreen() {
       */}
       <View style={styles.titleRow}>
         <Text style={styles.title}>{t('tabs.chats')}</Text>
+        {/*
+          Here as well as on Discover, because this is the other place people
+          arrive already knowing who they want: Discover is for finding someone,
+          Chats is for finding someone again.
+        */}
+        <PeopleSearch from="/(app)/chats" onSearchingChange={setSearching} />
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={t('chats.starredMessages')}
@@ -117,7 +127,7 @@ export default function ChatsScreen() {
         </View>
       ) : (
         <FlatList
-          data={items}
+          data={searching ? [] : items}
           keyExtractor={(item) => item._id}
           contentContainerStyle={styles.list}
           refreshControl={

--- a/apps/mobile/app/(app)/discover.tsx
+++ b/apps/mobile/app/(app)/discover.tsx
@@ -9,18 +9,9 @@ import { router, useLocalSearchParams } from 'expo-router'
 import { openProfile } from '../../src/lib/navigation'
 import { useMemo, useState } from 'react'
 import Feather from '@expo/vector-icons/Feather'
-import {
-  ActivityIndicator,
-  FlatList,
-  Pressable,
-  RefreshControl,
-  Text,
-  TextInput,
-  View,
-} from 'react-native'
+import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from 'react-native'
 import {
   useDiscovery,
-  useHandleSearch,
   useHasFeature,
   useIsPro,
   useMe,
@@ -30,6 +21,7 @@ import { ApiRequestError } from '../../src/api/client'
 import type { DiscoveryItem } from '../../src/api/types'
 import { DiscoveryCardSkeleton } from '../../src/components/skeletons/DiscoveryCardSkeleton'
 import { Avatar } from '../../src/components/ui/Avatar'
+import { PeopleSearch } from '../../src/components/PeopleSearch'
 import { Chip } from '../../src/components/ui/Chip'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { LevelBars } from '../../src/components/ui/LevelBars'
@@ -42,7 +34,6 @@ import {
   toQuery,
   withoutProFilters,
 } from '../../src/lib/discoveryFilters'
-import { useDebounced } from '../../src/hooks/useDebounced'
 import { showAlert } from '../../src/lib/alert'
 import { captureLocation, LOCATION_FAILURE_KEY } from '../../src/lib/location'
 import { openPaywall } from '../../src/lib/paywall'
@@ -86,17 +77,6 @@ export default function DiscoverScreen() {
   const [sort, setSort] = useState<DiscoverySort>('recommended')
   const [radiusKm, setRadiusKm] = useState<number>(NEARBY_MAX_KM)
   const [searching, setSearching] = useState(false)
-  const [term, setTerm] = useState('')
-  // The input renders `term` and the query follows the settled value, so
-  // typing stays responsive and "behic" is one request rather than five.
-  const search = useHandleSearch(useDebounced(term))
-
-  // Both the arrow and any future caller mean the same two things by it, and
-  // forgetting the second one leaves a stale query behind the next open.
-  function closeSearch(): void {
-    setSearching(false)
-    setTerm('')
-  }
 
   const isPro = useIsPro()
   const canUseNearby = useHasFeature('nearby')
@@ -188,25 +168,7 @@ export default function DiscoverScreen() {
           {/* Beside the filters, not above the list: the two are the same
               question asked two ways — "narrow this" and "I already know who
               I am looking for". */}
-          {/*
-            Opens search and nothing else. It used to toggle, which put the way
-            *out* of search up here in the header: a 22px glyph beside an
-            identical-looking filters icon, diagonally opposite the caret, and
-            announced to a screen reader as "Search by username" even while it
-            meant close. Leaving is now the arrow inside the field, at the
-            geometry every other back control in the app uses.
-          */}
-          {searching ? null : (
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t('discover.searchHandles')}
-              onPress={() => setSearching(true)}
-              style={({ pressed }) => [styles.filterButton, pressed && styles.pressed]}
-              hitSlop={8}
-            >
-              <Feather name="search" size={22} color={colors.text} />
-            </Pressable>
-          )}
+          <PeopleSearch from="/(app)/discover" onSearchingChange={setSearching} />
           <Pressable
             accessibilityRole="button"
             accessibilityLabel={
@@ -224,81 +186,6 @@ export default function DiscoverScreen() {
             {count > 0 ? <Text style={styles.filterCount}>{count}</Text> : null}
           </Pressable>
         </View>
-        {searching ? (
-          <View style={styles.searchField}>
-            {/*
-              Leaving search is local state, never navigation. Discover is a tab
-              root, so `router.back()` would drop the reader on the first tab —
-              see `backHref` for why `canGoBack()` does not save you there.
-            */}
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t('common.backPlain')}
-              onPress={closeSearch}
-              hitSlop={12}
-              style={({ pressed }) => [styles.searchLeave, pressed && styles.pressed]}
-            >
-              <Feather name="arrow-left" size={22} color={colors.text} />
-            </Pressable>
-            <TextInput
-              value={term}
-              onChangeText={setTerm}
-              placeholder={t('discover.searchPlaceholder')}
-              placeholderTextColor={colors.textFaint}
-              autoCapitalize="none"
-              autoCorrect={false}
-              autoFocus
-              returnKeyType="search"
-              style={styles.searchInput}
-            />
-            {/*
-              Clears the text without leaving search — a different intent from
-              the arrow, which is why it is a different control rather than one
-              button meaning two things. Only while there is something to clear.
-            */}
-            {term.length > 0 ? (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={t('common.clear')}
-                onPress={() => setTerm('')}
-                hitSlop={10}
-                style={({ pressed }) => pressed && styles.pressed}
-              >
-                <Feather name="x" size={18} color={colors.textMuted} />
-              </Pressable>
-            ) : null}
-          </View>
-        ) : null}
-
-        {searching ? (
-          <View style={styles.searchResults}>
-            {search.isFetching ? <ActivityIndicator style={styles.searchSpinner} /> : null}
-            {search.data?.items.map((result) => (
-              <Pressable
-                key={result._id}
-                accessibilityRole="button"
-                onPress={() => openProfile(result.handle, '/(app)/discover')}
-                style={({ pressed }) => [styles.resultRow, pressed && styles.pressed]}
-              >
-                <Avatar url={result.avatarUrl} name={result.displayName} size={36} />
-                <View style={styles.searchText}>
-                  <Text style={styles.searchName} numberOfLines={1}>
-                    {result.displayName}
-                  </Text>
-                  <Text style={styles.searchHandle} numberOfLines={1}>
-                    @{result.handle}
-                  </Text>
-                </View>
-              </Pressable>
-            ))}
-            {/* Only once a real search has settled: "no matches" under two
-                letters would be answering a question nobody finished asking. */}
-            {search.data?.items.length === 0 && !search.isFetching ? (
-              <Text style={styles.searchNone}>{t('discover.searchNone')}</Text>
-            ) : null}
-          </View>
-        ) : null}
-
         <View style={styles.segmented}>
           <SegmentedControl
             options={SORTS.map((option) => ({
@@ -450,44 +337,6 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
     marginStart: 'auto',
   },
   filterButton: { alignItems: 'center', flexDirection: 'row', gap: spacing.xs },
-  /**
-   * The input, and only the input. Both this and every result row used to be
-   * `searchRow`, so each result wore the field's fill, its pill radius and its
-   * top margin — the thing you type into and the things you tap looked like the
-   * same object stacked five deep. Splitting them is also what makes it safe to
-   * pad this one for the two controls inside it.
-   */
-  searchField: {
-    alignItems: 'center',
-    backgroundColor: colors.fill,
-    borderRadius: radius.pill,
-    flexDirection: 'row',
-    gap: spacing.sm,
-    marginTop: spacing.md,
-    paddingEnd: spacing.md,
-    paddingStart: spacing.sm,
-    paddingVertical: spacing.sm,
-  },
-  // Matches every other back control in the app: a 30x30 box, hitSlop 12.
-  searchLeave: { alignItems: 'center', height: 30, justifyContent: 'center', width: 30 },
-  resultRow: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: spacing.sm,
-    paddingVertical: spacing.sm,
-  },
-  searchInput: { ...font.body, color: colors.text, flex: 1, padding: 0 },
-  searchResults: { gap: spacing.xs, marginTop: spacing.xs },
-  searchSpinner: { marginTop: spacing.md },
-  searchText: { flex: 1, gap: 1 },
-  searchName: { ...font.label, color: colors.text, fontSize: 15 },
-  searchHandle: { ...font.caption, color: colors.textMuted },
-  searchNone: {
-    ...font.caption,
-    color: colors.textFaint,
-    marginTop: spacing.md,
-    textAlign: 'center',
-  },
   filterCount: {
     backgroundColor: colors.accent,
     borderRadius: radius.pill,

--- a/apps/mobile/src/components/PeopleSearch.tsx
+++ b/apps/mobile/src/components/PeopleSearch.tsx
@@ -1,0 +1,158 @@
+import Feather from '@expo/vector-icons/Feather'
+import { useState } from 'react'
+import { ActivityIndicator, Pressable, Text, TextInput, View } from 'react-native'
+import { useHandleSearch } from '../api/queries'
+import { useDebounced } from '../hooks/useDebounced'
+import { useT } from '../i18n'
+import { openProfile } from '../lib/navigation'
+import { makeStyles, useTheme } from '../lib/theme'
+import { Avatar } from './ui/Avatar'
+
+interface PeopleSearchProps {
+  /** Where a tapped result should come back to. */
+  from: '/(app)/discover' | '/(app)/chats'
+  /** Told when search opens or closes, so the host can blank its own list. */
+  onSearchingChange?: (searching: boolean) => void
+}
+
+/**
+ * Find somebody by username, wherever you already are.
+ *
+ * Extracted from Discover so the Chats tab can have it too. It was forty-five
+ * lines of JSX and eight style rules inlined into one screen, which is how a
+ * second copy gets written rather than a component reused.
+ *
+ * Free on every plan, and always was: the endpoint behind it is `requireAuth`
+ * with no tier check. Somebody who already knows the username is not browsing.
+ */
+export function PeopleSearch({ from, onSearchingChange }: PeopleSearchProps) {
+  const t = useT()
+  const styles = useStyles()
+  const { colors } = useTheme()
+  const [searching, setSearching] = useState(false)
+  const [term, setTerm] = useState('')
+  // The input renders `term` and the query follows the settled value, so
+  // typing stays responsive and "behic" is one request rather than five.
+  const search = useHandleSearch(useDebounced(term))
+
+  function open(next: boolean): void {
+    setSearching(next)
+    if (!next) setTerm('')
+    onSearchingChange?.(next)
+  }
+
+  if (!searching) {
+    return (
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={t('discover.searchHandles')}
+        onPress={() => open(true)}
+        style={({ pressed }) => [styles.toggle, pressed && styles.pressed]}
+        hitSlop={8}
+      >
+        <Feather name="search" size={22} color={colors.text} />
+      </Pressable>
+    )
+  }
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.field}>
+        {/*
+          Leaving search is local state, never navigation. Both hosts are tab
+          roots, so `router.back()` would drop the reader on the first tab —
+          see `backHref` for why `canGoBack()` does not save you there.
+        */}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t('common.backPlain')}
+          onPress={() => open(false)}
+          hitSlop={12}
+          style={({ pressed }) => [styles.leave, pressed && styles.pressed]}
+        >
+          <Feather name="arrow-left" size={22} color={colors.text} />
+        </Pressable>
+        <TextInput
+          value={term}
+          onChangeText={setTerm}
+          placeholder={t('discover.searchPlaceholder')}
+          placeholderTextColor={colors.textFaint}
+          autoCapitalize="none"
+          autoCorrect={false}
+          autoFocus
+          returnKeyType="search"
+          style={styles.input}
+        />
+        {/*
+          Clears the text without leaving search — a different intent from the
+          arrow, which is why it is a different control rather than one button
+          meaning two things.
+        */}
+        {term.length > 0 ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t('common.clear')}
+            onPress={() => setTerm('')}
+            hitSlop={10}
+            style={({ pressed }) => pressed && styles.pressed}
+          >
+            <Feather name="x" size={18} color={colors.textMuted} />
+          </Pressable>
+        ) : null}
+      </View>
+
+      <View style={styles.results}>
+        {search.isFetching ? <ActivityIndicator style={styles.spinner} /> : null}
+        {search.data?.items.map((result) => (
+          <Pressable
+            key={result._id}
+            accessibilityRole="button"
+            onPress={() => openProfile(result.handle, from)}
+            style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+          >
+            <Avatar url={result.avatarUrl} name={result.displayName} size={36} />
+            <View style={styles.text}>
+              <Text style={styles.name} numberOfLines={1}>
+                {result.displayName}
+              </Text>
+              <Text style={styles.handle} numberOfLines={1}>
+                @{result.handle}
+              </Text>
+            </View>
+          </Pressable>
+        ))}
+        {/* Only once a real search has settled: "no matches" under two letters
+            would be answering a question nobody finished asking. */}
+        {search.data?.items.length === 0 && !search.isFetching ? (
+          <Text style={styles.none}>{t('discover.searchNone')}</Text>
+        ) : null}
+      </View>
+    </View>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, radius, spacing }) => ({
+  wrap: { gap: spacing.xs },
+  toggle: { alignItems: 'center', flexDirection: 'row', gap: spacing.xs },
+  pressed: { opacity: 0.7 },
+  field: {
+    alignItems: 'center',
+    backgroundColor: colors.fill,
+    borderRadius: radius.pill,
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.md,
+    paddingEnd: spacing.md,
+    paddingStart: spacing.sm,
+    paddingVertical: spacing.sm,
+  },
+  leave: { alignItems: 'center', height: 30, justifyContent: 'center', width: 30 },
+  input: { ...font.body, color: colors.text, flex: 1, padding: 0 },
+  results: { gap: spacing.xs, marginTop: spacing.xs },
+  spinner: { marginTop: spacing.md },
+  row: { alignItems: 'center', flexDirection: 'row', gap: spacing.sm, paddingVertical: spacing.sm },
+  text: { flex: 1, gap: 1 },
+  name: { ...font.label, color: colors.text, fontSize: 15 },
+  handle: { ...font.caption, color: colors.textMuted },
+  none: { ...font.caption, color: colors.textFaint, marginTop: spacing.md, textAlign: 'center' },
+}))

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -871,7 +871,7 @@ export const ar: Localized<EnMessages> = {
     communitySection: 'المجتمع',
     linkDeviceBody: 'وافق على تسجيل دخول على حاسوب.',
     showInDiscover: 'أظهرني في الاستكشاف',
-    showInDiscoverBody: 'أغلق هذا ولن يجدك أحد في الاستكشاف.',
+    showInDiscoverBody: 'أطفئه ولن يعثر عليك أحد — لا في الاستكشاف ولا بالبحث عن اسم المستخدم.',
     incognito: 'تصفّح خفي',
     incognitoBody: 'لن تظهر ضمن زوّارهم.',
     hideOnline: 'أخفني عندما أكون متصلًا',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -740,7 +740,8 @@ export const de: Localized<EnMessages> = {
     communitySection: 'Community',
     linkDeviceBody: 'Eine Anmeldung am Computer bestätigen.',
     showInDiscover: 'In Entdecken zeigen',
-    showInDiscoverBody: 'Schalte das aus, und niemand findet dich in Entdecken.',
+    showInDiscoverBody:
+      'Schalte das aus und niemand findet dich — weder in Entdecken noch über deinen Benutzernamen.',
     incognito: 'Inkognito surfen',
     incognitoBody: 'Du erscheinst nicht in ihren Besuchern.',
     hideOnline: 'Verbergen, wenn ich online bin',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -759,7 +759,8 @@ export const en = {
     communitySection: 'Community',
     linkDeviceBody: 'Approve a sign-in on a computer.',
     showInDiscover: 'Show me in Discover',
-    showInDiscoverBody: 'Turn this off and nobody will find you in Discover.',
+    showInDiscoverBody:
+      'Turn this off and nobody will find you — not in Discover, and not by searching your username.',
     incognito: 'Browse incognito',
     incognitoBody: 'You won’t appear in their viewers.',
     hideOnline: 'Hide when I’m online',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -723,7 +723,8 @@ export const es: Localized<EnMessages> = {
     communitySection: 'Comunidad',
     linkDeviceBody: 'Aprueba un inicio de sesión en un ordenador.',
     showInDiscover: 'Mostrarme en Descubrir',
-    showInDiscoverBody: 'Desactívalo y nadie te encontrará en Descubrir.',
+    showInDiscoverBody:
+      'Desactívalo y nadie te encontrará: ni en Descubrir ni buscando tu nombre de usuario.',
     incognito: 'Navegar de incógnito',
     incognitoBody: 'No aparecerás entre sus visitas.',
     hideOnline: 'Ocultarme cuando esté en línea',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -722,7 +722,8 @@ export const fr: Localized<EnMessages> = {
     communitySection: 'Communauté',
     linkDeviceBody: 'Approuver une connexion sur un ordinateur.',
     showInDiscover: 'M’afficher dans Découvrir',
-    showInDiscoverBody: 'Désactive ceci et personne ne te trouvera dans Découvrir.',
+    showInDiscoverBody:
+      'Désactive-le et personne ne te trouvera — ni dans Découvrir, ni en cherchant ton nom d’utilisateur.',
     incognito: 'Navigation incognito',
     incognitoBody: 'Tu n’apparaîtras pas dans leurs visiteurs.',
     hideOnline: 'Me masquer quand je suis en ligne',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -716,7 +716,8 @@ export const ptBR: Localized<EnMessages> = {
     communitySection: 'Comunidade',
     linkDeviceBody: 'Aprove um login em um computador.',
     showInDiscover: 'Mostrar em Descobrir',
-    showInDiscoverBody: 'Desligue e ninguém vai te encontrar em Descobrir.',
+    showInDiscoverBody:
+      'Desligue e ninguém te encontra — nem no Descobrir, nem buscando seu nome de usuário.',
     incognito: 'Navegar anonimamente',
     incognitoBody: 'Você não vai aparecer entre os visitantes.',
     hideOnline: 'Esconder quando eu estiver on-line',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -833,7 +833,7 @@ export const ru: Localized<EnMessages> = {
     communitySection: 'Сообщество',
     linkDeviceBody: 'Подтвердить вход на компьютере.',
     showInDiscover: 'Показывать меня в Поиске',
-    showInDiscoverBody: 'Выключи — и никто не найдёт тебя в Поиске.',
+    showInDiscoverBody: 'Выключи — и тебя не найдут: ни в «Обзоре», ни по имени пользователя.',
     incognito: 'Невидимый просмотр',
     incognitoBody: 'Ты не появишься в списке их посетителей.',
     hideOnline: 'Скрывать, когда я в сети',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -731,7 +731,8 @@ export const tr: Localized<EnMessages> = {
     communitySection: 'Topluluk',
     linkDeviceBody: 'Bilgisayardaki bir girişi onayla.',
     showInDiscover: 'Keşfet’te görün',
-    showInDiscoverBody: 'Bunu kapatırsan kimse seni Keşfet’te bulamaz.',
+    showInDiscoverBody:
+      'Bunu kapatırsan kimse seni bulamaz — ne Keşfet’te, ne de kullanıcı adınla arayarak.',
     incognito: 'Gizli gezin',
     incognitoBody: 'Ziyaretçilerinde görünmezsin.',
     hideOnline: 'Çevrimiçiyken gizlen',


### PR DESCRIPTION
Searching by username existed only on Discover — as **forty-five lines of JSX
and eight style rules inlined into that screen**, which is how a second copy
gets written rather than a component reused.

`PeopleSearch` is that block extracted, and mounted in both places. Discover is
for finding someone; Chats is for finding someone *again*, which is the other
moment a person arrives already knowing who they want.

## Already free, already private

- **Free on every plan.** `GET /discovery/handles` is `requireAuth` with no tier
  check, and always has been. Somebody who already knows the username is not
  browsing.
- **The opt-out already existed and was already enforced.**
  `settings.discoverable: false` excludes a profile from handle search as well
  as from Discover — `handleSearch.ts:54`, pinned by
  `discovery.test.ts:789-797`.

What was actually wrong was the **copy**: *"Turn this off and nobody will find
you in Discover"* promised less than the switch did. Reworded in all eight
locales to name both.

I deliberately did **not** add a second boolean. It would duplicate an
enforcement point and give two switches one job — and the existing one is
already the right shape, it was just under-described.

## Verified in the running app

Both tabs, same component:

```
chats:    toggle present ✓   found @test_anna ✓   back closes it ✓
discover: toggle present ✓   found @test_anna ✓   back closes it ✓
```

`pnpm test` 1093 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)