### PR TITLE
Swipe a chat row to pin or archive it

### DIFF
--- a/apps/mobile/app/(app)/chats.tsx
+++ b/apps/mobile/app/(app)/chats.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-native'
 import { useConversationFlags, useConversations, useMe } from '../../src/api/queries'
 import { PeopleSearch } from '../../src/components/PeopleSearch'
+import { SwipeableRow } from '../../src/components/SwipeableRow'
 import { ConversationRowSkeleton } from '../../src/components/skeletons/ConversationRowSkeleton'
 import { Avatar } from '../../src/components/ui/Avatar'
 import { EmptyState } from '../../src/components/ui/EmptyState'
@@ -174,9 +175,24 @@ export default function ChatsScreen() {
             const mine = item.lastMessage.senderId === me.data?._id
 
             return (
-              <Pressable
-                onPress={() => router.push(`/(app)/chat/${item._id}`)}
-                /*
+              <SwipeableRow
+                right={{
+                  icon: item.pinned ? 'chevrons-down' : 'chevrons-up',
+                  label: item.pinned ? t('chats.unpin') : t('chats.pin'),
+                  colour: colors.accent,
+                  onAction: () => flags.mutate({ conversationId: item._id, pinned: !item.pinned }),
+                }}
+                left={{
+                  icon: item.archived ? 'inbox' : 'archive',
+                  label: item.archived ? t('chats.unarchive') : t('chats.archive'),
+                  colour: colors.textMuted,
+                  onAction: () =>
+                    flags.mutate({ conversationId: item._id, archived: !item.archived }),
+                }}
+              >
+                <Pressable
+                  onPress={() => router.push(`/(app)/chat/${item._id}`)}
+                  /*
                   Long press rather than a swipe. `react-native-gesture-handler`
                   is deliberately absent from this package, and the app already
                   teaches long-press-for-actions on every message bubble — a
@@ -187,70 +203,71 @@ export default function ChatsScreen() {
                   list of choices on every platform, including web, where
                   react-native's own `Alert` is an empty function.
                 */
-                onLongPress={() => {
-                  void chooseAlert(partner?.displayName ?? '', undefined, [
-                    { label: item.pinned ? t('chats.unpin') : t('chats.pin'), value: 'pin' },
-                    {
-                      label: item.archived ? t('chats.unarchive') : t('chats.archive'),
-                      value: 'archive',
-                    },
-                  ]).then((choice) => {
-                    if (choice === 'pin') {
-                      flags.mutate({ conversationId: item._id, pinned: !item.pinned })
-                    }
-                    if (choice === 'archive') {
-                      flags.mutate({ conversationId: item._id, archived: !item.archived })
-                    }
-                  })
-                }}
-                style={({ pressed }) => [
-                  styles.row,
-                  index === items.length - 1 && styles.rowLast,
-                  pressed && styles.rowPressed,
-                ]}
-              >
-                {partner ? (
-                  <Avatar
-                    url={partner.avatarUrl}
-                    name={partner.displayName}
-                    online={partner.isOnline}
-                    size={AVATAR_SIZE}
-                  />
-                ) : (
-                  <Skeleton width={AVATAR_SIZE} height={AVATAR_SIZE} radius={AVATAR_SIZE / 2} />
-                )}
-                <View style={styles.body}>
-                  <View style={styles.top}>
-                    {partner ? (
-                      <Text style={styles.name} numberOfLines={1}>
-                        {partner.displayName}
+                  onLongPress={() => {
+                    void chooseAlert(partner?.displayName ?? '', undefined, [
+                      { label: item.pinned ? t('chats.unpin') : t('chats.pin'), value: 'pin' },
+                      {
+                        label: item.archived ? t('chats.unarchive') : t('chats.archive'),
+                        value: 'archive',
+                      },
+                    ]).then((choice) => {
+                      if (choice === 'pin') {
+                        flags.mutate({ conversationId: item._id, pinned: !item.pinned })
+                      }
+                      if (choice === 'archive') {
+                        flags.mutate({ conversationId: item._id, archived: !item.archived })
+                      }
+                    })
+                  }}
+                  style={({ pressed }) => [
+                    styles.row,
+                    index === items.length - 1 && styles.rowLast,
+                    pressed && styles.rowPressed,
+                  ]}
+                >
+                  {partner ? (
+                    <Avatar
+                      url={partner.avatarUrl}
+                      name={partner.displayName}
+                      online={partner.isOnline}
+                      size={AVATAR_SIZE}
+                    />
+                  ) : (
+                    <Skeleton width={AVATAR_SIZE} height={AVATAR_SIZE} radius={AVATAR_SIZE / 2} />
+                  )}
+                  <View style={styles.body}>
+                    <View style={styles.top}>
+                      {partner ? (
+                        <Text style={styles.name} numberOfLines={1}>
+                          {partner.displayName}
+                        </Text>
+                      ) : (
+                        // The row is real, its partner is not resolved yet: the
+                        // names come from a separate batched query. This used to
+                        // read "Loading…", which looked like somebody's name.
+                        <Skeleton width={132} height={16} />
+                      )}
+                      <Text style={styles.time}>
+                        {relativeTimeCompact(item.lastMessage.createdAt, { t, locale })}
                       </Text>
-                    ) : (
-                      // The row is real, its partner is not resolved yet: the
-                      // names come from a separate batched query. This used to
-                      // read "Loading…", which looked like somebody's name.
-                      <Skeleton width={132} height={16} />
-                    )}
-                    <Text style={styles.time}>
-                      {relativeTimeCompact(item.lastMessage.createdAt, { t, locale })}
-                    </Text>
+                    </View>
+                    <View style={styles.bottom}>
+                      <Text
+                        style={[styles.preview, unread > 0 && styles.previewUnread]}
+                        numberOfLines={1}
+                      >
+                        {mine ? `${t('chats.youPrefix')} ` : ''}
+                        {item.lastMessage.body}
+                      </Text>
+                      {unread > 0 ? (
+                        <View style={styles.badge}>
+                          <Text style={styles.badgeText}>{unread}</Text>
+                        </View>
+                      ) : null}
+                    </View>
                   </View>
-                  <View style={styles.bottom}>
-                    <Text
-                      style={[styles.preview, unread > 0 && styles.previewUnread]}
-                      numberOfLines={1}
-                    >
-                      {mine ? `${t('chats.youPrefix')} ` : ''}
-                      {item.lastMessage.body}
-                    </Text>
-                    {unread > 0 ? (
-                      <View style={styles.badge}>
-                        <Text style={styles.badgeText}>{unread}</Text>
-                      </View>
-                    ) : null}
-                  </View>
-                </View>
-              </Pressable>
+                </Pressable>
+              </SwipeableRow>
             )
           }}
         />

--- a/apps/mobile/src/components/SwipeableRow.tsx
+++ b/apps/mobile/src/components/SwipeableRow.tsx
@@ -1,0 +1,145 @@
+import Feather from '@expo/vector-icons/Feather'
+import { useRef, type ReactNode } from 'react'
+import { Animated, PanResponder, Platform, Text, View } from 'react-native'
+import { makeStyles } from '../lib/theme'
+import {
+  rowReleased,
+  rowSwipeEnabled,
+  rowTranslation,
+  shouldCaptureRowSwipe,
+} from '../lib/swipeAction'
+
+/**
+ * Read once at module scope, like `MessageBubble` does, with the `typeof`
+ * guard because `navigator` is absent while the web bundle is being exported.
+ */
+const HAS_TOUCH =
+  Platform.OS !== 'web' || (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0)
+
+export interface SwipeableRowAction {
+  icon: keyof typeof Feather.glyphMap
+  label: string
+  colour: string
+  onAction: () => void
+}
+
+interface SwipeableRowProps {
+  /** Revealed by swiping right. */
+  right: SwipeableRowAction
+  /** Revealed by swiping left. */
+  left: SwipeableRowAction
+  children: ReactNode
+}
+
+/**
+ * A list row that can be swiped either way to act on it.
+ *
+ * **Swipe and release, not a drawer that stays open.** A row that stays open
+ * needs a shared "which row is open" across the whole list, and there is no
+ * precedent for that here — `MessageBubble`'s swipe always springs back. This
+ * is the same gesture that file already proved, given a second direction, and
+ * it means a row can never be left in a state the reader has to undo.
+ *
+ * RN's `PanResponder` and `Animated`, not gesture-handler and not Reanimated:
+ * `react-native-gesture-handler` is not a dependency at all (only a transitive
+ * peer of expo-router's drawer, unreachable under pnpm's isolated layout), and
+ * `ui/Skeleton.tsx` records why pulling Reanimated in would put its worklets
+ * bundle into the shipped web build.
+ *
+ * Off for a mouse. `rowSwipeEnabled` states why; the long-press menu on the row
+ * is the way in on a desktop, which it already was.
+ */
+export function SwipeableRow({ right, left, children }: SwipeableRowProps) {
+  const styles = useStyles()
+  const translateX = useRef(new Animated.Value(0)).current
+  // Read during the gesture without re-rendering the row on every frame.
+  const offset = useRef(0)
+
+  const enabled = rowSwipeEnabled(Platform.OS, HAS_TOUCH)
+
+  const pan = useRef(
+    PanResponder.create({
+      // Never on start: that would swallow the tap that opens the thread and
+      // the long press that opens the menu.
+      onStartShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponder: (_event, gesture) =>
+        enabled && shouldCaptureRowSwipe(gesture.dx, gesture.dy),
+      // The list asking for the responder back mid-scroll wins, always.
+      onPanResponderTerminationRequest: () => true,
+      onPanResponderMove: (_event, gesture) => {
+        offset.current = gesture.dx
+        translateX.setValue(rowTranslation(gesture.dx))
+      },
+      onPanResponderRelease: () => {
+        const fired = rowReleased(offset.current)
+        offset.current = 0
+        Animated.spring(translateX, {
+          toValue: 0,
+          useNativeDriver: true,
+          bounciness: 0,
+        }).start()
+        if (fired === 'right') right.onAction()
+        if (fired === 'left') left.onAction()
+      },
+      onPanResponderTerminate: () => {
+        offset.current = 0
+        Animated.spring(translateX, { toValue: 0, useNativeDriver: true, bounciness: 0 }).start()
+      },
+    }),
+  ).current
+
+  if (!enabled) return <>{children}</>
+
+  return (
+    <View style={styles.wrap}>
+      {/*
+        Both actions sit behind the row at once, each pinned to the side it is
+        reached from. The row itself hides whichever one is not being pulled
+        towards, so there is nothing to toggle and nothing to get out of step.
+      */}
+      <View style={styles.behind} pointerEvents="none">
+        <Action action={right} align="flex-start" styles={styles} />
+        <Action action={left} align="flex-end" styles={styles} />
+      </View>
+      <Animated.View style={{ transform: [{ translateX }] }} {...pan.panHandlers}>
+        {children}
+      </Animated.View>
+    </View>
+  )
+}
+
+function Action({
+  action,
+  align,
+  styles,
+}: {
+  action: SwipeableRowAction
+  align: 'flex-start' | 'flex-end'
+  styles: ReturnType<typeof useStyles>
+}) {
+  return (
+    <View style={[styles.action, { alignItems: align }]}>
+      <Feather name={action.icon} size={18} color={action.colour} />
+      <Text style={[styles.actionLabel, { color: action.colour }]} numberOfLines={1}>
+        {action.label}
+      </Text>
+    </View>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, spacing }) => ({
+  wrap: { backgroundColor: colors.bg, overflow: 'hidden' },
+  behind: {
+    ...({ position: 'absolute' } as const),
+    alignItems: 'center',
+    bottom: 0,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    left: 0,
+    paddingHorizontal: spacing.lg,
+    right: 0,
+    top: 0,
+  },
+  action: { gap: 2, justifyContent: 'center' },
+  actionLabel: { ...font.caption, fontSize: 11, fontWeight: '600' },
+}))

--- a/apps/mobile/src/lib/swipeAction.test.ts
+++ b/apps/mobile/src/lib/swipeAction.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ACTION_ACTIVATE_PX,
+  ACTION_LOCK_PX,
+  ACTION_MAX_PX,
+  rowReleased,
+  rowSwipeEnabled,
+  rowTranslation,
+  shouldCaptureRowSwipe,
+} from './swipeAction'
+
+describe('shouldCaptureRowSwipe', () => {
+  it('ignores movement that has not committed yet', () => {
+    expect(shouldCaptureRowSwipe(ACTION_LOCK_PX, 0)).toBe(false)
+    expect(shouldCaptureRowSwipe(-ACTION_LOCK_PX, 0)).toBe(false)
+  })
+
+  it('takes a clear horizontal drag either way', () => {
+    expect(shouldCaptureRowSwipe(40, 5)).toBe(true)
+    expect(shouldCaptureRowSwipe(-40, 5)).toBe(true)
+  })
+
+  /**
+   * The whole answer to "why does the list not scroll any more". A flick down a
+   * long list is never perfectly vertical.
+   */
+  it('leaves a diagonal flick to the list', () => {
+    expect(shouldCaptureRowSwipe(30, 30)).toBe(false)
+    expect(shouldCaptureRowSwipe(-30, 25)).toBe(false)
+  })
+})
+
+describe('rowTranslation', () => {
+  it('follows the finger up to the limit, in both directions', () => {
+    expect(rowTranslation(50)).toBe(50)
+    expect(rowTranslation(-50)).toBe(-50)
+    expect(rowTranslation(ACTION_MAX_PX)).toBe(ACTION_MAX_PX)
+  })
+
+  it('resists past the limit rather than stopping dead', () => {
+    const over = rowTranslation(ACTION_MAX_PX + 100)
+    expect(over).toBeGreaterThan(ACTION_MAX_PX)
+    expect(over).toBeLessThan(ACTION_MAX_PX + 100)
+    expect(rowTranslation(-(ACTION_MAX_PX + 100))).toBe(-over)
+  })
+})
+
+describe('rowReleased', () => {
+  it('names the direction once it has gone far enough', () => {
+    expect(rowReleased(ACTION_ACTIVATE_PX)).toBe('right')
+    expect(rowReleased(-ACTION_ACTIVATE_PX)).toBe('left')
+  })
+
+  /** A short swipe springs back and does nothing — no accidental archiving. */
+  it('is null for a swipe that stopped short', () => {
+    expect(rowReleased(ACTION_ACTIVATE_PX - 1)).toBeNull()
+    expect(rowReleased(-(ACTION_ACTIVATE_PX - 1))).toBeNull()
+    expect(rowReleased(0)).toBeNull()
+  })
+})
+
+describe('rowSwipeEnabled', () => {
+  it('is on natively and on a touchscreen browser', () => {
+    expect(rowSwipeEnabled('ios', false)).toBe(true)
+    expect(rowSwipeEnabled('android', false)).toBe(true)
+    expect(rowSwipeEnabled('web', true)).toBe(true)
+  })
+
+  /** A mouse drag across a row is also text selection; the two fight. */
+  it('is off in a browser driven by a mouse', () => {
+    expect(rowSwipeEnabled('web', false)).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/swipeAction.ts
+++ b/apps/mobile/src/lib/swipeAction.ts
@@ -1,0 +1,67 @@
+/**
+ * Swiping a row in a list to act on it.
+ *
+ * A sibling of `swipeToReply`, and deliberately the same shape: the thresholds
+ * live here as plain numbers and the gesture logic is a pure function, so the
+ * two things that are easy to get wrong — when a diagonal flick stops being a
+ * scroll, and how far the row may travel — are testable without a renderer.
+ *
+ * Unlike swipe-to-reply this is **two-directional**, because a chat row has two
+ * actions and a list has no second axis to spend.
+ */
+
+/** Past this, releasing performs the action. */
+export const ACTION_ACTIVATE_PX = 72
+/** Where the row stops following the finger one-to-one. */
+export const ACTION_MAX_PX = 96
+/** Movement below this is still undecided. */
+export const ACTION_LOCK_PX = 12
+/** How much of the overshoot past `ACTION_MAX_PX` still moves the row. */
+const RUBBER = 0.15
+/**
+ * How much more horizontal than vertical the movement has to be.
+ *
+ * Same 1.5 as `swipeToReply`, and for the same reason: a flick down a long list
+ * is never perfectly vertical, and at 1.0 a slightly diagonal one reads as a
+ * swipe and eats the scroll.
+ */
+const HORIZONTAL_BIAS = 1.5
+
+export type SwipeDirection = 'left' | 'right'
+
+/** Is this a row swipe, or the list scrolling? */
+export function shouldCaptureRowSwipe(dx: number, dy: number): boolean {
+  return Math.abs(dx) > ACTION_LOCK_PX && Math.abs(dx) > Math.abs(dy) * HORIZONTAL_BIAS
+}
+
+/** Follows the finger, then resists — so the limit is felt, not hit. */
+export function rowTranslation(dx: number): number {
+  const sign = dx < 0 ? -1 : 1
+  const distance = Math.abs(dx)
+  const eased =
+    distance <= ACTION_MAX_PX ? distance : ACTION_MAX_PX + (distance - ACTION_MAX_PX) * RUBBER
+  return sign * eased
+}
+
+/**
+ * Which action a release fires, or `null` for a swipe that did not go far
+ * enough — which springs back and does nothing.
+ */
+export function rowReleased(dx: number): SwipeDirection | null {
+  if (dx >= ACTION_ACTIVATE_PX) return 'right'
+  if (dx <= -ACTION_ACTIVATE_PX) return 'left'
+  return null
+}
+
+/**
+ * Whether the gesture is offered at all.
+ *
+ * The same rule `swipeToReply` states, and it has to be the same: on the web a
+ * mouse drag across a row is also the browser's own text selection, and the one
+ * that wins depends on where the drag started. A gesture that works from the
+ * padding and not from the words is worse than one that is plainly absent — so
+ * on a desktop the long-press menu stays the only way in, which it already was.
+ */
+export function rowSwipeEnabled(platform: string, hasTouch: boolean): boolean {
+  return platform === 'web' ? hasTouch : true
+}


### PR DESCRIPTION
Pinning and archiving already existed — behind a long press. A long press is
discoverable exactly once, by someone who happens to try it, and it is the wrong
shape for the thing people actually do to a list of threads.

**Swipe right to pin, left to archive**, both reversible by swiping again.

## Swipe and release, not a drawer that stays open

A row that stays open needs a shared "which row is open" across the whole list,
and there is **no precedent for that here** — `MessageBubble`'s swipe always
springs back. This is the same gesture that file already proved, given a second
direction, and it means a row can never be left in a state the reader has to
undo before they can scroll.

## RN `Animated`, not gesture-handler, not Reanimated

- **`react-native-gesture-handler` is not a dependency at all.** It exists only
  as a transitive peer of expo-router's drawer, which pnpm's isolated layout
  makes unreachable — adding it would mean a direct dependency *and* a fresh
  native build.
- **Reanimated 4 is installed and imported by nothing**, and `ui/Skeleton.tsx`
  records why: reaching for it puts its worklets bundle into the shipped web
  build.

The three properties `swipeToReply` had to get right are the same three here, so
the numbers are copied rather than reinvented:

| | why |
|---|---|
| `onStartShouldSetPanResponder: () => false` | the tap that opens the thread and the long press that opens the menu both survive |
| `onPanResponderTerminationRequest: () => true` | the list asking for the responder back mid-scroll wins, always |
| `HORIZONTAL_BIAS = 1.5` | the whole answer to "why does the list not scroll any more" — a flick down a long list is never perfectly vertical |

## Off for a mouse

`rowSwipeEnabled` mirrors `swipeToReplyEnabled`: on the web a mouse drag across a
row is also the browser's own text selection, and which one wins depends on
where the drag started. On a desktop the long-press menu stays the way in —
which it already was, so nothing is lost.

## Verified in the running app

Driven with **real touch events over CDP** (synthetic `TouchEvent`s do not reach
react-native-web's responder system, and `page.mouse` produces mouse events —
both were misleading before I switched):

```
touch, swipe right →  pinnedBy  = { <me>: true }     in the database
touch, swipe left  →  archivedBy = { <me>: true }
mouse (maxTouchPoints 0) → swipe layer not rendered at all
```

`pnpm test` 1113 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)