### PR TITLE
Give a guest a session, a viewer profile, and nothing else

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -2,6 +2,7 @@ import { APP_SCHEMES, IOS_BUNDLE_ID, PASSWORD_MIN_LENGTH, WEB_HOST } from '@lang
 import { betterAuth } from 'better-auth'
 import { mongodbAdapter } from 'better-auth/adapters/mongodb'
 import { expo } from '@better-auth/expo'
+import { anonymous } from 'better-auth/plugins/anonymous'
 import { deviceAuthorization } from 'better-auth/plugins/device-authorization'
 import type { Db, MongoClient } from 'mongodb'
 import { generateAppleClientSecret } from './auth/appleClientSecret'
@@ -164,6 +165,24 @@ export async function createAuth({ env, db, client, emailSender, revenueCat }: C
 
     plugins: [
       expo(),
+      /*
+       * A session for somebody who has not signed up yet, so the app can show
+       * them real people before asking for an email.
+       *
+       * Only half of this plugin is used. Its *linking* half is switched off by
+       * never being reached: `emailAndPassword` here has
+       * `requireEmailVerification: true` and `autoSignIn: false`, so
+       * `signUp.email` returns no session at all, and `onLinkAccount` would fire
+       * around a `newUser` that has none. The client signs the guest out and
+       * registers fresh instead — which loses nothing, because a guest cannot
+       * write and therefore owns no rows to carry over. The language choices
+       * travel in the device-side onboarding draft, which already survives a
+       * relaunch and is cleared only on a real submit.
+       *
+       * `.invalid` is reserved by RFC 2606 and can never resolve, so the
+       * synthetic addresses this mints cannot receive mail even by accident.
+       */
+      anonymous({ emailDomainName: 'guest.langx.invalid' }),
       /*
        * QR sign-in on the web, which is RFC 8628's device flow with a picture
        * in front of it: the browser asks for a code, shows it as a QR *and* as

--- a/apps/api/src/middleware/requireAuth.ts
+++ b/apps/api/src/middleware/requireAuth.ts
@@ -7,6 +7,8 @@ declare module 'fastify' {
     userId: string
     userEmail: string
     emailVerified: boolean
+    /** Set by requireAuth. A guest browsing without an account of their own. */
+    isGuest: boolean
   }
 }
 
@@ -36,6 +38,35 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply):
   request.userId = session.user.id
   request.userEmail = session.user.email
   request.emailVerified = session.user.emailVerified
+  // `isAnonymous` is declared by the plugin with `input: false`, so a client
+  // cannot assert it — it is only ever true because Better Auth made the user.
+  request.isGuest = (session.user as { isAnonymous?: boolean }).isAnonymous === true
+}
+
+/**
+ * Layer on top of `requireAuth` for anything a guest must not do.
+ *
+ * Guests are `emailVerified: false`, so every route already behind
+ * `requireVerifiedEmail` is closed to them for free — a happy accident, and the
+ * strongest single argument for using Better Auth's anonymous plugin rather
+ * than inventing a session. This covers the rest: the writes that only ever
+ * needed `requireAuth`, which is most of them.
+ *
+ * A distinct code rather than `UNAUTHENTICATED`, because the client's answer is
+ * different. Unauthenticated means "sign in"; this means "you are browsing as a
+ * guest, and this needs an account" — which is an offer, not an error.
+ */
+export async function requireMember(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  await requireAuth(request, reply)
+  if (reply.sent) return
+
+  if (request.isGuest) {
+    const body: ApiErrorBody = {
+      code: ERROR_CODES.GUEST_ACCOUNT,
+      message: 'Create an account to do that',
+    }
+    return reply.code(ERROR_STATUS.GUEST_ACCOUNT).send(body)
+  }
 }
 
 /**

--- a/apps/api/src/modules/account/purgeScheduler.ts
+++ b/apps/api/src/modules/account/purgeScheduler.ts
@@ -2,6 +2,7 @@ import type { Db } from 'mongodb'
 import type { StorageProvider } from '../../storage/StorageProvider'
 import type { SchedulerLogger } from '../tokens/poolScheduler'
 import { purgeExpiredAccounts } from './deletion'
+import { purgeStaleGuests } from '../profiles/purgeGuests'
 
 /** Hourly is plenty — the grace period is 30 days, nothing here is urgent. */
 export const PURGE_INTERVAL_MS = 60 * 60 * 1000
@@ -34,6 +35,14 @@ export function startPurgeScheduler(
           { purged: result.purged, objectsDeleted: result.objectsDeleted },
           'expired accounts purged',
         )
+      }
+
+      // Guest sessions ride the same tick rather than a second scheduler: the
+      // question is the same shape ("is anything past its cutoff?") and neither
+      // is urgent.
+      const guests = await purgeStaleGuests(db)
+      if (guests.purged > 0) {
+        logger.info({ purged: guests.purged }, 'stale guest sessions purged')
       }
     } catch (error) {
       logger.error({ err: error }, 'account purge failed')

--- a/apps/api/src/modules/discovery/discovery.ts
+++ b/apps/api/src/modules/discovery/discovery.ts
@@ -169,6 +169,11 @@ export async function discoverProfiles(
   const match: Document = {
     _id: { $nin: excludedIds },
     'settings.discoverable': true,
+    // Belt and braces. `discoverable: false` already excludes them, but a
+    // guest surfacing in somebody's results is the single worst failure of
+    // this feature, and one flag flipped by a future default should not be
+    // all that stands between here and there.
+    guest: { $exists: false },
     deletedAt: { $exists: false },
     // Mutual fit, both directions — the reason for the two split indexes.
     'nativeLanguages.code': { $in: wantTheirNative },

--- a/apps/api/src/modules/discovery/handleSearch.ts
+++ b/apps/api/src/modules/discovery/handleSearch.ts
@@ -52,6 +52,11 @@ export async function searchHandles(
         _id: { $nin: excludedIds },
         handle: { $regex: `^${escapeRegex(term)}` },
         'settings.discoverable': true,
+        // Belt and braces. `discoverable: false` already excludes them, but a
+        // guest surfacing in somebody's results is the single worst failure of
+        // this feature, and one flag flipped by a future default should not be
+        // all that stands between here and there.
+        guest: { $exists: false },
         deletedAt: { $exists: false },
       },
       {

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -4,6 +4,7 @@ import {
   ageFromBirthDate,
   cityKey,
   PLAN_LIMITS,
+  type GuestProfileInput,
   TIMEZONE_UPDATE_COOLDOWN_MS,
   effectivePlanTier,
   isOnlineAt,
@@ -36,6 +37,18 @@ import { grantSignupBonus } from '../tokens/signupBonus'
 
 export interface Profile {
   _id: string
+  /**
+   * A browsing session with no account behind it.
+   *
+   * The row exists because `discoverProfiles` needs a viewer document — it
+   * reads the viewer's languages, tier, location and blocks to build the whole
+   * mutual-fit match — and for no other reason. It is **not** an analytics
+   * record: it can say a guest existed and which languages they picked, and
+   * cannot say where in welcome → languages → discover → sign-up they stopped,
+   * which is the only question worth asking about a funnel. That is PostHog's
+   * job when it lands.
+   */
+  guest?: true
   handle: string
   displayName: string
   avatarUrl?: string
@@ -367,6 +380,62 @@ function assertLanguageCap(
 ): void {
   if (next <= max || next <= was) return
   throw new ApiError(ERROR_CODES.UPGRADE_REQUIRED, `Your plan allows ${max}`, { limit, max })
+}
+
+/**
+ * The profile a guest browses with: two languages and nothing else.
+ *
+ * Written by its own function rather than through `createProfile`, and the
+ * differences are all deliberate. No signup bonus — a guest has not signed up,
+ * and paying one here would pay it twice when they do. `discoverable: false`,
+ * so a guest can never appear in somebody else's discovery. And a synthetic
+ * handle: `handle_unique` is not sparse, so the row needs one, and
+ * `guest:<userId>` can never collide with a real username because
+ * `HANDLE_PATTERN` allows no colon and caps length at twenty. Which also means
+ * no route and no `/<handle>` link can ever resolve to it.
+ */
+export async function createGuestProfile(
+  db: Db,
+  userId: string,
+  input: GuestProfileInput,
+  connectionCountry?: string,
+): Promise<Profile> {
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  const existing = await profiles.findOne({ _id: userId })
+  if (existing) return existing
+
+  const now = new Date()
+  const profile: Profile = {
+    _id: userId,
+    guest: true,
+    handle: `guest:${userId}`,
+    displayName: '',
+    // Never rendered and never compared: a guest has no profile of their own
+    // and cannot be looked at. It is here because the type requires it, and a
+    // date rather than an empty string so nothing downstream has to guard.
+    birthDate: '1900-01-01',
+    gender: 'undisclosed',
+    nativeLanguages: input.nativeLanguages,
+    learning: input.learning,
+    interests: [],
+    settings: { discoverable: false, notifications: DEFAULT_NOTIFICATION_PREFS },
+    privacy: {
+      incognito: false,
+      hideOnlineStatus: false,
+      activityMapVisible: false,
+      statsVisible: false,
+    },
+    entitlement: { tier: 'free', updatedAt: now },
+    quota: { initiations: [], translations: [], media: [] },
+    streak: { current: 0, longest: 0, lastQualifiedDay: null },
+    stats: { lastActiveAt: now, messagesSent: 0 },
+    createdAt: now,
+    updatedAt: now,
+  }
+  if (connectionCountry) profile.country = connectionCountry
+
+  await profiles.insertOne(profile)
+  return profile
 }
 
 export async function updateProfile(

--- a/apps/api/src/modules/profiles/purgeGuests.ts
+++ b/apps/api/src/modules/profiles/purgeGuests.ts
@@ -1,0 +1,47 @@
+import type { Db } from 'mongodb'
+import { GUEST_TTL_MS } from '@langx/shared'
+import { COLLECTIONS } from '../../db/collections'
+import { authId } from '../../lib/authId'
+import type { Profile } from './profiles'
+
+/**
+ * Deletes guest sessions that were never turned into accounts.
+ *
+ * They accumulate by design — a guest row is written the moment somebody picks
+ * two languages, and most of those people will never come back. Without this,
+ * `profiles` fills with rows nobody will ever read again.
+ *
+ * Driven by a timestamp rather than a lock, like the account purge: a guest
+ * older than the cutoff is gone after the first pass and no longer matches, so
+ * two instances racing simply both find nothing the second time.
+ *
+ * **The Better Auth rows go through `authId`.** Those collections key on
+ * ObjectId while ours key on the string form, and a string filter against
+ * `user` matches nothing and reports success — which would leave the account
+ * and the session behind while the profile disappeared, i.e. exactly the
+ * silent half-delete the two-id-worlds note warns about.
+ */
+export async function purgeStaleGuests(
+  db: Db,
+  now: Date = new Date(),
+): Promise<{ purged: number }> {
+  const cutoff = new Date(now.getTime() - GUEST_TTL_MS)
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+
+  const stale = await profiles
+    .find({ guest: true, createdAt: { $lte: cutoff } }, { projection: { _id: 1 } })
+    .toArray()
+  if (stale.length === 0) return { purged: 0 }
+
+  const ids = stale.map((p) => p._id)
+  const authIds = ids.map((id) => authId(id))
+
+  await profiles.deleteMany({ _id: { $in: ids }, guest: true })
+  await Promise.all([
+    db.collection(COLLECTIONS.session).deleteMany({ userId: { $in: authIds } }),
+    db.collection(COLLECTIONS.account).deleteMany({ userId: { $in: authIds } }),
+    db.collection(COLLECTIONS.user).deleteMany({ _id: { $in: authIds } }),
+  ])
+
+  return { purged: ids.length }
+}

--- a/apps/api/src/modules/profiles/sharedProfile.ts
+++ b/apps/api/src/modules/profiles/sharedProfile.ts
@@ -28,7 +28,14 @@ import type { Profile } from './profiles'
  */
 export async function getSharedProfile(db: Db, handle: string): Promise<SharedProfile> {
   const profile = await db.collection<Profile>(COLLECTIONS.profiles).findOne(
-    { handle: handle.toLowerCase(), deletedAt: { $exists: false } },
+    {
+      handle: handle.toLowerCase(),
+      deletedAt: { $exists: false },
+      // A guest handle is `guest:<id>`, which `handleSchema` can never produce
+      // and no route can pass — but this read is the app's only unauthenticated
+      // one, so it says so rather than relying on that.
+      guest: { $exists: false },
+    },
     {
       projection: {
         handle: 1,

--- a/apps/api/src/routes/account.ts
+++ b/apps/api/src/routes/account.ts
@@ -1,6 +1,6 @@
 import { deleteAccountSchema, registerDeviceSchema } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
-import { requireAuth } from '../middleware/requireAuth'
+import { requireAuth, requireMember } from '../middleware/requireAuth'
 import {
   cancelDeletion,
   deletionStatus,
@@ -15,18 +15,18 @@ import { COLLECTIONS } from '../db/collections'
 export const accountRoutes: FastifyPluginAsyncZod = async (app) => {
   app.post(
     '/me/delete',
-    { preHandler: requireAuth, schema: { body: deleteAccountSchema } },
+    { preHandler: requireMember, schema: { body: deleteAccountSchema } },
     async (request, reply) => {
       const status = await requestDeletion(app.mongo.db, request.userId, request.body.reason)
       return reply.send(status)
     },
   )
 
-  app.post('/me/delete/cancel', { preHandler: requireAuth }, async (request, reply) => {
+  app.post('/me/delete/cancel', { preHandler: requireMember }, async (request, reply) => {
     return reply.send(await cancelDeletion(app.mongo.db, request.userId))
   })
 
-  app.get('/me/delete', { preHandler: requireAuth }, async (request, reply) => {
+  app.get('/me/delete', { preHandler: requireMember }, async (request, reply) => {
     return reply.send(await deletionStatus(app.mongo.db, request.userId))
   })
 
@@ -40,7 +40,7 @@ export const accountRoutes: FastifyPluginAsyncZod = async (app) => {
    * the timestamp around. 204 either way — the client's next question is only
    * ever "should I still show this?", and the answer is no in both cases.
    */
-  app.post('/me/welcome-back/ack', { preHandler: requireAuth }, async (request, reply) => {
+  app.post('/me/welcome-back/ack', { preHandler: requireMember }, async (request, reply) => {
     await app.mongo.db.collection<Profile>(COLLECTIONS.profiles).updateOne(
       {
         _id: request.userId,
@@ -62,14 +62,14 @@ export const accountRoutes: FastifyPluginAsyncZod = async (app) => {
 
   app.post(
     '/me/devices',
-    { preHandler: requireAuth, schema: { body: registerDeviceSchema } },
+    { preHandler: requireMember, schema: { body: registerDeviceSchema } },
     async (request, reply) => {
       await registerDevice(app.mongo.db, request.userId, request.body)
       return reply.code(204).send()
     },
   )
 
-  app.delete('/me/devices/:token', { preHandler: requireAuth }, async (request, reply) => {
+  app.delete('/me/devices/:token', { preHandler: requireMember }, async (request, reply) => {
     const { token } = request.params as { token: string }
     await unregisterDevice(app.mongo.db, request.userId, decodeURIComponent(token))
     return reply.code(204).send()

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -2,7 +2,7 @@ import { ERROR_CODES, revenueCatWebhookBodySchema } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { z } from 'zod'
 import { ApiError } from '../lib/ApiError'
-import { requireAuth } from '../middleware/requireAuth'
+import { requireMember } from '../middleware/requireAuth'
 import { asFakeRevenueCat } from '../modules/billing/fakeRevenueCat'
 import { refreshEntitlement } from '../modules/billing/refresh'
 import { processRevenueCatWebhook } from '../modules/billing/webhook'
@@ -52,7 +52,7 @@ export const billingRoutes: FastifyPluginAsyncZod = async (app) => {
     },
   )
 
-  app.post('/billing/refresh', { preHandler: requireAuth }, async (request, reply) => {
+  app.post('/billing/refresh', { preHandler: requireMember }, async (request, reply) => {
     const entitlement = await refreshEntitlement(app.mongo.db, app.revenueCat, request.userId)
     return reply.send(entitlement)
   })
@@ -87,7 +87,7 @@ function registerTestStoreRoute(app: Parameters<FastifyPluginAsyncZod>[0]): void
 
   app.post(
     '/billing/test-event',
-    { schema: { body: testEventBodySchema }, preHandler: requireAuth },
+    { schema: { body: testEventBodySchema }, preHandler: requireMember },
     async (request, reply) => {
       const { action, packageId } = request.body
       const userId = request.userId

--- a/apps/api/src/routes/guest.test.ts
+++ b/apps/api/src/routes/guest.test.ts
@@ -1,0 +1,175 @@
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import type { FastifyInstance, InjectOptions } from 'fastify'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { buildApp } from '../app'
+import { createAuth } from '../auth'
+import { connectToDatabase, type DbHandle } from '../db/client'
+import { COLLECTIONS } from '../db/collections'
+import { ensureIndexes } from '../db/indexes'
+import { loadEnv } from '../env'
+import type { Profile } from '../modules/profiles/profiles'
+import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
+import { createStorageProvider } from '../storage/createStorageProvider'
+import { CapturingEmailSender } from '../testSupport/authFlow'
+import { createTranslationProvider } from '../translation/createTranslationProvider'
+
+describe('guests', () => {
+  let replSet: MongoMemoryReplSet
+  let handle: DbHandle
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+    const env = loadEnv({
+      NODE_ENV: 'test',
+      MONGODB_URI: replSet.getUri(),
+      MONGODB_DB: 'langx_guest_test',
+      LOG_LEVEL: 'silent',
+      BETTER_AUTH_SECRET: 'a'.repeat(32),
+      BETTER_AUTH_URL: 'http://localhost:4000',
+    })
+    handle = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
+    await ensureIndexes(handle.db)
+    const revenueCat = createRevenueCatClientFromEnv(env)
+    app = await buildApp({
+      env,
+      db: handle.db,
+      client: handle.client,
+      auth: await createAuth({
+        env,
+        db: handle.db,
+        client: handle.client,
+        emailSender: new CapturingEmailSender(),
+        revenueCat,
+      }),
+      storage: createStorageProvider(env),
+      translation: createTranslationProvider(env),
+      revenueCat,
+    })
+    await app.ready()
+  }, 120_000)
+
+  afterAll(async () => {
+    await app?.close()
+    await handle?.client.close()
+    await replSet?.stop()
+  })
+
+  /** The plugin's own endpoint; the cookie it returns is an ordinary session. */
+  async function signInAsGuest(): Promise<string> {
+    const response = await app.inject({ method: 'POST', url: '/api/auth/sign-in/anonymous' })
+    if (response.statusCode !== 200) {
+      throw new Error(`anonymous sign-in failed (${response.statusCode}): ${response.body}`)
+    }
+    const cookie = response.headers['set-cookie']
+    return Array.isArray(cookie) ? cookie.join('; ') : String(cookie)
+  }
+
+  const guestBody = {
+    nativeLanguages: [{ code: 'tr' }],
+    learning: [{ code: 'en', level: 'intermediate', priority: 1 }],
+  }
+
+  it('can create a profile with only languages', async () => {
+    const cookie = await signInAsGuest()
+    const created = await app.inject({
+      method: 'POST',
+      url: '/profiles/guest',
+      headers: { cookie },
+      payload: guestBody,
+    })
+    expect(created.statusCode, created.body).toBe(201)
+
+    const profile = created.json<Profile>()
+    expect(profile.guest).toBe(true)
+    // The two things that keep a guest out of everybody else's way.
+    expect(profile.settings.discoverable).toBe(false)
+    expect(profile.handle.startsWith('guest:')).toBe(true)
+  })
+
+  /**
+   * A guest has not signed up, and paying the bonus here would pay it twice
+   * when they do — the ledger's unique is keyed on the *user id*, and
+   * registering mints a new one.
+   */
+  it('is not paid the signup bonus', async () => {
+    const cookie = await signInAsGuest()
+    const created = await app.inject({
+      method: 'POST',
+      url: '/profiles/guest',
+      headers: { cookie },
+      payload: guestBody,
+    })
+    const userId = created.json<Profile>()._id
+
+    const ledger = await handle.db
+      .collection(COLLECTIONS.tokenLedger)
+      .countDocuments({ userId, kind: 'signupBonus' })
+    expect(ledger).toBe(0)
+  })
+
+  it('can browse', async () => {
+    const cookie = await signInAsGuest()
+    await app.inject({
+      method: 'POST',
+      url: '/profiles/guest',
+      headers: { cookie },
+      payload: guestBody,
+    })
+
+    for (const url of ['/discovery', '/feed']) {
+      const response = await app.inject({ method: 'GET', url, headers: { cookie } })
+      expect(response.statusCode, `${url}: ${response.body}`).toBe(200)
+    }
+  })
+
+  /**
+   * Iterated over a table rather than written out one by one, so a write route
+   * added later without `requireMember` fails here rather than shipping.
+   */
+  it('is refused every write', async () => {
+    const cookie = await signInAsGuest()
+    await app.inject({
+      method: 'POST',
+      url: '/profiles/guest',
+      headers: { cookie },
+      payload: guestBody,
+    })
+
+    const writes: InjectOptions[] = [
+      { method: 'PATCH', url: '/profiles/me', payload: { bio: 'hello' } },
+      { method: 'POST', url: '/profiles/me/location', payload: { lat: 41, lng: 29 } },
+      { method: 'DELETE', url: '/profiles/me/location' },
+      { method: 'POST', url: '/billing/refresh' },
+      {
+        method: 'POST',
+        url: '/me/devices',
+        payload: { pushToken: 'ExponentPushToken[x]', platform: 'ios' },
+      },
+      { method: 'POST', url: '/blocks', payload: { userId: 'someone' } },
+      { method: 'POST', url: '/reports', payload: { userId: 'someone', reason: 'spam' } },
+    ]
+
+    for (const write of writes) {
+      const where = `${String(write.method)} ${JSON.stringify(write.url)}`
+      const response = await app.inject({ ...write, headers: { cookie } })
+      expect(response.statusCode, `${where} -> ${response.body}`).toBe(403)
+      expect(response.json<{ code: string }>().code, where).toBe('GUEST_ACCOUNT')
+    }
+  })
+
+  it('never appears in anybody else discovery', async () => {
+    const cookie = await signInAsGuest()
+    await app.inject({
+      method: 'POST',
+      url: '/profiles/guest',
+      headers: { cookie },
+      payload: guestBody,
+    })
+
+    const guests = await handle.db
+      .collection<Profile>(COLLECTIONS.profiles)
+      .countDocuments({ guest: true, 'settings.discoverable': true })
+    expect(guests).toBe(0)
+  })
+})

--- a/apps/api/src/routes/media.ts
+++ b/apps/api/src/routes/media.ts
@@ -14,7 +14,7 @@ import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { z } from 'zod'
 import { ApiError } from '../lib/ApiError'
 import { assertOwnBucket } from '../lib/assertOwnBucket'
-import { requireAuth, requireVerifiedEmail } from '../middleware/requireAuth'
+import { requireMember, requireVerifiedEmail } from '../middleware/requireAuth'
 import { assertConversationAccess } from '../modules/chat/access'
 import { addPhoto, removePhoto, setAvatarUrl } from '../modules/profiles/profiles'
 
@@ -29,7 +29,7 @@ export const mediaRoutes: FastifyPluginAsyncZod = async (app) => {
   app.post(
     '/me/avatar/upload-url',
     {
-      preHandler: requireAuth,
+      preHandler: requireMember,
       schema: { body: z.object({ contentType: avatarContentTypeSchema }) },
     },
     async (request, reply) => {
@@ -43,7 +43,7 @@ export const mediaRoutes: FastifyPluginAsyncZod = async (app) => {
 
   app.post(
     '/me/avatar/confirm',
-    { preHandler: requireAuth, schema: { body: avatarConfirmSchema } },
+    { preHandler: requireMember, schema: { body: avatarConfirmSchema } },
     async (request, reply) => {
       // Confirm-only, not free-form — an avatarUrl outside our own bucket
       // would break the Faz 10 "delete R2 avatars on hard delete" step and
@@ -60,7 +60,7 @@ export const mediaRoutes: FastifyPluginAsyncZod = async (app) => {
   app.post(
     '/me/photos/upload-url',
     {
-      preHandler: requireAuth,
+      preHandler: requireMember,
       schema: { body: z.object({ contentType: avatarContentTypeSchema }) },
     },
     async (request, reply) => {
@@ -72,7 +72,7 @@ export const mediaRoutes: FastifyPluginAsyncZod = async (app) => {
 
   app.post(
     '/me/photos',
-    { preHandler: requireAuth, schema: { body: photoAddSchema } },
+    { preHandler: requireMember, schema: { body: photoAddSchema } },
     async (request, reply) => {
       assertOwnBucket(app.env.STORAGE_PUBLIC_BASE_URL, request.body.url)
       return reply.send(await addPhoto(app.mongo.db, request.userId, request.body.url))
@@ -88,7 +88,7 @@ export const mediaRoutes: FastifyPluginAsyncZod = async (app) => {
    */
   app.post(
     '/messages/upload-url',
-    { preHandler: requireAuth, schema: { body: mediaUploadUrlSchema } },
+    { preHandler: requireMember, schema: { body: mediaUploadUrlSchema } },
     async (request, reply) => {
       const conversation = await assertConversationAccess(
         app.mongo.db,
@@ -151,7 +151,7 @@ export const mediaRoutes: FastifyPluginAsyncZod = async (app) => {
 
   app.delete(
     '/me/photos',
-    { preHandler: requireAuth, schema: { body: photoRemoveSchema } },
+    { preHandler: requireMember, schema: { body: photoRemoveSchema } },
     async (request, reply) => {
       return reply.send(await removePhoto(app.mongo.db, request.userId, request.body.url))
     },

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -9,7 +9,7 @@ import {
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { z } from 'zod'
 import { ApiError } from '../lib/ApiError'
-import { requireAuth } from '../middleware/requireAuth'
+import { requireAuth, requireMember } from '../middleware/requireAuth'
 import {
   listConversations,
   listMessages,
@@ -145,7 +145,7 @@ export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
   // notification before a socket connection exists) — still fans the
   // realtime `conversation:read` event out over `app.io`, so the sender's
   // UI updates the same way regardless of which transport the reader used.
-  app.post('/conversations/:id/read', { preHandler: requireAuth }, async (request, reply) => {
+  app.post('/conversations/:id/read', { preHandler: requireMember }, async (request, reply) => {
     const { id } = request.params as { id: string }
     const conversation = await markConversationRead(app.mongo.db, request.userId, id)
     const otherId = conversation.participants.find((p) => p !== request.userId)

--- a/apps/api/src/routes/moderation.ts
+++ b/apps/api/src/routes/moderation.ts
@@ -1,6 +1,6 @@
 import { blockSchema, moderationListQuerySchema, reportSchema } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
-import { requireAuth } from '../middleware/requireAuth'
+import { requireAuth, requireMember } from '../middleware/requireAuth'
 import { blockUser, listBlocked, reportUser, unblockUser } from '../modules/moderation/blocks'
 import { getViewers } from '../modules/moderation/profileViews'
 
@@ -8,7 +8,7 @@ import { getViewers } from '../modules/moderation/profileViews'
 export const moderationRoutes: FastifyPluginAsyncZod = async (app) => {
   app.post(
     '/blocks',
-    { preHandler: requireAuth, schema: { body: blockSchema } },
+    { preHandler: requireMember, schema: { body: blockSchema } },
     async (request, reply) => {
       const block = await blockUser(app.mongo.db, request.userId, request.body.userId)
       return reply.code(201).send(block)
@@ -23,7 +23,7 @@ export const moderationRoutes: FastifyPluginAsyncZod = async (app) => {
     },
   )
 
-  app.delete('/blocks/:userId', { preHandler: requireAuth }, async (request, reply) => {
+  app.delete('/blocks/:userId', { preHandler: requireMember }, async (request, reply) => {
     const { userId } = request.params as { userId: string }
     await unblockUser(app.mongo.db, request.userId, userId)
     return reply.code(204).send()
@@ -31,7 +31,7 @@ export const moderationRoutes: FastifyPluginAsyncZod = async (app) => {
 
   app.post(
     '/reports',
-    { preHandler: requireAuth, schema: { body: reportSchema } },
+    { preHandler: requireMember, schema: { body: reportSchema } },
     async (request, reply) => {
       const result = await reportUser(app.mongo.db, request.userId, request.body)
       // `xpFrozen` is deliberately not echoed to the reporter: whether someone

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -4,18 +4,21 @@ import {
   locationInputSchema,
   onboardingProfileSchema,
   updateProfileSchema,
+  ERROR_CODES,
+  guestProfileSchema,
 } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { z } from 'zod'
 import { ApiError } from '../lib/ApiError'
 import { findConversationBetween } from '../modules/chat/conversations'
 import { countryFromHeaders } from '../lib/requestCountry'
-import { requireAuth, requireVerifiedEmail } from '../middleware/requireAuth'
+import { requireAuth, requireMember, requireVerifiedEmail } from '../middleware/requireAuth'
 import { hashLegacyEmail } from '../modules/handles/legacyEmailHash'
 import { blockedUserIds } from '../modules/moderation/blocks'
 import { recordProfileView } from '../modules/moderation/profileViews'
 import {
   clearLocation,
+  createGuestProfile,
   createProfile,
   setCountryFromLocation,
   findProfileByHandleOrId,
@@ -69,7 +72,7 @@ export const profileRoutes: FastifyPluginAsyncZod = async (app) => {
    */
   app.patch(
     '/profiles/me/country',
-    { preHandler: requireAuth, schema: { body: countryFromLocationSchema } },
+    { preHandler: requireMember, schema: { body: countryFromLocationSchema } },
     async (request, reply) => {
       const profile = await setCountryFromLocation(
         app.mongo.db,
@@ -146,9 +149,33 @@ export const profileRoutes: FastifyPluginAsyncZod = async (app) => {
     },
   )
 
+  /**
+   * The one deliberate exception to `requireVerifiedEmail` on a profile write.
+   *
+   * A guest is `emailVerified: false` by construction — that is what closes
+   * every other write to them for free — so this route has to be `requireAuth`,
+   * and `createGuestProfile` is the only thing it can reach.
+   */
+  app.post(
+    '/profiles/guest',
+    { preHandler: requireAuth, schema: { body: guestProfileSchema } },
+    async (request, reply) => {
+      if (!request.isGuest) {
+        throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Not a guest session')
+      }
+      const profile = await createGuestProfile(
+        app.mongo.db,
+        request.userId,
+        request.body,
+        countryFromHeaders(request.headers, app.env.EDGE_SECRET),
+      )
+      return reply.code(201).send(profile)
+    },
+  )
+
   app.patch(
     '/profiles/me',
-    { preHandler: requireAuth, schema: { body: updateProfileSchema } },
+    { preHandler: requireMember, schema: { body: updateProfileSchema } },
     async (request, reply) => {
       const profile = await updateProfile(app.mongo.db, request.userId, request.body)
       return reply.send(profile)
@@ -168,14 +195,14 @@ export const profileRoutes: FastifyPluginAsyncZod = async (app) => {
    */
   app.post(
     '/profiles/me/location',
-    { preHandler: requireAuth, schema: { body: locationInputSchema } },
+    { preHandler: requireMember, schema: { body: locationInputSchema } },
     async (request, reply) => {
       const profile = await setLocation(app.mongo.db, request.userId, request.body)
       return reply.send(profile)
     },
   )
 
-  app.delete('/profiles/me/location', { preHandler: requireAuth }, async (request, reply) => {
+  app.delete('/profiles/me/location', { preHandler: requireMember }, async (request, reply) => {
     const profile = await clearLocation(app.mongo.db, request.userId)
     return reply.send(profile)
   })

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -8,6 +8,15 @@ export const ERROR_CODES = {
   UNAUTHENTICATED: 'UNAUTHENTICATED',
   FORBIDDEN: 'FORBIDDEN',
   EMAIL_NOT_VERIFIED: 'EMAIL_NOT_VERIFIED',
+  /**
+   * A guest tried to do something that needs an account of their own.
+   *
+   * Distinct from `UNAUTHENTICATED` because the answer is different: that one
+   * means "sign in", this one means "you are browsing as a guest, and this
+   * needs an account" — an offer rather than an error. The client turns it into
+   * the sign-up screen instead of a toast.
+   */
+  GUEST_ACCOUNT: 'GUEST_ACCOUNT',
   UNDERAGE: 'UNDERAGE',
 
   // entitlement + quota
@@ -72,6 +81,7 @@ export const ERROR_STATUS: Record<ErrorCode, number> = {
   UNAUTHENTICATED: 401,
   FORBIDDEN: 403,
   EMAIL_NOT_VERIFIED: 403,
+  GUEST_ACCOUNT: 403,
   UNDERAGE: 403,
   UPGRADE_REQUIRED: 403,
   QUOTA_EXCEEDED: 402,

--- a/packages/shared/src/profile.ts
+++ b/packages/shared/src/profile.ts
@@ -94,6 +94,34 @@ const learningLanguagesSchema = z.array(learningLanguageSchema).min(1).max(MAX_L
  * country from the connection instead, and only falls back to this when the
  * edge cannot say (Tor, an unknown range). See `countryFromRequest`.
  */
+/**
+ * What a guest supplies: the two language lists and nothing else.
+ *
+ * Deliberately not a subset of `onboardingProfileSchema`, which requires a
+ * handle, a display name, a birth date and a gender. A guest supplies none of
+ * those because a guest cannot be looked at — they browse, they do not appear.
+ */
+/**
+ * How long a guest session is kept before it is swept away.
+ *
+ * Long enough that somebody who tries the app, closes it and comes back next
+ * week still has their languages; short enough that the collection does not
+ * fill with rows nobody will read again. Most guests never return, and the row
+ * exists only so `discoverProfiles` has a viewer document.
+ */
+export const GUEST_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+export const guestProfileSchema = z
+  .object({
+    nativeLanguages: nativeLanguagesSchema,
+    learning: learningLanguagesSchema,
+  })
+  .refine(learningDoesNotOverlapNative, {
+    message: 'A learning language cannot also be listed as native',
+    path: ['learning'],
+  })
+export type GuestProfileInput = z.infer<typeof guestProfileSchema>
+
 export const onboardingProfileSchema = z
   .object({
     /**


### PR DESCRIPTION
The app demanded an account before it showed anything. A guest can now pick two
languages and see real people — and is refused every write.

Server half only; the welcome screen and the client gate follow.

## There is nothing to merge, so there is no merge

Better Auth's `anonymous` plugin issues the session, so `apiFetch`, the Expo
cookie bridge, `requireAuth` and `getSession` all keep working untouched.
Hand-rolling a session against Better Auth's internals is exactly what
`decisions.md` → *"Phase 1 — an upstream bug"* is a standing warning about.

**Only half the plugin is used.** Its linking half is never reached:
`requireEmailVerification: true` with `autoSignIn: false` means `signUp.email`
returns no session, so `onLinkAccount` would fire around a `newUser` that has
none — murky semantics to put under an identity transition.

And there is nothing to link. **A guest cannot write, so across all seventeen
domain collections a guest owns zero rows.** The only thing worth keeping is the
language choice, and `useOnboardingDraft` already carries it: device-scoped,
survives a relaunch, cleared on a real submit and nowhere else. So
`furthestOnboardingStep` will drop a registering guest on *about-you* with their
languages already filled in, for no new code at all.

## Why the profile row exists at all

`discoverProfiles` reads the viewer's languages, tier, location and blocks to
build the entire mutual-fit `$match`, and throws `NOT_FOUND` without a viewer
document. That is the whole reason, and the code says so — because the row is a
**poor analytics substitute** and should not be mistaken for one. It can say a
guest existed and which languages they picked; it cannot say where in welcome →
languages → discover → sign-up they stopped, which is the only question worth
asking about a funnel. `decisions.md` already picked PostHog for that.

## The guard

`requireMember`, layered exactly like `requireVerifiedEmail`, on **nineteen**
write routes. Everything already behind `requireVerifiedEmail` was closed to
guests for free, since a guest is `emailVerified: false` — a happy accident, and
the strongest single argument for the plugin over a bespoke session.

A distinct `GUEST_ACCOUNT` code rather than `UNAUTHENTICATED`, because the
client's answer differs: one means "sign in", the other means "you are browsing
as a guest, and this needs an account" — an offer, not an error.

## The invariant guests break

Every profile used to belong to a verified account; `ws/index.ts` states it in a
comment. The three reads that relied on it now say so explicitly: discovery,
handle search, and `getSharedProfile` — the app's **only** unauthenticated read.

`handle_unique` is not sparse, so the row needs a handle. `guest:<id>` contains a
colon, which `HANDLE_PATTERN` forbids, and exceeds twenty characters — so no
route and no `/<handle>` link can ever resolve to one.

## Cleanup

Swept after thirty days on the existing account-purge tick — same shape of
question, neither urgent. The Better Auth rows go through **`authId`**: a string
filter against `user` matches nothing and reports success, which is precisely the
silent half-delete the two-id-worlds note exists to warn about.

## Tests

`guest.test.ts` drives the plugin's real endpoint. The write table is **iterated**
rather than written out, so a route added later without `requireMember` fails
here instead of shipping.

```
can create a profile with only languages   ✓
is not paid the signup bonus               ✓
can browse (/discovery, /feed)             ✓
is refused every write (7 routes, 403)     ✓
never appears in anybody else's discovery  ✓
```

`pnpm test` 1109 passing · `pnpm -r typecheck` · `pnpm lint` · `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)