### PR TITLE
Answer a guest as a guest on the routes that ask for a verified email

### DIFF
--- a/apps/api/src/middleware/requireAuth.ts
+++ b/apps/api/src/middleware/requireAuth.ts
@@ -46,11 +46,12 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply):
 /**
  * Layer on top of `requireAuth` for anything a guest must not do.
  *
- * Guests are `emailVerified: false`, so every route already behind
+ * Guests are `emailVerified: false`, so every route behind
  * `requireVerifiedEmail` is closed to them for free — a happy accident, and the
  * strongest single argument for using Better Auth's anonymous plugin rather
- * than inventing a session. This covers the rest: the writes that only ever
- * needed `requireAuth`, which is most of them.
+ * than inventing a session. That guard now answers them with this same code
+ * rather than an email error they can do nothing about. This covers the rest:
+ * the writes that only ever needed `requireAuth`, which is most of them.
  *
  * A distinct code rather than `UNAUTHENTICATED`, because the client's answer is
  * different. Unauthenticated means "sign in"; this means "you are browsing as a
@@ -82,6 +83,28 @@ export async function requireVerifiedEmail(
 ): Promise<void> {
   await requireAuth(request, reply)
   if (reply.sent) return
+
+  /*
+   * A guest is answered as a guest, before the email check that would also
+   * have stopped them.
+   *
+   * Both refusals close the route, so this changes nothing about who gets in.
+   * What it changes is what the client can do next: `EMAIL_NOT_VERIFIED` says
+   * "verify your email", and a guest has no email to verify — the screen has
+   * nowhere to send them, so it falls through to a generic failure toast. It
+   * was found that way, on `Follow`, which is behind this guard rather than
+   * `requireMember` and so never produced the code the transport watches for.
+   *
+   * Ordering it before the email check is what makes `requireMember`
+   * unnecessary on a route that already requires verification.
+   */
+  if (request.isGuest) {
+    const body: ApiErrorBody = {
+      code: ERROR_CODES.GUEST_ACCOUNT,
+      message: 'Create an account to do that',
+    }
+    return reply.code(ERROR_STATUS.GUEST_ACCOUNT).send(body)
+  }
 
   if (!request.emailVerified) {
     const body: ApiErrorBody = {

--- a/apps/api/src/routes/guest.test.ts
+++ b/apps/api/src/routes/guest.test.ts
@@ -148,6 +148,20 @@ describe('guests', () => {
       },
       { method: 'POST', url: '/blocks', payload: { userId: 'someone' } },
       { method: 'POST', url: '/reports', payload: { userId: 'someone', reason: 'spam' } },
+
+      /*
+       * Behind `requireVerifiedEmail` rather than `requireMember`, and in the
+       * table for that reason. They were already closed to a guest — an
+       * anonymous user is never `emailVerified` — but they answered with
+       * `EMAIL_NOT_VERIFIED`, and a guest has no email to verify, so the
+       * client had nowhere to send them and fell through to a generic toast.
+       * Found on `Follow`, which is the primary button on a profile.
+       */
+      { method: 'POST', url: '/profiles/someone/follow' },
+      { method: 'POST', url: '/posts', payload: { body: 'hello', language: 'tr' } },
+      { method: 'PUT', url: '/likes', payload: { targetType: 'post', targetId: 'x' } },
+      { method: 'POST', url: '/conversations', payload: { toUserId: 'someone', body: 'hi' } },
+      { method: 'POST', url: '/translate', payload: { text: 'merhaba', targetLang: 'en' } },
     ]
 
     for (const write of writes) {

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -276,12 +276,18 @@ export default function ProfileScreen() {
             loading={setFollow.isPending}
             // No confirmation on unfollow. It is trivially reversible, and
             // `confirmAlert` is what blocking is for.
-            onPress={() =>
+            // Gated like `send()` above, and for the same reason: this is the
+            // primary button on the screen, so it is the write a guest reaches
+            // first. Without the guard the transport still catches it, but a
+            // round trip later and only after `onError` has already shown a
+            // toast that says nothing about needing an account.
+            onPress={() => {
+              if (!requireAccount(session?.user)) return
               setFollow.mutate(
                 { userId: user._id, following: !user.follow.viewerFollows },
                 { onError: () => showToast(t('profile.followFailed')) },
               )
-            }
+            }}
             style={styles.followButton}
           />
         )}


### PR DESCRIPTION
`requireMember` was applied to the writes that only ever needed `requireAuth`,
on the reasoning that `requireVerifiedEmail` already closes the rest for free —
a guest is never `emailVerified`. Closed, yes, but with the wrong code. Those
routes answered `EMAIL_NOT_VERIFIED`, and a guest has no email to verify, so
`client.ts`'s net never fired and the screen fell through to whatever its
`onError` said.

Found live on `Follow`, which is the primary button on a profile and therefore
the first write a guest reaches: it showed "That did not work. Try again." and
stopped there.

`requireVerifiedEmail` now checks `isGuest` first. Nothing changes about who is
let in — both branches refuse — only about what the client can do next, which
is the whole point of the code being distinct.

The `Follow` handler also gets the call-site guard the composer next to it
already had, so the guest reaches sign-up without a round trip.

`guest.test.ts` iterated over `requireMember` routes only, which is why the gap
survived. The table now carries five verified-email writes as well, so the next
route added behind either guard fails here rather than shipping.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Found on app2 with a real guest session: tapping **Follow** produced *"That did not work. Try again."* and a 403 in the console, with no way forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)