### PR TITLE
Give the open search field the row it is standing in

### DIFF
--- a/apps/mobile/app/(app)/chats.tsx
+++ b/apps/mobile/app/(app)/chats.tsx
@@ -84,21 +84,25 @@ export default function ChatsScreen() {
         without an entry point here it is a write with no read.
       */}
       <View style={styles.titleRow}>
-        <Text style={styles.title}>{t('tabs.chats')}</Text>
+        {/* Hidden while search is open, for the reason Discover's copy of this
+            row records: the field needs the whole row, not what is left of it. */}
+        {searching ? null : <Text style={styles.title}>{t('tabs.chats')}</Text>}
         {/*
           Here as well as on Discover, because this is the other place people
           arrive already knowing who they want: Discover is for finding someone,
           Chats is for finding someone again.
         */}
         <PeopleSearch from="/(app)/chats" onSearchingChange={setSearching} />
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t('chats.starredMessages')}
-          hitSlop={10}
-          onPress={() => router.push('/(app)/starred')}
-        >
-          <Feather name="star" size={21} color={colors.textMuted} />
-        </Pressable>
+        {searching ? null : (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t('chats.starredMessages')}
+            hitSlop={10}
+            onPress={() => router.push('/(app)/starred')}
+          >
+            <Feather name="star" size={21} color={colors.textMuted} />
+          </Pressable>
+        )}
       </View>
 
       {/*
@@ -108,17 +112,21 @@ export default function ChatsScreen() {
         happened to be fetched, which is exactly wrong for "who am I keeping
         waiting" — the answer is usually further down the list.
       */}
-      <View style={styles.filters}>
-        <SegmentedControl<ConversationFilter>
-          options={CONVERSATION_FILTERS.map((value) => ({
-            value,
-            label: t(`chats.tab_${value}` as MessageKey),
-          }))}
-          selected={[filter]}
-          onToggle={setFilter}
-          accessibilityLabel={t('chats.filterPicker')}
-        />
-      </View>
+      {/* Hidden while searching, as on Discover: the list underneath is blank,
+          so a filter over it has nothing to filter. */}
+      {searching ? null : (
+        <View style={styles.filters}>
+          <SegmentedControl<ConversationFilter>
+            options={CONVERSATION_FILTERS.map((value) => ({
+              value,
+              label: t(`chats.tab_${value}` as MessageKey),
+            }))}
+            selected={[filter]}
+            onToggle={setFilter}
+            accessibilityLabel={t('chats.filterPicker')}
+          />
+        </View>
+      )}
 
       {state === 'skeleton' ? (
         <View style={styles.list}>
@@ -278,7 +286,14 @@ export default function ChatsScreen() {
 
 const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   filters: { paddingBottom: spacing.sm, paddingTop: spacing.md },
-  titleRow: { alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between' },
+  // `zIndex` for the same reason Discover's copy of this row carries one:
+  // the search results float, and a later sibling would paint over them.
+  titleRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    zIndex: 2,
+  },
   title: { ...font.title, color: colors.text, fontSize: 34, paddingTop: spacing.md },
   list: { paddingBottom: spacing.xxl, paddingTop: spacing.sm },
   footer: { paddingVertical: spacing.lg },

--- a/apps/mobile/app/(app)/discover.tsx
+++ b/apps/mobile/app/(app)/discover.tsx
@@ -153,13 +153,19 @@ export default function DiscoverScreen() {
   return (
     <Screen fluid>
       <View style={styles.header}>
+        {/*
+          While search is open the row belongs to the field. Everything else
+          here competed with it for the same 420px and lost — the title slid
+          off the leading edge and the language pair broke onto three lines.
+          The arrow inside the field puts them all back.
+        */}
         <View style={styles.titleRow}>
-          <Text style={styles.title}>{t('discover.title')}</Text>
+          {searching ? null : <Text style={styles.title}>{t('discover.title')}</Text>}
           {/* Which direction this list is matched in. Every row below is
               someone native in what you are learning and learning what you
               speak, and without this the list looks unsorted rather than
               matched. */}
-          {pair ? <Text style={styles.pair}>{pair}</Text> : null}
+          {pair && !searching ? <Text style={styles.pair}>{pair}</Text> : null}
           {/* Advanced filters are the Pro hook, so the control is shown to
               everyone and the *screen* handles the upsell — hiding it makes
               the paywall a surprise instead of an offer. Free filters still
@@ -169,35 +175,43 @@ export default function DiscoverScreen() {
               question asked two ways — "narrow this" and "I already know who
               I am looking for". */}
           <PeopleSearch from="/(app)/discover" onSearchingChange={setSearching} />
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={
-              count > 0
-                ? t('discover.filtersWithCount', { count })
-                : isPro
-                  ? t('filters.title')
-                  : t('discover.filters')
-            }
-            onPress={() => router.push({ pathname: '/(app)/filters', params })}
-            style={({ pressed }) => [styles.filterButton, pressed && styles.pressed]}
-            hitSlop={8}
-          >
-            <Feather name="sliders" size={22} color={colors.text} />
-            {count > 0 ? <Text style={styles.filterCount}>{count}</Text> : null}
-          </Pressable>
+          {searching ? null : (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={
+                count > 0
+                  ? t('discover.filtersWithCount', { count })
+                  : isPro
+                    ? t('filters.title')
+                    : t('discover.filters')
+              }
+              onPress={() => router.push({ pathname: '/(app)/filters', params })}
+              style={({ pressed }) => [styles.filterButton, pressed && styles.pressed]}
+              hitSlop={8}
+            >
+              <Feather name="sliders" size={22} color={colors.text} />
+              {count > 0 ? <Text style={styles.filterCount}>{count}</Text> : null}
+            </Pressable>
+          )}
         </View>
-        <View style={styles.segmented}>
-          <SegmentedControl
-            options={SORTS.map((option) => ({
-              value: option.key,
-              label:
-                option.key === 'nearby' && !canUseNearby ? `${t(option.label)} ✦` : t(option.label),
-            }))}
-            selected={[sort]}
-            onToggle={(key) => (key === 'nearby' ? void chooseNearby() : setSort(key))}
-            accessibilityLabel={t('discover.sortLabel')}
-          />
-        </View>
+        {/* Search takes the screen, not a strip of it: a sort control above a
+            list that has been blanked is answering a question nobody asked. */}
+        {searching ? null : (
+          <View style={styles.segmented}>
+            <SegmentedControl
+              options={SORTS.map((option) => ({
+                value: option.key,
+                label:
+                  option.key === 'nearby' && !canUseNearby
+                    ? `${t(option.label)} ✦`
+                    : t(option.label),
+              }))}
+              selected={[sort]}
+              onToggle={(key) => (key === 'nearby' ? void chooseNearby() : setSort(key))}
+              accessibilityLabel={t('discover.sortLabel')}
+            />
+          </View>
+        )}
         <View style={styles.chips}>
           {/* Only while it applies. A radius control above a list that is not
               sorted by distance would be a control with nothing to control. */}
@@ -327,7 +341,13 @@ export default function DiscoverScreen() {
 const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   flag: { fontSize: 15 },
   header: { paddingTop: spacing.md },
-  titleRow: { alignItems: 'center', flexDirection: 'row', gap: spacing.md },
+  /*
+   * `zIndex` so `PeopleSearch`'s floated results paint over the list below.
+   * The results carry their own, but `zIndex` only orders within a stacking
+   * context — without one here the segmented control, a later sibling, is
+   * painted after this whole row and covers them.
+   */
+  titleRow: { alignItems: 'center', flexDirection: 'row', gap: spacing.md, zIndex: 2 },
   title: { ...font.title, color: colors.text, flexShrink: 1, fontSize: 34 },
   pair: {
     ...font.label,

--- a/apps/mobile/src/components/PeopleSearch.tsx
+++ b/apps/mobile/src/components/PeopleSearch.tsx
@@ -31,6 +31,16 @@ export function PeopleSearch({ from, onSearchingChange }: PeopleSearchProps) {
   const { colors } = useTheme()
   const [searching, setSearching] = useState(false)
   const [term, setTerm] = useState('')
+  /*
+   * Where the results start.
+   *
+   * Both hosts mount this inside their title row, which is a flex row — so a
+   * results list laid out in normal flow becomes a *third column* beside the
+   * title and the filter icon rather than a list under the field. Measuring
+   * the field and floating the results under it is what keeps the component
+   * droppable into a row without either host restructuring its header.
+   */
+  const [below, setBelow] = useState(0)
   // The input renders `term` and the query follows the settled value, so
   // typing stays responsive and "behic" is one request rather than five.
   const search = useHandleSearch(useDebounced(term))
@@ -57,7 +67,13 @@ export function PeopleSearch({ from, onSearchingChange }: PeopleSearchProps) {
 
   return (
     <View style={styles.wrap}>
-      <View style={styles.field}>
+      <View
+        style={styles.field}
+        onLayout={(event) => {
+          const { y, height } = event.nativeEvent.layout
+          setBelow(y + height)
+        }}
+      >
         {/*
           Leaving search is local state, never navigation. Both hosts are tab
           roots, so `router.back()` would drop the reader on the first tab —
@@ -101,7 +117,7 @@ export function PeopleSearch({ from, onSearchingChange }: PeopleSearchProps) {
         ) : null}
       </View>
 
-      <View style={styles.results}>
+      <View style={[styles.results, { top: below }]}>
         {search.isFetching ? <ActivityIndicator style={styles.spinner} /> : null}
         {search.data?.items.map((result) => (
           <Pressable
@@ -132,7 +148,13 @@ export function PeopleSearch({ from, onSearchingChange }: PeopleSearchProps) {
 }
 
 const useStyles = makeStyles(({ colors, font, radius, spacing }) => ({
-  wrap: { gap: spacing.xs },
+  /*
+   * `flex: 1` so the open field takes the row it was dropped into. Without it
+   * the field is content-width, the row overflows, and the host's own title
+   * slides off the leading edge — which is how this shipped and what it looked
+   * like on a 420px screen.
+   */
+  wrap: { flex: 1 },
   toggle: { alignItems: 'center', flexDirection: 'row', gap: spacing.xs },
   pressed: { opacity: 0.7 },
   field: {
@@ -148,7 +170,21 @@ const useStyles = makeStyles(({ colors, font, radius, spacing }) => ({
   },
   leave: { alignItems: 'center', height: 30, justifyContent: 'center', width: 30 },
   input: { ...font.body, color: colors.text, flex: 1, padding: 0 },
-  results: { gap: spacing.xs, marginTop: spacing.xs },
+  /*
+   * Floated, for the reason `below` records. `end: 0` rather than `right: 0`
+   * so it follows the writing direction, and `zIndex` because the list it
+   * covers is drawn after this in the tree.
+   */
+  results: {
+    backgroundColor: colors.bg,
+    end: 0,
+    gap: spacing.xs,
+    paddingBottom: spacing.md,
+    paddingTop: spacing.xs,
+    position: 'absolute',
+    start: 0,
+    zIndex: 2,
+  },
   spinner: { marginTop: spacing.md },
   row: { alignItems: 'center', flexDirection: 'row', gap: spacing.sm, paddingVertical: spacing.sm },
   text: { flex: 1, gap: 1 },


### PR DESCRIPTION
`PeopleSearch` is mounted inside each host's title row, and when it opened it
kept everything else in that row: on a 420px screen the title slid off the
leading edge, the language pair broke onto three lines, and the field ran past
the right edge. It also laid its results out in normal flow, which inside a
flex row makes them a third *column* beside the title rather than a list under
the field.

Three parts, and each is the smallest thing that fixes what it fixes:

- `wrap` takes `flex: 1`, so the open field fills the row instead of sizing to
  its content.
- The results float under the field, positioned from an `onLayout` measurement
  of it. That keeps the component droppable into a row without either host
  restructuring its header — and it needs a `zIndex` on the host's row, because
  `zIndex` only orders within a stacking context and the control below is a
  later sibling of the whole row.
- Both hosts hide what they had in that row while searching — title, language
  pair, filters and star — and hide the sort control underneath it too. The
  list is already blanked while searching, so a sort above it was answering a
  question nobody asked.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Found on app2 at 420px: the title had slid off the leading edge, `EN → TR` had broken onto three lines, and the input ran past the right edge of the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)