### PR TITLE
Let the fixtures seed again, and say which collection an index conflict is in

### DIFF
--- a/apps/api/scripts/testAccounts.ts
+++ b/apps/api/scripts/testAccounts.ts
@@ -21,7 +21,7 @@ import { hashPassword } from 'better-auth/crypto'
 import { ObjectId, type Db } from 'mongodb'
 import type { OnboardingProfileInput } from '@langx/shared'
 import { COLLECTIONS } from '../src/db/collections'
-import { createProfile } from '../src/modules/profiles/profiles'
+import { createProfile, type Profile } from '../src/modules/profiles/profiles'
 
 /**
  * Which database a fixture script writes to.
@@ -124,7 +124,36 @@ export async function ensureAccount(
     updatedAt: now,
   })
 
-  await createProfile(db, String(userId), null, person)
+  /*
+   * Onboarding caps both language lists at the free tier's one, so a fixture
+   * with two learning languages cannot be created through `createProfile` any
+   * more. The first entry of each goes in through the real path, and the rest
+   * are written straight onto the document afterwards.
+   *
+   * That is not a way round the cap — it is the shape a migrated v1 profile
+   * already has, and the one the grandfathering clause in `updateProfile`
+   * exists for. A fixture that can only ever hold one language would take that
+   * whole branch out of local testing, which is the half most likely to break.
+   */
+  await createProfile(db, String(userId), null, {
+    ...person,
+    nativeLanguages: [person.nativeLanguages[0]!],
+    learning: [person.learning[0]!],
+  })
+
+  if (person.nativeLanguages.length > 1 || person.learning.length > 1) {
+    await db.collection<Profile>(COLLECTIONS.profiles).updateOne(
+      { _id: String(userId) },
+      {
+        $set: {
+          nativeLanguages: person.nativeLanguages,
+          learning: person.learning,
+          updatedAt: new Date(),
+        },
+      },
+    )
+  }
+
   return { userId: String(userId), created: true }
 }
 

--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -445,8 +445,21 @@ export async function ensureIndexes(db: Db): Promise<EnsureIndexesResult[]> {
 
   for (const [collection, indexes] of Object.entries(INDEXES)) {
     if (!indexes || indexes.length === 0) continue
-    const created = await db.collection(collection).createIndexes(indexes)
-    results.push({ collection, created })
+    try {
+      const created = await db.collection(collection).createIndexes(indexes)
+      results.push({ collection, created })
+    } catch (caught) {
+      /*
+       * Name the collection. `IndexOptionsConflict` says only "Index already
+       * exists with a different name: <theirs>" — not which collection, and
+       * not which of ours asked. This runs at boot, so the process dies with
+       * that one line and no stack frame inside this file that says where.
+       * It has cost real time twice; the second was a boot against an empty
+       * database, where "which collection" is the entire question.
+       */
+      if (caught instanceof Error) caught.message = `${collection}: ${caught.message}`
+      throw caught
+    }
   }
 
   return results


### PR DESCRIPTION
Two things found while bringing a local stack up from an empty database.

**`seed-test-users.ts` stopped working.** Tiering the language allowance capped
onboarding at the free tier's one of each, and three of the eight fixtures have
two learning languages — so the script died on the fourth with
`UPGRADE_REQUIRED`, and with it `seed-test-chat.ts`, which shares the same
account helper. Nothing in CI seeds, so it broke quietly.

`ensureAccount` now creates through the real path with the first of each list
and writes the rest onto the document afterwards. That is not a way round the
cap: it is the shape a migrated v1 profile already has, and the one the
grandfathering clause in `updateProfile` exists for. Fixtures that could only
hold one language would take that branch out of local testing entirely, and it
is the half most likely to break.

**`ensureIndexes` did not say where it failed.** `IndexOptionsConflict` reports
only "Index already exists with a different name: <theirs>" — not the
collection, and there is no frame inside this file to infer it from, so the
process dies at boot with one line and nothing to go on. It cost real time
twice; the second was a boot against a database with older index names, where
"which collection" was the entire question. The name is now prefixed onto the
message and the error is rethrown unchanged otherwise.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)