### PR TITLE
Make the shop a ladder, since it was already priced as one

### DIFF
--- a/apps/api/src/modules/billing/welcomePack.test.ts
+++ b/apps/api/src/modules/billing/welcomePack.test.ts
@@ -109,12 +109,16 @@ describe('grantWelcomePack', () => {
    * push: even with the latch lost, a second run cannot duplicate a cosmetic.
    */
   it('cannot duplicate a cosmetic somebody already bought with token', async () => {
-    const id = await seed({ cosmetics: ['frame.bronze'] })
+    // Derived from the pack rather than naming an id, so this keeps testing
+    // the behaviour when the pack's contents move.
+    const already = PRO_WELCOME_PACKS.pro.cosmetics[0]!
+    const id = await seed({ cosmetics: [already] })
     const result = await grantWelcomePack(handle.db, id, 'pro')
 
-    expect(result.cosmetics).not.toContain('frame.bronze')
+    expect(result.cosmetics).not.toContain(already)
     const profile = await read(id)
-    expect(profile?.cosmetics).toEqual(['frame.bronze'])
+    expect(profile?.cosmetics?.filter((c) => c === already)).toHaveLength(1)
+    expect(new Set(profile?.cosmetics)).toEqual(new Set(PRO_WELCOME_PACKS.pro.cosmetics))
   })
 
   /**

--- a/apps/api/src/modules/tokens/wallet.ts
+++ b/apps/api/src/modules/tokens/wallet.ts
@@ -4,6 +4,7 @@ import {
   STREAK_RESTORE_SKU,
   TOKEN_RULES,
   findCosmetic,
+  previousCosmetic,
   meetsRequirement,
   localDayKey,
   periodKeys,
@@ -113,6 +114,25 @@ export async function purchase(db: Db, userId: string, sku: string): Promise<Pur
       )
     }
   }
+  /*
+   * The rung below has to be owned first. Unlike the requirement above, this
+   * one *is* a field on this document, so it is re-checked in the atomic
+   * filter properly rather than as a best-effort pre-read — and ownership is
+   * monotonic in the same way `streak.longest` is, so a gate that has opened
+   * can never close again.
+   *
+   * A gift skips it, which is deliberate: `grantWelcomePack` writes with
+   * `$addToSet` and never comes through here. The packs start at the bottom of
+   * each ladder so that nothing is handed out above a rung nobody owns.
+   */
+  const previous = cosmetic ? previousCosmetic(cosmetic) : undefined
+  if (previous && !(profile.cosmetics ?? []).includes(previous.id)) {
+    throw new ApiError(
+      ERROR_CODES.VALIDATION_FAILED,
+      `${previous.id} has to be bought before ${sku}`,
+    )
+  }
+
   if (isFreeze && (profile.streakFreezes ?? 0) >= TOKEN_RULES.sinks.maxBankedStreakFreezes) {
     throw new ApiError(
       ERROR_CODES.VALIDATION_FAILED,
@@ -133,7 +153,25 @@ export async function purchase(db: Db, userId: string, sku: string): Promise<Pur
       // check and charge twice for one item.
       ...(isFreeze
         ? { streakFreezes: { $not: { $gte: TOKEN_RULES.sinks.maxBankedStreakFreezes } } }
-        : { cosmetics: { $ne: sku } }),
+        : {
+            /*
+             * Both cosmetic conditions under one key, because they are about
+             * one field and a second `cosmetics:` in this object literal would
+             * silently replace the first rather than add to it — and the one
+             * that lost would be the guard against paying twice for the same
+             * item.
+             *
+             * `$nin`: two concurrent buys of the same cosmetic would otherwise
+             * both pass the read-time check and charge twice for one item.
+             *
+             * `$all`: the ladder, re-checked where it counts. Two buys of
+             * adjacent rungs fired together would otherwise both pass the read
+             * above — the second one reading a profile that does not own the
+             * first yet — and land out of order, which is the whole thing this
+             * gate exists to prevent.
+             */
+            cosmetics: { $nin: [sku], ...(previous ? { $all: [previous.id] } : {}) },
+          }),
       // The half of the gate that is a field on this document, re-checked
       // where it counts. The correction count is not one, so it stays a
       // pre-check — see above for why that is safe.

--- a/apps/api/src/routes/leaderboard.test.ts
+++ b/apps/api/src/routes/leaderboard.test.ts
@@ -130,6 +130,27 @@ describe('Faz 9 — daily pool, leaderboards and token sinks', () => {
     })
   }
 
+  /**
+   * Grants every rung below `sku` directly, the way a welcome pack does.
+   * Tests about the price, the earned gate or the race are not about the
+   * ladder, and buying nine frames to reach the tenth would bury what each of
+   * them is actually asserting.
+   */
+  async function ownLadderBelow(userId: string, sku: string) {
+    const target = COSMETICS.find((c) => c.id === sku)!
+    const ladder = COSMETICS.filter((c) => c.kind === target.kind)
+    const below = ladder
+      .slice(
+        0,
+        ladder.findIndex((c) => c.id === sku),
+      )
+      .map((c) => c.id)
+    if (below.length === 0) return
+    await handle.db
+      .collection<Profile>(COLLECTIONS.profiles)
+      .updateOne({ _id: userId }, { $set: { cosmetics: below } })
+  }
+
   beforeAll(async () => {
     replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
     handle = await connectToDatabase(replSet.getUri(), 'langx_faz9_test')
@@ -589,6 +610,9 @@ describe('Faz 9 — daily pool, leaderboards and token sinks', () => {
           createdAt: new Date(),
         })),
       )
+      // Aurora sits at the top of the frame ladder as well as behind the
+      // earned gate; this test is about the gate.
+      await ownLadderBelow(user.userId, 'frame.aurora')
 
       const response = await buy(user, 'frame.aurora')
       expect(response.statusCode, response.body).toBe(200)
@@ -926,6 +950,9 @@ describe('Faz 9 — daily pool, leaderboards and token sinks', () => {
     it('refuses a purchase the balance cannot cover', async () => {
       const user = await newUser()
       const priciest = COSMETICS.reduce((a, b) => (a.price > b.price ? a : b))
+      // Everything below it granted, so the balance is the only thing left in
+      // the way — otherwise this would pass on the ladder's message instead.
+      await ownLadderBelow(user.userId, priciest.id)
       const response = await buy(user, priciest.id)
       expect(response.statusCode).toBe(400)
       expect(response.json<{ message: string }>().message).toContain('Not enough token')
@@ -941,9 +968,84 @@ describe('Faz 9 — daily pool, leaderboards and token sinks', () => {
         refId: 'sink-race',
       })
 
+      await ownLadderBelow(user.userId, frame.id)
+
       const responses = await Promise.all(Array.from({ length: 5 }, () => buy(user, frame.id)))
       expect(responses.filter((r) => r.statusCode === 200)).toHaveLength(1)
       expect((await wallet(user)).spent).toBe(frame.price)
+    })
+
+    /**
+     * The ladder. The catalogue's order is the rule now — each item needs the
+     * one below it in the same kind — so the prestige rows cannot be reached
+     * by saving up and skipping the middle. The total sink is unchanged; what
+     * changed is that you cannot buy the top of it first.
+     */
+    describe('the ladder', () => {
+      async function rich(sku: string) {
+        const user = await newUser()
+        await awardTokens(handle.db, {
+          userId: user.userId,
+          kind: 'adjustment',
+          amount: 500_000,
+          refId: `ladder-${sku}-${user.userId}`,
+        })
+        return user
+      }
+
+      it('sells the first rung of a ladder to anybody who can pay', async () => {
+        const user = await rich('frame.slate')
+        expect((await buy(user, 'frame.slate')).statusCode).toBe(200)
+      })
+
+      it('refuses a rung whose predecessor is missing, and charges nothing', async () => {
+        const user = await rich('frame.gold')
+
+        const response = await buy(user, 'frame.gold')
+        expect(response.statusCode, response.body).toBe(400)
+        expect(response.json<{ message: string }>().message).toContain('frame.ember')
+
+        const profile = await handle.db
+          .collection<Profile>(COLLECTIONS.profiles)
+          .findOne({ _id: user.userId })
+        expect(profile?.cosmetics ?? []).not.toContain('frame.gold')
+        expect(profile?.tokenSpent ?? 0).toBe(0)
+      })
+
+      it('sells it the moment the rung below is owned', async () => {
+        const user = await rich('frame.gold')
+        await ownLadderBelow(user.userId, 'frame.gold')
+        expect((await buy(user, 'frame.gold')).statusCode).toBe(200)
+      })
+
+      it('keeps frames and titles as two ladders, not one queue', async () => {
+        const user = await rich('title.beginner')
+        // No frames owned at all, and the first title is still buyable.
+        expect((await buy(user, 'title.beginner')).statusCode).toBe(200)
+      })
+
+      /**
+       * The reason the condition is in the update's filter and not only in the
+       * read before it: fired together, the second buy reads a profile that
+       * does not own the first rung yet. Without the filter both would land
+       * and the ladder would be climbable two rungs at a time by tapping fast.
+       */
+      it('cannot be climbed two rungs at once by firing both together', async () => {
+        const user = await rich('frame.bronze')
+
+        const [slate, bronze] = await Promise.all([
+          buy(user, 'frame.slate'),
+          buy(user, 'frame.bronze'),
+        ])
+
+        expect(slate.statusCode, slate.body).toBe(200)
+        expect(bronze.statusCode, bronze.body).toBe(400)
+
+        const profile = await handle.db
+          .collection<Profile>(COLLECTIONS.profiles)
+          .findOne({ _id: user.userId })
+        expect(profile?.cosmetics ?? []).toEqual(['frame.slate'])
+      })
     })
 
     it('rejects an unknown sku', async () => {

--- a/apps/mobile/src/components/store/StoreRow.tsx
+++ b/apps/mobile/src/components/store/StoreRow.tsx
@@ -44,7 +44,9 @@ export function StoreRow({
       ) : null}
       <View style={styles.text}>
         <Text style={styles.name}>{offer.title}</Text>
-        {offer.requirement ? (
+        {offer.needs ? (
+          <Text style={styles.meta}>{t('store.lockedNeeds', { title: offer.needs })}</Text>
+        ) : offer.requirement ? (
           <Text style={styles.meta}>
             {t(
               offer.requirement.kind === 'streak'

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -968,6 +968,7 @@ export const ar: Localized<EnMessages> = {
     locked: 'مقفل',
     lockedAccessibility: '‏{title}، مقفل',
     lockedStreak: '‏{current} من {threshold} يوم',
+    lockedNeeds: 'اشترِ {title} أولًا',
     lockedCorrections: '‏{current} من {threshold} تصحيح',
     owned: 'مملوك',
     frameKind: 'إطار الملف',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -832,6 +832,7 @@ export const de: Localized<EnMessages> = {
     locked: 'Gesperrt',
     lockedAccessibility: '{title}, gesperrt',
     lockedStreak: '{current} von {threshold} Tagen',
+    lockedNeeds: 'Erst {title} kaufen',
     lockedCorrections: '{current} von {threshold} Korrekturen',
     owned: 'Vorhanden',
     frameKind: 'Profilrahmen',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -849,6 +849,7 @@ export const en = {
     locked: 'Locked',
     lockedAccessibility: '{title}, locked',
     lockedStreak: '{current} of {threshold} days',
+    lockedNeeds: 'Buy {title} first',
     lockedCorrections: '{current} of {threshold} corrections',
     owned: 'Owned',
     frameKind: 'Profile frame',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -811,6 +811,7 @@ export const es: Localized<EnMessages> = {
     locked: 'Bloqueado',
     lockedAccessibility: '{title}, bloqueado',
     lockedStreak: '{current} de {threshold} días',
+    lockedNeeds: 'Compra antes {title}',
     lockedCorrections: '{current} de {threshold} correcciones',
     owned: 'Tuyo',
     frameKind: 'Marco de perfil',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -812,6 +812,7 @@ export const fr: Localized<EnMessages> = {
     locked: 'Verrouillé',
     lockedAccessibility: '{title}, verrouillé',
     lockedStreak: '{current} jours sur {threshold}',
+    lockedNeeds: 'Achète d’abord {title}',
     lockedCorrections: '{current} corrections sur {threshold}',
     owned: 'Acquis',
     frameKind: 'Cadre de profil',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -806,6 +806,7 @@ export const ptBR: Localized<EnMessages> = {
     locked: 'Bloqueado',
     lockedAccessibility: '{title}, bloqueado',
     lockedStreak: '{current} de {threshold} dias',
+    lockedNeeds: 'Compre antes {title}',
     lockedCorrections: '{current} de {threshold} correções',
     owned: 'Você tem',
     frameKind: 'Moldura de perfil',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -922,6 +922,7 @@ export const ru: Localized<EnMessages> = {
     locked: 'Закрыто',
     lockedAccessibility: '{title}, закрыто',
     lockedStreak: '{current} из {threshold} дней',
+    lockedNeeds: 'Сначала купи {title}',
     lockedCorrections: '{current} из {threshold} исправлений',
     owned: 'Есть',
     frameKind: 'Рамка профиля',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -821,6 +821,7 @@ export const tr: Localized<EnMessages> = {
     locked: 'Kilitli',
     lockedAccessibility: '{title}, kilitli',
     lockedStreak: '{threshold} günün {current} günü',
+    lockedNeeds: 'Önce {title} al',
     lockedCorrections: '{threshold} düzeltmenin {current} tanesi',
     owned: 'Sende',
     frameKind: 'Profil çerçevesi',

--- a/apps/mobile/src/lib/storeOffers.test.ts
+++ b/apps/mobile/src/lib/storeOffers.test.ts
@@ -96,4 +96,70 @@ describe('buildStoreOffers', () => {
       expect(byId(tr, 'title.tutor')?.title).toBe('Eğitmen')
     })
   })
+
+  /**
+   * The row has to say *which* lock it is under. "Locked" alone reads as "come
+   * back when you are better", when the answer is usually "buy the one below,
+   * it is right there".
+   */
+  describe('the ladder', () => {
+    const ladderBelow = (id: string) => {
+      const target = COSMETICS.find((c) => c.id === id)!
+      const ladder = COSMETICS.filter((c) => c.kind === target.kind)
+      return ladder
+        .slice(
+          0,
+          ladder.findIndex((c) => c.id === id),
+        )
+        .map((c) => c.id)
+    }
+    const rich = { balance: 1_000_000 }
+
+    it('leaves the first rung of each ladder unlocked', () => {
+      expect(byId(rich, 'frame.slate')).toMatchObject({ affordable: true })
+      expect(byId(rich, 'frame.slate')?.locked).toBeUndefined()
+      expect(byId(rich, 'title.beginner')).toMatchObject({ affordable: true })
+    })
+
+    it('locks a rung whose predecessor is missing, however large the balance', () => {
+      expect(byId(rich, 'frame.gold')).toMatchObject({
+        locked: true,
+        affordable: false,
+        needs: 'Ember frame',
+      })
+    })
+
+    it('unlocks it once the one below is owned', () => {
+      const offer = byId({ ...rich, owned: ladderBelow('frame.gold') }, 'frame.gold')
+      expect(offer?.affordable).toBe(true)
+      expect(offer?.locked).toBeUndefined()
+      expect(offer?.needs).toBeUndefined()
+    })
+
+    it('does not let a frame gate a title', () => {
+      expect(byId({ ...rich, owned: [] }, 'title.beginner')?.locked).toBeUndefined()
+    })
+
+    /**
+     * `frame.aurora` is behind both gates. The nearer answer wins: a year of
+     * streak means nothing while the rung below is missing, and telling
+     * somebody to write five thousand corrections when the real obstacle is a
+     * 35,000-token frame is the wrong instruction.
+     */
+    it('shows the missing rung rather than the earned gate when both are unmet', () => {
+      expect(byId(rich, 'frame.aurora')).toMatchObject({
+        locked: true,
+        needs: 'Midnight frame',
+      })
+      expect(byId(rich, 'frame.aurora')?.requirement).toBeUndefined()
+    })
+
+    it('falls back to the earned gate once the ladder is satisfied', () => {
+      const owned = { ...rich, owned: ladderBelow('frame.aurora') }
+      const offer = byId(owned, 'frame.aurora')
+      expect(offer?.needs).toBeUndefined()
+      expect(offer).toMatchObject({ locked: true })
+      expect(offer?.requirement).toBeDefined()
+    })
+  })
 })

--- a/apps/mobile/src/lib/storeOffers.ts
+++ b/apps/mobile/src/lib/storeOffers.ts
@@ -1,6 +1,7 @@
 import {
   COSMETICS,
   meetsRequirement,
+  previousCosmetic,
   type CosmeticTone,
   STREAK_FREEZE_SKU,
   STREAK_RESTORE_SKU,
@@ -28,6 +29,15 @@ export interface StoreOffer {
   locked?: boolean
   /** What the lock is waiting for, so the row can draw progress. */
   requirement?: { current: number; threshold: number; kind: 'streak' | 'corrections' }
+  /**
+   * The rung below, when it is what is standing in the way. Its *title*, not
+   * its id: this is read by a person, and `frame.midnight` is not a sentence.
+   *
+   * Separate from `requirement` because there is no progress to draw — you own
+   * the thing below or you do not, and a bar that is either empty or gone is
+   * not a bar.
+   */
+  needs?: string
   /** Whether the balance covers the price. Separate from `owned`: an owned
    *  item is never buyable however much the balance is. */
   affordable: boolean
@@ -138,7 +148,19 @@ export function buildStoreOffers(input: StoreInput): StoreOffer[] {
     )
     if (item.tone) offer.tone = item.tone
 
-    if (item.requires && !offer.owned && !meetsRequirement(item.requires, progress)) {
+    /*
+     * The ladder is checked before the earned gate, and shown instead of it
+     * when both are unmet. `frame.aurora` is the only item with both, and
+     * "buy Midnight first" is the nearer and more actionable of the two
+     * answers — a year of streak means nothing while the rung below is
+     * missing.
+     */
+    const previous = previousCosmetic(item)
+    if (previous && !offer.owned && !input.owned.includes(previous.id)) {
+      offer.locked = true
+      offer.affordable = false
+      offer.needs = t(cosmeticKey(previous.id))
+    } else if (item.requires && !offer.owned && !meetsRequirement(item.requires, progress)) {
       offer.locked = true
       offer.affordable = false
       // The requirement furthest from being met is the one worth showing: it

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -937,6 +937,50 @@ differently from convenience behind one — and the answer was to keep it paid �
 is a gender filter, the server gates those together, and splitting one of them
 out would make the paywall's rule harder to explain than it is worth.
 
+## The shop is two ladders, and its order is the rule
+
+The catalogue was priced as a progression from the day it grew — 1,000 to
+50,000 for frames, 1,500 to 100,000 for titles — and then sold as a shelf.
+Anyone with 100,000 token could buy `title.legend` and ignore the nine rungs
+under it, which made the price a number rather than a distance.
+
+Each item now needs the one below it in the same kind. Frames and titles are
+two ladders, not one queue: buying a frame has never had anything to do with
+owning a title.
+
+**The total sink does not change.** All twenty items still cost about 395,000
+either way. What changes is that the prestige rows cannot be reached first —
+Legend is 231,500 cumulative rather than 100,000 — so the top of the shop is
+evidence of a long time spent here, which is the only thing a cosmetic in this
+app is for.
+
+The gate is _own the one below_, not _own everything below_. Read against a
+catalogue nobody has skipped rungs in, the two are the same rule by induction.
+They differ only for the accounts that were **given** rungs, and those are the
+ones the weaker rule protects: `grantWelcomePack` writes with `$addToSet` and
+never comes through `purchase`, so a subscriber holding gold without silver has
+to keep moving. Asking them to go back and buy the rungs under a gift would
+turn a gift into a bill.
+
+New packs start at the bottom for the same reason. They used to hand out the
+2nd, 4th and 7th frames and the 2nd title, which was fine for a shelf and
+incoherent for a ladder. Starting at the bottom is what collapses the two
+readings of the gate into one sentence: **you buy them in order.**
+
+Two things this made load-bearing that were not before. `COSMETICS`'s array
+order is now the rule, so `cosmetics.test.ts` asserts each kind is strictly
+ascending in price — otherwise the shop could ask somebody to buy the expensive
+thing first while showing them a bargain they are not allowed to have. And
+`previousCosmetic` is derived from the order rather than from the price, so a
+repricing cannot silently reorder what has to be earned first.
+
+The condition is checked twice, like every other guard in `purchase`: once as a
+read that produces a useful message, and once inside the atomic filter, which
+is the one that counts. Both cosmetic conditions live under a single
+`cosmetics` key there — a second key of the same name in that object literal
+would have replaced the first rather than added to it, and the one that lost
+would have been the guard against paying twice for the same item.
+
 ## Countries are a compile-time table, like languages
 
 `profiles.country` was a free-text two-letter field, which meant the edit form

--- a/packages/shared/src/cosmetics.test.ts
+++ b/packages/shared/src/cosmetics.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { COSMETIC_KINDS } from './cosmetics'
 import { PAID_PLAN_TIERS } from './limits'
 import { TOKEN_RULES } from './token'
 import {
@@ -7,6 +8,7 @@ import {
   PRO_WELCOME_PACKS,
   findCosmetic,
   meetsRequirement,
+  previousCosmetic,
   welcomePackDelta,
   wornCosmetic,
 } from './cosmetics'
@@ -56,6 +58,63 @@ describe('the catalogue', () => {
     const cheapest = Math.min(...COSMETICS.map((c) => c.price))
     expect(cheapest).toBeGreaterThan(TOKEN_RULES.signupBonus)
     expect(cheapest).toBeLessThanOrEqual(2000)
+  })
+
+  /**
+   * The array's order is the ladder, and the prices are how it is explained.
+   * If they disagree — a cheaper item sitting above a dearer one — then the
+   * shop asks somebody to buy the expensive thing first and shows them a
+   * bargain they are not allowed to have. Nothing else would catch it: every
+   * other test here passes on a shuffled catalogue.
+   */
+  it('prices each ladder strictly upwards, so order and price tell one story', () => {
+    for (const kind of COSMETIC_KINDS) {
+      const ladder = COSMETICS.filter((c) => c.kind === kind)
+      expect(ladder.length, kind).toBeGreaterThan(1)
+      for (let i = 1; i < ladder.length; i++) {
+        expect(ladder[i]!.price, `${ladder[i]!.id} after ${ladder[i - 1]!.id}`).toBeGreaterThan(
+          ladder[i - 1]!.price,
+        )
+      }
+    }
+  })
+})
+
+describe('previousCosmetic', () => {
+  it('has nothing below the first rung of either ladder', () => {
+    for (const kind of COSMETIC_KINDS) {
+      const first = COSMETICS.find((c) => c.kind === kind)!
+      expect(previousCosmetic(first), first.id).toBeUndefined()
+    }
+  })
+
+  it('walks one step down, never across to the other kind', () => {
+    for (const kind of COSMETIC_KINDS) {
+      const ladder = COSMETICS.filter((c) => c.kind === kind)
+      for (let i = 1; i < ladder.length; i++) {
+        const previous = previousCosmetic(ladder[i]!)
+        expect(previous?.id, ladder[i]!.id).toBe(ladder[i - 1]!.id)
+        expect(previous?.kind, ladder[i]!.id).toBe(kind)
+      }
+    }
+  })
+
+  /**
+   * Walking down from the top has to reach the bottom in exactly as many steps
+   * as there are rungs. A cycle or a gap would hang the shop rather than
+   * mis-price it.
+   */
+  it('reaches the bottom of each ladder without looping', () => {
+    for (const kind of COSMETIC_KINDS) {
+      const ladder = COSMETICS.filter((c) => c.kind === kind)
+      let current = ladder.at(-1)
+      let steps = 0
+      while (current && steps <= ladder.length) {
+        current = previousCosmetic(current)
+        steps++
+      }
+      expect(steps, kind).toBe(ladder.length)
+    }
   })
 })
 
@@ -136,6 +195,36 @@ describe('PRO_WELCOME_PACKS', () => {
     )
   })
 
+  /**
+   * A gift bypasses the ladder — `grantWelcomePack` writes with `$addToSet`
+   * and never goes through `purchase` — so the packs are the one place that
+   * can hand somebody a rung above one they do not own. Starting at the bottom
+   * is what keeps "own the one below" and "own everything below" the same
+   * rule, which is what makes the shop explainable in one sentence.
+   */
+  it('grants the bottom of each ladder, contiguously, never a rung from up it', () => {
+    for (const tier of PAID_PLAN_TIERS) {
+      const granted = new Set(PRO_WELCOME_PACKS[tier].cosmetics)
+      for (const kind of COSMETIC_KINDS) {
+        const ladder = COSMETICS.filter((c) => c.kind === kind)
+        const count = ladder.filter((c) => granted.has(c.id)).length
+        // Whatever many it gives of a kind, they are the first that many.
+        expect(
+          ladder.slice(0, count).map((c) => c.id),
+          `${tier}/${kind}`,
+        ).toEqual(ladder.filter((c) => granted.has(c.id)).map((c) => c.id))
+      }
+    }
+  })
+
+  it('never gifts an item that also has to be earned', () => {
+    for (const tier of PAID_PLAN_TIERS) {
+      for (const id of PRO_WELCOME_PACKS[tier].cosmetics) {
+        expect(findCosmetic(id)?.requires, `${tier}: ${id}`).toBeUndefined()
+      }
+    }
+  })
+
   it('stays inside the banked-freeze cap, so the grant is never partly discarded', () => {
     for (const tier of PAID_PLAN_TIERS) {
       expect(PRO_WELCOME_PACKS[tier].streakFreezes, tier).toBeLessThanOrEqual(
@@ -154,8 +243,14 @@ describe('welcomePackDelta', () => {
     expect(welcomePackDelta('pro_plus', [...PRO_WELCOME_PACKS.pro_plus.cosmetics])).toEqual([])
   })
 
-  /** Somebody who bought the frame with token does not get a second one. */
+  /**
+   * Somebody who bought a frame with token does not get a second one. Derived
+   * from the pack rather than naming an id, so it keeps testing the behaviour
+   * when the pack's contents move.
+   */
   it('skips what was already earned rather than paid for', () => {
-    expect(welcomePackDelta('pro', ['frame.bronze'])).toEqual([])
+    const [first, ...rest] = PRO_WELCOME_PACKS.pro.cosmetics
+    expect(first).toBeDefined()
+    expect(welcomePackDelta('pro', [first!])).toEqual(rest)
   })
 })

--- a/packages/shared/src/cosmetics.ts
+++ b/packages/shared/src/cosmetics.ts
@@ -69,6 +69,14 @@ export interface Cosmetic {
  * It fixes a v1 problem on the way. The largest v1 balance converts to 22,800
  * token; at the old prices a returning user cleared almost the whole
  * catalogue on their first day.
+ *
+ * **The order of this array is a rule, not a layout.** Each item can only be
+ * bought once the one before it in the same `kind` is owned — see
+ * `previousCosmetic` — so inserting a row in the middle inserts a rung, and
+ * reordering two rows swaps what has to be earned first. It used to be free to
+ * shuffle these; it is not any more. `rules.test.ts` asserts each kind is
+ * strictly ascending in price, which is what keeps the ladder and the prices
+ * from telling different stories.
  */
 export const COSMETICS: readonly Cosmetic[] = [
   { id: 'frame.slate', kind: 'frame', label: 'Slate frame', price: 1000, tone: 'slate' },
@@ -138,6 +146,25 @@ export function findCosmetic(id: string): Cosmetic | undefined {
 }
 
 /**
+ * The rung below this one, or nothing if it is the first.
+ *
+ * Frames and titles are two ladders, not one list, so "the one before" is
+ * scoped to the kind — buying a frame has never had anything to do with
+ * owning a title and still does not.
+ *
+ * Derived from the array rather than from the price, even though the two
+ * agree and a test says so. A price comparison would quietly turn two items
+ * priced the same into an unbuyable pair, and it would make a repricing
+ * silently reorder what has to be earned first. The order is the rule; the
+ * prices are how it is explained.
+ */
+export function previousCosmetic(cosmetic: Cosmetic): Cosmetic | undefined {
+  const ladder = COSMETICS.filter((c) => c.kind === cosmetic.kind)
+  const index = ladder.findIndex((c) => c.id === cosmetic.id)
+  return index > 0 ? ladder[index - 1] : undefined
+}
+
+/**
  * What subscribing includes, once, per tier.
  *
  * **Items, not token.** Granting token for money is the one thing every public
@@ -160,10 +187,36 @@ export interface WelcomePack {
   streakFreezes: number
 }
 
+/**
+ * The **first** rungs of each ladder, not a handful picked from up it.
+ *
+ * These used to be `frame.bronze` and `frame.bronze/silver/gold` — the 2nd,
+ * 4th and 7th frames, plus the 2nd title. That was fine while the catalogue
+ * was a shelf. Now that it is a ladder it would have handed somebody the
+ * rungs above ones they did not own, which is either incoherent or a debt,
+ * depending on how strictly the gate is read.
+ *
+ * Starting at the bottom makes the two possible readings of the gate — "own
+ * the one below" and "own everything below" — the same rule, by induction.
+ * There is only one sentence to explain: you buy them in order.
+ *
+ * Existing subscribers keep what they were given; `welcomePackAt` latches per
+ * tier and is never re-run. They are the reason the gate is written as *own
+ * the one below* rather than *own everything below*: somebody holding gold
+ * without silver must still be able to move, and asking them to go back and
+ * buy the rungs under a gift would turn a gift into a bill.
+ */
 export const PRO_WELCOME_PACKS: Readonly<Record<PaidPlanTier, WelcomePack>> = {
-  pro: { cosmetics: ['frame.bronze'], streakFreezes: 2 },
+  pro: { cosmetics: ['frame.slate', 'frame.bronze'], streakFreezes: 2 },
   pro_plus: {
-    cosmetics: ['frame.bronze', 'frame.silver', 'frame.gold', 'title.learner'],
+    cosmetics: [
+      'frame.slate',
+      'frame.bronze',
+      'frame.sky',
+      'frame.silver',
+      'title.beginner',
+      'title.learner',
+    ],
     streakFreezes: 2,
   },
 }


### PR DESCRIPTION
`COSMETICS` has been a progression since the day it grew — 1,000 → 50,000 for frames, 1,500 → 100,000 for titles — and then sold as a shelf. Anyone holding 100,000 token could buy `title.legend` and ignore the nine rungs under it, which made the price a number rather than a distance.

Each item now needs the one below it **in the same kind**. Frames and titles stay two ladders, not one queue.

## The sink does not change; the order does

All twenty items still cost ~395,000 either way. What changes is that the prestige rows cannot be reached first — Legend is **231,500 cumulative** rather than 100,000 — so the top of the shop becomes evidence of time spent here, which is the only thing a cosmetic in this app is for.

## Why "own the one below" and not "own everything below"

Against a catalogue nobody has skipped rungs in, the two are the same rule by induction. They differ only for accounts that were **given** rungs — and those are exactly who the weaker rule protects. `grantWelcomePack` writes with `$addToSet` and never comes through `purchase`, so an existing Pro+ subscriber holding gold without silver has to keep moving. Asking them to go back and buy the rungs under a gift would turn a gift into a bill.

## The welcome packs move to the bottom

They handed out the **2nd, 4th and 7th** frames and the **2nd** title — fine for a shelf, incoherent for a ladder. Starting at the bottom is what collapses both readings of the gate into one sentence: *you buy them in order*. Existing subscribers keep what they were given; `welcomePackAt` latches per tier and is never re-run.

## Two things that are load-bearing now and were not

- **`COSMETICS`'s array order is the rule.** A test asserts each kind is strictly ascending in price — otherwise the shop could ask somebody to buy the expensive thing first while showing them a bargain they are not allowed to have. Every other test in that file passes on a shuffled catalogue.
- **`previousCosmetic` reads the order, not the price.** A repricing must not silently reorder what has to be earned first, and two items priced the same must not become an unbuyable pair.

## One bug caught while writing it

The first draft added `cosmetics: previous.id` as a second key beside `cosmetics: { $ne: sku }` in the same atomic filter object. The later key silently replaces the earlier one — and the one that lost would have been the guard against paying twice for a single item. Both conditions now live under one key (`$nin` + `$all`), with a comment naming the trap.

## Client

`StoreOffer.needs` carries the missing rung's **localized title**, separate from `requirement` because there is no progress to draw. `frame.aurora` is behind both gates and shows the ladder first: a year of streak means nothing while the rung below is missing.

## Tests

`1149 passed` — shared 208, mobile 366, api 575. New coverage for the ladder on both sides, including that adjacent rungs fired concurrently cannot land out of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)