### PR TITLE
Refuse a photo in the first five messages of a conversation

### DIFF
--- a/apps/api/src/modules/chat/access.ts
+++ b/apps/api/src/modules/chat/access.ts
@@ -1,8 +1,8 @@
-import { ERROR_CODES } from '@langx/shared'
+import { ERROR_CODES, MEDIA_UNLOCKS_AFTER_MESSAGES } from '@langx/shared'
 import { ObjectId, type Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import { ApiError } from '../../lib/ApiError'
-import type { Conversation } from './conversations'
+import type { Conversation, Message } from './conversations'
 
 /**
  * The one gate every conversation-scoped operation goes through — REST
@@ -46,4 +46,50 @@ export async function assertConversationAccess(
     throw new ApiError(ERROR_CODES.BLOCKED, 'Cannot access a conversation with a blocked user')
 
   return conversation
+}
+
+/**
+ * How many messages this thread has actually carried.
+ *
+ * Reads the denormalized counter, and falls back to counting for the
+ * conversations that predate it. An absent `messageCount` cannot mean "no
+ * messages" — every conversation is created with at least one, and with the
+ * field set — so it can only mean the document was written before the counter
+ * existed. Those are exactly the threads with the most history, and reading
+ * their absence as zero would lock two-year-old conversations out of sending a
+ * photo.
+ *
+ * The count is not written back. It is one query, on the media path only, for
+ * a set of documents that shrinks every time one of them gets a message.
+ */
+async function messagesInThread(db: Db, conversation: Conversation): Promise<number> {
+  if (typeof conversation.messageCount === 'number') return conversation.messageCount
+  return db
+    .collection<Message>(COLLECTIONS.messages)
+    .countDocuments({ conversationId: conversation._id })
+}
+
+/**
+ * Refuses a photo or a voice note into a conversation that has not said
+ * `MEDIA_UNLOCKS_AFTER_MESSAGES` things yet.
+ *
+ * Called from two places on purpose, and the *first* one is the one that
+ * matters. `POST /messages/upload-url` is where the bytes are stopped: the
+ * client uploads straight to the bucket through a presigned URL and only then
+ * sends the message, so a check on the send path alone would refuse a message
+ * pointing at a photograph we had already stored and could already serve. The
+ * second call, in `sendMediaMessage`, catches a URL signed a moment before the
+ * fifth message was undone — and any future transport that forgets the first.
+ *
+ * No tier check anywhere in here, deliberately. See
+ * `MEDIA_UNLOCKS_AFTER_MESSAGES`.
+ */
+export async function assertMediaUnlocked(db: Db, conversation: Conversation): Promise<void> {
+  const sent = await messagesInThread(db, conversation)
+  if (sent >= MEDIA_UNLOCKS_AFTER_MESSAGES) return
+  throw new ApiError(
+    ERROR_CODES.MEDIA_LOCKED,
+    `Photos and voice notes unlock after ${MEDIA_UNLOCKS_AFTER_MESSAGES} messages`,
+    { max: MEDIA_UNLOCKS_AFTER_MESSAGES },
+  )
 }

--- a/apps/api/src/modules/chat/conversationView.ts
+++ b/apps/api/src/modules/chat/conversationView.ts
@@ -1,3 +1,4 @@
+import { MEDIA_UNLOCKS_AFTER_MESSAGES } from '@langx/shared'
 import type { Conversation } from './conversations'
 
 /**
@@ -25,7 +26,27 @@ export interface ConversationView {
   /** They spoke last, so the next move is the viewer's. */
   unreplied: boolean
   bothSpoke: boolean
+  /**
+   * How many more messages before a photo or a voice note can be sent, or 0
+   * once they can. A number rather than a boolean so the composer can say
+   * *how many*, which is the difference between a rule and a broken button.
+   */
+  mediaLockedFor: number
   updatedAt: Date
+}
+
+/**
+ * How many more messages before an attachment is allowed, or 0.
+ *
+ * One function, read by both projections. An absent `messageCount` means the
+ * conversation predates the counter, never that it is empty — see
+ * `messagesInThread`, which is the server's own reading of the same field.
+ * Those threads have history, so the composer is unlocked rather than showing
+ * a countdown that would be wrong; signing an upload URL still checks properly.
+ */
+export function mediaLockedFor(conversation: Conversation): number {
+  const sent = conversation.messageCount ?? MEDIA_UNLOCKS_AFTER_MESSAGES
+  return Math.max(0, MEDIA_UNLOCKS_AFTER_MESSAGES - sent)
 }
 
 export function toConversationView(conversation: Conversation, viewerId: string): ConversationView {
@@ -44,6 +65,7 @@ export function toConversationView(conversation: Conversation, viewerId: string)
      */
     unreplied: conversation.lastMessage.senderId !== viewerId,
     bothSpoke: conversation.bothSpoke,
+    mediaLockedFor: mediaLockedFor(conversation),
     updatedAt: conversation.updatedAt,
   }
 }

--- a/apps/api/src/modules/chat/conversations.ts
+++ b/apps/api/src/modules/chat/conversations.ts
@@ -36,6 +36,19 @@ export interface Conversation {
   firstMessageBy: string
   firstMessageAt: Date
   bothSpoke: boolean
+  /**
+   * Messages in this thread, both sides together. Denormalized because the
+   * media gate reads it on a path that must not pay for a `countDocuments` —
+   * and it costs nothing to keep, since `recordMessage` already issues a
+   * `findOneAndUpdate` on this document for `lastMessage` and `unread`.
+   *
+   * Optional, and the absence means something specific: the conversation
+   * predates the counter. Those threads are the ones with history, so
+   * `messagesInThread` counts them rather than treating a missing field as
+   * zero and locking a two-year-old conversation out of sending a photo. The
+   * cost decays to nothing as old threads get their next message.
+   */
+  messageCount?: number
   createdAt: Date
   updatedAt: Date
 }
@@ -224,6 +237,11 @@ export async function startConversation(
     firstMessageBy: viewerId,
     firstMessageAt: now,
     bothSpoke: false,
+    // One, because this call writes the opening message itself rather than
+    // going through `recordMessage`. Set here so no conversation created from
+    // now on can have an absent count — which is what lets `messagesInThread`
+    // read an absent one as "predates the counter" instead of as zero.
+    messageCount: 1,
     createdAt: now,
     updatedAt: now,
   }

--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -14,10 +14,10 @@ import { ApiError } from '../../lib/ApiError'
 import { assertMediaAllowed } from '../media/assertMedia'
 import { blockedUserIds } from '../moderation/blocks'
 import { awardForSend } from '../tokens/awards'
-import { assertConversationAccess } from './access'
+import { assertConversationAccess, assertMediaUnlocked } from './access'
 import { toMessageView, type MessageView } from './messageView'
 import type { Conversation, Message } from './conversations'
-import { toConversationView, type ConversationView } from './conversationView'
+import { mediaLockedFor, toConversationView, type ConversationView } from './conversationView'
 
 export interface SendResult {
   message: Message
@@ -98,7 +98,9 @@ async function recordMessage(
         updatedAt: message.createdAt,
         bothSpoke,
       },
-      ...(recipientId ? { $inc: { [`unread.${recipientId}`]: 1 } } : {}),
+      // Riding the write that was already happening. The media gate reads this
+      // and must not pay for a `countDocuments` on the send path.
+      $inc: { messageCount: 1, ...(recipientId ? { [`unread.${recipientId}`]: 1 } : {}) },
     },
     { returnDocument: 'after' },
   )
@@ -222,6 +224,10 @@ export async function sendMediaMessage(
   storagePublicBaseUrl: string | undefined,
 ): Promise<SendResult> {
   const conversation = await assertConversationAccess(db, input.conversationId, senderId)
+  // The belt to the upload URL's braces. A URL signed a moment before the
+  // fifth message was deleted would otherwise still land, and any future
+  // transport that forgets the first check lands here instead of nowhere.
+  await assertMediaUnlocked(db, conversation)
 
   // Shared with the feed — see `assertMediaAllowed`. The ceilings are the real
   // cost control, and there must be exactly one copy of them.
@@ -265,6 +271,13 @@ export interface MessagePage {
    * never fetches the conversation document on its own.
    */
   pinned: { messageId: string; byUserId: string; at: string } | null
+  /**
+   * How many more messages before an attachment is allowed here, or 0. On the
+   * page for the same reason `participants` and `pinned` are: the composer
+   * needs it before anything else has loaded, and the client never fetches the
+   * conversation document on its own.
+   */
+  mediaLockedFor: number
   /** Set only by `listMessagesAround`, so a client knows what to scroll to. */
   anchorId?: string
 }
@@ -325,6 +338,7 @@ export async function listMessages(
     // The thread header needs the counterpart even before anyone has replied,
     // and a one-sided thread has no message to read a partner id off.
     participants: conversation.participants,
+    mediaLockedFor: mediaLockedFor(conversation),
     pinned: conversation.pinned
       ? {
           messageId: conversation.pinned.messageId.toHexString(),
@@ -407,6 +421,7 @@ export async function listMessagesAround(
     nextCursor: hasOlder && oldest ? encodeDateIdCursor(oldest.createdAt, oldest._id) : null,
     prevCursor: hasNewer && newest ? encodeDateIdCursor(newest.createdAt, newest._id) : null,
     participants: conversation.participants,
+    mediaLockedFor: mediaLockedFor(conversation),
     pinned: conversation.pinned
       ? {
           messageId: conversation.pinned.messageId.toHexString(),

--- a/apps/api/src/modules/handles/legacyConversations.ts
+++ b/apps/api/src/modules/handles/legacyConversations.ts
@@ -226,6 +226,9 @@ async function importRoom(
     firstMessageBy,
     firstMessageAt: first.createdAt,
     bothSpoke: senders.size > 1,
+    // Imported history counts. A restored thread with two years of messages in
+    // it is not a stranger's opening move, and the media gate reads this.
+    messageCount: staged.length,
     // The thread is as old as its first message. Dating it "now" would sort a
     // 2023 conversation above everything the user has actually been doing.
     createdAt: first.createdAt,
@@ -337,6 +340,13 @@ async function mergeIntoExisting(
   const increments: Record<string, number> = {}
   for (const [participantId, count] of Object.entries(unread)) {
     if (count > 0) increments[`unread.${participantId}`] = count
+  }
+  // The imported messages are additional to whatever the v2 thread already
+  // holds, so this is an increment like `unread` and not a `$set` like the
+  // rest. A conversation from before the counter existed stays absent here and
+  // is counted on demand — see `messagesInThread`.
+  if (seed.messageCount && typeof existing.messageCount === 'number') {
+    increments.messageCount = seed.messageCount
   }
 
   await conversations.updateOne(

--- a/apps/api/src/routes/media.ts
+++ b/apps/api/src/routes/media.ts
@@ -15,7 +15,7 @@ import { z } from 'zod'
 import { ApiError } from '../lib/ApiError'
 import { assertOwnBucket } from '../lib/assertOwnBucket'
 import { requireMember, requireVerifiedEmail } from '../middleware/requireAuth'
-import { assertConversationAccess } from '../modules/chat/access'
+import { assertConversationAccess, assertMediaUnlocked } from '../modules/chat/access'
 import { addPhoto, removePhoto, setAvatarUrl } from '../modules/profiles/profiles'
 
 const EXTENSION_BY_CONTENT_TYPE: Record<string, string> = {
@@ -95,6 +95,11 @@ export const mediaRoutes: FastifyPluginAsyncZod = async (app) => {
         request.body.conversationId,
         request.userId,
       )
+      // Before any URL is signed, and this is the only place that can stop the
+      // bytes: the client PUTs straight to the bucket and only then sends the
+      // message, so refusing at send time would refuse a message pointing at a
+      // photograph we had already stored.
+      await assertMediaUnlocked(app.mongo.db, conversation)
 
       const { kind, contentType } = request.body
       const allowed =

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -1,4 +1,4 @@
-import { MAX_IMAGE_BYTES, PLAN_LIMITS } from '@langx/shared'
+import { MAX_IMAGE_BYTES, MEDIA_UNLOCKS_AFTER_MESSAGES, PLAN_LIMITS } from '@langx/shared'
 import { ObjectId } from 'mongodb'
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
 import type { FastifyInstance } from 'fastify'
@@ -621,11 +621,29 @@ describe('Faz 5 — conversation/message history REST', () => {
       height: 600,
     }
 
-    async function pair(prefix: string) {
+    /**
+     * A conversation warmed past the media gate, because these tests are about
+     * content types, ceilings and quota rather than about the gate — and a
+     * fresh thread cannot carry an attachment at all. `warm: false` gives back
+     * the one-message thread the gate's own tests need.
+     */
+    async function pair(prefix: string, { warm = true }: { warm?: boolean } = {}) {
       const a = await newUser(`${prefix}-a@example.com`)
       const b = await newUser(`${prefix}-b@example.com`)
       const conversation = await startConversation(a, b.userId, 'hi')
+      if (warm) await warmPast(conversation._id, a.userId, b.userId)
       return { a, b, conversationId: conversation._id }
+    }
+
+    /** Talks until an attachment is allowed. `startConversation` wrote one. */
+    async function warmPast(conversationId: string, aId: string, bId: string) {
+      const { sendTextMessage } = await import('../modules/chat/messages')
+      for (let sent = 1; sent < MEDIA_UNLOCKS_AFTER_MESSAGES; sent++) {
+        await sendTextMessage(handle.db, sent % 2 === 1 ? bId : aId, {
+          conversationId,
+          body: `filler ${sent}`,
+        })
+      }
     }
 
     it('sends an image and shows a label in the chat list instead of an empty line', async () => {
@@ -700,6 +718,132 @@ describe('Faz 5 — conversation/message history REST', () => {
           BUCKET,
         ),
       ).rejects.toThrow(/too large/)
+    })
+
+    /**
+     * The rule with no exceptions: no photo and no voice note until the thread
+     * has carried `MEDIA_UNLOCKS_AFTER_MESSAGES` messages. Not a Pro feature,
+     * not a setting, not something a report has to catch after the fact — the
+     * first message from a stranger cannot be a photograph, of anybody, ever.
+     */
+    describe('attachments are locked until the thread has been talked in', () => {
+      async function uploadUrl(user: SignedUpUser, conversationId: string) {
+        return app.inject({
+          method: 'POST',
+          url: '/messages/upload-url',
+          headers: { cookie: user.cookie },
+          payload: { conversationId, kind: 'image', contentType: 'image/jpeg' },
+        })
+      }
+
+      /**
+       * Whether the *gate* refused, which is the only thing these tests are
+       * about. Storage is not configured in this suite, so a request that gets
+       * past the gate fails later for an unrelated reason — asserting a 200
+       * would be asserting that R2 credentials exist.
+       */
+      async function locked(user: SignedUpUser, conversationId: string) {
+        const response = await uploadUrl(user, conversationId)
+        return response.json<{ code?: string }>().code === 'MEDIA_LOCKED'
+      }
+
+      /**
+       * The upload URL is the check that matters. The client PUTs straight to
+       * the bucket and only then sends the message, so refusing at send time
+       * would refuse a message pointing at a photograph already stored.
+       */
+      it('refuses to sign an upload URL into a brand new conversation', async () => {
+        const { a, conversationId } = await pair('media-gate-new', { warm: false })
+        const response = await uploadUrl(a, conversationId)
+        expect(response.statusCode, response.body).toBe(409)
+        expect(response.json()).toMatchObject({
+          code: 'MEDIA_LOCKED',
+          max: MEDIA_UNLOCKS_AFTER_MESSAGES,
+        })
+      })
+
+      it('refuses the send itself too, for a URL signed before the gate closed', async () => {
+        const { a, conversationId } = await pair('media-gate-send', { warm: false })
+        const { sendMediaMessage } = await import('../modules/chat/messages')
+        await expect(
+          sendMediaMessage(
+            handle.db,
+            a.userId,
+            { conversationId, kind: 'image', media: image },
+            BUCKET,
+          ),
+        ).rejects.toThrow(/unlock after/)
+      })
+
+      it('opens on the message that reaches the threshold, not the one after', async () => {
+        const { a, b, conversationId } = await pair('media-gate-open', { warm: false })
+        const { sendTextMessage } = await import('../modules/chat/messages')
+
+        for (let sent = 1; sent < MEDIA_UNLOCKS_AFTER_MESSAGES; sent++) {
+          expect(await locked(a, conversationId), `after ${sent}`).toBe(true)
+          await sendTextMessage(handle.db, sent % 2 === 1 ? b.userId : a.userId, {
+            conversationId,
+            body: `filler ${sent}`,
+          })
+        }
+
+        expect(await locked(a, conversationId)).toBe(false)
+      })
+
+      /** Both sides count. It is a conversation, not a quota per person. */
+      it('counts what either of them said, not what one of them did', async () => {
+        const { a, b, conversationId } = await pair('media-gate-both', { warm: false })
+        const { sendTextMessage } = await import('../modules/chat/messages')
+        for (let sent = 1; sent < MEDIA_UNLOCKS_AFTER_MESSAGES; sent++) {
+          await sendTextMessage(handle.db, b.userId, { conversationId, body: `b ${sent}` })
+        }
+        expect(await locked(a, conversationId)).toBe(false)
+      })
+
+      /**
+       * The slogan is "nobody", and a paid tier would make it false. This is
+       * the assertion that keeps it true.
+       */
+      it('applies to a paid account exactly as it does to a free one', async () => {
+        const { a, conversationId } = await pair('media-gate-pro', { warm: false })
+        await handle.db
+          .collection<Profile>(COLLECTIONS.profiles)
+          .updateOne(
+            { _id: a.userId },
+            { $set: { entitlement: { tier: 'pro_plus', updatedAt: new Date() } } },
+          )
+        expect(await locked(a, conversationId)).toBe(true)
+      })
+
+      /**
+       * A conversation written before the counter existed has no
+       * `messageCount`, and reading that as zero would lock a two-year-old
+       * thread out of sending a photo. It is counted instead.
+       */
+      it('counts the messages of a conversation that predates the counter', async () => {
+        const { a, b, conversationId } = await pair('media-gate-legacy', { warm: false })
+        const { sendTextMessage } = await import('../modules/chat/messages')
+        for (let sent = 1; sent < MEDIA_UNLOCKS_AFTER_MESSAGES; sent++) {
+          await sendTextMessage(handle.db, b.userId, { conversationId, body: `b ${sent}` })
+        }
+        await handle.db
+          .collection(COLLECTIONS.conversations)
+          .updateOne({ _id: new ObjectId(conversationId) }, { $unset: { messageCount: '' } })
+
+        expect(await locked(a, conversationId)).toBe(false)
+      })
+
+      it('tells the client how many more are needed, so it can say so', async () => {
+        const { a, conversationId } = await pair('media-gate-count', { warm: false })
+        const page = await app.inject({
+          method: 'GET',
+          url: `/conversations/${conversationId}/messages`,
+          headers: { cookie: a.cookie },
+        })
+        expect(page.json<{ mediaLockedFor: number }>().mediaLockedFor).toBe(
+          MEDIA_UNLOCKS_AFTER_MESSAGES - 1,
+        )
+      })
     })
 
     it('will not sign an upload URL for a conversation you are not in', async () => {

--- a/apps/api/src/routes/moderation.test.ts
+++ b/apps/api/src/routes/moderation.test.ts
@@ -1,5 +1,6 @@
 import {
   ACCOUNT_DELETION_GRACE_DAYS,
+  MEDIA_UNLOCKS_AFTER_MESSAGES,
   REPORTS_TO_FREEZE_XP,
   type AccountDeletionStatus,
   type DataExport,
@@ -709,7 +710,17 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
       const started = await startConversation(me, partner.userId, 'here is a photo')
       const conversationId = started.json<{ _id: string }>()._id
 
-      const { sendMediaMessage } = await import('../modules/chat/messages')
+      // An attachment needs a thread that has been talked in — see
+      // `MEDIA_UNLOCKS_AFTER_MESSAGES`. This test is about the purge, not the
+      // gate, so the conversation is warmed past it first.
+      const { sendMediaMessage, sendTextMessage } = await import('../modules/chat/messages')
+      for (let sent = 1; sent < MEDIA_UNLOCKS_AFTER_MESSAGES; sent++) {
+        await sendTextMessage(handle.db, sent % 2 === 1 ? partner.userId : me.userId, {
+          conversationId,
+          body: `filler ${sent}`,
+        })
+      }
+
       await sendMediaMessage(
         handle.db,
         me.userId,

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -151,6 +151,15 @@ export default function ChatScreen() {
   // Optional on `participants` too: the response is a bare cast, so an API
   // older than this field would throw here rather than fall back.
   const partnerId = messages.data?.pages[0]?.participants?.find((p) => p !== me.data?._id) ?? ''
+  /*
+   * How many more messages before an attachment is allowed here. Read off the
+   * live page, which `appendIncomingMessage` counts down, so the camera comes
+   * back on the message that unlocked it rather than on the next refetch.
+   *
+   * Disabled rather than hidden. A control that vanishes teaches nothing, and
+   * the whole value of this rule is that people know it is there.
+   */
+  const mediaLockedFor = messages.data?.pages[0]?.mediaLockedFor ?? 0
   const partners = useProfileCache(partnerId ? [partnerId] : [])
   const partner = partners[partnerId]
 
@@ -236,6 +245,13 @@ export default function ChatScreen() {
   }
 
   async function toggleRecording(): Promise<void> {
+    // Guarded at the microphone rather than at the send, because starting a
+    // recording somebody is not allowed to send is a worse answer than not
+    // starting one: they would speak, then be told.
+    if (mediaLockedFor > 0) {
+      await showAlert(t('chat.mediaLockedTitle'), t('chat.mediaLocked', { count: mediaLockedFor }))
+      return
+    }
     if (!recorder.isRecording) {
       const started = await recorder.start()
       if (!started && recorder.error) void showAlert(t('chat.microphoneTitle'), recorder.error)
@@ -897,12 +913,28 @@ export default function ChatScreen() {
             </View>
           ) : (
             <Pressable
-              onPress={() => void pickImage()}
+              accessibilityLabel={
+                mediaLockedFor > 0
+                  ? t('chat.mediaLocked', { count: mediaLockedFor })
+                  : t('chat.attachPhoto')
+              }
+              onPress={() =>
+                mediaLockedFor > 0
+                  ? void showAlert(
+                      t('chat.mediaLockedTitle'),
+                      t('chat.mediaLocked', { count: mediaLockedFor }),
+                    )
+                  : void pickImage()
+              }
               disabled={sendingMedia}
               hitSlop={8}
               style={styles.attach}
             >
-              <Feather name="camera" size={20} color={colors.textMuted} />
+              <Feather
+                name="camera"
+                size={20}
+                color={mediaLockedFor > 0 ? colors.textFaint : colors.textMuted}
+              />
             </Pressable>
           )}
           <TextInput

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -274,6 +274,8 @@ export interface ConversationDto {
   /** They spoke last, so the next move is mine. */
   unreplied: boolean
   bothSpoke: boolean
+  /** How many more messages before an attachment is allowed, or 0. */
+  mediaLockedFor: number
   updatedAt: string
 }
 

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -570,6 +570,12 @@ export const ar: Localized<EnMessages> = {
     speedNormal: '1x',
     playSlowly: 'تشغيل بطيء',
     playAtNormalSpeed: 'تشغيل بالسرعة العادية',
+    mediaLockedTitle: 'ليس بعد',
+    mediaLocked: {
+      one: 'تُفتح الصور والرسائل الصوتية بعد رسالة واحدة أخرى.',
+      other: 'تُفتح الصور والرسائل الصوتية بعد {count} رسائل أخرى.',
+    },
+    attachPhoto: 'إرفاق صورة',
     copied: 'تم النسخ',
     couldNotSend: 'تعذّر الإرسال',
     mediaQuota: 'بلغت حدّ اليوم للصور والرسائل الصوتية.',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -490,6 +490,12 @@ export const de: Localized<EnMessages> = {
     speedNormal: '1x',
     playSlowly: 'Langsam abspielen',
     playAtNormalSpeed: 'Mit normaler Geschwindigkeit abspielen',
+    mediaLockedTitle: 'Noch nicht',
+    mediaLocked: {
+      one: 'Fotos und Sprachnachrichten gibt es nach einer weiteren Nachricht.',
+      other: 'Fotos und Sprachnachrichten gibt es nach {count} weiteren Nachrichten.',
+    },
+    attachPhoto: 'Foto anhängen',
     copied: 'Kopiert',
     couldNotSend: 'Konnte nicht gesendet werden',
     mediaQuota: 'Du hast das heutige Limit für Fotos und Sprachnachrichten erreicht.',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -504,6 +504,12 @@ export const en = {
     speedNormal: '1x',
     playSlowly: 'Play slowly',
     playAtNormalSpeed: 'Play at normal speed',
+    mediaLockedTitle: 'Not yet',
+    mediaLocked: {
+      one: 'Photos and voice notes unlock after one more message.',
+      other: 'Photos and voice notes unlock after {count} more messages.',
+    },
+    attachPhoto: 'Attach a photo',
     copied: 'Copied',
     couldNotSend: 'Could not send',
     mediaQuota: 'You’ve reached today’s limit for photos and voice messages.',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -472,6 +472,12 @@ export const es: Localized<EnMessages> = {
     speedNormal: '1x',
     playSlowly: 'Reproducir despacio',
     playAtNormalSpeed: 'Reproducir a velocidad normal',
+    mediaLockedTitle: 'Todavía no',
+    mediaLocked: {
+      one: 'Las fotos y las notas de voz se activan tras un mensaje más.',
+      other: 'Las fotos y las notas de voz se activan tras {count} mensajes más.',
+    },
+    attachPhoto: 'Adjuntar una foto',
     copied: 'Copiado',
     couldNotSend: 'No se pudo enviar',
     mediaQuota: 'Has llegado al límite de hoy para fotos y mensajes de voz.',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -472,6 +472,12 @@ export const fr: Localized<EnMessages> = {
     speedNormal: '1x',
     playSlowly: 'Lire lentement',
     playAtNormalSpeed: 'Lire à vitesse normale',
+    mediaLockedTitle: 'Pas encore',
+    mediaLocked: {
+      one: 'Photos et messages vocaux après un message de plus.',
+      other: 'Photos et messages vocaux après {count} messages de plus.',
+    },
+    attachPhoto: 'Joindre une photo',
     copied: 'Copié',
     couldNotSend: 'Envoi impossible',
     mediaQuota: 'Tu as atteint la limite du jour pour les photos et les messages vocaux.',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -466,6 +466,12 @@ export const ptBR: Localized<EnMessages> = {
     speedNormal: '1x',
     playSlowly: 'Tocar devagar',
     playAtNormalSpeed: 'Tocar em velocidade normal',
+    mediaLockedTitle: 'Ainda não',
+    mediaLocked: {
+      one: 'Fotos e áudios liberam depois de mais uma mensagem.',
+      other: 'Fotos e áudios liberam depois de mais {count} mensagens.',
+    },
+    attachPhoto: 'Anexar uma foto',
     copied: 'Copiado',
     couldNotSend: 'Não deu para enviar',
     mediaQuota: 'Você chegou ao limite de hoje para fotos e mensagens de voz.',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -541,6 +541,12 @@ export const ru: Localized<EnMessages> = {
     speedNormal: '1x',
     playSlowly: 'Медленное воспроизведение',
     playAtNormalSpeed: 'Обычная скорость',
+    mediaLockedTitle: 'Пока нет',
+    mediaLocked: {
+      one: 'Фото и голосовые откроются ещё через одно сообщение.',
+      other: 'Фото и голосовые откроются ещё через {count} сообщения.',
+    },
+    attachPhoto: 'Прикрепить фото',
     copied: 'Скопировано',
     couldNotSend: 'Не удалось отправить',
     mediaQuota: 'Ты исчерпал дневной лимит на фото и голосовые.',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -478,6 +478,12 @@ export const tr: Localized<EnMessages> = {
     speedNormal: '1x',
     playSlowly: 'Yavaş çal',
     playAtNormalSpeed: 'Normal hızda çal',
+    mediaLockedTitle: 'Henüz değil',
+    mediaLocked: {
+      one: 'Fotoğraf ve ses kaydı bir mesaj sonra açılır.',
+      other: 'Fotoğraf ve ses kaydı {count} mesaj sonra açılır.',
+    },
+    attachPhoto: 'Fotoğraf ekle',
     copied: 'Kopyalandı',
     couldNotSend: 'Gönderilemedi',
     mediaQuota: 'Bugünkü fotoğraf ve sesli mesaj sınırına ulaştın.',

--- a/apps/mobile/src/lib/conversationCache.test.ts
+++ b/apps/mobile/src/lib/conversationCache.test.ts
@@ -18,6 +18,7 @@ function conversation(id: string, unreadForMe = 0): ConversationDto {
     archived: false,
     unreplied: true,
     bothSpoke: true,
+    mediaLockedFor: 0,
     updatedAt: '2026-08-01T00:00:00.000Z',
   }
 }

--- a/apps/mobile/src/lib/messageCache.test.ts
+++ b/apps/mobile/src/lib/messageCache.test.ts
@@ -33,6 +33,7 @@ function pages(...groups: MessageDto[][]): InfiniteData<MessagePageDto> {
       prevCursor: null,
       pinned: null,
       participants: [ME, THEM],
+      mediaLockedFor: 0,
     })),
     pageParams: groups.map((_, i) => (i === 0 ? '' : 'c')),
   }
@@ -92,6 +93,34 @@ describe('appendIncomingMessage', () => {
   it('ignores a message already in any page', () => {
     const data = pages([message('new1')], [message('old1')])
     expect(appendIncomingMessage(data, message('old1'))).toBe(data)
+  })
+})
+
+/**
+ * The composer reads this to decide whether the camera does anything, so it
+ * has to move on the message that moved it. Waiting for a refetch would leave
+ * the button lying for as long as the cache is warm.
+ */
+describe('the media lock counts down as messages arrive', () => {
+  function locked(n: number): InfiniteData<MessagePageDto> {
+    const data = pages([message('a', THEM)])
+    return { ...data, pages: [{ ...data.pages[0]!, mediaLockedFor: n }] }
+  }
+
+  it('drops by one for each message appended', () => {
+    const after = appendIncomingMessage(locked(3), message('b', ME))
+    expect(after?.pages[0]?.mediaLockedFor).toBe(2)
+  })
+
+  it('stops at zero rather than going negative', () => {
+    const after = appendIncomingMessage(locked(0), message('b', ME))
+    expect(after?.pages[0]?.mediaLockedFor).toBe(0)
+  })
+
+  it('does not move when the message was a duplicate echo', () => {
+    const data = locked(3)
+    const after = appendIncomingMessage(data, message('a', THEM))
+    expect(after?.pages[0]?.mediaLockedFor).toBe(3)
   })
 })
 

--- a/apps/mobile/src/lib/messageCache.ts
+++ b/apps/mobile/src/lib/messageCache.ts
@@ -9,6 +9,8 @@ export interface MessagePageDto {
   prevCursor: string | null
   participants: string[]
   pinned: { messageId: string; byUserId: string; at: string } | null
+  /** How many more messages before an attachment is allowed here, or 0. */
+  mediaLockedFor: number
   /** Only a jump window has one — the message it was opened on. */
   anchorId?: string
 }
@@ -33,7 +35,21 @@ export function appendIncomingMessage(data: Pages, message: MessageDto): Pages {
   // ago in after one from last year. Live pages never carry `prevCursor`, so
   // this is a no-op for them.
   if (first.prevCursor) return data
-  return { ...data, pages: [{ ...first, items: [...first.items, message] }, ...rest] }
+  return {
+    ...data,
+    pages: [
+      {
+        ...first,
+        items: [...first.items, message],
+        // Counted down here rather than waiting for a refetch, so the composer
+        // unlocks on the message that unlocked it. The server decides for
+        // real when it signs the upload URL; this only keeps the button from
+        // lying for a few seconds.
+        mediaLockedFor: Math.max(0, first.mediaLockedFor - 1),
+      },
+      ...rest,
+    ],
+  }
 }
 
 /**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -498,6 +498,16 @@ deliberate: one is about fairness, the other about how it feels.
 Tokens can never buy a paid feature — if they could, a subscription's value
 erodes and farming tokens becomes a substitute for subscribing.
 
+### Attachments unlock after five messages
+
+A conversation carries no image or voice note until it has carried
+`MEDIA_UNLOCKS_AFTER_MESSAGES` messages, counted across both participants. No
+tier is exempt. Enforced when the upload URL is **signed** — the client PUTs
+straight to the bucket, so a check at send time would arrive after the bytes —
+and re-checked in `sendMediaMessage`. `conversations.messageCount` backs it and
+rides the write `recordMessage` was already making; an absent value means the
+thread predates the counter and is counted on demand.
+
 ### Anti-abuse
 
 The reciprocity requirement, per-partner caps, daily caps, a ramp-up for new

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1058,6 +1058,49 @@ The toggle is local state, not a preference. This is per sentence, not per
 person: the note you need slowed is the one you did not follow, and the next
 one is usually fine.
 
+## No photo in the first five messages. From anybody.
+
+The failure this exists to prevent has one shape: the first thing a stranger
+sends is a photograph, and the person receiving it did not agree to look at it.
+Moderation cannot fix that one. A report arrives after the picture has been
+seen, and being right afterwards is not the same as it not happening.
+
+So the rule is structural rather than punitive: a conversation carries no
+attachment until it has carried `MEDIA_UNLOCKS_AFTER_MESSAGES` messages,
+counted across both people. Nothing has to be detected, nobody has to be
+judged, and there is no model deciding what a photograph contains.
+
+**There is no exception, and that is the feature.** Not for Pro, not for
+Polyglot, not for somebody with a long history who has opened a new thread. A
+paid tier attached to this rule would say the behaviour is acceptable from
+customers, and it is not acceptable from anybody. It is also the only version
+that survives being said in one sentence: _photos unlock after five messages,
+for everyone._ Every carve-out costs a clause, and a rule people cannot repeat
+is a rule that does not deter.
+
+Five, because it is more than a greeting and fewer than a conversation. Two is
+cleared by "hi" / "hi". Twenty breaks the ordinary case of sending a picture of
+the menu you are asking about.
+
+**The gate is on `POST /messages/upload-url`, not on the send.** The client
+uploads straight to the bucket through a presigned URL and only then emits
+`message:media`, so a check at send time refuses a message pointing at a
+photograph we have already stored and can already serve. Refusing to _sign_ is
+what stops the bytes. `sendMediaMessage` checks too, for a URL signed a moment
+before the fifth message was deleted and for any future transport that forgets
+the first check — that one is the belt, not the braces.
+
+`messageCount` rides the `findOneAndUpdate` that `recordMessage` was already
+issuing for `lastMessage` and `unread`, so the counter is free. Its **absence**
+means something specific: the conversation predates it. Those are the threads
+with the most history, so `messagesInThread` counts them rather than reading a
+missing field as zero and locking a two-year-old conversation out of sending a
+photo — a cost that decays to nothing as old threads get their next message.
+
+The client is told how many more are needed rather than just that it cannot,
+and the camera is disabled rather than hidden. A control that vanishes teaches
+nothing, and a rule nobody knows about deters nobody.
+
 ## Countries are a compile-time table, like languages
 
 `profiles.country` was a free-text two-letter field, which meant the edit form

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -51,6 +51,29 @@ export type QuotaStatus = z.infer<typeof quotaStatusSchema>
  * a conversation with holes in it is worse than not importing it. They come
  * first so the migration can bring the whole thread.
  */
+/**
+ * How many messages a conversation has to carry before a photo or a voice note
+ * can be sent into it. Counted across both people, not per sender.
+ *
+ * This is the one rule in the app with no exception anywhere: not for Pro, not
+ * for Polyglot, not for somebody you have talked to for a year and then
+ * started a new thread with. That is deliberate, and it is the point. A rule
+ * with a paid tier attached to it is a rule that says the behaviour is
+ * acceptable from customers, and the behaviour this exists to stop — an
+ * unsolicited photograph from a stranger — is not acceptable from anybody. It
+ * is also the only version that can be said in one sentence and be true.
+ *
+ * Five, because it is more than a greeting and fewer than a conversation. Two
+ * would be cleared by "hi" / "hi". Twenty would break the ordinary case of
+ * sending somebody a picture of the menu you are asking about.
+ *
+ * It does not replace blocking or reporting, and it stops nothing between
+ * people who have talked. What it removes is the *first* message being a
+ * photograph, which is the one nobody consented to and the one no amount of
+ * moderation can un-see.
+ */
+export const MEDIA_UNLOCKS_AFTER_MESSAGES = 5
+
 export const MESSAGE_TYPES = ['text', 'correction', 'image', 'audio'] as const
 export type MessageType = (typeof MESSAGE_TYPES)[number]
 

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -32,6 +32,18 @@ export const ERROR_CODES = {
   BLOCKED: 'BLOCKED',
   /** A conversation between these two already exists — see `conversations.pairKey`. */
   CONVERSATION_EXISTS: 'CONVERSATION_EXISTS',
+  /**
+   * A photo or voice note into a conversation that has not exchanged
+   * `MEDIA_UNLOCKS_AFTER_MESSAGES` messages yet.
+   *
+   * Its own code rather than `VALIDATION_FAILED` because the request is
+   * well-formed and the fix is not in it — the client has to say *how many
+   * more*, and it can only know to do that if this is its own code. Not
+   * `UPGRADE_REQUIRED` either: there is nothing to buy. The rule applies to
+   * every account on every plan, which is the whole of what makes it worth
+   * saying out loud.
+   */
+  MEDIA_LOCKED: 'MEDIA_LOCKED',
 
   // discovery
   /**
@@ -85,6 +97,7 @@ export const ERROR_STATUS: Record<ErrorCode, number> = {
   UNDERAGE: 403,
   UPGRADE_REQUIRED: 403,
   QUOTA_EXCEEDED: 402,
+  MEDIA_LOCKED: 409,
   HANDLE_TAKEN: 409,
   HANDLE_RESERVED: 409,
   HANDLE_ALREADY_CLAIMED: 409,


### PR DESCRIPTION
> **İlk 5 mesajda fotoğraf gönderilemez. Hiç kimse tarafından.**

The failure this exists to prevent has one shape: the first thing a stranger sends is a photograph, and the person receiving it did not agree to look at it. Moderation cannot fix that one — a report arrives *after* the picture has been seen, and being right afterwards is not the same as it not happening.

So the rule is **structural rather than punitive**: a conversation carries no attachment until it has carried `MEDIA_UNLOCKS_AFTER_MESSAGES` messages, counted across both people. Nothing has to be detected, nobody has to be judged, and there is no model deciding what a photograph contains.

## There is no exception, and that is the feature

Not for Pro, not for Polyglot, not for someone with years of history who opened a new thread. A paid tier attached to this rule would say the behaviour is acceptable *from customers*, and it is not acceptable from anybody. It is also the only version that survives being said in one sentence — and a rule people cannot repeat is a rule that does not deter. There is a test whose entire job is to keep that true (`applies to a paid account exactly as it does to a free one`).

Five: more than a greeting, fewer than a conversation. Two is cleared by "hi" / "hi". Twenty breaks sending a picture of the menu you are asking about.

## The gate is on signing the URL, not on the send

This is the part that decides whether the feature works at all. The client uploads **straight to the bucket** through a presigned URL and only then emits `message:media` — so a check at send time refuses a message pointing at a photograph we have already stored and can already serve. `POST /messages/upload-url` is where the bytes stop.

`sendMediaMessage` checks too, for a URL signed a moment before the fifth message was deleted, and for any future transport that forgets the first. That one is the belt, not the braces.

## The counter

`conversations.messageCount` rides the `findOneAndUpdate` that `recordMessage` was **already** issuing for `lastMessage` and `unread`, so it costs no extra write.

Its *absence* means something specific: the conversation predates the counter. Those are the threads with the most history, so `messagesInThread` counts them rather than reading a missing field as zero and locking a two-year-old conversation out of sending a photo. The cost decays to nothing as old threads get their next message. Legacy v1 imports set it from the imported history.

## Client

`mediaLockedFor` is on the message page — same reasoning as `participants` and `pinned`, which that file already records: the composer needs it before anything else has loaded, and the client never fetches the conversation document. `appendIncomingMessage` counts it down, so the camera comes back on the message that unlocked it rather than on the next refetch.

The camera is **disabled, not hidden**, and tapping it says how many more are needed. A control that vanishes teaches nothing. The microphone is guarded at the *start* of recording, because letting somebody speak and then telling them is worse than not starting.

## New error code

`MEDIA_LOCKED` (409) rather than `VALIDATION_FAILED`: the request is well-formed and the fix is not in it — the client has to say *how many more*, and it can only know to do that if this is its own code. Not `UPGRADE_REQUIRED` either; there is nothing to buy.

## Tests

`1166 passed` — shared 209, mobile 371, api 586. Two existing suites needed their fixtures warmed past the gate, which is itself the change working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)