### PR TITLE
Let somebody browse from the sign-in screen, without the last account's chats

### DIFF
--- a/apps/mobile/app/(auth)/sign-in.tsx
+++ b/apps/mobile/app/(auth)/sign-in.tsx
@@ -7,6 +7,7 @@ import type { LoginResult } from '../../src/api/types'
 import { Button } from '../../src/components/ui/Button'
 import { FormField } from '../../src/components/ui/FormField'
 import { useAppConfig } from '../../src/hooks/useAppConfig'
+import { useGuestBrowse } from '../../src/hooks/useGuestBrowse'
 import { isNativeAppleSignInAvailable, requestAppleIdentity } from '../../src/lib/appleSignIn'
 import { authClient } from '../../src/lib/auth-client'
 import { authErrorKey } from '../../src/lib/errors'
@@ -15,6 +16,7 @@ import { useT } from '../../src/i18n'
 export default function SignIn() {
   const styles = useStyles()
   const t = useT()
+  const { start: browse } = useGuestBrowse()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
@@ -216,6 +218,20 @@ export default function SignIn() {
         <Link href="/(auth)/sign-up" style={styles.link}>
           {t('auth.signUp')}
         </Link>
+      </View>
+
+      {/*
+        The way out, for somebody who did not mean to be asked for a password.
+        The welcome screen offers this and leads with it, but this screen is
+        reachable without passing through it — a bookmark, a shared link, or
+        tapping "I already have an account" and thinking better of it — and it
+        draws no back control of its own, so on web that was a dead end.
+      */}
+      <View style={styles.footer}>
+        <Text style={styles.footerText}>{t('auth.justLooking')}</Text>
+        <Text style={styles.link} onPress={() => void browse()}>
+          {t('welcome.browse')}
+        </Text>
       </View>
     </KeyboardAvoidingView>
   )

--- a/apps/mobile/app/(auth)/welcome.tsx
+++ b/apps/mobile/app/(auth)/welcome.tsx
@@ -1,14 +1,9 @@
 import { router } from 'expo-router'
-import { useEffect, useState } from 'react'
 import { Text, View } from 'react-native'
-import { useQueryClient } from '@tanstack/react-query'
-import { keys } from '../../src/api/queries'
 import { Button } from '../../src/components/ui/Button'
 import { Screen } from '../../src/components/ui/Screen'
+import { useGuestBrowse } from '../../src/hooks/useGuestBrowse'
 import { useT } from '../../src/i18n'
-import { showAlert } from '../../src/lib/alert'
-import { authClient } from '../../src/lib/auth-client'
-import { shouldGateGuest } from '../../src/lib/guestGate'
 import { makeStyles } from '../../src/lib/theme'
 
 /**
@@ -23,56 +18,8 @@ import { makeStyles } from '../../src/lib/theme'
  */
 export default function WelcomeScreen() {
   const t = useT()
-  const { data: session } = authClient.useSession()
   const styles = useStyles()
-  const queryClient = useQueryClient()
-  const [starting, setStarting] = useState(false)
-
-  async function browse(): Promise<void> {
-    if (starting) return
-    setStarting(true)
-    /*
-     * `try`, not just the returned `error`. Better Auth's client returns one
-     * for a rejected *request*, and throws for a failed *connection* — the
-     * offline case is the throw, and it is also the likeliest one on a first
-     * launch. Catching only the first left an uncaught error on the very first
-     * screen somebody sees.
-     */
-    const failed = await authClient.signIn
-      .anonymous()
-      .then(({ error }) => Boolean(error))
-      .catch(() => true)
-    if (failed) {
-      setStarting(false)
-      await showAlert(t('welcome.guestFailed'), t('common.retry'))
-      return
-    }
-    /*
-     * The session changed, so anything cached under the previous one is about
-     * to be answered differently — the gate reads `useMe` to decide where to
-     * send them, and a stale 404 or a stale profile would send them to the
-     * wrong place.
-     */
-    await queryClient.invalidateQueries({ queryKey: keys.me })
-    // The effect below does the navigating; see why there.
-  }
-
-  /*
-   * Navigating from inside `browse()` does not work, and neither of the two
-   * obvious targets does either.
-   *
-   * `/(onboarding)/languages` fails because at that instant `useSession` has
-   * not re-rendered the root layout, so `(onboarding)` is not mounted and the
-   * replace silently does nothing. And `/` fails differently: both this group
-   * and the root have an `index`, and expo-router resolves it to `(auth)/index`
-   * — which reads the intro flag and sends the reader straight back here.
-   *
-   * So it waits for the session to actually exist, which is also the only
-   * moment the destination is guaranteed to be mounted.
-   */
-  useEffect(() => {
-    if (shouldGateGuest(session?.user)) router.replace('/(onboarding)/languages')
-  }, [session])
+  const { start: browse, starting } = useGuestBrowse()
 
   return (
     <Screen>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -23,6 +23,7 @@ import { ToastHost } from '../src/components/ToastHost'
 import { authClient } from '../src/lib/auth-client'
 import { shouldGateGuest } from '../src/lib/guestGate'
 import { forgetPurchasesIdentity, identifyForPurchases } from '../src/lib/purchases'
+import { isAccountSwitch } from '../src/lib/sessionSwitch'
 import { ThemeProvider, useTheme } from '../src/lib/theme'
 import { I18nProvider } from '../src/i18n'
 
@@ -87,6 +88,31 @@ function RootShell() {
     if (userId && !isGuest) void identifyForPurchases(userId)
     else void forgetPurchasesIdentity()
   }, [userId])
+
+  /**
+   * Empties the query cache when the person behind it changes.
+   *
+   * The client is made once and this tree never unmounts, so without this
+   * every answer fetched for one account survives into the next session:
+   * signing out and browsing as a guest showed the previous account's
+   * conversations, because `useConversations` is handed its cached pages
+   * before the guest's own (empty) list can come back. Not only chats —
+   * `keys.me`, the feed and discovery are all cached the same way.
+   *
+   * `clear()` rather than `invalidateQueries()`: invalidating leaves the data
+   * in place and merely refetches it, which still paints somebody else's rows
+   * first and leaves them there for good if the refetch fails.
+   *
+   * At the root rather than in `signOut()` because sign-out is not the only
+   * way the session changes hands — an expired cookie ends one without
+   * passing through that button, and `sign-up.tsx` ends a guest's.
+   */
+  const seenUserId = useRef<string | null | undefined>(undefined)
+  useEffect(() => {
+    const current = userId ?? null
+    if (isAccountSwitch(seenUserId.current, current)) queryClient.clear()
+    seenUserId.current = current
+  }, [userId, queryClient])
 
   // useSession() sets isPending on every refetch, not just the first load —
   // sign-up, sign-in and sign-out all trigger one. Gating the whole <Stack>

--- a/apps/mobile/src/hooks/useGuestBrowse.ts
+++ b/apps/mobile/src/hooks/useGuestBrowse.ts
@@ -1,0 +1,73 @@
+import { router } from 'expo-router'
+import { useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { keys } from '../api/queries'
+import { useT } from '../i18n'
+import { showAlert } from '../lib/alert'
+import { authClient } from '../lib/auth-client'
+import { shouldGateGuest } from '../lib/guestGate'
+
+/**
+ * Starting to look around without an account.
+ *
+ * A hook rather than a function on the welcome screen, because two screens
+ * offer this now and the hard part is not the sign-in call — it is the two
+ * failure shapes and the fact that the navigation cannot happen inline. A
+ * second copy of that would drift, and the way it would drift is silently: a
+ * screen that starts a guest session and then does not move.
+ */
+export function useGuestBrowse(): { start: () => Promise<void>; starting: boolean } {
+  const t = useT()
+  const { data: session } = authClient.useSession()
+  const queryClient = useQueryClient()
+  const [starting, setStarting] = useState(false)
+
+  async function start(): Promise<void> {
+    if (starting) return
+    setStarting(true)
+    /*
+     * `try`, not just the returned `error`. Better Auth's client returns one
+     * for a rejected *request*, and throws for a failed *connection* — the
+     * offline case is the throw, and it is also the likeliest one on a first
+     * launch. Catching only the first left an uncaught error on the very first
+     * screen somebody sees.
+     */
+    const failed = await authClient.signIn
+      .anonymous()
+      .then(({ error }) => Boolean(error))
+      .catch(() => true)
+    if (failed) {
+      setStarting(false)
+      await showAlert(t('welcome.guestFailed'), t('common.retry'))
+      return
+    }
+    /*
+     * The session changed, so anything cached under the previous one is about
+     * to be answered differently — the gate reads `useMe` to decide where to
+     * send them, and a stale 404 or a stale profile would send them to the
+     * wrong place.
+     */
+    await queryClient.invalidateQueries({ queryKey: keys.me })
+    // The effect below does the navigating; see why there.
+  }
+
+  /*
+   * Navigating from inside `start()` does not work, and neither of the two
+   * obvious targets does either.
+   *
+   * `/(onboarding)/languages` fails because at that instant `useSession` has
+   * not re-rendered the root layout, so `(onboarding)` is not mounted and the
+   * replace silently does nothing. And `/` fails differently: both the auth
+   * group and the root have an `index`, and expo-router resolves it to
+   * `(auth)/index` — which reads the intro flag and sends the reader straight
+   * back to where they started.
+   *
+   * So it waits for the session to actually exist, which is also the only
+   * moment the destination is guaranteed to be mounted.
+   */
+  useEffect(() => {
+    if (shouldGateGuest(session?.user)) router.replace('/(onboarding)/languages')
+  }, [session])
+
+  return { start, starting }
+}

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -282,6 +282,7 @@ export const ar: Localized<EnMessages> = {
     continueWithApple: 'المتابعة باستخدام Apple',
     or: 'أو',
     noAccount: 'ليس لديك حساب؟ ',
+    justLooking: 'مجرد إلقاء نظرة؟',
     haveAccount: 'لديك حساب بالفعل؟ ',
     createAccount: 'أنشئ حسابك',
     minimumAge: 'يجب أن يكون عمرك {age} عامًا أو أكثر لاستخدام LangX.',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -234,6 +234,7 @@ export const de: Localized<EnMessages> = {
     continueWithApple: 'Mit Apple fortfahren',
     or: 'oder',
     noAccount: 'Noch kein Konto? ',
+    justLooking: 'Nur schauen?',
     haveAccount: 'Schon ein Konto? ',
     createAccount: 'Erstelle dein Konto',
     minimumAge: 'Du musst {age} oder älter sein, um LangX zu nutzen.',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -265,6 +265,7 @@ export const en = {
     continueWithApple: 'Continue with Apple',
     or: 'or',
     noAccount: 'Don’t have an account? ',
+    justLooking: 'Just looking?',
     haveAccount: 'Already have an account? ',
     createAccount: 'Create your account',
     minimumAge: 'You must be {age}+ to use LangX.',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -233,6 +233,7 @@ export const es: Localized<EnMessages> = {
     continueWithApple: 'Continuar con Apple',
     or: 'o',
     noAccount: '¿No tienes cuenta? ',
+    justLooking: '¿Solo mirando?',
     haveAccount: '¿Ya tienes cuenta? ',
     createAccount: 'Crea tu cuenta',
     minimumAge: 'Debes tener {age} años o más para usar LangX.',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -234,6 +234,7 @@ export const fr: Localized<EnMessages> = {
     continueWithApple: 'Continuer avec Apple',
     or: 'ou',
     noAccount: 'Pas encore de compte ? ',
+    justLooking: 'Juste un coup d’œil ?',
     haveAccount: 'Tu as déjà un compte ? ',
     createAccount: 'Crée ton compte',
     minimumAge: 'Tu dois avoir {age} ans ou plus pour utiliser LangX.',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -230,6 +230,7 @@ export const ptBR: Localized<EnMessages> = {
     continueWithApple: 'Continuar com a Apple',
     or: 'ou',
     noAccount: 'Não tem conta? ',
+    justLooking: 'Só dando uma olhada?',
     haveAccount: 'Já tem conta? ',
     createAccount: 'Crie sua conta',
     minimumAge: 'Você precisa ter {age} anos ou mais para usar o LangX.',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -269,6 +269,7 @@ export const ru: Localized<EnMessages> = {
     continueWithApple: 'Продолжить с Apple',
     or: 'или',
     noAccount: 'Нет аккаунта? ',
+    justLooking: 'Просто смотришь?',
     haveAccount: 'Уже есть аккаунт? ',
     createAccount: 'Создай аккаунт',
     minimumAge: 'Чтобы пользоваться LangX, тебе должно быть {age} или больше.',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -244,6 +244,7 @@ export const tr: Localized<EnMessages> = {
     continueWithApple: 'Apple ile devam et',
     or: 'ya da',
     noAccount: 'Hesabın yok mu? ',
+    justLooking: 'Sadece bakıyor musun?',
     haveAccount: 'Zaten hesabın var mı? ',
     createAccount: 'Hesabını oluştur',
     minimumAge: 'LangX’i kullanmak için {age} yaşından büyük olmalısın.',

--- a/apps/mobile/src/lib/sessionSwitch.test.ts
+++ b/apps/mobile/src/lib/sessionSwitch.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { isAccountSwitch } from './sessionSwitch'
+
+describe('isAccountSwitch', () => {
+  it('is a switch whenever a known account is replaced', () => {
+    // The reported case: an account signs out, a guest signs in, and the
+    // conversation list cached under the first one is still in the client.
+    expect(isAccountSwitch('user-a', null)).toBe(true)
+    expect(isAccountSwitch('user-a', 'guest-1')).toBe(true)
+    // Straight from one account to another, without a null in between: the
+    // effect can miss the intermediate state, so this has to stand alone.
+    expect(isAccountSwitch('user-a', 'user-b')).toBe(true)
+  })
+
+  it('is not a switch while the same account stays signed in', () => {
+    expect(isAccountSwitch('user-a', 'user-a')).toBe(false)
+  })
+
+  /**
+   * The launch sequence, which must not clear anything: `useSession` resolves
+   * from "not observed yet" to whoever it finds, and a cache emptied at that
+   * moment would throw away the prefetch the first screen just started.
+   */
+  it('is not a switch before anyone has been observed', () => {
+    expect(isAccountSwitch(undefined, null)).toBe(false)
+    expect(isAccountSwitch(undefined, 'user-a')).toBe(false)
+  })
+
+  /** Signing in from a signed-out app: the cache was already dropped. */
+  it('is not a switch when nobody was signed in', () => {
+    expect(isAccountSwitch(null, 'user-a')).toBe(false)
+    expect(isAccountSwitch(null, null)).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/sessionSwitch.ts
+++ b/apps/mobile/src/lib/sessionSwitch.ts
@@ -1,0 +1,34 @@
+/**
+ * Whether the cache in hand belongs to somebody else now.
+ *
+ * The QueryClient is built once, at the root, and nothing below it ever
+ * unmounts — so every answer fetched for one account is still sitting in it
+ * when the next one arrives. React Query hands cached data to the first screen
+ * that asks for it, before any refetch can disagree, which is how somebody who
+ * signed out and started browsing as a guest was shown the previous account's
+ * conversation list. The rows were real; they were just not theirs.
+ *
+ * Pure, and apart from the layout that calls it, for the reason `guestGate`
+ * gives: `vitest.config.ts` sees `src/lib/**` and nothing that imports
+ * `expo-router`, so the decision is testable only when it is separate from the
+ * `queryClient.clear()` it triggers.
+ *
+ * Three states, not two, which is the whole reason this is not `a !== b`:
+ *
+ * - `undefined` — nobody observed yet. This is the first render of every
+ *   launch, while `useSession` is still resolving. Nothing has been cached
+ *   under anyone, so there is nothing to drop.
+ * - `null` — observed, and signed out. Also nothing to drop: the cache was
+ *   already emptied on the way out.
+ * - an id — observed, and somebody's. Anything else arriving after this is a
+ *   switch, including `null`: signing out has to drop the cache, or the next
+ *   account inherits it.
+ *
+ * Better Auth keeps `data` across a refetch (it only nulls it on a 401), so an
+ * id going missing here means the session really ended rather than that it is
+ * being re-checked — and a 401 has ended it too.
+ */
+export function isAccountSwitch(seen: string | null | undefined, current: string | null): boolean {
+  if (seen === undefined || seen === null) return false
+  return seen !== current
+}


### PR DESCRIPTION
## What

Two things, one path.

**The guest offer on sign-in.** The welcome screen leads with "just look around", but it is not the only way in — a bookmark, a shared link, or tapping "I already have an account" and thinking better of it all land on sign-in, which asks for a password and draws no back control of its own. On web that was a dead end. The offer now sits on both screens, through a shared `useGuestBrowse` hook rather than a second copy: the hard part is not `signIn.anonymous()` but the two failure shapes (returned error vs. thrown connection error) and the navigation, which cannot happen inline because `(onboarding)` is not mounted yet at that instant.

**The cache that followed the last account.** Found while testing the path above. The `QueryClient` is built once at the root and nothing under it ever unmounts, so answers fetched for one account outlived sign-out: signing out and browsing as a guest showed the previous account's conversation list, because `useConversations` is handed its cached pages before any refetch can disagree — and with `staleTime: 30_000`, no refetch was even due. The rows were real; they were just not theirs.

Nothing was wrong on the server. `GET /conversations` has always been scoped to `request.userId`, and a guest's own list is empty, which is why this could only ever be seen in the app.

## How

`isAccountSwitch` (pure, `src/lib`, tested) reads three states rather than comparing two ids — "nobody observed yet" at launch and "observed, signed out" are both non-switches, so the cache is not cleared out from under the first screen. The root layout calls `queryClient.clear()` on a real switch.

`clear()` rather than `invalidateQueries()`: invalidating leaves the data in place and merely refetches it, which still paints somebody else's rows first and keeps them for good if the refetch fails. At the root rather than in `signOut()`, because that button is not the only way a session changes hands — an expired cookie ends one without passing through it, and `sign-up.tsx` ends a guest's.

## Checks

`pnpm test` (mobile 378, api 586), `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` — all clean locally.

## Known, not fixed here

The onboarding draft (`useOnboardingDraft`) is persisted to device storage and cleared only when onboarding completes, so a guest sent to `/(onboarding)/languages` hydrates whatever the previous account left half-filled. Same family of leak, different fix — either clear it on the same switch (which costs you your own draft across a sign-out) or key it by user id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)