### PR TITLE
Read the invite link the app remembered, and let the fixtures show it

### DIFF
--- a/apps/api/scripts/seed-test-chat.ts
+++ b/apps/api/scripts/seed-test-chat.ts
@@ -47,6 +47,13 @@ import { PASSWORD, emailFor, ensureAccount, purgeTestAccounts, resolveDbName } f
 
 type Side = 'george' | 'marina'
 
+/**
+ * George first, and not only for readability: `Object.keys` preserves
+ * insertion order, `seed()` walks it in that order, and Marina names George as
+ * her referrer. `attachReferral` resolves a handle against profiles that
+ * already exist, so an invitee created before their referrer is silently not
+ * attributed — which is the correct behaviour and a confusing fixture.
+ */
 const CAST: Record<Side, OnboardingProfileInput> = {
   george: {
     handle: 'test_george',
@@ -62,6 +69,16 @@ const CAST: Record<Side, OnboardingProfileInput> = {
   },
   marina: {
     handle: 'test_marina',
+    /*
+     * So the invite screen has a *paid* row rather than only pending ones.
+     * Nothing here credits George: Marina earns from the conversation below
+     * like anybody else, `awardForSend` calls `settleReferral`, and the
+     * activation lands through the real path. That is the whole point of
+     * putting it here instead of writing a ledger row — the fixture
+     * demonstrates the rule (an invitation earns only once the invited person
+     * turns up) rather than asserting it.
+     */
+    referredByHandle: 'test_george',
     displayName: 'Marina',
     birthDate: '1996-06-15',
     gender: 'female',

--- a/apps/api/scripts/seed-test-users.ts
+++ b/apps/api/scripts/seed-test-users.ts
@@ -21,6 +21,20 @@ import { PASSWORD, emailFor, ensureAccount, purgeTestAccounts, resolveDbName } f
  * mutual fit Discover needs to return anyone at all for an English speaker
  * learning Russian. The rest are there so filtering by language visibly
  * changes the result rather than always matching everyone.
+ *
+ * Three of them name Anna as their referrer, so the invite screen has a list
+ * rather than an empty state. The order matters and is not incidental:
+ * `attachReferral` resolves a handle against profiles that already exist, so
+ * an invitee has to come *after* the person who invited them in this array.
+ *
+ * One of them arrives by link and two by typing the code, so `referrals.source`
+ * holds both of its values rather than only the default.
+ *
+ * Nothing here pays anybody. The awards are settled by `seed-test-chat.ts`
+ * when the cast actually talks, through `awardForSend` like any other
+ * message — which is the point. A fixture that credited the referrer directly
+ * would prove the ledger writes and nothing about the rule the feature is,
+ * which is that an invitation earns only once the invited person turns up.
  */
 const PEOPLE: OnboardingProfileInput[] = [
   {
@@ -52,6 +66,10 @@ const PEOPLE: OnboardingProfileInput[] = [
   },
   {
     handle: 'test_katya',
+    referredByHandle: 'test_anna',
+    // One of the three arrived on a link rather than typing the code, so the
+    // column has both values in it and a query against it means something.
+    referredBySource: 'link',
     displayName: 'Katya',
     birthDate: '2001-06-15',
     gender: 'female',
@@ -64,6 +82,7 @@ const PEOPLE: OnboardingProfileInput[] = [
   },
   {
     handle: 'test_pavel',
+    referredByHandle: 'test_anna',
     displayName: 'Pavel',
     birthDate: '1988-06-15',
     gender: 'male',
@@ -76,6 +95,7 @@ const PEOPLE: OnboardingProfileInput[] = [
   },
   {
     handle: 'test_olga',
+    referredByHandle: 'test_anna',
     displayName: 'Olga',
     birthDate: '1995-06-15',
     gender: 'female',

--- a/apps/api/scripts/testAccounts.ts
+++ b/apps/api/scripts/testAccounts.ts
@@ -205,6 +205,21 @@ export async function purgeTestAccounts(db: Db): Promise<void> {
     await db.collection(collection).deleteMany({ userId: { $in: stringIds } })
   }
 
+  /*
+   * Not in the loop above, because a referral has no `userId`: it is keyed by
+   * the *invitee* and carries the referrer separately, so both ends have to be
+   * named or a half-purged pair is left pointing at a profile that is gone.
+   *
+   * The reading side already survives that — `readReferralStatus` skips an
+   * invitee whose profile has been removed rather than drawing a blank row —
+   * but surviving litter is not the same as not leaving it.
+   */
+  const referrals = await db
+    .collection<{ _id: string; referrerId: string }>(COLLECTIONS.referrals)
+    .deleteMany({
+      $or: [{ _id: { $in: stringIds } }, { referrerId: { $in: stringIds } }],
+    })
+
   // `profiles._id` is the user id as a string, not an ObjectId.
   const profiles = await db
     .collection<{ _id: string }>(COLLECTIONS.profiles)
@@ -217,6 +232,7 @@ export async function purgeTestAccounts(db: Db): Promise<void> {
   console.log(
     `purged ${removed.deletedCount} users, ${profiles.deletedCount} profiles, ` +
       `${accounts.deletedCount} accounts, ${sessions.deletedCount} sessions, ` +
-      `${threads.deletedCount} conversations, ${messages.deletedCount} messages`,
+      `${threads.deletedCount} conversations, ${messages.deletedCount} messages, ` +
+      `${referrals.deletedCount} referrals`,
   )
 }

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -357,7 +357,7 @@ export async function createProfile(
    */
   if (input.referredByHandle) {
     try {
-      await attachReferral(db, userId, input.referredByHandle, 'manual')
+      await attachReferral(db, userId, input.referredByHandle, input.referredBySource ?? 'manual')
     } catch (error) {
       console.error('[referral] attach failed', { userId, error })
     }

--- a/apps/api/src/modules/referrals/referrals.ts
+++ b/apps/api/src/modules/referrals/referrals.ts
@@ -1,5 +1,5 @@
 import { ERROR_CODES, REFERRAL_LIST_LIMIT, TOKEN_RULES } from '@langx/shared'
-import type { PaidPlanTier, ReferralInvitee, ReferralStatus } from '@langx/shared'
+import type { PaidPlanTier, ReferralInvitee, ReferralSource, ReferralStatus } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import type { Profile } from '../profiles/profiles'
@@ -25,7 +25,7 @@ export interface Referral {
    */
   referrerHandle: string
   /** Where the code came from: a marked invite URL, or typed in at onboarding. */
-  source: 'link' | 'manual'
+  source: ReferralSource
   createdAt: Date
 
   /**

--- a/apps/api/src/routes/referrals.test.ts
+++ b/apps/api/src/routes/referrals.test.ts
@@ -155,6 +155,23 @@ describe('referrals', () => {
       expect(await ledgerOf(a.userId, 'referral')).toHaveLength(0)
     })
 
+    /**
+     * The client says where the code came from; the server cannot infer it.
+     * Without this the column is always `manual`, including for the links —
+     * and the question it exists to answer (should an unmarked profile link
+     * count as an invitation?) has no data behind it.
+     */
+    it('records whether the code came from a link or was typed', async () => {
+      const a = await newUser()
+      const b = await newUser({ referredByHandle: a.handle, referredBySource: 'link' })
+      expect((await rowOf(b.userId))?.source).toBe('link')
+
+      const c = await newUser()
+      const d = await newUser({ referredByHandle: c.handle })
+      // Absent from an older client, and "typed" is the claim that asserts less.
+      expect((await rowOf(d.userId))?.source).toBe('manual')
+    })
+
     it('ignores an unknown code rather than failing the sign-up', async () => {
       const b = await newUser({ referredByHandle: 'nobodyhere' })
       expect(await rowOf(b.userId)).toBeNull()

--- a/apps/mobile/app/(onboarding)/handle.tsx
+++ b/apps/mobile/app/(onboarding)/handle.tsx
@@ -108,7 +108,12 @@ export default function HandleStep() {
         ...(current.avatarUrl ? { avatarUrl: current.avatarUrl } : {}),
         // Silently ignored by the server if it resolves to nobody — see
         // `attachReferral`. Nothing here should be able to fail a sign-up.
-        ...(current.referredByHandle ? { referredByHandle: current.referredByHandle } : {}),
+        ...(current.referredByHandle
+          ? {
+              referredByHandle: current.referredByHandle,
+              referredBySource: current.referredBySource,
+            }
+          : {}),
         // The device already knows the user's timezone; asking would be a
         // question with one correct answer the app can read itself. It drives
         // the streak's notion of "today".
@@ -194,7 +199,11 @@ export default function HandleStep() {
               label={t('onboarding.inviteCodeLabel')}
               value={draft.referredByHandle}
               onChangeText={(value) =>
-                updateDraft({ referredByHandle: normalizeInviteCode(value) ?? value.trim() })
+                updateDraft({
+                  referredByHandle: normalizeInviteCode(value) ?? value.trim(),
+                  // Typed over, so it is no longer whatever the link said.
+                  referredBySource: 'manual',
+                })
               }
               placeholder={t('onboarding.inviteCodePlaceholder')}
               autoCapitalize="none"

--- a/apps/mobile/src/hooks/useOnboardingDraft.ts
+++ b/apps/mobile/src/hooks/useOnboardingDraft.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from 'react'
-import type { LanguageLevel, Gender } from '@langx/shared'
-import { FLAG_KEYS, clearFlag, readJsonFlag, writeJsonFlag } from '../lib/localFlags'
+import type { LanguageLevel, Gender, ReferralSource } from '@langx/shared'
+import { resolveReferrer } from '../lib/inviteLink'
+import { FLAG_KEYS, clearFlag, readFlag, readJsonFlag, writeJsonFlag } from '../lib/localFlags'
 
 export interface OnboardingDraft {
   nativeLanguages: string[]
@@ -23,6 +24,13 @@ export interface OnboardingDraft {
    * languages — the link is opened once and the form is finished later.
    */
   referredByHandle: string
+  /**
+   * Which of those two it was. The server stores it on the referral row, and
+   * it is the only way to answer a question the product will ask: whether an
+   * unmarked profile link should count as an invitation too. Without it every
+   * row says "typed", including the ones that were not.
+   */
+  referredBySource: ReferralSource
   country: string
   /** Uploaded during the wizard; written by `POST /profiles`, not by `confirm`. */
   avatarUrl: string
@@ -39,6 +47,7 @@ const EMPTY: OnboardingDraft = {
   city: '',
   interests: [],
   referredByHandle: '',
+  referredBySource: 'manual',
   country: '',
   avatarUrl: '',
 }
@@ -104,6 +113,26 @@ export async function hydrateDraft(): Promise<void> {
   if (hydrated) return
   const stored = await readJsonFlag<Partial<OnboardingDraft>>(FLAG_KEYS.onboardingDraft)
   if (stored) draft = { ...EMPTY, ...stored, ...diffFromEmpty(draft) }
+
+  /*
+   * Whoever's invite link opened the app, if the draft has not already been
+   * told. Read here rather than on the handle screen because the flag is
+   * written long before that screen exists — often before there is an account
+   * at all — and this is the one place the draft is assembled from everything
+   * the device remembers.
+   *
+   * A code already in the draft wins. It was either typed, which is a more
+   * deliberate answer than a link, or it came from this same flag on an
+   * earlier launch.
+   */
+  const referrer = resolveReferrer(
+    draft.referredByHandle,
+    await readFlag(FLAG_KEYS.pendingReferrer),
+  )
+  if (referrer) {
+    draft = { ...draft, referredByHandle: referrer.handle, referredBySource: referrer.source }
+  }
+
   hydrated = true
   // Anything typed while the read was in flight has not been written yet,
   // because `schedulePersist` refuses to run before this point.

--- a/apps/mobile/src/lib/inviteLink.test.ts
+++ b/apps/mobile/src/lib/inviteLink.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { inviteHandleFromUrl, normalizeInviteCode } from './inviteLink'
+import { inviteHandleFromUrl, normalizeInviteCode, resolveReferrer } from './inviteLink'
 
 /**
  * These run on paths where a throw is not an error message but a launch that
@@ -54,5 +54,30 @@ describe('inviteHandleFromUrl, as the app calls it', () => {
   it('reads only a marked link, so sharing a profile is not an attribution', () => {
     expect(inviteHandleFromUrl('https://app2.langx.io/deniz?invite=1')).toBe('deniz')
     expect(inviteHandleFromUrl('https://app2.langx.io/deniz')).toBeNull()
+  })
+})
+
+/**
+ * The gap this closes: `pendingReferrer` shipped written in two places and
+ * read in none, so an invite link stored a handle that onboarding never saw.
+ * The link path attributed nobody and only a typed code worked.
+ */
+describe('resolveReferrer', () => {
+  it('takes the handle an invite link left on the device', () => {
+    expect(resolveReferrer('', 'deniz')).toEqual({ handle: 'deniz', source: 'link' })
+  })
+
+  it('leaves a code already in the draft alone, and does not relabel it', () => {
+    expect(resolveReferrer('typed', 'deniz')).toBeNull()
+  })
+
+  it('has nothing to say when no link was opened', () => {
+    for (const pending of [null, undefined, '', 'not a handle!!']) {
+      expect(resolveReferrer('', pending), String(pending)).toBeNull()
+    }
+  })
+
+  it('normalises what it found, since the flag is written from a URL', () => {
+    expect(resolveReferrer('', '@Deniz')?.handle).toBe('deniz')
   })
 })

--- a/apps/mobile/src/lib/inviteLink.ts
+++ b/apps/mobile/src/lib/inviteLink.ts
@@ -1,5 +1,5 @@
-import { inviteHandleFromUrl } from '@langx/shared'
-import { HANDLE_PATTERN } from '@langx/shared'
+import { inviteHandleFromUrl, HANDLE_PATTERN } from '@langx/shared'
+import type { ReferralSource } from '@langx/shared'
 
 export { inviteHandleFromUrl }
 
@@ -29,4 +29,29 @@ export function normalizeInviteCode(input: string | null | undefined): string | 
   const pathish = trimmed.match(/^(?:[a-z][a-z0-9+.-]*:\/\/)?[^/\s]*\/([^/?#\s]+)/i)?.[1]
   const candidate = (pathish ?? trimmed).replace(/^@/, '').toLowerCase()
   return HANDLE_PATTERN.test(candidate) ? candidate : null
+}
+
+/**
+ * Which referrer onboarding should carry, given what the draft already holds
+ * and what an invite link left on the device.
+ *
+ * A pure function rather than a branch inside `hydrateDraft`, because that
+ * store cannot be reached by `vitest` — it only covers `src/lib` — and this is
+ * the part with a rule in it. The rule shipped once already as a flag that was
+ * written in two places and read in none, which is a link that silently
+ * attributes nobody; the point of pulling it out is that the next such gap
+ * fails a test instead.
+ *
+ * A code already in the draft wins. It was either typed, which is a more
+ * deliberate answer than a link, or it is this same flag from an earlier
+ * launch — and re-labelling that one `link` would overwrite a `manual` the
+ * reader chose.
+ */
+export function resolveReferrer(
+  draftHandle: string,
+  pending: string | null | undefined,
+): { handle: string; source: ReferralSource } | null {
+  if (draftHandle) return null
+  const handle = normalizeInviteCode(pending)
+  return handle ? { handle, source: 'link' } : null
 }

--- a/apps/mobile/src/lib/onboardingStep.test.ts
+++ b/apps/mobile/src/lib/onboardingStep.test.ts
@@ -13,6 +13,7 @@ const EMPTY: OnboardingDraft = {
   city: '',
   interests: [],
   referredByHandle: '',
+  referredBySource: 'manual' as const,
   country: '',
   avatarUrl: '',
 }

--- a/packages/shared/src/profile.ts
+++ b/packages/shared/src/profile.ts
@@ -3,6 +3,7 @@ import { PLAN_LIMITS } from './limits'
 import { notificationPrefsSchema } from './notifications'
 import { birthDateSchema } from './age'
 import { languageLevelSchema } from './level'
+import { referralSourceSchema } from './referral'
 import { handleSchema } from './handle'
 import { languageCodeSchema } from './languages'
 import { z } from 'zod'
@@ -152,6 +153,13 @@ export const onboardingProfileSchema = z
      * same reason.
      */
     referredByHandle: handleSchema.optional().catch(undefined),
+    /**
+     * Whether that handle came from a link or was typed. Defaulted rather than
+     * required, because an older client sends the handle and not this — and
+     * "somebody put it there by hand" is the safer thing to record when we do
+     * not know, since it is the claim that asserts less.
+     */
+    referredBySource: referralSourceSchema.optional().catch(undefined),
     bio: bioSchema.optional(),
     interests: interestsSchema.optional(),
     country: countryCodeSchema.optional(),

--- a/packages/shared/src/referral.ts
+++ b/packages/shared/src/referral.ts
@@ -86,6 +86,19 @@ export function inviteHandleFromUrl(url: string | null | undefined): string | nu
  */
 export const REFERRAL_LIST_LIMIT = 50
 
+/**
+ * Where an invite code came from.
+ *
+ * `link` means a marked invite URL put it there; `manual` means somebody typed
+ * or pasted it into onboarding. The distinction exists to answer a question
+ * the product will ask — whether an unmarked profile link should count as an
+ * invitation too — with data rather than a guess. The server cannot infer it,
+ * so the client says.
+ */
+export const REFERRAL_SOURCES = ['link', 'manual'] as const
+export type ReferralSource = (typeof REFERRAL_SOURCES)[number]
+export const referralSourceSchema = z.enum(REFERRAL_SOURCES)
+
 export const REFERRAL_STATUSES = ['pending', 'activated', 'subscribed'] as const
 export type ReferralInviteeStatus = (typeof REFERRAL_STATUSES)[number]
 


### PR DESCRIPTION
Started as "what is `seed/chat-fixture` and can it be closed" — it can, its two commits are already in main and main is ahead of it. But looking at the seeds for the invite screen turned up a real defect in what shipped yesterday.

## `pendingReferrer` was written in two places and read in none

`usePendingInvite` and `app/[username].tsx` both store the handle from an invite link. Nothing ever read it back. So a person who opened somebody's invite link had the handle sitting on their device while onboarding submitted nothing — **the headline flow attributed nobody**, and only typing the code by hand worked.

`hydrateDraft` reads it now, since that is where the draft is assembled from everything the device remembers. The decision moved to `resolveReferrer` in `src/lib`, because that is the half with a rule in it and `vitest` only reaches `src/lib` and `src/i18n`. This gap shipped once as a flag nobody read; pulling it out is so the next one fails a test instead.

A code already in the draft wins over the flag — it was either typed, which is more deliberate than a link, or it is the same flag from an earlier launch, and relabelling that would overwrite a `manual` the reader chose.

## `referrals.source` could only ever be `manual`

Including for the links. The column exists to answer a product question — should an unmarked profile link count as an invitation too? — and it had no data behind it. The client now says which, since the server cannot infer it. An older client that sends no source still records `manual`, the claim that asserts less.

## The fixtures

- **Anna invites three of the cast**, one by link and two by typed code, so `source` holds both of its values.
- **Marina names George**, and because `seed-test-chat` makes them talk, `awardForSend` settles that referral through the real path.

Nothing writes a ledger row directly. A fixture that credited the referrer would prove the ledger works and nothing about the rule, which is that an invitation earns only once the invited person turns up. Verified against a scratch replica set: 3 pending, 1 activated at `award=1000`, 1 ledger row.

## The purge could not have known about `referrals`

The rows carry no `userId` — they are keyed by the invitee and hold the referrer separately — so they fell outside the `{ userId: { $in } }` loop. Both ends are named now, or a half-purged pair is left pointing at a profile that is gone. `deleteMany` also had to be typed: `referrals._id` is a string, and the default `ObjectId` filter type is exactly the two-id-worlds trap that file already warns about. Verified: 4 referrals purged, 0 left.

## Tests

`1265 passed` — shared 223, mobile 396, api 646.

Once this lands, `seed/chat-fixture` can be deleted; it carries nothing main does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)