### PR TITLE
Show the invite code a link filled in, instead of hiding it

### DIFF
--- a/apps/mobile/app/(onboarding)/handle.tsx
+++ b/apps/mobile/app/(onboarding)/handle.tsx
@@ -70,8 +70,15 @@ export default function HandleStep() {
   const available = availability.data?.available
   const checking = debouncedHandle.length > 0 && availability.isFetching
 
-  // Opened by hand, or already open because a link filled it in.
-  const [inviteOpen, setInviteOpen] = useState(draft.referredByHandle.length > 0)
+  /*
+   * Derived, not seeded. `useState`'s initialiser runs once, on the first
+   * render — and the draft hydrates asynchronously, so at that moment an
+   * invite link's handle has not arrived yet. Seeding it left the row
+   * collapsed for exactly the people it is for: the code was submitted, and
+   * they never saw that they had been invited.
+   */
+  const [inviteOpenedByHand, setInviteOpenedByHand] = useState(false)
+  const inviteOpen = inviteOpenedByHand || draft.referredByHandle.length > 0
 
   /*
    * The *public* profile route, not `/profiles/:handleOrId`. That one calls
@@ -218,7 +225,7 @@ export default function HandleStep() {
             ) : null}
           </>
         ) : (
-          <Text style={styles.inviteToggle} onPress={() => setInviteOpen(true)}>
+          <Text style={styles.inviteToggle} onPress={() => setInviteOpenedByHand(true)}>
             {t('onboarding.inviteCodeToggle')}
           </Text>
         )}


### PR DESCRIPTION
`useState`'s initialiser runs once, on the first render. The onboarding draft hydrates **asynchronously**, so at that moment the handle an invite link left on the device has not arrived yet.

Seeding the row's open state from `draft.referredByHandle.length > 0` therefore captured `false` and never updated — leaving the row collapsed for exactly the people it is for. The code *was* submitted with the profile, so attribution worked; the invited person simply never saw that they had been invited, and could not change it without discovering the collapsed toggle and finding it prefilled.

Derived from the draft now, with the by-hand toggle kept as its own state so opening it stays open.

**Caught by looking at the screen.** The draft held the right value in local storage the whole time and every test passed — the defect was only ever visible as pixels.

| | before | after |
|---|---|---|
| link opened, at the handle step | `Have an invite code?` (collapsed) | `Invite code: annaseed` + *"You were invited by Anna."* |

Verified end to end against a local stack: open `/annaseed?invite=1` signed out → `pendingReferrer` written → sign in → onboarding → the draft carries `annaseed` / `link` and the row shows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)