### PR TITLE
Fold the feed's two correction tabs into one queue, people you follow first

### DIFF
--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -367,7 +367,7 @@ export const INDEXES: Partial<IndexSpec> = {
   ],
 
   [COLLECTIONS.posts]: [
-    // The `needsCorrection` tab, and the plain recency feed behind it. Both
+    // The correction queue, and the plain recency feed behind it. Both
     // read newest-first within a `correctionCount` bucket, so one compound
     // index serves both orders.
     { key: { correctionCount: 1, createdAt: -1, _id: -1 }, name: 'needs_correction' },

--- a/apps/api/src/lib/feedCursor.test.ts
+++ b/apps/api/src/lib/feedCursor.test.ts
@@ -7,29 +7,32 @@ describe('feed cursor', () => {
   const at = new Date('2026-08-29T17:50:49.159Z')
   const id = new ObjectId('65f0000000000000000000ff')
 
-  it('round-trips a countless cursor', () => {
-    // The regression. An ISO timestamp carries its own dot before the `Z`, so
-    // splitting on the first one found the milliseconds and made this branch
-    // unreachable — every `following` page-two request was a 400.
-    const decoded = decodeFeedCursor(encodeFeedCursor(at, id, null))
-    expect(decoded.count).toBeNull()
+  it('round-trips a cursor from the people you follow', () => {
+    const decoded = decodeFeedCursor(encodeFeedCursor(at, id, 3, true))
+    expect(decoded.followed).toBe(true)
+    expect(decoded.count).toBe(3)
     expect(decoded.date.toISOString()).toBe(at.toISOString())
     expect(decoded.id.toHexString()).toBe(id.toHexString())
   })
 
-  it('round-trips a counted cursor', () => {
-    const decoded = decodeFeedCursor(encodeFeedCursor(at, id, 3))
+  it('round-trips a cursor from everybody else', () => {
+    const decoded = decodeFeedCursor(encodeFeedCursor(at, id, 3, false))
+    expect(decoded.followed).toBe(false)
     expect(decoded.count).toBe(3)
     expect(decoded.date.toISOString()).toBe(at.toISOString())
   })
 
   it('round-trips a zero count', () => {
     // The common case: every post nobody has answered yet.
-    expect(decodeFeedCursor(encodeFeedCursor(at, id, 0)).count).toBe(0)
+    expect(decodeFeedCursor(encodeFeedCursor(at, id, 0, false)).count).toBe(0)
   })
 
   it('rejects a malformed cursor', () => {
     expect(() => decodeFeedCursor('nonsense')).toThrow(ApiError)
     expect(() => decodeFeedCursor('7.nonsense')).toThrow(ApiError)
+    expect(() => decodeFeedCursor('f.nonsense')).toThrow(ApiError)
+    // The old countless form from the recency-only tab. An ISO timestamp's
+    // own dot must not be mistaken for the count separator.
+    expect(() => decodeFeedCursor(`${at.toISOString()}|${id.toHexString()}`)).toThrow(ApiError)
   })
 })

--- a/apps/api/src/lib/feedCursor.ts
+++ b/apps/api/src/lib/feedCursor.ts
@@ -1,42 +1,50 @@
+import { ERROR_CODES } from '@langx/shared'
 import type { ObjectId } from 'mongodb'
+import { ApiError } from './ApiError'
 import { decodeDateIdCursor, encodeDateIdCursor } from './dateIdCursor'
 
 /**
- * The feed's cursor, which carries its sort's own keys.
+ * The feed's cursor, which carries its sort's own keys and which half of the
+ * feed it stopped in.
  *
- * `needsCorrection` sorts `(correctionCount, createdAt, _id)`, and paging that
- * with a `createdAt`-only cursor would silently skip every post whose count
- * differs — which is most of them. `following` sorts by recency alone and needs
- * no count, so the count is optional and the two encodings have to be told
- * apart on the way back in.
+ * The queue sorts `(count, createdAt, _id)`, and paging that with a
+ * `createdAt`-only cursor would silently skip every post whose count differs —
+ * which is most of them. The correction section is also two queries stitched
+ * end to end — the people you follow, then everybody else — so the cursor
+ * says which one it came from, or page two would start the first half again.
  *
  * Pure, and deliberately out of the repository: a cursor bug is cheapest to
  * prove fixed where there is no database to stand up.
  */
 
-/** `<dateIdCursor>` for the recency sort, `<count>.<dateIdCursor>` for the queue. */
-export function encodeFeedCursor(date: Date, id: ObjectId, count: number | null): string {
-  const base = encodeDateIdCursor(date, id)
-  return count === null ? base : `${count}.${base}`
+/** `<count>.<dateIdCursor>`, with `f.` in front while still inside the people you follow. */
+export function encodeFeedCursor(
+  date: Date,
+  id: ObjectId,
+  count: number,
+  followed: boolean,
+): string {
+  return `${followed ? 'f.' : ''}${count}.${encodeDateIdCursor(date, id)}`
 }
 
 export function decodeFeedCursor(cursor: string): {
   date: Date
   id: ObjectId
-  count: number | null
+  count: number
+  followed: boolean
 } {
   /*
    * Recognised by *shape*, not by position. The payload after the separator is
-   * an ISO timestamp, which carries a dot of its own before the `Z` — so
-   * splitting on the first dot found the milliseconds instead, the countless
-   * branch became unreachable, and every `following` page-two request was a
-   * 400. `needsCorrection` only ever worked because a leading `"3."` happens to
-   * put a dot at index 1.
-   *
-   * `^\d+\.` cannot match an ISO timestamp, whose fifth character is `-`, so
-   * cursors already in a client's hand still decode.
+   * an ISO timestamp, which carries a dot of its own before the `Z` — so an
+   * earlier decoder that split on the first dot found the milliseconds
+   * instead, and every page-two request on a countless cursor was a 400.
+   * `^\d+\.` cannot match an ISO timestamp, whose fifth character is `-`.
    */
-  const match = /^(\d+)\./.exec(cursor)
-  if (!match) return { ...decodeDateIdCursor(cursor), count: null }
-  return { ...decodeDateIdCursor(cursor.slice(match[0].length)), count: Number(match[1]) }
+  const match = /^(f\.)?(\d+)\./.exec(cursor)
+  if (!match) throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Malformed cursor')
+  return {
+    ...decodeDateIdCursor(cursor.slice(match[0].length)),
+    count: Number(match[2]),
+    followed: match[1] !== undefined,
+  }
 }

--- a/apps/api/src/modules/feed/documents.ts
+++ b/apps/api/src/modules/feed/documents.ts
@@ -27,7 +27,7 @@ export interface Post {
   kind?: 'correction' | 'pronunciation'
   /**
    * Denormalized, and one of the two numbers here that are. It is the sort key
-   * for the `needsCorrection` tab, and an index cannot sort on a count it would
+   * for the correction queue, and an index cannot sort on a count it would
    * have to join to find. Written only by `$inc` inside the same call that
    * inserts the correction, so it cannot drift the way a periodically-rebuilt
    * counter would.

--- a/apps/api/src/modules/feed/feed.ts
+++ b/apps/api/src/modules/feed/feed.ts
@@ -83,30 +83,27 @@ async function readCorrectionSummary(
 export async function listFeed(db: Db, userId: string, query: ListFeedQuery): Promise<FeedPage> {
   const posts = db.collection<Post>(COLLECTIONS.posts)
 
+  /**
+   * The section decides which posts are in the queue and which count it drains
+   * by. Both sections sort the same way — fewest answers first, then newest —
+   * and only the *meaning* of the integer changes, which is why one field name
+   * and not two code paths.
+   */
+  const pronunciation = query.kind === 'pronunciation'
+  const countField: 'correctionCount' | 'answerCount' = pronunciation
+    ? 'answerCount'
+    : 'correctionCount'
+
   // Blocks are symmetric here as everywhere else: `blockedUserIds` returns
   // both directions, so neither party appears in the other's feed.
   // Independent of each other, so they go together: the block list does not
-  // narrow the conversation lookup, it filters its result.
-  /**
-   * The section, and the two things it decides: which posts are in it, and what
-   * the queue is ordered by. `filter` is a *correction*-section control, so it
-   * is read only when the section is that one — the pronunciation tab has one
-   * order (unanswered first) and no tabs of its own.
-   */
-  const pronunciation = query.kind === 'pronunciation'
-  const following = !pronunciation && query.filter === 'following'
-  const needsFirst = !pronunciation && query.filter === 'needsCorrection'
-  const countField: 'correctionCount' | 'answerCount' | null = pronunciation
-    ? 'answerCount'
-    : needsFirst
-      ? 'correctionCount'
-      : null
-
+  // narrow the audience lookups, it filters their result.
   const [hidden, follows, conversations] = await Promise.all([
     blockedUserIds(db, userId),
-    following ? followingIds(db, userId, FEED_FOLLOWING_SOURCE_LIMIT) : Promise.resolve([]),
-    following
-      ? db
+    pronunciation ? Promise.resolve([]) : followingIds(db, userId, FEED_FOLLOWING_SOURCE_LIMIT),
+    pronunciation
+      ? Promise.resolve([])
+      : db
           .collection<{ participants: string[] }>(COLLECTIONS.conversations)
           .find({ participants: userId })
           // Sorted and capped, which is what makes the truncation below mean
@@ -115,10 +112,29 @@ export async function listFeed(db: Db, userId: string, query: ListFeedQuery): Pr
           .sort({ 'lastMessage.createdAt': -1 })
           .limit(FEED_FOLLOWING_SOURCE_LIMIT)
           .project<{ participants: string[] }>({ participants: 1 })
-          .toArray()
-      : Promise.resolve([]),
+          .toArray(),
   ])
-  const filter: Document = hidden.length > 0 ? { authorId: { $nin: hidden } } : {}
+
+  /*
+   * Who comes first: the union of two relationships, not one.
+   *
+   * The follow graph is the real answer, and the people you have actually
+   * talked to are the one this app had before there was a graph — dropping
+   * them would have emptied the old "Following" tab for every existing user on
+   * the day the Follow button shipped, and a conversation partner is somebody
+   * you are following in every sense except the button.
+   *
+   * Bounded, because the result is an `$in`: see
+   * `FEED_FOLLOWING_SOURCE_LIMIT`. Follows come first in the union so that a
+   * deliberate choice outranks an incidental one when the cap bites.
+   *
+   * Empty for the pronunciation section, which has one queue and no graph in
+   * it yet — so it falls straight through to the second query below.
+   */
+  const partners = conversations.flatMap((c) => c.participants).filter((id) => id !== userId)
+  const audience = [...new Set([...follows, ...partners])]
+    .filter((id) => id !== userId && !hidden.includes(id))
+    .slice(0, FEED_FOLLOWING_SOURCE_LIMIT)
 
   /**
    * `$in` with `null`, not `$ne`.
@@ -130,62 +146,68 @@ export async function listFeed(db: Db, userId: string, query: ListFeedQuery): Pr
    * and cannot be bounded — it would quietly turn the main feed into a
    * collection scan, which nothing would fail to warn about.
    */
-  filter.kind = pronunciation ? 'pronunciation' : { $in: ['correction', null] }
-
-  if (following) {
-    /*
-     * The union of two relationships, not one.
-     *
-     * The follow graph is the real answer, and the people you have actually
-     * talked to are the one this app had before there was a graph — dropping
-     * them would empty the tab for every existing user on the day the Follow
-     * button shipped, and a conversation partner is somebody you are following
-     * in every sense except the button.
-     *
-     * Bounded, because the result is an `$in`: see
-     * `FEED_FOLLOWING_SOURCE_LIMIT`. Follows come first in the union so that a
-     * deliberate choice outranks an incidental one when the cap bites.
-     */
-    const partners = conversations.flatMap((c) => c.participants).filter((id) => id !== userId)
-    const audience = [...new Set([...follows, ...partners])]
-      .filter((id) => id !== userId && !hidden.includes(id))
-      .slice(0, FEED_FOLLOWING_SOURCE_LIMIT)
-    if (audience.length === 0) return { items: [], nextCursor: null }
-    filter.authorId = { $in: audience }
-  }
+  const base: Document = { kind: pronunciation ? 'pronunciation' : { $in: ['correction', null] } }
+  const sort: Document = { [countField]: 1, createdAt: -1, _id: -1 }
 
   /**
-   * The cursor carries the sort's own keys — `(count, createdAt, _id)` whenever
-   * the sort leads with a count, and paging that with a `createdAt`-only cursor
-   * would silently skip every post whose count differs, which is most of them.
-   *
-   * Both counting sections share one encoding, because they are structurally
-   * the same sort: an ascending integer, then newest first. Only the *meaning*
-   * of the integer changes, which is why `countField` and not a second cursor
-   * format.
+   * The cursor carries the sort's own keys — `(count, createdAt, _id)` — and
+   * which of the two queries below it stopped in. Paging a count-led sort with
+   * a `createdAt`-only cursor would silently skip every post whose count
+   * differs, which is most of them.
    */
-  if (query.cursor) {
-    const { date, id, count } = decodeFeedCursor(query.cursor)
-    const after: Document[] = [{ createdAt: { $lt: date } }, { createdAt: date, _id: { $lt: id } }]
-    filter.$and = [
-      countField && count !== null
-        ? { $or: [{ [countField]: { $gt: count } }, { [countField]: count, $or: after }] }
-        : { $or: after },
-    ]
+  const cursor = query.cursor ? decodeFeedCursor(query.cursor) : null
+  const after = (c: NonNullable<typeof cursor>): Document => ({
+    $or: [
+      { [countField]: { $gt: c.count } },
+      {
+        [countField]: c.count,
+        $or: [{ createdAt: { $lt: c.date } }, { createdAt: c.date, _id: { $lt: c.id } }],
+      },
+    ],
+  })
+
+  /**
+   * Two queries stitched into one page, rather than one sort.
+   *
+   * "People you follow first" is not a field on the post, so no index can sort
+   * by it, and computing it per document (`$addFields` + `$in`) would make
+   * every page an in-memory sort of the whole collection. Reading the
+   * audience's posts to exhaustion and then everybody else's is the same
+   * order, served from `kind_needs_correction` both times, and the cursor
+   * remembers which half it is in so page two does not start the first half
+   * again.
+   *
+   * The second query runs even when the first filled the page exactly: its
+   * `+1` is what tells the client whether there *is* a page two.
+   */
+  const items: Post[] = []
+  let hasMore = false
+  let fromAudience = 0
+  if (audience.length > 0 && (!cursor || cursor.followed)) {
+    const filter: Document = { ...base, authorId: { $in: audience } }
+    if (cursor) filter.$and = [after(cursor)]
+    const page = await posts
+      .find(filter)
+      .sort(sort)
+      .limit(query.limit + 1)
+      .toArray()
+    hasMore = page.length > query.limit
+    items.push(...page.slice(0, query.limit))
+    fromAudience = items.length
   }
-
-  const sort: Document = countField
-    ? { [countField]: 1, createdAt: -1, _id: -1 }
-    : { createdAt: -1, _id: -1 }
-
-  const page = await posts
-    .find(filter)
-    .sort(sort)
-    .limit(query.limit + 1)
-    .toArray()
-
-  const hasMore = page.length > query.limit
-  const items = hasMore ? page.slice(0, query.limit) : page
+  if (!hasMore) {
+    const remaining = query.limit - items.length
+    const excluded = [...hidden, ...audience]
+    const filter: Document = excluded.length > 0 ? { ...base, authorId: { $nin: excluded } } : base
+    if (cursor && !cursor.followed) filter.$and = [after(cursor)]
+    const page = await posts
+      .find(filter)
+      .sort(sort)
+      .limit(remaining + 1)
+      .toArray()
+    hasMore = page.length > remaining
+    items.push(...page.slice(0, remaining))
+  }
   const last = items.at(-1)
 
   const ids = items.map((post) => post._id)
@@ -236,7 +258,14 @@ export async function listFeed(db: Db, userId: string, query: ListFeedQuery): Pr
     }),
     nextCursor:
       hasMore && last
-        ? encodeFeedCursor(last.createdAt, last._id, countField ? (last[countField] ?? 0) : null)
+        ? encodeFeedCursor(
+            last.createdAt,
+            last._id,
+            last[countField] ?? 0,
+            // The page ended inside the audience exactly when nothing after
+            // it came from the second query.
+            items.length === fromAudience,
+          )
         : null,
   }
 }

--- a/apps/api/src/routes/feed.test.ts
+++ b/apps/api/src/routes/feed.test.ts
@@ -75,7 +75,7 @@ describe('community feed', () => {
     })
   }
 
-  /** The `following` tab's audience is who you have talked to, so tests need one. */
+  /** The front of the feed is who you have talked to, so tests need someone. */
   async function talkTo(user: SignedUpUser, toUserId: string) {
     const response = await app.inject({
       method: 'POST',
@@ -271,9 +271,7 @@ describe('community feed', () => {
     const newer = (await post(author, 'The second sentence is wrong.')).json<{ _id: string }>()._id
     await correct(helper, newer, 'The second sentence is fine.')
 
-    const items = (await feed(helper, 'filter=needsCorrection')).json<{
-      items: { _id: string }[]
-    }>().items
+    const items = (await feed(helper)).json<{ items: { _id: string }[] }>().items
     // `newer` is more recent, so plain recency would put it first. The queue
     // exists so an unanswered post does not sink under every newer one.
     expect(items.findIndex((i) => i._id === older)).toBeLessThan(
@@ -350,41 +348,89 @@ describe('community feed', () => {
     const items = (await feed(viewer)).json<{ items: { _id: string }[] }>().items
     expect(items.some((item) => item._id === postId)).toBe(false)
   })
-  it('pages the following tab', async () => {
-    // The regression that made this tab a one-page feed. Its cursor carries no
-    // count, and the countless branch was unreachable — `indexOf('.')` found
-    // the milliseconds in the ISO timestamp, so page two was always a 400.
-    const viewer = await newUser('following-pager-viewer@example.com')
-    const author = await newUser('following-pager-author@example.com')
-    await talkTo(viewer, author.userId)
+  it('puts the people you follow first, even when their post is already corrected', async () => {
+    // Following outranks the queue: a friend's answered sentence still comes
+    // before a stranger's unanswered one. Within each half the queue order
+    // holds, which is what keeps the front from turning into a recency feed.
+    const viewer = await newUser('front-viewer@example.com')
+    const friend = await newUser('front-friend@example.com')
+    const stranger = await newUser('front-stranger@example.com')
+    const helper = await newUser('front-helper@example.com')
+    await talkTo(viewer, friend.userId)
 
-    const ids: string[] = []
-    for (let i = 0; i < 3; i++) {
-      ids.push((await post(author, `Sentence number ${i}.`)).json<{ _id: string }>()._id)
-    }
+    const friendCorrected = (await post(friend, 'A friend, corrected.')).json<{ _id: string }>()._id
+    const friendOpen = (await post(friend, 'A friend, waiting.')).json<{ _id: string }>()._id
+    const strangerOpen = (await post(stranger, 'A stranger, waiting.')).json<{ _id: string }>()._id
+    await correct(helper, friendCorrected, 'A friend, corrected indeed.')
 
-    const first = await feed(viewer, 'filter=following&limit=2')
-    expect(first.statusCode).toBe(200)
-    const page1 = first.json<{ items: { _id: string }[]; nextCursor: string | null }>()
-    expect(page1.items).toHaveLength(2)
-    expect(page1.nextCursor).not.toBeNull()
-
-    const second = await feed(
-      viewer,
-      `filter=following&limit=2&cursor=${encodeURIComponent(page1.nextCursor!)}`,
-    )
-    expect(second.statusCode).toBe(200)
-    const page2 = second.json<{ items: { _id: string }[] }>()
-
-    const seen = [...page1.items, ...page2.items].map((item) => item._id)
-    expect(new Set(seen).size).toBe(seen.length)
-    for (const id of ids) expect(seen).toContain(id)
+    const items = (await feed(viewer, 'limit=50')).json<{ items: { _id: string }[] }>().items
+    const at = (id: string) => items.findIndex((i) => i._id === id)
+    expect(at(friendOpen)).toBe(0)
+    expect(at(friendCorrected)).toBe(1)
+    expect(at(strangerOpen)).toBeGreaterThan(1)
   })
 
-  it('shows both the people you follow and the people you have talked to', async () => {
-    // The tab is a union, not a replacement. Dropping the conversation
-    // stand-in would have emptied it for every existing user on the day the
-    // Follow button shipped.
+  it('pages across the boundary between the people you follow and everybody else', async () => {
+    // Two queries stitched into one list. The cursor has to say which half it
+    // stopped in, or page two starts the first half again; and a page that
+    // ends exactly on the boundary still has to know there is a page two.
+    const viewer = await newUser('boundary-viewer@example.com')
+    const friend = await newUser('boundary-friend@example.com')
+    const stranger = await newUser('boundary-stranger@example.com')
+    await talkTo(viewer, friend.userId)
+
+    const friendIds: string[] = []
+    for (let i = 0; i < 2; i++) {
+      friendIds.push((await post(friend, `Friend sentence ${i}.`)).json<{ _id: string }>()._id)
+    }
+    const strangerIds: string[] = []
+    for (let i = 0; i < 3; i++) {
+      strangerIds.push(
+        (await post(stranger, `Stranger sentence ${i}.`)).json<{ _id: string }>()._id,
+      )
+    }
+
+    type Page = { items: { _id: string }[]; nextCursor: string | null }
+    async function walk(firstLimit: number): Promise<{ first: Page; all: string[] }> {
+      const first = (await feed(viewer, `limit=${firstLimit}`)).json<Page>()
+      const all = first.items.map((i) => i._id)
+      let cursor = first.nextCursor
+      while (cursor) {
+        const next = await feed(viewer, `limit=50&cursor=${encodeURIComponent(cursor)}`)
+        expect(next.statusCode).toBe(200)
+        const page = next.json<Page>()
+        all.push(...page.items.map((i) => i._id))
+        cursor = page.nextCursor
+      }
+      return { first, all }
+    }
+
+    // A page that ends exactly where the friend's posts do.
+    const exact = await walk(2)
+    expect(exact.first.items.map((i) => i._id)).toEqual(expect.arrayContaining(friendIds))
+    expect(exact.first.items).toHaveLength(2)
+    expect(exact.first.nextCursor).not.toBeNull()
+
+    // A page that runs out of friend and is topped up with everybody else.
+    const stitched = await walk(3)
+    expect(stitched.first.items).toHaveLength(3)
+    expect(friendIds).toContain(stitched.first.items[0]!._id)
+    expect(friendIds).toContain(stitched.first.items[1]!._id)
+    expect(friendIds).not.toContain(stitched.first.items[2]!._id)
+
+    for (const { all } of [exact, stitched]) {
+      expect(new Set(all).size).toBe(all.length)
+      for (const id of [...friendIds, ...strangerIds]) expect(all).toContain(id)
+      const lastFriend = Math.max(...friendIds.map((id) => all.indexOf(id)))
+      const firstStranger = Math.min(...strangerIds.map((id) => all.indexOf(id)))
+      expect(lastFriend).toBeLessThan(firstStranger)
+    }
+  })
+
+  it('puts both the people you follow and the people you have talked to first', async () => {
+    // The front of the feed is a union, not a replacement. Dropping the
+    // conversation stand-in would have emptied it for every existing user on
+    // the day the Follow button shipped.
     const viewer = await newUser('union-viewer@example.com')
     const followed = await newUser('union-followed@example.com')
     const partner = await newUser('union-partner@example.com')
@@ -411,14 +457,12 @@ describe('community feed', () => {
       stranger: (await post(stranger, 'From a stranger.')).json<{ _id: string }>()._id,
     }
 
-    const items = (await feed(viewer, 'filter=following')).json<{ items: { _id: string }[] }>()
-      .items
+    const items = (await feed(viewer, 'limit=50')).json<{ items: { _id: string }[] }>().items
     const seen = items.map((item) => item._id)
 
-    expect(seen).toContain(ids.followed)
-    expect(seen).toContain(ids.partner)
-    expect(seen).toContain(ids.both)
-    expect(seen).not.toContain(ids.stranger)
+    expect(seen.slice(0, 3)).toEqual(expect.arrayContaining([ids.followed, ids.partner, ids.both]))
+    // The stranger is still in the feed — just behind everybody you know.
+    expect(seen.indexOf(ids.stranger)).toBeGreaterThan(2)
     // Being both is not being twice.
     expect(seen.filter((id) => id === ids.both)).toHaveLength(1)
   })

--- a/apps/mobile/app/(app)/feed.tsx
+++ b/apps/mobile/app/(app)/feed.tsx
@@ -1,10 +1,4 @@
-import {
-  FEED_FILTERS,
-  MAX_POST_LENGTH,
-  POST_KINDS,
-  type FeedFilter,
-  type PostKind,
-} from '@langx/shared'
+import { MAX_POST_LENGTH, POST_KINDS, type PostKind } from '@langx/shared'
 import { useMemo, useState } from 'react'
 import {
   ActivityIndicator,
@@ -41,15 +35,10 @@ import { ApiRequestError } from '../../src/api/client'
 import { showToast } from '../../src/lib/toast'
 import { relativeTime } from '../../src/lib/format'
 
-const FILTER_LABELS: Record<FeedFilter, MessageKey> = {
-  needsCorrection: 'feed.needsCorrection',
-  following: 'feed.following',
-}
-
 /**
- * The two halves of the feed. A `Record` keyed on `PostKind` rather than a list,
- * for the same reason `FILTER_LABELS` is one: adding a section without a label
- * has to be a compile error, not a screen that renders the enum value.
+ * The two halves of the feed. A `Record` keyed on `PostKind` rather than a list
+ * so that adding a section without a label is a compile error, not a screen
+ * that renders the enum value.
  */
 const SECTION_LABELS: Record<PostKind, MessageKey> = {
   correction: 'feed.correctionSection',
@@ -87,7 +76,6 @@ export default function FeedScreen() {
   const { locale } = useLocale()
 
   const [section, setSection] = useState<PostKind>('correction')
-  const [filter, setFilter] = useState<FeedFilter>('needsCorrection')
   /**
    * Composing happens inline rather than in a modal. Both things being written
    * here are *about* something on screen — a sentence you are unsure of, or
@@ -103,7 +91,7 @@ export default function FeedScreen() {
   const [uploading, setUploading] = useState(false)
   const { data: session } = authClient.useSession()
   const me = useMe()
-  const feed = useFeed(section, filter)
+  const feed = useFeed(section)
   const createPost = useCreatePost()
   const correctPost = useCorrectPost()
   const deletePost = useDeletePost()
@@ -312,26 +300,6 @@ export default function FeedScreen() {
             accessibilityLabel={t('feed.title')}
           />
         </View>
-
-        {/*
-          `needsCorrection` and `following` are controls on the correction
-          queue, not on the feed as a whole: the pronunciation section has one
-          order — unanswered first — and nothing to filter by yet. Showing them
-          there would offer two switches that change nothing.
-        */}
-        {pronouncing ? null : (
-          <View style={styles.filters}>
-            <SegmentedControl<FeedFilter>
-              options={FEED_FILTERS.map((option) => ({
-                value: option,
-                label: t(FILTER_LABELS[option]),
-              }))}
-              selected={[filter]}
-              onToggle={setFilter}
-              accessibilityLabel={t('feed.title')}
-            />
-          </View>
-        )}
       </View>
 
       {state === 'skeleton' ? (
@@ -354,12 +322,6 @@ export default function FeedScreen() {
                 icon="mic"
                 title={t('feed.pronounceEmptyTitle')}
                 body={t('feed.pronounceEmptyBody')}
-              />
-            ) : filter === 'following' ? (
-              <EmptyState
-                icon="users"
-                title={t('feed.followingEmptyTitle')}
-                body={t('feed.followingEmptyBody')}
               />
             ) : (
               <EmptyState
@@ -687,7 +649,6 @@ const useStyles = makeStyles(({ colors, font, radius, spacing }) => ({
   title: { ...font.title, color: colors.text, fontSize: 34 },
   ask: { color: colors.accent, fontSize: 16, fontWeight: '700' },
   sections: { marginTop: 18 },
-  filters: { marginTop: spacing.sm },
   compose: { gap: spacing.md, marginTop: spacing.md },
   grow: { flex: 1, width: 'auto' },
   loading: { marginTop: spacing.xxl },

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -24,7 +24,6 @@ import type {
   CreatePostCorrectionInput,
   CreatePostInput,
   CreatePronunciationAnswerInput,
-  FeedFilter,
   FeedPage,
   FeedPost,
   FollowState,
@@ -102,7 +101,7 @@ export const keys = {
    * feed matches on the `['feed']` prefix, so a third segment costs those call
    * sites nothing while keeping the two sections' pages apart.
    */
-  feed: (kind: string, filter: string) => ['feed', kind, filter] as const,
+  feed: (kind: string) => ['feed', kind] as const,
   postCorrections: (id: string) => ['postCorrections', id] as const,
   postComments: (id: string) => ['postComments', id] as const,
   postAnswers: (id: string) => ['postAnswers', id] as const,
@@ -631,12 +630,12 @@ export function useConversationFlags() {
   })
 }
 
-export function useFeed(kind: PostKind, filter: FeedFilter) {
+export function useFeed(kind: PostKind) {
   return useInfiniteQuery({
-    queryKey: keys.feed(kind, filter),
+    queryKey: keys.feed(kind),
     queryFn: ({ pageParam }) =>
       api.get<FeedPage>(
-        `/feed?kind=${kind}&filter=${filter}${pageParam ? `&cursor=${encodeURIComponent(pageParam)}` : ''}`,
+        `/feed?kind=${kind}${pageParam ? `&cursor=${encodeURIComponent(pageParam)}` : ''}`,
       ),
     initialPageParam: '',
     getNextPageParam: (last) => last.nextCursor ?? undefined,
@@ -743,8 +742,8 @@ export function useSetFollow(handleOrId: string) {
       const previous = client.getQueryData<PublicProfileDto>(keys.profile(handleOrId))
       if (previous)
         client.setQueryData<PublicProfileDto>(keys.profile(handleOrId), { ...previous, follow })
-      // Following somebody changes what the Following tab contains, and the
-      // follower list has gained or lost exactly one row.
+      // Following somebody moves their posts to the front of the feed, and
+      // the follower list has gained or lost exactly one row.
       void client.invalidateQueries({ queryKey: ['feed'] })
       void client.invalidateQueries({ queryKey: ['follows'] })
     },
@@ -767,9 +766,9 @@ export function useCreatePost() {
   const client = useQueryClient()
   return useMutation({
     mutationFn: (input: CreatePostInput) => api.post<FeedPost>('/posts', input),
-    // Both tabs, and the badges: a post changes neither, but the correction
-    // below does, and invalidating one list and not the other is how a feed
-    // starts disagreeing with itself.
+    // Both sections, and the badges: a post changes neither, but the
+    // correction below does, and invalidating one list and not the other is
+    // how a feed starts disagreeing with itself.
     onSuccess: () => {
       void client.invalidateQueries({ queryKey: ['feed'] })
     },

--- a/apps/mobile/src/api/types.ts
+++ b/apps/mobile/src/api/types.ts
@@ -14,7 +14,6 @@ export type {
   CreatePostCorrectionInput,
   CreatePostInput,
   CreatePronunciationAnswerInput,
-  FeedFilter,
   FeedPage,
   FeedPost,
   FollowState,

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -682,16 +682,12 @@ export const ar: Localized<EnMessages> = {
 
   feed: {
     topTag: 'الأفضل',
-    needsCorrection: 'بحاجة إلى تصحيح',
     ask: '+ اسأل',
     askTitle: 'جملتك بلغة {language}',
     askPlaceholder: 'الجملة التي لست متأكدًا منها…',
     posting: 'جارٍ النشر…',
     posted: 'نُشرت. سيصحّحها أحدهم.',
     correctionSent: 'أُرسل التصحيح. شكرًا.',
-    followingEmptyTitle: 'لا شيء ممن تتابعهم',
-    followingEmptyBody:
-      'تعرض هذه العلامة منشورات من تتابعهم أو تحدثت إليهم. تابع أحدهم لتظهر منشوراته هنا.',
     correctedEmptyTitle: 'كل شيء مُصحَّح',
     correctedEmptyBody: 'لا أحد ينتظر المساعدة الآن. انشر جملة لك أو عد لاحقًا.',
     noCorrections: 'لا تصحيحات بعد',
@@ -736,7 +732,6 @@ export const ar: Localized<EnMessages> = {
     correctionsEmptyTitle: 'لا توجد تصحيحات بعد',
     correctionsEmptyBody: 'كن أول من يصحح هذه الجملة.',
     title: 'الأخبار',
-    following: 'المتابَعون',
     post: 'نشر',
     correctionSection: 'التصحيحات',
     pronunciationSection: 'النطق',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -587,16 +587,12 @@ export const de: Localized<EnMessages> = {
 
   feed: {
     topTag: 'Top',
-    needsCorrection: 'Braucht eine Korrektur',
     ask: '+ Fragen',
     askTitle: 'Dein Satz auf {language}',
     askPlaceholder: 'Der Satz, bei dem du unsicher bist…',
     posting: 'Wird gepostet…',
     posted: 'Gepostet. Jemand wird ihn korrigieren.',
     correctionSent: 'Korrektur gesendet. Danke.',
-    followingEmptyTitle: 'Nichts von Leuten, denen du folgst',
-    followingEmptyBody:
-      'Dieser Tab zeigt Beiträge von Leuten, denen du folgst oder mit denen du geschrieben hast. Folge jemandem, und die Beiträge erscheinen hier.',
     correctedEmptyTitle: 'Alles ist korrigiert',
     correctedEmptyBody:
       'Gerade wartet niemand auf Hilfe. Poste einen eigenen Satz oder komm später wieder.',
@@ -628,7 +624,6 @@ export const de: Localized<EnMessages> = {
     correctionsEmptyTitle: 'Noch keine Korrekturen',
     correctionsEmptyBody: 'Korrigiere diesen Satz als Erste oder Erster.',
     title: 'Feed',
-    following: 'Gefolgt',
     post: 'Posten',
     correctionSection: 'Korrekturen',
     pronunciationSection: 'Aussprache',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -607,16 +607,12 @@ export const en = {
 
   feed: {
     topTag: 'Top',
-    needsCorrection: 'Needs a correction',
     ask: '+ Ask',
     askTitle: 'Your sentence in {language}',
     askPlaceholder: 'The sentence you are unsure about…',
     posting: 'Posting…',
     posted: 'Posted. Somebody will correct it.',
     correctionSent: 'Correction sent. Thank you.',
-    followingEmptyTitle: 'Nothing from people you follow',
-    followingEmptyBody:
-      'This tab shows posts by people you follow or have talked to. Follow someone and their posts appear here.',
     correctedEmptyTitle: 'Everything is corrected',
     correctedEmptyBody:
       'Nobody is waiting for help right now. Post a sentence of your own, or come back later.',
@@ -648,7 +644,6 @@ export const en = {
     correctionsEmptyTitle: 'No corrections yet',
     correctionsEmptyBody: 'Be the first to correct this sentence.',
     title: 'Feed',
-    following: 'Following',
     post: 'Post',
     correctionSection: 'Corrections',
     pronunciationSection: 'Pronunciation',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -569,16 +569,12 @@ export const es: Localized<EnMessages> = {
 
   feed: {
     topTag: 'Mejor',
-    needsCorrection: 'Necesita corrección',
     ask: '+ Preguntar',
     askTitle: 'Tu frase en {language}',
     askPlaceholder: 'La frase de la que no estás seguro…',
     posting: 'Publicando…',
     posted: 'Publicado. Alguien lo corregirá.',
     correctionSent: 'Corrección enviada. Gracias.',
-    followingEmptyTitle: 'Nada de las personas que sigues',
-    followingEmptyBody:
-      'Esta pestaña muestra publicaciones de personas a las que sigues o con las que has hablado. Sigue a alguien y sus publicaciones aparecerán aquí.',
     correctedEmptyTitle: 'Todo está corregido',
     correctedEmptyBody:
       'Ahora mismo nadie espera ayuda. Publica una frase tuya o vuelve más tarde.',
@@ -610,7 +606,6 @@ export const es: Localized<EnMessages> = {
     correctionsEmptyTitle: 'Aún no hay correcciones',
     correctionsEmptyBody: 'Sé la primera persona en corregir esta frase.',
     title: 'Muro',
-    following: 'Siguiendo',
     post: 'Publicar',
     correctionSection: 'Correcciones',
     pronunciationSection: 'Pronunciación',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -569,16 +569,12 @@ export const fr: Localized<EnMessages> = {
 
   feed: {
     topTag: 'Meilleure',
-    needsCorrection: 'À corriger',
     ask: '+ Demander',
     askTitle: 'Ta phrase en {language}',
     askPlaceholder: 'La phrase dont tu n’es pas sûr…',
     posting: 'Publication…',
     posted: 'Publié. Quelqu’un la corrigera.',
     correctionSent: 'Correction envoyée. Merci.',
-    followingEmptyTitle: 'Rien de la part des personnes que vous suivez',
-    followingEmptyBody:
-      'Cet onglet montre les publications des personnes que vous suivez ou à qui vous avez parlé. Suivez quelqu’un et ses publications apparaîtront ici.',
     correctedEmptyTitle: 'Tout est corrigé',
     correctedEmptyBody:
       'Personne n’attend d’aide pour le moment. Publie une phrase à toi, ou reviens plus tard.',
@@ -610,7 +606,6 @@ export const fr: Localized<EnMessages> = {
     correctionsEmptyTitle: 'Pas encore de corrections',
     correctionsEmptyBody: 'Soyez la première personne à corriger cette phrase.',
     title: 'Fil',
-    following: 'Abonnements',
     post: 'Publier',
     correctionSection: 'Corrections',
     pronunciationSection: 'Prononciation',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -562,16 +562,12 @@ export const ptBR: Localized<EnMessages> = {
 
   feed: {
     topTag: 'Melhor',
-    needsCorrection: 'Precisa de correção',
     ask: '+ Perguntar',
     askTitle: 'Sua frase em {language}',
     askPlaceholder: 'A frase da qual você não tem certeza…',
     posting: 'Publicando…',
     posted: 'Publicado. Alguém vai corrigir.',
     correctionSent: 'Correção enviada. Obrigado.',
-    followingEmptyTitle: 'Nada de quem você segue',
-    followingEmptyBody:
-      'Esta aba mostra publicações de pessoas que você segue ou com quem já conversou. Siga alguém e as publicações aparecerão aqui.',
     correctedEmptyTitle: 'Está tudo corrigido',
     correctedEmptyBody:
       'Ninguém está esperando ajuda agora. Publique uma frase sua ou volte mais tarde.',
@@ -603,7 +599,6 @@ export const ptBR: Localized<EnMessages> = {
     correctionsEmptyTitle: 'Ainda sem correções',
     correctionsEmptyBody: 'Seja a primeira pessoa a corrigir esta frase.',
     title: 'Feed',
-    following: 'Seguindo',
     post: 'Publicar',
     correctionSection: 'Correções',
     pronunciationSection: 'Pronúncia',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -645,16 +645,12 @@ export const ru: Localized<EnMessages> = {
 
   feed: {
     topTag: 'Лучшая',
-    needsCorrection: 'Нужно исправление',
     ask: '+ Спросить',
     askTitle: 'Твоё предложение на языке {language}',
     askPlaceholder: 'Предложение, в котором ты не уверен…',
     posting: 'Публикуем…',
     posted: 'Опубликовано. Кто-нибудь исправит.',
     correctionSent: 'Исправление отправлено. Спасибо.',
-    followingEmptyTitle: 'Ничего от тех, на кого вы подписаны',
-    followingEmptyBody:
-      'На этой вкладке — посты тех, на кого вы подписаны или с кем говорили. Подпишитесь, и посты появятся здесь.',
     correctedEmptyTitle: 'Всё исправлено',
     correctedEmptyBody:
       'Сейчас никто не ждёт помощи. Опубликуй своё предложение или загляни позже.',
@@ -701,7 +697,6 @@ export const ru: Localized<EnMessages> = {
     correctionsEmptyTitle: 'Исправлений пока нет',
     correctionsEmptyBody: 'Исправьте это предложение первым.',
     title: 'Лента',
-    following: 'Подписки',
     post: 'Опубликовать',
     correctionSection: 'Исправления',
     pronunciationSection: 'Произношение',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -578,16 +578,12 @@ export const tr: Localized<EnMessages> = {
 
   feed: {
     topTag: 'En iyi',
-    needsCorrection: 'Düzeltme bekliyor',
     ask: '+ Sor',
     askTitle: '{language} dilindeki cümlen',
     askPlaceholder: 'Emin olmadığın cümle…',
     posting: 'Paylaşılıyor…',
     posted: 'Paylaşıldı. Birisi düzeltecektir.',
     correctionSent: 'Düzeltme gönderildi. Teşekkürler.',
-    followingEmptyTitle: 'Takip ettiklerinden bir şey yok',
-    followingEmptyBody:
-      'Bu sekme, takip ettiğin ya da konuştuğun kişilerin gönderilerini gösterir. Birini takip et, gönderileri burada görünsün.',
     correctedEmptyTitle: 'Her şey düzeltilmiş',
     correctedEmptyBody:
       'Şu anda yardım bekleyen kimse yok. Kendi cümleni paylaş ya da sonra tekrar uğra.',
@@ -619,7 +615,6 @@ export const tr: Localized<EnMessages> = {
     correctionsEmptyTitle: 'Henüz düzeltme yok',
     correctionsEmptyBody: 'Bu cümleyi ilk düzelten sen ol.',
     title: 'Akış',
-    following: 'Takip',
     post: 'Paylaş',
     correctionSection: 'Düzeltmeler',
     pronunciationSection: 'Telaffuz',

--- a/apps/mobile/src/lib/feedCache.ts
+++ b/apps/mobile/src/lib/feedCache.ts
@@ -19,7 +19,7 @@ type AnswerPages = InfiniteData<PronunciationAnswersPage> | undefined
  * A correction patched into the loaded feed pages instead of invalidating them.
  *
  * The invalidation was not a performance choice that went too far, it was a
- * disappearing card. `needsCorrection` sorts `correctionCount` **ascending**,
+ * disappearing card. The correction queue sorts `correctionCount` **ascending**,
  * so a refetch right after you answer re-sorts that post behind every
  * unanswered post in the collection — the card you just acted on vanished
  * rather than flipping to "You corrected this". That sort is not the bug: it is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -789,9 +789,11 @@ a page the same as one with two.
 a profile, since profiles are keyed by a string — the no-like/match/swipe rule
 expressed as a type. A like grants nothing, pays nothing and opens no channel.
 
-`follows` is one-directional and unconfirmed. The feed's "Following" tab reads
-the union of the follow graph and the people you have talked to, capped at
-`FEED_FOLLOWING_SOURCE_LIMIT`; see `decisions.md`.
+`follows` is one-directional and unconfirmed. The feed has no tabs: it puts
+posts by the union of the follow graph and the people you have talked to first,
+capped at `FEED_FOLLOWING_SOURCE_LIMIT`, then everybody else — uncorrected first
+within each half. Two queries stitched end to end, with the cursor recording
+which half it stopped in; see `decisions.md`.
 
 ## Updates, maintenance and remote config
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2075,3 +2075,26 @@ outright. A day that opened as a check-in and later saw a real message keeps
 
 Never on somebody else's map. The public activity endpoint sends an intensity
 and no source, the same line that already hides which squares were bought.
+
+## The feed has one queue, and the people you follow come first
+
+The correction section had two tabs, "Needs a correction" and "Following". The
+second one split a small feed into two smaller ones, and made the reader choose
+between helping a friend and helping whoever had waited longest — a choice the
+app can make for them. It is one list now: the people you follow (and have
+talked to, the union from the section above), uncorrected first; then everybody
+else, uncorrected first. Following outranks the count, so a friend's answered
+sentence still sits above a stranger's open one.
+
+"People you follow" is not a field on the post, so no index can sort by it, and
+computing it per document would make every page an in-memory sort of the whole
+collection. `listFeed` is two queries stitched end to end instead — the
+audience's posts to exhaustion, then everybody else's, both served from
+`kind_needs_correction` — and the cursor carries an `f.` prefix while it is
+still inside the first half, so page two does not start it again. The second
+query runs even when the first filled the page exactly: its `+1` is the only
+thing that can say whether there is a page two. The countless cursor form went
+with the recency tab; every feed page now sorts on a count.
+
+The pronunciation section is unchanged — one queue, no graph in it yet — and
+takes the same code path with an empty audience.

--- a/packages/shared/src/feed.ts
+++ b/packages/shared/src/feed.ts
@@ -19,24 +19,27 @@ export const MAX_POST_NOTE_LENGTH = 500
 export const postBodySchema = z.string().trim().min(1).max(MAX_POST_LENGTH)
 
 /**
- * `needsCorrection` is the default, and it is the whole reason the feed has
- * tabs. Sorting a feed by recency alone means the newest post gets every
- * correction and a post that sat unanswered for an hour never gets one; putting
- * the uncorrected ones first is what makes the queue drain.
+ * One queue, not a recency feed. Sorting by recency alone means the newest
+ * post gets every correction and a post that sat unanswered for an hour never
+ * gets one; putting the uncorrected ones first is what makes the queue drain.
+ *
+ * Within that, the people you follow come first. There used to be a second
+ * tab for them; it split one small feed into two smaller ones and made the
+ * reader choose between helping a friend and helping whoever waited longest.
+ * Now it is one list: your people, uncorrected first — then everybody else,
+ * uncorrected first.
  */
-export const FEED_FILTERS = ['needsCorrection', 'following'] as const
-export type FeedFilter = (typeof FEED_FILTERS)[number]
 
 /**
- * How many people the "Following" tab reads from.
+ * How many people the front of the feed reads from.
  *
  * The audience is an `$in`, and an `$in` is a list the query planner has to
  * carry — so it needs a ceiling that does not grow with how social somebody is.
  * Truncated by recency, which is the tiebreak the rest of the app already uses:
  * somebody following nine hundred people cares most about the ones they most
- * recently chose. Above this the tab is a sample of the graph rather than all
- * of it, and that is a deliberate trade against a fan-out table we do not need
- * yet.
+ * recently chose. Above this the front of the feed is a sample of the graph
+ * rather than all of it, and that is a deliberate trade against a fan-out
+ * table we do not need yet.
  */
 export const FEED_FOLLOWING_SOURCE_LIMIT = 500
 
@@ -270,9 +273,8 @@ export const postMediaUploadUrlSchema = z.object({
 export type PostMediaUploadUrlInput = z.infer<typeof postMediaUploadUrlSchema>
 
 export const listFeedQuerySchema = z.object({
-  /** Which section. `filter` below is read only when this is `'correction'`. */
+  /** Which section. */
   kind: z.enum(POST_KINDS).default('correction'),
-  filter: z.enum(FEED_FILTERS).default('needsCorrection'),
   cursor: z.string().optional(),
   limit: z.coerce.number().int().min(1).max(50).default(20),
 })


### PR DESCRIPTION
## What

The correction section of the feed had two tabs, **Needs a correction** and **Following**. This folds them into a single queue:

1. Posts by people you follow or have talked to, uncorrected first, then newest.
2. Everybody else, uncorrected first, then newest.

Following outranks the correction count, so a friend's already-answered sentence still sits above a stranger's open one.

## How

- `listFeed` runs two queries stitched into one page instead of one sort: the audience's posts to exhaustion, then everybody else's. Both are served from `kind_needs_correction`. "Followed" is not a field on the post, so no index could sort by it and an `$addFields` sort would be an in-memory sort of the whole collection per page.
- The feed cursor gains an `f.` prefix while still inside the first half, so page two does not restart it. The countless cursor form is gone; every feed page now sorts on a count.
- The second query runs even when the first filled the page exactly, because its `+1` is the only thing that can tell the client there is a page two.
- `filter` is removed from the `/feed` query schema and `FEED_FILTERS` from shared. Old clients sending it are ignored (zod strips unknown keys).
- Mobile: the filter segmented control, its state and the "Following" empty state are gone from the feed screen; four i18n keys removed from all eight locales.
- Pronunciation section unchanged: same code path with an empty audience.

## Tests

- `feedCursor.test.ts`: round-trips both halves; rejects the old countless form.
- `feed.test.ts`: followed-first even when corrected; paging across the boundary with a page that ends exactly on it and one that is topped up from the second half; the follow/conversation union still comes first and strangers are still present.

`pnpm test` and `pnpm -r typecheck` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
