### PR TITLE
Make posts, profiles, streaks, ranks, badges and messages shareable

### DIFF
--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -57,6 +57,7 @@ import { openMessageMenu, type AnchorRect } from '../../../src/lib/messageMenu'
 import { goBackTo, openProfile } from '../../../src/lib/navigation'
 import { openPaywall } from '../../../src/lib/paywall'
 import { pickImageAsset } from '../../../src/lib/pickImageAsset'
+import { shareLink } from '../../../src/lib/share'
 import { showToast } from '../../../src/lib/toast'
 import { messagesNewestFirst } from '../../../src/lib/messageCache'
 import { dayLabel, messageRows, type MessageRow } from '../../../src/lib/messageGroups'
@@ -423,6 +424,8 @@ export default function ChatScreen() {
     } else if (picked.id === 'copy') {
       await Clipboard.setStringAsync(message.body)
       showToast(t('chat.copied'))
+    } else if (picked.id === 'share') {
+      await shareLink({ message: message.body })
     } else if (picked.id === 'translate') {
       await translate(message, alreadyTranslated)
     } else if (picked.id === 'correct') {

--- a/apps/mobile/app/(app)/feed.tsx
+++ b/apps/mobile/app/(app)/feed.tsx
@@ -32,6 +32,8 @@ import { makeStyles } from '../../src/lib/theme'
 import { useDisplayNames, useLocale, useT, type MessageKey } from '../../src/i18n'
 import { isImageContentType } from '@langx/shared'
 import { ApiRequestError } from '../../src/api/client'
+import { shareLink } from '../../src/lib/share'
+import { postShareText } from '../../src/lib/shareText'
 import { showToast } from '../../src/lib/toast'
 import { relativeTime } from '../../src/lib/format'
 
@@ -424,6 +426,23 @@ export default function FeedScreen() {
                         ? t('feed.comment')
                         : t('feed.comments', { count: item.commentCount })}
                     </Text>
+                  </Pressable>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={t('share.post')}
+                    hitSlop={8}
+                    onPress={() =>
+                      void shareLink(
+                        postShareText(t, {
+                          id: item._id,
+                          body: item.body,
+                          languageName: names.language(item.language),
+                        }),
+                      )
+                    }
+                    style={({ pressed }) => (pressed ? styles.pressed : null)}
+                  >
+                    <Text style={styles.commentCount}>{t('share.action')}</Text>
                   </Pressable>
                   {mine ? (
                     <Pressable

--- a/apps/mobile/app/(app)/invite.tsx
+++ b/apps/mobile/app/(app)/invite.tsx
@@ -1,7 +1,7 @@
 import { inviteQrUrl, inviteUrl, TOKEN_RULES } from '@langx/shared'
 import * as Clipboard from 'expo-clipboard'
 import { Image } from 'expo-image'
-import { ActivityIndicator, Share, Text, View } from 'react-native'
+import { ActivityIndicator, Text, View } from 'react-native'
 import { useMe, useReferrals } from '../../src/api/queries'
 import { Avatar } from '../../src/components/ui/Avatar'
 import { Button } from '../../src/components/ui/Button'
@@ -13,6 +13,7 @@ import { useLocale, useT } from '../../src/i18n'
 import { API_URL } from '../../src/lib/apiUrl'
 import { showAlert } from '../../src/lib/alert'
 import { goBackTo } from '../../src/lib/navigation'
+import { shareLink } from '../../src/lib/share'
 import { makeStyles } from '../../src/lib/theme'
 
 const RULES = TOKEN_RULES.referral
@@ -70,14 +71,7 @@ export default function InviteScreen() {
       <View style={styles.actions}>
         <Button
           label={t('invite.share')}
-          onPress={() =>
-            void Share.share({
-              message: t('invite.shareMessage', { url }),
-              // iOS reads `url` and `message` as separate fields; Android has
-              // only the one, which is why the URL is in both.
-              url,
-            })
-          }
+          onPress={() => void shareLink({ message: t('invite.shareMessage', { url }), url })}
         />
         <Button
           label={t('invite.copy')}

--- a/apps/mobile/app/(app)/leaderboard.tsx
+++ b/apps/mobile/app/(app)/leaderboard.tsx
@@ -1,7 +1,8 @@
 import { findCosmetic, type CosmeticTone, type PeriodType } from '@langx/shared'
+import Feather from '@expo/vector-icons/Feather'
 import { useState } from 'react'
 import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from 'react-native'
-import { useBadges, useLeaderboard, useTokens } from '../../src/api/queries'
+import { useBadges, useLeaderboard, useMe, useTokens } from '../../src/api/queries'
 import { BadgeGrid } from '../../src/components/BadgeGrid'
 import { CosmeticTitle } from '../../src/components/CosmeticTitle'
 import { Avatar } from '../../src/components/ui/Avatar'
@@ -11,7 +12,9 @@ import { Screen } from '../../src/components/ui/Screen'
 import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
 import { SegmentedControl } from '../../src/components/ui/SegmentedControl'
 import { goBackTo, openProfile } from '../../src/lib/navigation'
-import { makeStyles } from '../../src/lib/theme'
+import { shareLink } from '../../src/lib/share'
+import { badgeShareText, leaderboardShareText } from '../../src/lib/shareText'
+import { makeStyles, useTheme } from '../../src/lib/theme'
 import { badgeLabel, periodLabel, useLocale, useT } from '../../src/i18n'
 import { dedupeById } from '../../src/lib/dedupeById'
 
@@ -21,6 +24,7 @@ const MEDALS = ['🥇', '🥈', '🥉']
 
 export default function LeaderboardScreen() {
   const styles = useStyles()
+  const { colors } = useTheme()
   const t = useT()
   const { locale } = useLocale()
 
@@ -28,6 +32,8 @@ export default function LeaderboardScreen() {
   const board = useLeaderboard(period)
   const xp = useTokens()
   const badges = useBadges()
+  const me = useMe()
+  const handle = me.data?.handle
 
   const streak = xp.data?.streak
   const next = badges.data?.next
@@ -36,6 +42,10 @@ export default function LeaderboardScreen() {
   )
   // The viewer's own standing is about the whole table, not this page.
   const viewer = board.data?.pages[0]?.viewer
+  // Built here rather than in the handler so the button exists only when the
+  // sentence does: a rank of null is "not on the board", not "#0".
+  const rankShare =
+    viewer?.rank && handle ? leaderboardShareText(t, { rank: viewer.rank, period, handle }) : null
 
   return (
     <Screen fluid>
@@ -91,7 +101,14 @@ export default function LeaderboardScreen() {
         </View>
       ) : null}
 
-      {badges.data ? <BadgeGrid badges={badges.data.badges} /> : null}
+      {badges.data ? (
+        <BadgeGrid
+          badges={badges.data.badges}
+          {...(handle
+            ? { onShare: (label: string) => void shareLink(badgeShareText(t, { label, handle })) }
+            : {})}
+        />
+      ) : null}
 
       {streak ? (
         <Text style={styles.streakHint}>
@@ -108,6 +125,18 @@ export default function LeaderboardScreen() {
           accessibilityLabel={t('leaderboard.periodPicker')}
         />
       </View>
+
+      {rankShare ? (
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => void shareLink(rankShare)}
+          hitSlop={8}
+          style={({ pressed }) => [styles.shareRank, pressed && styles.rowPressed]}
+        >
+          <Feather name="share" size={16} color={colors.textMuted} />
+          <Text style={styles.shareRankLabel}>{t('share.rank')}</Text>
+        </Pressable>
+      ) : null}
 
       {board.isPending ? (
         <ActivityIndicator style={styles.loading} />
@@ -197,6 +226,14 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   nextMeta: { color: colors.textMuted, fontSize: 13, marginTop: 10 },
   streakHint: { ...font.caption, color: colors.textMuted, marginTop: spacing.sm },
   tabs: { marginTop: spacing.lg },
+  shareRank: {
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    gap: spacing.xs,
+    marginTop: spacing.sm,
+  },
+  shareRankLabel: { ...font.caption, color: colors.textMuted, fontWeight: '600' },
   loading: { marginTop: spacing.xxl },
   footer: { paddingVertical: spacing.lg },
   list: { paddingBottom: spacing.xxl, paddingTop: spacing.sm },

--- a/apps/mobile/app/(app)/post/[id].tsx
+++ b/apps/mobile/app/(app)/post/[id].tsx
@@ -1,3 +1,4 @@
+import Feather from '@expo/vector-icons/Feather'
 import { useLocalSearchParams } from 'expo-router'
 import { useMemo, useState } from 'react'
 import {
@@ -42,7 +43,9 @@ import { listState } from '../../../src/lib/listState'
 import { goBackTo, openProfile } from '../../../src/lib/navigation'
 import { relativeTime } from '../../../src/lib/format'
 import { showToast } from '../../../src/lib/toast'
-import { makeStyles } from '../../../src/lib/theme'
+import { shareLink } from '../../../src/lib/share'
+import { postShareText } from '../../../src/lib/shareText'
+import { makeStyles, useTheme } from '../../../src/lib/theme'
 import { useDisplayNames, useLocale, useT } from '../../../src/i18n'
 
 /** The folded diff line — same drawing as the feed's top-correction panel. */
@@ -74,6 +77,7 @@ function CorrectedLine({ original, corrected }: { original: string; corrected: s
  */
 export default function PostScreen() {
   const styles = useStyles()
+  const { colors } = useTheme()
   const t = useT()
   const names = useDisplayNames()
   const { locale } = useLocale()
@@ -145,6 +149,17 @@ export default function PostScreen() {
   })
 
   const mine = post ? post.author._id === me.data?._id : false
+
+  function share(): void {
+    if (!post) return
+    void shareLink(
+      postShareText(t, {
+        id: post._id,
+        body: post.body,
+        languageName: names.language(post.language),
+      }),
+    )
+  }
   const replyCount = post ? (pronouncing ? post.answerCount : post.correctionCount) : 0
   const answeredByViewer = post
     ? pronouncing
@@ -265,7 +280,23 @@ export default function PostScreen() {
 
   return (
     <Screen fluid>
-      <ScreenHeader title={t('feed.post')} onBack={() => goBackTo('/(app)/feed', from)} />
+      <ScreenHeader
+        title={t('feed.post')}
+        onBack={() => goBackTo('/(app)/feed', from)}
+        trailing={
+          post ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t('share.post')}
+              hitSlop={12}
+              onPress={share}
+              style={({ pressed }) => (pressed ? styles.pressed : null)}
+            >
+              <Feather name="share" size={20} color={colors.textMuted} />
+            </Pressable>
+          ) : null
+        }
+      />
 
       {state === 'skeleton' || !post ? (
         <ActivityIndicator style={styles.loading} />
@@ -344,6 +375,15 @@ export default function PostScreen() {
                       ? t('feed.comment')
                       : t('feed.comments', { count: post.commentCount })}
                   </Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={t('share.post')}
+                    hitSlop={8}
+                    onPress={share}
+                    style={({ pressed }) => (pressed ? styles.pressed : null)}
+                  >
+                    <Text style={styles.commentCount}>{t('share.action')}</Text>
+                  </Pressable>
                   {mine ? (
                     <Pressable
                       accessibilityRole="button"

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -30,6 +30,8 @@ import { StatTile } from '../../../src/components/ui/StatTile'
 import { Screen } from '../../../src/components/ui/Screen'
 import { chooseAlert, confirmAlert } from '../../../src/lib/alert'
 import { goBackTo, openFollows } from '../../../src/lib/navigation'
+import { shareLink } from '../../../src/lib/share'
+import { profileShareText } from '../../../src/lib/shareText'
 import { openPaywall } from '../../../src/lib/paywall'
 import { showToast } from '../../../src/lib/toast'
 import { days } from '../../../src/lib/format'
@@ -173,12 +175,19 @@ export default function ProfileScreen() {
       )
   }
 
-  /** The kebab is a shortcut to the same two actions the footer offers. */
+  /**
+   * The kebab: share first, then the two actions the footer also offers.
+   * Share sits on somebody else's profile only — your own has a screen for it
+   * under Me, with a code that can be photographed.
+   */
   async function openActions(): Promise<void> {
     const action = await chooseAlert(user.displayName, undefined, [
+      { label: t('share.profile'), value: 'share' },
       { label: t('common.report'), value: 'report' },
       { label: t('common.block'), value: 'block' },
     ])
+    if (action === 'share')
+      void shareLink(profileShareText(t, { name: user.displayName, handle: user.handle }))
     if (action === 'report') void confirmReport()
     if (action === 'block') void confirmBlock()
   }
@@ -198,7 +207,7 @@ export default function ProfileScreen() {
         {isSelf ? null : (
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel={`${t('common.report')} · ${t('common.block')}`}
+            accessibilityLabel={`${t('share.profile')} · ${t('common.report')} · ${t('common.block')}`}
             onPress={() => void openActions()}
             hitSlop={12}
             style={({ pressed }) => [styles.iconButton, pressed && styles.iconPressed]}

--- a/apps/mobile/app/(app)/share-profile.tsx
+++ b/apps/mobile/app/(app)/share-profile.tsx
@@ -1,7 +1,7 @@
 import { profileQrUrl, profileUrl } from '@langx/shared'
 import * as Clipboard from 'expo-clipboard'
 import { Image } from 'expo-image'
-import { ActivityIndicator, Share, Text, View } from 'react-native'
+import { ActivityIndicator, Text, View } from 'react-native'
 import { LoadFailed } from '../../src/components/LoadFailed'
 import { useMe } from '../../src/api/queries'
 import { Button } from '../../src/components/ui/Button'
@@ -10,6 +10,7 @@ import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
 import { API_URL } from '../../src/lib/apiUrl'
 import { showAlert } from '../../src/lib/alert'
 import { goBackTo } from '../../src/lib/navigation'
+import { shareLink } from '../../src/lib/share'
 import { makeStyles } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
 
@@ -78,14 +79,7 @@ export default function ShareProfileScreen() {
       <View style={styles.actions}>
         <Button
           label={t('shareProfile.share')}
-          onPress={() =>
-            void Share.share({
-              message: t('me.shareMessage', { url }),
-              // iOS reads `url` and `message` as separate fields; Android has
-              // only the one, which is why the URL is in both.
-              url,
-            })
-          }
+          onPress={() => void shareLink({ message: t('me.shareMessage', { url }), url })}
         />
         <Button
           label={t('shareProfile.copy')}

--- a/apps/mobile/app/(app)/streak.tsx
+++ b/apps/mobile/app/(app)/streak.tsx
@@ -2,7 +2,8 @@ import Feather from '@expo/vector-icons/Feather'
 import { shiftDayKey } from '@langx/shared'
 import { useMemo } from 'react'
 import { ActivityIndicator, Text, View } from 'react-native'
-import { useActivity, useTokens } from '../../src/api/queries'
+import { useActivity, useMe, useTokens } from '../../src/api/queries'
+import { Button } from '../../src/components/ui/Button'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
 import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
@@ -11,6 +12,8 @@ import { useLocale, useT } from '../../src/i18n'
 import type { TranslateFn } from '../../src/i18n/runtime'
 import { dayLabel } from '../../src/lib/messageGroups'
 import { goBackTo } from '../../src/lib/navigation'
+import { shareLink } from '../../src/lib/share'
+import { streakShareText } from '../../src/lib/shareText'
 import { streakHistory, type StreakHistoryRow } from '../../src/lib/streakHistory'
 import { makeStyles, useTheme } from '../../src/lib/theme'
 
@@ -31,6 +34,7 @@ export default function StreakScreen() {
   const styles = useStyles()
   const { colors } = useTheme()
   const tokens = useTokens()
+  const me = useMe()
 
   const to = new Date().toISOString().slice(0, 10)
   const from = shiftDayKey(to, -DAYS)
@@ -57,6 +61,23 @@ export default function StreakScreen() {
         <StatTile label={t('me.dayStreak')} value={`🔥 ${streak?.current ?? 0}`} />
         <StatTile label={t('streak.longest')} value={String(streak?.longest ?? 0)} />
       </View>
+
+      {/*
+        Only once there is a number worth saying. A zero-day streak shared is
+        an invitation to laugh, not to join — and the sentence carries the
+        invite link, so it is that too.
+      */}
+      {streak && streak.current > 0 && me.data ? (
+        <View style={styles.share}>
+          <Button
+            label={t('share.streak')}
+            variant="secondary"
+            onPress={() =>
+              void shareLink(streakShareText(t, { count: streak.current, handle: me.data.handle }))
+            }
+          />
+        </View>
+      ) : null}
 
       {rows.length === 0 ? (
         <EmptyState icon="calendar" title={t('streak.emptyTitle')} body={t('streak.emptyBody')} />
@@ -123,6 +144,7 @@ function detail(t: TranslateFn, locale: string, row: StreakHistoryRow): string {
 
 const useStyles = makeStyles(({ colors, font, spacing }) => ({
   loading: { paddingVertical: spacing.xl },
+  share: { marginTop: spacing.md },
   tiles: {
     borderBottomColor: colors.border,
     borderBottomWidth: 1,

--- a/apps/mobile/src/components/BadgeGrid.tsx
+++ b/apps/mobile/src/components/BadgeGrid.tsx
@@ -1,5 +1,5 @@
 import Feather from '@expo/vector-icons/Feather'
-import { Text, View } from 'react-native'
+import { Pressable, Text, View } from 'react-native'
 import type { EarnedBadge } from '../api/types'
 import type { Locale } from '@langx/shared'
 import { makeStyles, useTheme } from '../lib/theme'
@@ -19,14 +19,21 @@ function earnedMonth(iso: string, locale: Locale): string {
  * as a whole rather than recolouring, so the two states differ in exactly one
  * way each.
  */
-function BadgeRow({ badge }: { badge: EarnedBadge }) {
+function BadgeRow({
+  badge,
+  onShare,
+}: {
+  badge: EarnedBadge
+  onShare?: ((label: string) => void) | undefined
+}) {
   const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()
   const { locale } = useLocale()
+  const label = badgeLabel({ t, locale }, badge.kind, badge.threshold)
 
-  return (
-    <View style={[styles.row, !badge.earned && styles.locked]}>
+  const content = (
+    <>
       {/*
         The glyph comes off the badge, not off a `kind === 'streak'` ternary.
         That ternary handed every kind added after it the correction tick, and
@@ -44,7 +51,7 @@ function BadgeRow({ badge }: { badge: EarnedBadge }) {
         )}
       </View>
       <Text style={styles.name} numberOfLines={1}>
-        {badgeLabel({ t, locale }, badge.kind, badge.threshold)}
+        {label}
       </Text>
       <Text style={[styles.state, badge.earned && styles.stateEarned]}>
         {badge.earned
@@ -53,15 +60,42 @@ function BadgeRow({ badge }: { badge: EarnedBadge }) {
             : t('badges.earnedLabel')
           : t('badges.locked')}
       </Text>
-    </View>
+    </>
+  )
+
+  /*
+   * Earned rows are the only ones that press. A locked badge is a promise,
+   * not a result, and "share the badge I do not have" is a sentence nobody
+   * means; keeping the row inert also keeps the faded state honest — nothing
+   * happens there yet.
+   */
+  if (!badge.earned || !onShare) {
+    return <View style={[styles.row, !badge.earned && styles.locked]}>{content}</View>
+  }
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={t('share.badge', { label })}
+      onPress={() => onShare(label)}
+      style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+    >
+      {content}
+    </Pressable>
   )
 }
 
-export function BadgeGrid({ badges }: { badges: readonly EarnedBadge[] }) {
+export function BadgeGrid({
+  badges,
+  onShare,
+}: {
+  badges: readonly EarnedBadge[]
+  /** Given, an earned row opens the share sheet with its name. */
+  onShare?: (label: string) => void
+}) {
   return (
     <View>
       {badges.map((badge) => (
-        <BadgeRow key={badge.id} badge={badge} />
+        <BadgeRow key={badge.id} badge={badge} onShare={onShare} />
       ))}
     </View>
   )
@@ -79,6 +113,7 @@ const useStyles = makeStyles(({ colors, font }) => ({
     paddingVertical: 17,
   },
   locked: { opacity: 0.45 },
+  pressed: { opacity: 0.7 },
   slot: { alignItems: 'flex-start', width: 32 },
   emoji: { fontSize: 22 },
   name: { ...font.body, color: colors.text, flex: 1, fontSize: 16, fontWeight: '600' },

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -81,6 +81,7 @@ export const ar: Localized<EnMessages> = {
     unpin: 'إلغاء التثبيت',
     report: 'إبلاغ',
     correctedCannotEdit: 'مُصحَّحة — لا يمكن تعديلها',
+    share: 'مشاركة',
   },
 
   messageMeta: {
@@ -1263,6 +1264,34 @@ export const ar: Localized<EnMessages> = {
     share: 'مشاركة',
     copy: 'نسخ الرابط',
     copied: 'تم نسخ الرابط',
+  },
+
+  share: {
+    action: 'مشاركة',
+    copied: 'تم نسخ الرابط',
+    copiedText: 'تم نسخ النص',
+    profile: 'مشاركة الملف',
+    profileMessage: 'تعرّف على {name} في LangX: {url}',
+    post: 'مشاركة المنشور',
+    postMessage: '«{excerpt}» — تدريب على {language} في LangX: {url}',
+    streak: 'مشاركة سلسلتي',
+    streakMessage: {
+      zero: '🔥 سلسلة {count} يوم في LangX. تدرّب معي: {url}',
+      one: '🔥 سلسلة يوم واحد في LangX. تدرّب معي: {url}',
+      two: '🔥 سلسلة يومين في LangX. تدرّب معي: {url}',
+      few: '🔥 سلسلة {count} أيام في LangX. تدرّب معي: {url}',
+      many: '🔥 سلسلة {count} يومًا في LangX. تدرّب معي: {url}',
+      other: '🔥 سلسلة {count} يوم في LangX. تدرّب معي: {url}',
+    },
+    rank: 'مشاركة ترتيبي',
+    leaderboardMessage: {
+      week: 'أنا في المركز {rank} في LangX هذا الأسبوع. تدرّب معي: {url}',
+      month: 'أنا في المركز {rank} في LangX هذا الشهر. تدرّب معي: {url}',
+      year: 'أنا في المركز {rank} في LangX هذه السنة. تدرّب معي: {url}',
+      all: 'أنا في المركز {rank} في LangX على مدار الوقت. تدرّب معي: {url}',
+    },
+    badge: 'مشاركة شارة {label}',
+    badgeMessage: 'حصلت على شارة «{label}» في LangX. تدرّب معي: {url}',
   },
 
   linkDevice: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -70,6 +70,7 @@ export const de: Localized<EnMessages> = {
     unpin: 'Losheften',
     report: 'Melden',
     correctedCannotEdit: 'Korrigiert — nicht mehr änderbar',
+    share: 'Teilen',
   },
 
   messageMeta: {
@@ -1062,6 +1063,30 @@ export const de: Localized<EnMessages> = {
     share: 'Teilen',
     copy: 'Link kopieren',
     copied: 'Link kopiert',
+  },
+
+  share: {
+    action: 'Teilen',
+    copied: 'Link kopiert',
+    copiedText: 'Text kopiert',
+    profile: 'Profil teilen',
+    profileMessage: 'Lern {name} auf LangX kennen: {url}',
+    post: 'Beitrag teilen',
+    postMessage: '„{excerpt}“ — {language} üben auf LangX: {url}',
+    streak: 'Meine Serie teilen',
+    streakMessage: {
+      one: '🔥 {count} Tag Serie auf LangX. Üb mit mir: {url}',
+      other: '🔥 {count} Tage Serie auf LangX. Üb mit mir: {url}',
+    },
+    rank: 'Meinen Platz teilen',
+    leaderboardMessage: {
+      week: 'Ich bin diese Woche Platz {rank} auf LangX. Üb mit mir: {url}',
+      month: 'Ich bin diesen Monat Platz {rank} auf LangX. Üb mit mir: {url}',
+      year: 'Ich bin dieses Jahr Platz {rank} auf LangX. Üb mit mir: {url}',
+      all: 'Ich bin insgesamt Platz {rank} auf LangX. Üb mit mir: {url}',
+    },
+    badge: 'Abzeichen {label} teilen',
+    badgeMessage: 'Ich habe auf LangX das Abzeichen „{label}“ verdient. Üb mit mir: {url}',
   },
 
   linkDevice: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -94,6 +94,7 @@ export const en = {
     unpin: 'Unpin',
     report: 'Report',
     correctedCannotEdit: 'Corrected — can’t be edited',
+    share: 'Share',
   },
 
   messageMeta: {
@@ -1079,6 +1080,30 @@ export const en = {
     share: 'Share',
     copy: 'Copy link',
     copied: 'Link copied',
+  },
+
+  share: {
+    action: 'Share',
+    copied: 'Link copied',
+    copiedText: 'Text copied',
+    profile: 'Share profile',
+    profileMessage: 'Meet {name} on LangX: {url}',
+    post: 'Share post',
+    postMessage: '“{excerpt}” — {language} practice on LangX: {url}',
+    streak: 'Share my streak',
+    streakMessage: {
+      one: '🔥 {count}-day streak on LangX. Practise with me: {url}',
+      other: '🔥 {count}-day streak on LangX. Practise with me: {url}',
+    },
+    rank: 'Share my rank',
+    leaderboardMessage: {
+      week: 'I’m #{rank} on LangX this week. Practise with me: {url}',
+      month: 'I’m #{rank} on LangX this month. Practise with me: {url}',
+      year: 'I’m #{rank} on LangX this year. Practise with me: {url}',
+      all: 'I’m #{rank} on LangX, all time. Practise with me: {url}',
+    },
+    badge: 'Share the {label} badge',
+    badgeMessage: 'I earned the “{label}” badge on LangX. Practise with me: {url}',
   },
 
   linkDevice: {

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -71,6 +71,7 @@ export const es: Localized<EnMessages> = {
     unpin: 'Dejar de fijar',
     report: 'Denunciar',
     correctedCannotEdit: 'Corregido: no se puede editar',
+    share: 'Compartir',
   },
 
   messageMeta: {
@@ -1039,6 +1040,30 @@ export const es: Localized<EnMessages> = {
     share: 'Compartir',
     copy: 'Copiar enlace',
     copied: 'Enlace copiado',
+  },
+
+  share: {
+    action: 'Compartir',
+    copied: 'Enlace copiado',
+    copiedText: 'Texto copiado',
+    profile: 'Compartir perfil',
+    profileMessage: 'Conoce a {name} en LangX: {url}',
+    post: 'Compartir publicación',
+    postMessage: '“{excerpt}” — práctica de {language} en LangX: {url}',
+    streak: 'Compartir mi racha',
+    streakMessage: {
+      one: '🔥 Racha de {count} día en LangX. Practica conmigo: {url}',
+      other: '🔥 Racha de {count} días en LangX. Practica conmigo: {url}',
+    },
+    rank: 'Compartir mi puesto',
+    leaderboardMessage: {
+      week: 'Soy el n.º {rank} en LangX esta semana. Practica conmigo: {url}',
+      month: 'Soy el n.º {rank} en LangX este mes. Practica conmigo: {url}',
+      year: 'Soy el n.º {rank} en LangX este año. Practica conmigo: {url}',
+      all: 'Soy el n.º {rank} en LangX de todos los tiempos. Practica conmigo: {url}',
+    },
+    badge: 'Compartir la insignia {label}',
+    badgeMessage: 'Gané la insignia “{label}” en LangX. Practica conmigo: {url}',
   },
 
   linkDevice: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -70,6 +70,7 @@ export const fr: Localized<EnMessages> = {
     unpin: 'Désépingler',
     report: 'Signaler',
     correctedCannotEdit: 'Corrigé — non modifiable',
+    share: 'Partager',
   },
 
   messageMeta: {
@@ -1045,6 +1046,30 @@ export const fr: Localized<EnMessages> = {
     share: 'Partager',
     copy: 'Copier le lien',
     copied: 'Lien copié',
+  },
+
+  share: {
+    action: 'Partager',
+    copied: 'Lien copié',
+    copiedText: 'Texte copié',
+    profile: 'Partager le profil',
+    profileMessage: 'Fais connaissance avec {name} sur LangX : {url}',
+    post: 'Partager la publication',
+    postMessage: '« {excerpt} » — {language}, en pratique sur LangX : {url}',
+    streak: 'Partager ma série',
+    streakMessage: {
+      one: '🔥 Série de {count} jour sur LangX. Pratique avec moi : {url}',
+      other: '🔥 Série de {count} jours sur LangX. Pratique avec moi : {url}',
+    },
+    rank: 'Partager mon classement',
+    leaderboardMessage: {
+      week: 'Je suis n° {rank} sur LangX cette semaine. Pratique avec moi : {url}',
+      month: 'Je suis n° {rank} sur LangX ce mois-ci. Pratique avec moi : {url}',
+      year: 'Je suis n° {rank} sur LangX cette année. Pratique avec moi : {url}',
+      all: 'Je suis n° {rank} sur LangX, toutes périodes confondues. Pratique avec moi : {url}',
+    },
+    badge: 'Partager le badge {label}',
+    badgeMessage: 'J’ai obtenu le badge « {label} » sur LangX. Pratique avec moi : {url}',
   },
 
   linkDevice: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -68,6 +68,7 @@ export const ptBR: Localized<EnMessages> = {
     unpin: 'Desafixar',
     report: 'Denunciar',
     correctedCannotEdit: 'Corrigida — não dá para editar',
+    share: 'Compartilhar',
   },
 
   messageMeta: {
@@ -1036,6 +1037,30 @@ export const ptBR: Localized<EnMessages> = {
     share: 'Compartilhar',
     copy: 'Copiar link',
     copied: 'Link copiado',
+  },
+
+  share: {
+    action: 'Compartilhar',
+    copied: 'Link copiado',
+    copiedText: 'Texto copiado',
+    profile: 'Compartilhar perfil',
+    profileMessage: 'Conheça {name} no LangX: {url}',
+    post: 'Compartilhar publicação',
+    postMessage: '“{excerpt}” — prática de {language} no LangX: {url}',
+    streak: 'Compartilhar minha sequência',
+    streakMessage: {
+      one: '🔥 Sequência de {count} dia no LangX. Pratique comigo: {url}',
+      other: '🔥 Sequência de {count} dias no LangX. Pratique comigo: {url}',
+    },
+    rank: 'Compartilhar minha posição',
+    leaderboardMessage: {
+      week: 'Estou em {rank}º no LangX esta semana. Pratique comigo: {url}',
+      month: 'Estou em {rank}º no LangX este mês. Pratique comigo: {url}',
+      year: 'Estou em {rank}º no LangX este ano. Pratique comigo: {url}',
+      all: 'Estou em {rank}º no LangX, no geral. Pratique comigo: {url}',
+    },
+    badge: 'Compartilhar a insígnia {label}',
+    badgeMessage: 'Ganhei a insígnia “{label}” no LangX. Pratique comigo: {url}',
   },
 
   linkDevice: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -78,6 +78,7 @@ export const ru: Localized<EnMessages> = {
     unpin: 'Открепить',
     report: 'Пожаловаться',
     correctedCannotEdit: 'Исправлено — изменить нельзя',
+    share: 'Поделиться',
   },
 
   messageMeta: {
@@ -1197,6 +1198,32 @@ export const ru: Localized<EnMessages> = {
     share: 'Поделиться',
     copy: 'Скопировать ссылку',
     copied: 'Ссылка скопирована',
+  },
+
+  share: {
+    action: 'Поделиться',
+    copied: 'Ссылка скопирована',
+    copiedText: 'Текст скопирован',
+    profile: 'Поделиться профилем',
+    profileMessage: 'Познакомьтесь с {name} в LangX: {url}',
+    post: 'Поделиться постом',
+    postMessage: '«{excerpt}» — {language}, практика в LangX: {url}',
+    streak: 'Поделиться серией',
+    streakMessage: {
+      one: '🔥 Серия {count} день в LangX. Занимайтесь со мной: {url}',
+      few: '🔥 Серия {count} дня в LangX. Занимайтесь со мной: {url}',
+      many: '🔥 Серия {count} дней в LangX. Занимайтесь со мной: {url}',
+      other: '🔥 Серия {count} дня в LangX. Занимайтесь со мной: {url}',
+    },
+    rank: 'Поделиться местом',
+    leaderboardMessage: {
+      week: 'Я на {rank}-м месте в LangX на этой неделе. Занимайтесь со мной: {url}',
+      month: 'Я на {rank}-м месте в LangX в этом месяце. Занимайтесь со мной: {url}',
+      year: 'Я на {rank}-м месте в LangX в этом году. Занимайтесь со мной: {url}',
+      all: 'Я на {rank}-м месте в LangX за всё время. Занимайтесь со мной: {url}',
+    },
+    badge: 'Поделиться значком {label}',
+    badgeMessage: 'У меня значок «{label}» в LangX. Занимайтесь со мной: {url}',
   },
 
   linkDevice: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -83,6 +83,7 @@ export const tr: Localized<EnMessages> = {
     unpin: 'Sabitlemeyi kaldır',
     report: 'Bildir',
     correctedCannotEdit: 'Düzeltilmiş — değiştirilemez',
+    share: 'Paylaş',
   },
 
   messageMeta: {
@@ -1048,6 +1049,30 @@ export const tr: Localized<EnMessages> = {
     share: 'Paylaş',
     copy: 'Linki kopyala',
     copied: 'Link kopyalandı',
+  },
+
+  share: {
+    action: 'Paylaş',
+    copied: 'Link kopyalandı',
+    copiedText: 'Metin kopyalandı',
+    profile: 'Profili paylaş',
+    profileMessage: 'LangX’te {name} ile tanış: {url}',
+    post: 'Gönderiyi paylaş',
+    postMessage: '“{excerpt}” — LangX’te {language} pratiği: {url}',
+    streak: 'Serimi paylaş',
+    streakMessage: {
+      one: 'LangX’te 🔥 {count} günlük seri. Benimle pratik yap: {url}',
+      other: 'LangX’te 🔥 {count} günlük seri. Benimle pratik yap: {url}',
+    },
+    rank: 'Sıramı paylaş',
+    leaderboardMessage: {
+      week: 'Bu hafta LangX’te {rank}. sıradayım. Benimle pratik yap: {url}',
+      month: 'Bu ay LangX’te {rank}. sıradayım. Benimle pratik yap: {url}',
+      year: 'Bu yıl LangX’te {rank}. sıradayım. Benimle pratik yap: {url}',
+      all: 'LangX’te tüm zamanlarda {rank}. sıradayım. Benimle pratik yap: {url}',
+    },
+    badge: '{label} rozetini paylaş',
+    badgeMessage: 'LangX’te “{label}” rozetini kazandım. Benimle pratik yap: {url}',
   },
 
   linkDevice: {

--- a/apps/mobile/src/lib/messageActions.test.ts
+++ b/apps/mobile/src/lib/messageActions.test.ts
@@ -30,6 +30,7 @@ describe('messageActionsFor', () => {
       'delete',
       'star',
       'pin',
+      'share',
       'report',
     ])
   })
@@ -51,8 +52,13 @@ describe('messageActionsFor', () => {
     }
   })
 
-  it('has nothing to copy on a captionless voice note', () => {
+  it('has nothing to copy or share on a captionless voice note', () => {
     expect(ids({ type: 'audio', hasBody: false })).not.toContain('copy')
+    expect(ids({ type: 'audio', hasBody: false })).not.toContain('share')
+  })
+
+  it('shares text from either side of the conversation', () => {
+    for (const mine of [true, false]) expect(ids({ mine })).toContain('share')
   })
 
   /** A filter on your own copy, so it never depends on age or authorship. */
@@ -96,7 +102,7 @@ describe('paginateActions', () => {
 
   it('puts the rest behind More', () => {
     const { actions, hasMore } = paginateActions(all, 'more')
-    expect(actions.map((a) => a.id)).toEqual(['star', 'pin', 'report'])
+    expect(actions.map((a) => a.id)).toEqual(['star', 'pin', 'share', 'report'])
     expect(hasMore).toBe(false)
   })
 

--- a/apps/mobile/src/lib/messageActions.ts
+++ b/apps/mobile/src/lib/messageActions.ts
@@ -9,6 +9,7 @@ export const MESSAGE_ACTION_IDS = [
   'edit',
   'star',
   'pin',
+  'share',
   'report',
 ] as const
 export type MessageActionId = (typeof MESSAGE_ACTION_IDS)[number]
@@ -156,6 +157,19 @@ export function messageActionsFor(context: MessageActionContext): MessageAction[
     icon: 'pin-outline',
     page: 'more',
   })
+
+  // Out through the platform sheet, as text: a message has no address of its
+  // own, and a link into a private thread would resolve for nobody but the
+  // two people already in it. Same gate as copy — a captionless voice note has
+  // nothing to hand over.
+  if (context.hasBody) {
+    actions.push({
+      id: 'share',
+      label: t('messageActions.share'),
+      icon: 'share-outline',
+      page: 'more',
+    })
+  }
 
   if (!context.mine) {
     actions.push({

--- a/apps/mobile/src/lib/share.ts
+++ b/apps/mobile/src/lib/share.ts
@@ -1,0 +1,36 @@
+import * as Clipboard from 'expo-clipboard'
+import { Share } from 'react-native'
+import { currentTranslate } from '../i18n/runtime'
+import { isShareCancel, type ShareContent } from './shareText'
+import { showToast } from './toast'
+
+/**
+ * Opens the platform share sheet with a sentence and, usually, a link.
+ *
+ * The one call site for `Share.share`, so the two platform quirks are handled
+ * once. iOS reads `url` and `message` as separate fields; Android has only the
+ * one, which is why the builders in `shareText.ts` put the URL inside the
+ * message as well as beside it.
+ *
+ * On the web `Share.share` is `navigator.share`, which desktop Firefox and
+ * some embedded browsers do not have — react-native-web rejects with "not
+ * supported" and the button would silently do nothing. Anything that is not
+ * the person closing the sheet falls back to the clipboard, which is the
+ * outcome they were after anyway, and a toast says so.
+ */
+export async function shareLink({ message, url }: ShareContent): Promise<void> {
+  try {
+    await Share.share(url ? { message, url } : { message })
+  } catch (error) {
+    if (isShareCancel(error)) return
+    try {
+      await Clipboard.setStringAsync(url ?? message)
+    } catch {
+      // The clipboard is the fallback; there is no fallback for the fallback.
+      // A browser that refuses both (no focus, no permission) gets no toast
+      // rather than a promise nobody awaits rejecting into the console.
+      return
+    }
+    showToast(currentTranslate()(url ? 'share.copied' : 'share.copiedText'))
+  }
+}

--- a/apps/mobile/src/lib/shareText.test.ts
+++ b/apps/mobile/src/lib/shareText.test.ts
@@ -1,0 +1,112 @@
+import { PERIOD_TYPES } from '@langx/shared'
+import { describe, expect, it } from 'vitest'
+import { createTranslate } from '../i18n/runtime'
+import {
+  badgeShareText,
+  isShareCancel,
+  leaderboardShareText,
+  postExcerpt,
+  postShareText,
+  profileShareText,
+  SHARE_EXCERPT_LENGTH,
+  streakShareText,
+} from './shareText'
+
+const t = createTranslate('en')
+
+describe('postExcerpt', () => {
+  it('leaves a short post alone, ellipsis and all', () => {
+    expect(postExcerpt('Bonjour à tous!')).toBe('Bonjour à tous!')
+    expect(postExcerpt('Bonjour à tous!')).not.toContain('…')
+  })
+
+  it('collapses the whitespace a multi-line post carries', () => {
+    expect(postExcerpt('  one\n\ntwo   three ')).toBe('one two three')
+  })
+
+  it('cuts a long post at a word and never past the limit', () => {
+    const body = Array.from({ length: 40 }, (_, i) => `word${i}`).join(' ')
+    const excerpt = postExcerpt(body)
+    expect(excerpt.endsWith('…')).toBe(true)
+    expect(excerpt.length).toBeLessThanOrEqual(SHARE_EXCERPT_LENGTH)
+    expect(excerpt).toMatch(/word\d+…$/)
+  })
+
+  it('cuts mid-word rather than throwing away half the excerpt', () => {
+    const excerpt = postExcerpt('a'.repeat(400))
+    expect(excerpt.length).toBe(SHARE_EXCERPT_LENGTH)
+    expect(excerpt.endsWith('…')).toBe(true)
+  })
+})
+
+describe('the sentences', () => {
+  it('put the link inside the message, for the platform with one field', () => {
+    for (const content of [
+      profileShareText(t, { name: 'Deniz', handle: 'deniz' }),
+      postShareText(t, { id: 'abc', body: 'Hola', languageName: 'Spanish' }),
+      streakShareText(t, { count: 12, handle: 'deniz' }),
+      leaderboardShareText(t, { rank: 3, period: 'week', handle: 'deniz' }),
+      badgeShareText(t, { label: '30 days', handle: 'deniz' }),
+    ]) {
+      expect(content.url).toBeDefined()
+      expect(content.message).toContain(content.url)
+    }
+  })
+
+  it('links a profile to the profile, not to an invite', () => {
+    const { url } = profileShareText(t, { name: 'Deniz', handle: 'deniz' })
+    expect(url).toBe('https://app2.langx.io/deniz')
+  })
+
+  it('links a post to the post', () => {
+    const { url, message } = postShareText(t, { id: 'abc', body: 'Hola', languageName: 'Spanish' })
+    expect(url).toBe('https://app2.langx.io/post/abc')
+    expect(message).toContain('Hola')
+    expect(message).toContain('Spanish')
+  })
+
+  /** A brag is the moment a friend is most likely to try the app. */
+  it('sends every achievement out with the invite marker', () => {
+    for (const { url } of [
+      streakShareText(t, { count: 12, handle: 'deniz' }),
+      leaderboardShareText(t, { rank: 3, period: 'all', handle: 'deniz' }),
+      badgeShareText(t, { label: '30 days', handle: 'deniz' }),
+    ]) {
+      expect(url).toBe('https://app2.langx.io/deniz?invite=1')
+    }
+  })
+
+  it('has a whole sentence for every leaderboard period', () => {
+    for (const period of PERIOD_TYPES) {
+      const { message } = leaderboardShareText(t, { rank: 7, period, handle: 'deniz' })
+      expect(message).not.toContain('share.leaderboardMessage')
+      expect(message).toContain('#7')
+    }
+  })
+
+  it('pluralises the streak', () => {
+    expect(streakShareText(t, { count: 1, handle: 'd' }).message).toContain('1-day')
+    expect(streakShareText(t, { count: 30, handle: 'd' }).message).toContain('30-day')
+  })
+
+  /** `token-messaging-brief.md`: achievements, never balances. */
+  it('never mentions tokens', () => {
+    for (const { message } of [
+      profileShareText(t, { name: 'Deniz', handle: 'deniz' }),
+      postShareText(t, { id: 'abc', body: 'Hola', languageName: 'Spanish' }),
+      streakShareText(t, { count: 12, handle: 'deniz' }),
+      leaderboardShareText(t, { rank: 3, period: 'month', handle: 'deniz' }),
+    ]) {
+      expect(message).not.toMatch(/token/i)
+    }
+  })
+})
+
+describe('isShareCancel', () => {
+  it('recognises the browser closing the sheet, and nothing else', () => {
+    expect(isShareCancel({ name: 'AbortError' })).toBe(true)
+    expect(isShareCancel(new Error('Share is not supported in this browser'))).toBe(false)
+    expect(isShareCancel(null)).toBe(false)
+    expect(isShareCancel('AbortError')).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/shareText.ts
+++ b/apps/mobile/src/lib/shareText.ts
@@ -1,0 +1,114 @@
+import { inviteUrl, postUrl, profileUrl, type PeriodType } from '@langx/shared'
+import type { MessageKey, TranslateFn } from '../i18n/runtime'
+
+/**
+ * The sentences that go out through the share sheet, and nothing else.
+ *
+ * Pure on purpose: `share.ts` reaches for `react-native`, which vitest cannot
+ * load, so everything worth a test — the wording, which link each thing
+ * carries, how a post is cut down — lives here and is handed to it.
+ *
+ * Two rules shape every builder:
+ *
+ *   - **An achievement carries the invite link.** A streak, a rank and a badge
+ *     are things somebody is proud of, and "look at mine" is the moment a
+ *     friend is most likely to try the app. `inviteUrl` is a profile link with
+ *     a marker, so the brag and the referral are one sentence.
+ *   - **No balances.** `docs/token-messaging-brief.md`: say it as an
+ *     achievement, never as money. A streak count and a rank are achievements;
+ *     a token total is a number about money and stays off the sheet.
+ */
+export interface ShareContent {
+  message: string
+  /**
+   * Absent when there is nothing to link — a chat message goes out as its own
+   * text. Present, it is also what the clipboard receives when the sheet
+   * cannot open.
+   */
+  url?: string
+}
+
+/**
+ * How much of a post travels with its link. `MAX_POST_LENGTH` is 300, so most
+ * posts fit whole; the cut is for the ones that would turn a share into a
+ * wall of text above the link.
+ */
+export const SHARE_EXCERPT_LENGTH = 140
+
+export function postExcerpt(body: string): string {
+  const flat = body.replace(/\s+/g, ' ').trim()
+  if (flat.length <= SHARE_EXCERPT_LENGTH) return flat
+  // One short of the limit leaves room for the ellipsis, so the result never
+  // exceeds what the constant promises.
+  const cut = flat.slice(0, SHARE_EXCERPT_LENGTH - 1)
+  const space = cut.lastIndexOf(' ')
+  // A word boundary, unless honouring it would throw away half the excerpt —
+  // a single very long token is cut mid-way rather than dropped.
+  const kept = space > SHARE_EXCERPT_LENGTH / 2 ? cut.slice(0, space) : cut
+  return `${kept.trimEnd()}…`
+}
+
+/**
+ * Whether a rejected share was the person closing the sheet.
+ *
+ * Only the web rejects on cancel — `navigator.share` throws a DOMException
+ * named `AbortError`; native resolves with `dismissedAction` instead. Named
+ * here so the fallback in `share.ts` has one tested line to branch on, and so
+ * no DOM type is needed to read it.
+ */
+export function isShareCancel(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { name?: unknown }).name === 'AbortError'
+  )
+}
+
+export function profileShareText(
+  t: TranslateFn,
+  { name, handle }: { name: string; handle: string },
+): ShareContent {
+  const url = profileUrl(handle)
+  return { message: t('share.profileMessage', { name, url }), url }
+}
+
+export function postShareText(
+  t: TranslateFn,
+  { id, body, languageName }: { id: string; body: string; languageName: string },
+): ShareContent {
+  const url = postUrl(id)
+  return {
+    message: t('share.postMessage', { excerpt: postExcerpt(body), language: languageName, url }),
+    url,
+  }
+}
+
+export function streakShareText(
+  t: TranslateFn,
+  { count, handle }: { count: number; handle: string },
+): ShareContent {
+  const url = inviteUrl(handle)
+  return { message: t('share.streakMessage', { count, url }), url }
+}
+
+/**
+ * One whole sentence per period rather than `periodLabel` dropped into a
+ * template: "This week" cannot be bent into "on this week's leaderboard" in
+ * English, let alone in seven other languages. Same reasoning as
+ * `lastSeenLabel` in `labels.ts`.
+ */
+export function leaderboardShareText(
+  t: TranslateFn,
+  { rank, period, handle }: { rank: number; period: PeriodType; handle: string },
+): ShareContent {
+  const url = inviteUrl(handle)
+  return { message: t(`share.leaderboardMessage.${period}` as MessageKey, { rank, url }), url }
+}
+
+export function badgeShareText(
+  t: TranslateFn,
+  { label, handle }: { label: string; handle: string },
+): ShareContent {
+  const url = inviteUrl(handle)
+  return { message: t('share.badgeMessage', { label, url }), url }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -732,6 +732,35 @@ Three consequences for handles:
 purpose — collapsing them would make re-pointing links a store-submission
 change wearing the clothes of a URL edit.
 
+### What can be shared
+
+Every share is a sentence and a link through the platform share sheet — one
+call site, `src/lib/share.ts`, and the wording in `src/lib/shareText.ts`, which
+is pure so the sentences are tested. Nothing is rendered to an image: a card
+would need `react-native-view-shot`, a native module, for a picture.
+
+| What                     | Where                                     | Link         |
+| ------------------------ | ----------------------------------------- | ------------ |
+| Your own profile, QR too | Me → Share my profile                     | `profileUrl` |
+| Somebody else's profile  | the kebab on their profile                | `profileUrl` |
+| A feed post              | the row's action strip, the post's header | `postUrl`    |
+| Your streak              | the streak screen, once it is above zero  | `inviteUrl`  |
+| Your leaderboard rank    | the leaderboard, when you are on it       | `inviteUrl`  |
+| An earned badge          | its row on the leaderboard screen         | `inviteUrl`  |
+| A chat message           | long-press → More… → Share, text only     | none         |
+
+Two rules. An **achievement carries the invite link**: a streak, a rank and a
+badge are the moment a friend is most likely to try the app, and `inviteUrl`
+is the profile link with the referral marker, so the brag and the invite are
+one sentence. And **no balances**: `token-messaging-brief.md` says an
+achievement, never money, so a token total never goes out on the sheet.
+
+The profile card above is still the only unauthenticated read. A post link
+resolves inside `Stack.Protected`, so on the web a stranger lands on sign-in
+and a member on the post; the excerpt in the sentence is what tells the
+recipient whether that is worth doing. When the app claims the host its links
+point at, the same links open the app instead — nothing here changes.
+
 ### Community feed
 
 Six collections, none of them a conversation with one participant: a post has

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2098,3 +2098,36 @@ with the recency tab; every feed page now sorts on a count.
 
 The pronunciation section is unchanged — one queue, no graph in it yet — and
 takes the same code path with an empty audience.
+
+## Sharing is a sentence and a link, not a card
+
+Six more things can leave the app through the share sheet — somebody else's
+profile, a post, a streak, a rank, a badge, a message — and every one of them
+goes out as words with a URL after them. The obvious alternative was a shareable
+image: a streak card, a badge tile, the kind of thing that does well on a
+story. It was not built, for three reasons that each stand on their own.
+
+**No image export.** Drawing a card means `react-native-view-shot`, a native
+module: a new binary for every store, and no OTA for a picture. The QR code
+already went server-side for exactly this reason, and a share card is a bigger
+picture with the same cost.
+
+**No new public reads.** `GET /public/profiles/:handle` is the one
+unauthenticated endpoint and it hides streak, tokens and tier on purpose. A
+"view this post" page for strangers would be a second one, with a post's full
+text behind a guessable id. So a post link resolves inside `Stack.Protected`:
+sign-in for a stranger, the post for a member — and the sentence carries an
+excerpt so the recipient knows what they are being asked to open. Accepted
+until universal links land, when the same link opens the app.
+
+**The wording is the product, so it is tested.** `shareText.ts` is pure and
+`share.ts` is the only file that touches `Share.share`. Two rules live there:
+an achievement carries `inviteUrl`, because "look at my streak" is the moment a
+friend tries the app and the referral marker costs nothing; and a token total
+never appears — `token-messaging-brief.md` says an achievement, never money,
+and a share is the most public sentence the app writes.
+
+One quirk worth knowing: only the web rejects when the sheet is closed
+(`AbortError`), and desktop browsers without `navigator.share` reject with
+"not supported". `shareLink` treats the first as nothing and the second as
+"copy it instead", with a toast — the button never silently does nothing.

--- a/packages/shared/src/appIdentity.test.ts
+++ b/packages/shared/src/appIdentity.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { postUrl, profileUrl, WEB_HOST } from './appIdentity'
+import { RESERVED_HANDLES } from './reservedHandles'
+
+describe('postUrl', () => {
+  it('points at the web host, under /post', () => {
+    expect(postUrl('64f1c0ffee')).toBe(`https://${WEB_HOST}/post/64f1c0ffee`)
+  })
+
+  it('shares its origin with profile links, so one constant moves both', () => {
+    const origin = profileUrl('a').replace(/\/a$/, '')
+    expect(postUrl('a').startsWith(`${origin}/post/`)).toBe(true)
+  })
+
+  /**
+   * A handle called `post` would sit exactly where post links resolve. The
+   * static route wins, so the link would still open — but the person who
+   * claimed the handle would have a profile address that never reaches them.
+   */
+  it('cannot be shadowed by a handle', () => {
+    expect(RESERVED_HANDLES.has('post')).toBe(true)
+  })
+
+  it('escapes an id that is not a plain ObjectId', () => {
+    expect(postUrl('a b/c')).toBe(`https://${WEB_HOST}/post/a%20b%2Fc`)
+  })
+})

--- a/packages/shared/src/appIdentity.ts
+++ b/packages/shared/src/appIdentity.ts
@@ -70,6 +70,23 @@ export function profileUrl(handle: string): string {
 }
 
 /**
+ * The link somebody shares for a feed post.
+ *
+ * Built on `WEB_HOST` for the same reason `inviteUrl` is: when the app finally
+ * claims the host its links point at, this is not a second line to remember.
+ * `post` is a reserved handle, so no profile can ever sit under this path.
+ *
+ * Unlike a profile link there is no signed-out card behind it — `/post/[id]`
+ * lives inside `Stack.Protected`, so on the web a stranger lands on sign-in
+ * and a member lands on the post. That is accepted: a post is written to
+ * members, and the sentence sent with the link carries an excerpt so the
+ * recipient knows what they are being asked to open.
+ */
+export function postUrl(postId: string): string {
+  return `https://${WEB_HOST}/post/${encodeURIComponent(postId)}`
+}
+
+/**
  * SHA-256 fingerprints of the certificates Android accepts as "this app", for
  * `assetlinks.json`.
  *


### PR DESCRIPTION
## What

Six more things can leave the app through the platform share sheet, each as a sentence plus a link:

| Object | Where | Link |
| --- | --- | --- |
| Somebody else's profile | kebab on their profile | `profileUrl` |
| Feed post | row action strip + post header/strip | new `postUrl` |
| Streak | streak screen, once above zero | `inviteUrl` |
| Leaderboard rank | leaderboard, when on the board | `inviteUrl` |
| Earned badge | its row on the leaderboard screen | `inviteUrl` |
| Chat message | long-press → More… → Share (text only) | none |

## Why it is shaped this way

- **A sentence and a link, not a card.** An image export needs `react-native-view-shot`, a native module, for a picture — same reason the QR is drawn server-side.
- **No new public reads.** `GET /public/profiles/:handle` stays the only unauthenticated endpoint; a post link resolves inside `Stack.Protected`, and the excerpt in the sentence tells the recipient what they are opening.
- **Achievements carry the invite link**, so a brag doubles as a referral. **No token balances** in any sentence (`token-messaging-brief.md`).
- `shareText.ts` is pure and tested; `share.ts` is the one `Share.share` call site. On the web, a browser without `navigator.share` falls back to the clipboard with a toast.

Strings added in all eight locales. `architecture.md` gets a "What can be shared" section; `decisions.md` records the reasoning.

## Verification

- `pnpm test`, `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` all green.
- Driven end to end on Expo web against an isolated in-memory stack with Playwright: feed share → clipboard fallback + "Link copied" toast; post header and strip → `navigator.share` receives excerpt + language + URL; profile kebab → "Meet Bora Share on LangX: …/borashare"; streak → "🔥 1-day streak on LangX … ?invite=1"; all-time rank → "I’m #2 on LangX, all time … ?invite=1"; chat long-press → More… → Share hands over the message text only. Locked badges stay inert; unranked periods show no rank button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)