### PR TITLE
Let people with more than one learning language choose which to post in

### DIFF
--- a/apps/mobile/app/(app)/feed.tsx
+++ b/apps/mobile/app/(app)/feed.tsx
@@ -1,5 +1,6 @@
+import Feather from '@expo/vector-icons/Feather'
 import { MAX_POST_LENGTH, POST_KINDS, type PostKind } from '@langx/shared'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   ActivityIndicator,
   Alert,
@@ -13,7 +14,7 @@ import { FormField } from '../../src/components/ui/FormField'
 import { Button } from '../../src/components/ui/Button'
 import { uploadPostMedia } from '../../src/api/queries'
 import { useCorrectPost, useCreatePost, useDeletePost, useFeed, useMe } from '../../src/api/queries'
-import type { CreatePostInput, FeedPost } from '../../src/api/types'
+import type { FeedPost } from '../../src/api/types'
 import { AttachmentBar, type PendingAttachment } from '../../src/components/AttachmentBar'
 import { AudioBubble, ImageBubble } from '../../src/components/MediaBubble'
 import { Avatar } from '../../src/components/ui/Avatar'
@@ -22,12 +23,16 @@ import { authClient } from '../../src/lib/auth-client'
 import { requireAccount } from '../../src/lib/requireAccount'
 import { LikeButton } from '../../src/components/LikeButton'
 import { SegmentedControl } from '../../src/components/ui/SegmentedControl'
+import { Dropdown, type AnchorRect } from '../../src/components/ui/Dropdown'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
 import { dedupeById } from '../../src/lib/dedupeById'
 import { foldCorrection } from '../../src/lib/feedCache'
 import { openPost, openProfile } from '../../src/lib/navigation'
 import { listState } from '../../src/lib/listState'
+import { FLAG_KEYS, readFlag, writeFlag } from '../../src/lib/localFlags'
+import { postLanguages, resolvePostLanguage } from '../../src/lib/postLanguage'
+import { LABEL_MARKER, splitLabel } from '../../src/lib/splitLabel'
 import { makeStyles } from '../../src/lib/theme'
 import { useDisplayNames, useLocale, useT, type MessageKey } from '../../src/i18n'
 import { isImageContentType } from '@langx/shared'
@@ -69,6 +74,49 @@ function CorrectedLine({ original, corrected }: { original: string; corrected: s
   )
 }
 
+/**
+ * The field's label, with the language in it as the control that changes it.
+ *
+ * When there is only one language to post in the marker never arrives and this
+ * is a plain line of text — the same one it always was. `splitLabel` returning
+ * `null` lands in the same branch, which is what a translation that dropped the
+ * placeholder should degrade to.
+ */
+function ComposerLabel({
+  text,
+  language,
+  onPress,
+  anchorRef,
+  styles,
+}: {
+  text: string
+  language: string
+  onPress: () => void
+  anchorRef: React.RefObject<View | null>
+  styles: ReturnType<typeof useStyles>
+}) {
+  const parts = splitLabel(text)
+  if (!parts) return <Text style={styles.label}>{text}</Text>
+
+  return (
+    <View style={styles.labelLine}>
+      {parts.before ? <Text style={styles.label}>{parts.before}</Text> : null}
+      <Pressable
+        ref={anchorRef}
+        accessibilityRole="button"
+        accessibilityState={{ expanded: false }}
+        hitSlop={8}
+        onPress={onPress}
+        style={({ pressed }) => [styles.languageButton, pressed && styles.pressed]}
+      >
+        <Text style={styles.languageText}>{language}</Text>
+        <Feather name="chevron-down" size={14} style={styles.chevron} />
+      </Pressable>
+      {parts.after ? <Text style={styles.label}>{parts.after}</Text> : null}
+    </View>
+  )
+}
+
 export default function FeedScreen() {
   const styles = useStyles()
   const t = useT()
@@ -105,11 +153,60 @@ export default function FeedScreen() {
   })
 
   /**
-   * The language you post in is the first one you are learning. Asking which
-   * would be a second question on top of the sentence, and the overwhelming
-   * majority of people here are learning exactly one.
+   * The language you post in defaults to the most important one you are
+   * learning, and is only ever *asked* about when there is more than one — the
+   * free tier allows exactly one, so for most people this is still no question
+   * at all.
+   *
+   * State holds the raw wish, never the resolved code. `askLanguage` is derived
+   * on every render, so a language dropped in `edit-profile` — or a wish
+   * restored from this device that belongs to somebody else's account — falls
+   * back to the default instead of leaving the composer pointed at a language
+   * the server would refuse the post in.
    */
-  const askLanguage = me.data?.learning[0]?.code
+  const [chosenLanguage, setChosenLanguage] = useState<string | null>(null)
+  const askLanguages = useMemo(() => postLanguages(me.data?.learning), [me.data])
+  const askLanguage = resolvePostLanguage(askLanguages, chosenLanguage)
+
+  // Read-once hydration, the same shape `ThemeProvider` uses: `readFlag` is
+  // async, and until it lands the composer shows the default — which is what
+  // the stored value usually says anyway.
+  useEffect(() => {
+    let cancelled = false
+    void readFlag(FLAG_KEYS.postLanguage).then((stored) => {
+      if (!cancelled && stored) setChosenLanguage(stored)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  /**
+   * The language sits *inside* the field's own label — "Your sentence in
+   * **Russian**" — and opens a menu when pressed.
+   *
+   * A row of chips above the field said the same thing twice: the chips named
+   * the languages and the label underneath named the chosen one again. Putting
+   * the control in the sentence leaves one place to read and one to press, and
+   * costs the composer no height at all for the people who never change it.
+   */
+  const languageRef = useRef<View | null>(null)
+  const [languageAnchor, setLanguageAnchor] = useState<AnchorRect | null>(null)
+
+  function openLanguages(): void {
+    // Measured on press rather than on layout: the composer moves as the draft
+    // grows, and a rect captured at mount would place the menu where the word
+    // used to be.
+    languageRef.current?.measureInWindow((x, y, width, height) =>
+      setLanguageAnchor({ x, y, width, height }),
+    )
+  }
+
+  function chooseLanguage(code: string): void {
+    setChosenLanguage(code)
+    setLanguageAnchor(null)
+    void writeFlag(FLAG_KEYS.postLanguage, code)
+  }
 
   /**
    * The attachment is uploaded here, on submit, not when it was picked.
@@ -175,11 +272,9 @@ export default function FeedScreen() {
     setUploading(false)
 
     createPost.mutate(
-      // `Profile.learning[].code` is a bare string on the DTO; `CreatePostInput`
-      // wants the code union. The server validates it again either way.
       {
         body: draft.trim(),
-        language: askLanguage as CreatePostInput['language'],
+        language: askLanguage,
         kind: section,
         ...(media ? { media } : {}),
       },
@@ -262,9 +357,17 @@ export default function FeedScreen() {
         {asking && askLanguage ? (
           <View style={styles.compose}>
             <FormField
-              label={t(pronouncing ? 'feed.pronounceTitle' : 'feed.askTitle', {
-                language: names.language(askLanguage),
-              })}
+              label={
+                <ComposerLabel
+                  text={t(pronouncing ? 'feed.pronounceTitle' : 'feed.askTitle', {
+                    language: askLanguages.length > 1 ? LABEL_MARKER : names.language(askLanguage),
+                  })}
+                  language={names.language(askLanguage)}
+                  onPress={openLanguages}
+                  anchorRef={languageRef}
+                  styles={styles}
+                />
+              }
               value={draft}
               onChangeText={setDraft}
               placeholder={t(pronouncing ? 'feed.pronouncePlaceholder' : 'feed.askPlaceholder')}
@@ -287,6 +390,17 @@ export default function FeedScreen() {
               />
             </View>
           </View>
+        ) : null}
+
+        {languageAnchor && askLanguage ? (
+          <Dropdown
+            anchor={languageAnchor}
+            options={askLanguages.map((code) => ({ value: code, label: names.language(code) }))}
+            selected={askLanguage}
+            onSelect={chooseLanguage}
+            onDismiss={() => setLanguageAnchor(null)}
+            accessibilityLabel={t('feed.postLanguage')}
+          />
         ) : null}
 
         <View style={styles.sections}>
@@ -650,6 +764,18 @@ const useStyles = makeStyles(({ colors, font, radius, spacing }) => ({
   ask: { color: colors.accent, fontSize: 16, fontWeight: '700' },
   sections: { marginTop: 18 },
   compose: { gap: spacing.md, marginTop: spacing.md },
+  labelLine: { alignItems: 'center', flexDirection: 'row', flexWrap: 'wrap' },
+  label: { ...font.caption, color: colors.textMuted, fontWeight: '600' },
+  // Underlined, not just tinted: colour alone does not say "press me" to a
+  // reader who cannot separate it from the label beside it.
+  languageButton: { alignItems: 'center', flexDirection: 'row', gap: 2 },
+  languageText: {
+    ...font.caption,
+    color: colors.text,
+    fontWeight: '700',
+    textDecorationLine: 'underline',
+  },
+  chevron: { color: colors.textMuted },
   grow: { flex: 1, width: 'auto' },
   loading: { marginTop: spacing.xxl },
   list: { paddingBottom: spacing.xxl },

--- a/apps/mobile/src/components/ui/Dropdown.tsx
+++ b/apps/mobile/src/components/ui/Dropdown.tsx
@@ -1,0 +1,118 @@
+import Feather from '@expo/vector-icons/Feather'
+import { Modal, Pressable, Text, useWindowDimensions } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { dropdownLayout, type AnchorRect } from '../../lib/dropdownLayout'
+import { makeStyles, useTheme } from '../../lib/theme'
+
+export type { AnchorRect } from '../../lib/dropdownLayout'
+
+interface DropdownProps<T extends string> {
+  /** Where the control that opened it sits, in window coordinates. */
+  anchor: AnchorRect
+  options: readonly { value: T; label: string }[]
+  selected: T | undefined
+  onSelect: (value: T) => void
+  onDismiss: () => void
+  /** Names the list for a screen reader — the control's own label rarely does. */
+  accessibilityLabel: string
+}
+
+/** A row's height, and the padding above and below the list. Used to place it. */
+const ROW_HEIGHT = 44
+const LIST_PADDING = 6
+const MIN_WIDTH = 160
+
+/**
+ * A short list of choices, drawn against whatever opened it.
+ *
+ * A `Modal` rather than an absolutely positioned view in the composer, for the
+ * same two reasons `MessageMenuHost` is one: it paints above the tab bar on
+ * every platform without depending on mount order, and `onRequestClose` gives
+ * Android's back button something to close. Both are things a plain overlay
+ * would have to rebuild, and the second is easy to forget until a back press
+ * leaves the app instead of the menu.
+ *
+ * Deliberately not the full `LanguagePicker` shape: that one searches 180
+ * languages and needs a bounded height. This is for a handful of options that
+ * already belong to you, where a search field would be furniture.
+ */
+export function Dropdown<T extends string>({
+  anchor,
+  options,
+  selected,
+  onSelect,
+  onDismiss,
+  accessibilityLabel,
+}: DropdownProps<T>) {
+  const styles = useStyles()
+  const { colors } = useTheme()
+  const insets = useSafeAreaInsets()
+  const screen = useWindowDimensions()
+
+  // Derived from the row count rather than measured, so the flip is decided
+  // before the first paint. See `dropdownLayout`.
+  const height = options.length * ROW_HEIGHT + LIST_PADDING * 2
+  const width = Math.max(MIN_WIDTH, anchor.width)
+  const { top, left } = dropdownLayout({
+    anchor,
+    screen: { width: screen.width, height: screen.height },
+    insets: { top: insets.top, bottom: insets.bottom },
+    menu: { width, height },
+  })
+
+  return (
+    <Modal transparent animationType="fade" visible onRequestClose={onDismiss}>
+      <Pressable style={styles.backdrop} onPress={onDismiss} accessibilityRole="button">
+        {/* Swallows the press so tapping the list itself does not close it. */}
+        <Pressable
+          style={[styles.menu, { top, left, width }]}
+          onPress={() => {}}
+          accessibilityRole="radiogroup"
+          accessibilityLabel={accessibilityLabel}
+        >
+          {options.map((option) => {
+            const on = option.value === selected
+            return (
+              <Pressable
+                key={option.value}
+                accessibilityRole="radio"
+                accessibilityState={{ selected: on }}
+                onPress={() => onSelect(option.value)}
+                style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+              >
+                <Text style={[styles.label, on && styles.labelOn]} numberOfLines={1}>
+                  {option.label}
+                </Text>
+                {/* A tick, not a highlight: the chosen row has to stay legible
+                    against the same background as the others. */}
+                {on ? <Feather name="check" size={16} color={colors.text} /> : null}
+              </Pressable>
+            )
+          })}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  )
+}
+
+const useStyles = makeStyles(({ cardShadow, colors, font, radius, spacing }) => ({
+  backdrop: { backgroundColor: colors.scrim, flex: 1 },
+  menu: {
+    ...cardShadow,
+    backgroundColor: colors.bg,
+    borderRadius: radius.lg,
+    paddingVertical: LIST_PADDING,
+    position: 'absolute',
+  },
+  row: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: spacing.sm,
+    height: ROW_HEIGHT,
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.md,
+  },
+  pressed: { opacity: 0.6 },
+  label: { ...font.body, color: colors.textMuted, flexShrink: 1 },
+  labelOn: { color: colors.text, fontWeight: '700' },
+}))

--- a/apps/mobile/src/components/ui/FormField.tsx
+++ b/apps/mobile/src/components/ui/FormField.tsx
@@ -1,11 +1,16 @@
 import Feather from '@expo/vector-icons/Feather'
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { Pressable, Text, TextInput, type TextInputProps, View } from 'react-native'
 import { makeStyles, useTheme } from '../../lib/theme'
 import { useT } from '../../i18n'
 
 interface FormFieldProps extends TextInputProps {
-  label: string
+  /**
+   * A node, not just a string: the feed composer draws part of its label as a
+   * control — the language you are posting in, which opens a menu. Every other
+   * caller still passes a plain string and gets the same `Text` as before.
+   */
+  label: ReactNode
   error?: string | undefined
   /**
    * Shows a live `used / max` counter beside the label. The limits live in
@@ -37,7 +42,7 @@ export function FormField({ label, error, maxLength, style, ...inputProps }: For
   return (
     <View style={styles.container}>
       <View style={styles.labelRow}>
-        <Text style={styles.label}>{label}</Text>
+        {typeof label === 'string' ? <Text style={styles.label}>{label}</Text> : label}
         {showCount ? (
           <Text style={[styles.count, used > maxLength ? styles.countOver : null]}>
             {used} / {maxLength}

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -685,6 +685,7 @@ export const ar: Localized<EnMessages> = {
     topTag: 'الأفضل',
     ask: '+ اسأل',
     askTitle: 'جملتك بلغة {language}',
+    postLanguage: 'لغة المنشور',
     askPlaceholder: 'الجملة التي لست متأكدًا منها…',
     posting: 'جارٍ النشر…',
     posted: 'نُشرت. سيصحّحها أحدهم.',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -590,6 +590,7 @@ export const de: Localized<EnMessages> = {
     topTag: 'Top',
     ask: '+ Fragen',
     askTitle: 'Dein Satz auf {language}',
+    postLanguage: 'Sprache des Beitrags',
     askPlaceholder: 'Der Satz, bei dem du unsicher bist…',
     posting: 'Wird gepostet…',
     posted: 'Gepostet. Jemand wird ihn korrigieren.',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -610,6 +610,7 @@ export const en = {
     topTag: 'Top',
     ask: '+ Ask',
     askTitle: 'Your sentence in {language}',
+    postLanguage: 'Language to post in',
     askPlaceholder: 'The sentence you are unsure about…',
     posting: 'Posting…',
     posted: 'Posted. Somebody will correct it.',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -572,6 +572,7 @@ export const es: Localized<EnMessages> = {
     topTag: 'Mejor',
     ask: '+ Preguntar',
     askTitle: 'Tu frase en {language}',
+    postLanguage: 'Idioma en el que publicar',
     askPlaceholder: 'La frase de la que no estás seguro…',
     posting: 'Publicando…',
     posted: 'Publicado. Alguien lo corregirá.',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -572,6 +572,7 @@ export const fr: Localized<EnMessages> = {
     topTag: 'Meilleure',
     ask: '+ Demander',
     askTitle: 'Ta phrase en {language}',
+    postLanguage: 'Langue de la publication',
     askPlaceholder: 'La phrase dont tu n’es pas sûr…',
     posting: 'Publication…',
     posted: 'Publié. Quelqu’un la corrigera.',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -565,6 +565,7 @@ export const ptBR: Localized<EnMessages> = {
     topTag: 'Melhor',
     ask: '+ Perguntar',
     askTitle: 'Sua frase em {language}',
+    postLanguage: 'Idioma da publicação',
     askPlaceholder: 'A frase da qual você não tem certeza…',
     posting: 'Publicando…',
     posted: 'Publicado. Alguém vai corrigir.',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -648,6 +648,7 @@ export const ru: Localized<EnMessages> = {
     topTag: 'Лучшая',
     ask: '+ Спросить',
     askTitle: 'Твоё предложение на языке {language}',
+    postLanguage: 'Язык публикации',
     askPlaceholder: 'Предложение, в котором ты не уверен…',
     posting: 'Публикуем…',
     posted: 'Опубликовано. Кто-нибудь исправит.',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -581,6 +581,7 @@ export const tr: Localized<EnMessages> = {
     topTag: 'En iyi',
     ask: '+ Sor',
     askTitle: '{language} dilindeki cümlen',
+    postLanguage: 'Paylaşacağın dil',
     askPlaceholder: 'Emin olmadığın cümle…',
     posting: 'Paylaşılıyor…',
     posted: 'Paylaşıldı. Birisi düzeltecektir.',

--- a/apps/mobile/src/lib/dropdownLayout.test.ts
+++ b/apps/mobile/src/lib/dropdownLayout.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { dropdownLayout } from './dropdownLayout'
+
+const screen = { width: 400, height: 800 }
+const insets = { top: 50, bottom: 30 }
+const menu = { width: 160, height: 120 }
+const at = (x: number, y: number) => ({ x, y, width: 90, height: 20 })
+
+describe('dropdownLayout', () => {
+  it('drops below the control, just under it', () => {
+    const layout = dropdownLayout({ anchor: at(20, 100), screen, insets, menu })
+    expect(layout.placement).toBe('below')
+    expect(layout.top).toBe(126)
+    expect(layout.left).toBe(20)
+  })
+
+  it('flips above when below would run past the bottom', () => {
+    const layout = dropdownLayout({ anchor: at(20, 700), screen, insets, menu })
+    expect(layout.placement).toBe('above')
+    expect(layout.top).toBe(574)
+  })
+
+  /**
+   * A control low on a short screen: neither arrangement fits. Below wins and
+   * the end is cut off, because flipping above would put the first option off
+   * the top of the screen — unreachable rather than merely clipped.
+   */
+  it('stays below when neither side fits, clamped into the safe area', () => {
+    const tiny = { width: 400, height: 200 }
+    const layout = dropdownLayout({ anchor: at(20, 150), screen: tiny, insets, menu })
+    expect(layout.placement).toBe('below')
+    expect(layout.top).toBe(62)
+  })
+
+  it('pulls a menu near the right edge back inside the screen', () => {
+    const layout = dropdownLayout({ anchor: at(330, 100), screen, insets, menu })
+    expect(layout.left).toBe(228)
+  })
+
+  it('starts at the gutter when the menu is wider than the screen', () => {
+    const wide = { width: 500, height: 120 }
+    const layout = dropdownLayout({ anchor: at(20, 100), screen, insets, menu: wide })
+    expect(layout.left).toBe(12)
+  })
+})

--- a/apps/mobile/src/lib/dropdownLayout.ts
+++ b/apps/mobile/src/lib/dropdownLayout.ts
@@ -1,0 +1,68 @@
+export interface AnchorRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface DropdownLayoutInput {
+  /** Where the control that opened it sits, in window coordinates. */
+  anchor: AnchorRect
+  screen: { width: number; height: number }
+  insets: { top: number; bottom: number }
+  /** Measured from the option count before the first paint — see below. */
+  menu: { width: number; height: number }
+}
+
+export interface DropdownLayout {
+  placement: 'below' | 'above'
+  top: number
+  left: number
+}
+
+const GUTTER = 12
+const GAP = 6
+
+/**
+ * Where a dropdown goes once its control has been pressed.
+ *
+ * Pure, and given the menu's height rather than left to measure its own: a
+ * height measured after mounting means one frame drawn in the wrong place and
+ * a visible jump on exactly the gesture that is supposed to feel immediate.
+ * Deciding the flip from the row count settles it before the first paint, and
+ * keeps these rules testable without a renderer — the same split, and for the
+ * same reason, as `messageMenuLayout`.
+ *
+ * Below the control by default, because that is what "drops down" means and it
+ * keeps the control itself visible. Above only when below would run past the
+ * safe area.
+ *
+ * When neither side fits — a short screen, or the keyboard having taken half
+ * of it — the menu is pulled back inside the safe area instead, overlapping
+ * the control if it has to. Covering the word you just tapped is worth it: the
+ * alternative is a menu whose first option is off-screen, which reads as
+ * nothing having happened.
+ */
+export function dropdownLayout(input: DropdownLayoutInput): DropdownLayout {
+  const { anchor, screen, insets, menu } = input
+
+  const safeTop = insets.top + GUTTER
+  const safeBottom = screen.height - insets.bottom - GUTTER
+
+  const below = anchor.y + anchor.height + GAP
+  const above = anchor.y - GAP - menu.height
+  const placement: DropdownLayout['placement'] =
+    below + menu.height <= safeBottom || above < safeTop ? 'below' : 'above'
+
+  // Clamped both ways. `min` first so a menu that would overrun the bottom is
+  // pulled up; `max` last so the pull can never push its first row off the top.
+  const wanted = placement === 'below' ? below : above
+  const top = Math.max(safeTop, Math.min(wanted, safeBottom - menu.height))
+
+  // Aligned to the control's leading edge, then pulled back inside the screen.
+  // `Math.max` last so a menu wider than the screen still starts at the gutter
+  // rather than at a negative offset.
+  const left = Math.max(GUTTER, Math.min(anchor.x, screen.width - GUTTER - menu.width))
+
+  return { placement, top, left }
+}

--- a/apps/mobile/src/lib/localFlags.ts
+++ b/apps/mobile/src/lib/localFlags.ts
@@ -55,6 +55,16 @@ export const FLAG_KEYS = {
    * have read is a fact about you having read it on this phone.
    */
   tips: 'tips',
+  /**
+   * Which of your learning languages the feed composer is set to.
+   *
+   * Device-level like the theme and the locale, and for a reason of its own:
+   * the value is a *wish*, never a fact. It can name a language the account
+   * signed in here is not learning — a shared phone, or a language dropped
+   * since it was written. `resolvePostLanguage` sanitises it on read, so
+   * nothing here has to be kept in step with the profile.
+   */
+  postLanguage: 'postLanguage',
 } as const
 
 export type FlagKey = (typeof FLAG_KEYS)[keyof typeof FLAG_KEYS]

--- a/apps/mobile/src/lib/postLanguage.test.ts
+++ b/apps/mobile/src/lib/postLanguage.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { postLanguages, resolvePostLanguage } from './postLanguage'
+
+describe('postLanguages', () => {
+  it('orders by priority, not by the order the API sent', () => {
+    const learning = [
+      { code: 'ru', priority: 2 },
+      { code: 'es', priority: 1 },
+    ]
+    expect(postLanguages(learning)).toEqual(['es', 'ru'])
+  })
+
+  it('leaves the caller list alone', () => {
+    const learning = [
+      { code: 'ru', priority: 2 },
+      { code: 'es', priority: 1 },
+    ]
+    postLanguages(learning)
+    expect(learning.map((entry) => entry.code)).toEqual(['ru', 'es'])
+  })
+
+  it('drops a code this build has no name for', () => {
+    expect(
+      postLanguages([
+        { code: 'zz', priority: 1 },
+        { code: 'en', priority: 2 },
+      ]),
+    ).toEqual(['en'])
+  })
+
+  it('has nothing to offer before the profile arrives', () => {
+    expect(postLanguages(undefined)).toEqual([])
+    expect(postLanguages([])).toEqual([])
+  })
+})
+
+describe('resolvePostLanguage', () => {
+  it('keeps a choice that is still on offer', () => {
+    expect(resolvePostLanguage(['es', 'ru'], 'ru')).toBe('ru')
+  })
+
+  it('defaults to the most important language when nothing was chosen', () => {
+    expect(resolvePostLanguage(['es', 'ru'], null)).toBe('es')
+  })
+
+  /**
+   * The reason `chosen` is a loose string: a stored choice outlives the profile
+   * it was made against. Dropping a learning language must not leave the
+   * composer pointed at it — the server would reject the post.
+   */
+  it('falls back when the chosen language is no longer learned', () => {
+    expect(resolvePostLanguage(['es'], 'ru')).toBe('es')
+  })
+
+  it('resolves to nothing when there is nothing to post in', () => {
+    expect(resolvePostLanguage([], 'ru')).toBeUndefined()
+    expect(resolvePostLanguage([], null)).toBeUndefined()
+  })
+})

--- a/apps/mobile/src/lib/postLanguage.ts
+++ b/apps/mobile/src/lib/postLanguage.ts
@@ -1,0 +1,52 @@
+import { isLanguageCode, type LanguageCode } from '@langx/shared'
+
+/** The shape the profile DTO hands over: `code` is a bare string there. */
+interface LearningEntry {
+  code: string
+  priority: number
+}
+
+/**
+ * The languages you can post in, most important first.
+ *
+ * Sorted here rather than trusted, because the API returns `learning` in stored
+ * array order — `profiles.ts` reads the field straight off the document — while
+ * `priority` is what actually says which language matters most to you. The
+ * profile screen already sorts for the same reason; the composer used to take
+ * `learning[0]` and so could disagree with it about your own main language.
+ *
+ * `isLanguageCode` is doing two jobs at once: it drops a code this build has no
+ * name for, and it is the only place `string` becomes `LanguageCode`. That
+ * narrowing is why the composer can hand its choice to `createPost` without an
+ * assertion.
+ */
+export function postLanguages(learning: readonly LearningEntry[] | undefined): LanguageCode[] {
+  if (!learning) return []
+  // Copied before sorting: `me.data` is React Query's cache, and sorting it in
+  // place mutates what every other screen is reading.
+  return [...learning]
+    .sort((a, b) => a.priority - b.priority)
+    .map((entry) => entry.code)
+    .filter(isLanguageCode)
+}
+
+/**
+ * Which language the composer is actually posting in.
+ *
+ * Takes `chosen` as a loose `string | null` on purpose: it is a *wish*, not a
+ * fact. It comes from a tap the reader made earlier — possibly in a previous
+ * session, possibly before they edited their learning languages, possibly under
+ * a different account on the same phone. Any of those can leave it naming a
+ * language that is no longer on offer, and the answer to all of them is the
+ * same: fall back to the most important one rather than reconciling state.
+ *
+ * So the caller stores the wish and derives the answer every render. There is
+ * nothing to keep in step, and nothing to go stale.
+ */
+export function resolvePostLanguage(
+  languages: readonly LanguageCode[],
+  chosen: string | null,
+): LanguageCode | undefined {
+  const wanted = languages.find((code) => code === chosen)
+  return wanted ?? languages[0]
+}

--- a/apps/mobile/src/lib/splitLabel.test.ts
+++ b/apps/mobile/src/lib/splitLabel.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { LABEL_MARKER, splitLabel } from './splitLabel'
+
+const withMarker = (template: string) => template.replace('{language}', LABEL_MARKER)
+
+describe('splitLabel', () => {
+  it('cuts a label that ends with its placeholder', () => {
+    expect(splitLabel(withMarker('Your sentence in {language}'))).toEqual({
+      before: 'Your sentence in ',
+      after: '',
+    })
+  })
+
+  // Turkish opens with the language, which is the case a hard-coded prefix
+  // would get wrong while every English test still passed.
+  it('cuts a label that opens with its placeholder', () => {
+    expect(splitLabel(withMarker('{language} dilindeki c\u00fcmlen'))).toEqual({
+      before: '',
+      after: ' dilindeki c\u00fcmlen',
+    })
+  })
+
+  it('cuts a label with the placeholder in the middle', () => {
+    expect(splitLabel(withMarker('Say {language} out loud'))).toEqual({
+      before: 'Say ',
+      after: ' out loud',
+    })
+  })
+
+  it('gives back nothing when a translation dropped the placeholder', () => {
+    expect(splitLabel('Your sentence')).toBeNull()
+  })
+})

--- a/apps/mobile/src/lib/splitLabel.ts
+++ b/apps/mobile/src/lib/splitLabel.ts
@@ -1,0 +1,27 @@
+/**
+ * A marker no message can contain, so splitting on it cannot cut real text.
+ * Interpolated in place of the value, then split back out.
+ */
+export const LABEL_MARKER = '\u0000'
+
+/**
+ * A translated label broken around one of its own placeholders, so the value
+ * can be drawn as something other than text.
+ *
+ * The placeholder does not sit in the same place in every language — English
+ * ends with it ("Your sentence in Russian") and Turkish opens with it
+ * ("Rusca dilindeki cumlen") — so the two halves cannot be hard-coded, and a
+ * second message key holding "the bit before" would be a translator's trap.
+ * Asking the existing key to interpolate a marker and cutting there keeps one
+ * string per language, still translated as one sentence.
+ *
+ * Returns `null` when the marker is absent, which means a translation dropped
+ * the placeholder. The caller falls back to the plain label: a sentence with
+ * the language named but not tappable is worse than this one, and much better
+ * than a blank line.
+ */
+export function splitLabel(label: string): { before: string; after: string } | null {
+  const at = label.indexOf(LABEL_MARKER)
+  if (at === -1) return null
+  return { before: label.slice(0, at), after: label.slice(at + LABEL_MARKER.length) }
+}


### PR DESCRIPTION
The feed composer took `learning[0]` and never asked which language you were writing in. That is right for the free tier, which allows exactly one learning language, and wrong for everybody above it: a Pro+ account learning five could only ever post in one of them.

### The control is the sentence

The language sits inside the field's own label — "Your sentence in **Russian**", underlined, with a chevron — and opens a menu when pressed. One place to read and one to press, and the composer gains no height at all for the people who never change it.

With a single learning language the label is the plain line of text it always was, with nothing to press. That is most people.

### Two things that made this harder than it sounds

**The placeholder moves between languages.** English ends with it, Turkish opens with it — "Rusça dilindeki cümlen". So `splitLabel` asks the existing message to interpolate a marker and cuts there. One string per language, still translated as one sentence, no new key, and no hard-coded prefix that would pass every English test. A translation that dropped the placeholder degrades to plain text rather than a blank line.

**A menu that measures itself after mounting draws one frame in the wrong place.** `dropdownLayout` takes the height from the row count and decides below-or-above before the first paint — the same split, and for the same reason, as the existing `messageMenuLayout`. When neither side fits it pulls the menu back inside the safe area rather than letting its first row go off-screen.

`Dropdown` is a `Modal` for the two reasons `MessageMenuHost` is one: it paints above the tab bar without depending on mount order, and `onRequestClose` gives Android's back button something to close.

### Stale selections

The chosen language is remembered per device, and stored as a raw *wish* rather than a resolved code. It can name a language the account signed in here does not study — a shared phone, or a language dropped since. So the composer derives the answer every render through `resolvePostLanguage`, which falls back to the default when the wish no longer applies. Nothing to reconcile, and no way to end up posting in a language the server refuses.

### In passing

`postLanguages` sorts by `priority`. The API returns `learning` in stored array order, so "the first one you are learning" could already disagree with the profile screen, which has always sorted. And because it narrows through `isLanguageCode`, the `as CreatePostInput['language']` cast at the call site goes away.

`FormField` now accepts a `ReactNode` label. Every other caller still passes a string and renders exactly as before.

No API, schema or database change — `createPostSchema` already required `language`, and the server already rejects a post in a language you are not learning.

### Verified

`pnpm test`, `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` all green, with 17 new unit tests across `postLanguage`, `dropdownLayout` and `splitLabel`.

Driven live in Expo web against a throwaway API and database:
- the language is a button; pressing it opens the menu anchored under the word, with a tick on the current one
- choosing rewrites the sentence and closes the menu; tapping outside closes it too
- the choice survives the correction ↔ pronunciation switch and a page reload, and the posted card names it
- a stored language that is no longer learned falls back to the default
- **Turkish** puts the language first and still reads as one sentence — the case the marker split exists for
- **Arabic** renders it in RTL with the menu anchored on the right
- an account with one learning language gets plain text, no button and no menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
