### PR TITLE
Give people somewhere to find the posts they wrote

### DIFF
--- a/apps/api/src/modules/feed/feed.ts
+++ b/apps/api/src/modules/feed/feed.ts
@@ -80,6 +80,61 @@ async function readCorrectionSummary(
   }
 }
 
+/**
+ * A page of posts turned into what a card needs: the author, the one reply
+ * shown under it, the viewer's own like and reply state, and the comment count.
+ *
+ * `want` is here because the two readers disagree about which reply matters. A
+ * section of the feed shows one kind at a time — a correction page never draws
+ * a `topAnswer`, a pronunciation page never draws a `topCorrection` — and
+ * running both aggregates would make each section pay for the other's on every
+ * page. A list that mixes the kinds has to ask for both, and can afford to:
+ * it is one person's own posts, not the whole collection.
+ */
+async function hydratePosts(
+  db: Db,
+  userId: string,
+  items: Post[],
+  want: { corrections: boolean; answers: boolean },
+): Promise<FeedPost[]> {
+  const ids = items.map((post) => post._id)
+  const [corrections, answers, commentCounts] = await Promise.all([
+    want.corrections ? readCorrectionSummary(db, userId, ids) : EMPTY_CORRECTION_SUMMARY,
+    want.answers ? readAnswerSummary(db, userId, ids) : EMPTY_ANSWER_SUMMARY,
+    readCommentSummary(db, ids),
+  ])
+  const tops = [...corrections.topByPost.values()]
+  const topAnswers = [...answers.topByPost.values()]
+
+  const [authors, likes] = await Promise.all([
+    loadAuthors(db, [
+      ...items.map((post) => post.authorId),
+      ...tops.map((c) => c.authorId),
+      ...topAnswers.map((a) => a.authorId),
+    ]),
+    // One call for the whole page — every post *and* the one reply each card
+    // shows. Lists rather than calls, because they share a query.
+    readLikeSummary(db, userId, {
+      postIds: ids,
+      correctionIds: tops.map((c) => c._id),
+      answerIds: topAnswers.map((a) => a._id),
+    }),
+  ])
+
+  return items.map((post) => {
+    const key = post._id.toHexString()
+    return postDto(post, {
+      authors,
+      likes,
+      top: corrections.topByPost.get(key) ?? null,
+      topAnswer: answers.topByPost.get(key) ?? null,
+      correctedByViewer: corrections.viewerCorrected.has(key),
+      answeredByViewer: answers.viewerAnswered.has(key),
+      commentCount: commentCounts.get(key) ?? 0,
+    })
+  })
+}
+
 export async function listFeed(db: Db, userId: string, query: ListFeedQuery): Promise<FeedPage> {
   const posts = db.collection<Post>(COLLECTIONS.posts)
 
@@ -210,51 +265,10 @@ export async function listFeed(db: Db, userId: string, query: ListFeedQuery): Pr
   }
   const last = items.at(-1)
 
-  const ids = items.map((post) => post._id)
-  /**
-   * Only the summary this section can use. A correction page never shows a
-   * `topAnswer` and a pronunciation page never shows a `topCorrection`, so
-   * running both would make each tab pay for the other's aggregate on every
-   * page. The comment count is the one both need — a single extra `$group`, and
-   * the only new per-page cost here.
-   */
-  const [corrections, answers, commentCounts] = await Promise.all([
-    pronunciation
-      ? Promise.resolve(EMPTY_CORRECTION_SUMMARY)
-      : readCorrectionSummary(db, userId, ids),
-    pronunciation ? readAnswerSummary(db, userId, ids) : Promise.resolve(EMPTY_ANSWER_SUMMARY),
-    readCommentSummary(db, ids),
-  ])
-  const tops = [...corrections.topByPost.values()]
-  const topAnswers = [...answers.topByPost.values()]
-
-  const [authors, likes] = await Promise.all([
-    loadAuthors(db, [
-      ...items.map((post) => post.authorId),
-      ...tops.map((c) => c.authorId),
-      ...topAnswers.map((a) => a.authorId),
-    ]),
-    // One call for the whole page — every post *and* the one reply each card
-    // shows. Lists rather than calls, because they share a query.
-    readLikeSummary(db, userId, {
-      postIds: ids,
-      correctionIds: tops.map((c) => c._id),
-      answerIds: topAnswers.map((a) => a._id),
-    }),
-  ])
-
   return {
-    items: items.map((post) => {
-      const key = post._id.toHexString()
-      return postDto(post, {
-        authors,
-        likes,
-        top: corrections.topByPost.get(key) ?? null,
-        topAnswer: answers.topByPost.get(key) ?? null,
-        correctedByViewer: corrections.viewerCorrected.has(key),
-        answeredByViewer: answers.viewerAnswered.has(key),
-        commentCount: commentCounts.get(key) ?? 0,
-      })
+    items: await hydratePosts(db, userId, items, {
+      corrections: !pronunciation,
+      answers: pronunciation,
     }),
     nextCursor:
       hasMore && last

--- a/apps/api/src/modules/feed/feed.ts
+++ b/apps/api/src/modules/feed/feed.ts
@@ -7,6 +7,7 @@ import {
   type FeedPost,
   FEED_FOLLOWING_SOURCE_LIMIT,
   type ListFeedQuery,
+  type ListMyPostsQuery,
   type ListPostCorrectionsQuery,
   type PostCorrectionsPage,
   type PostCorrection,
@@ -281,6 +282,48 @@ export async function listFeed(db: Db, userId: string, query: ListFeedQuery): Pr
             items.length === fromAudience,
           )
         : null,
+  }
+}
+
+/**
+ * Everything you have posted, newest first.
+ *
+ * Separate from `listFeed` rather than a filter on it, because almost nothing
+ * they do is shared. There is no queue to drain here — the count-led sort that
+ * puts unanswered sentences first is the wrong order for looking back at your
+ * own — no section to pick, and no audience to stitch two queries around.
+ * Blocks do not apply either: these are your posts, and you cannot be hidden
+ * from yourself. What is left is a plain keyset over `{ authorId, createdAt }`,
+ * which is the `author` index this collection has always carried.
+ */
+export async function listMyPosts(
+  db: Db,
+  userId: string,
+  query: ListMyPostsQuery,
+): Promise<FeedPage> {
+  const filter: Document = { authorId: userId }
+  if (query.cursor) {
+    const { date, id } = decodeDateIdCursor(query.cursor)
+    filter.$or = [{ createdAt: { $lt: date } }, { createdAt: date, _id: { $lt: id } }]
+  }
+
+  // One over, so "is there another page" is answered without a second count.
+  const page = await db
+    .collection<Post>(COLLECTIONS.posts)
+    .find(filter)
+    .sort({ createdAt: -1, _id: -1 })
+    .limit(query.limit + 1)
+    .toArray()
+
+  const hasMore = page.length > query.limit
+  const items = hasMore ? page.slice(0, query.limit) : page
+  const last = items.at(-1)
+
+  return {
+    // Both, because the list mixes the sections: a sentence you asked to have
+    // corrected and a word you asked to hear said sit next to each other here.
+    items: await hydratePosts(db, userId, items, { corrections: true, answers: true }),
+    nextCursor: hasMore && last ? encodeDateIdCursor(last.createdAt, last._id) : null,
   }
 }
 

--- a/apps/api/src/routes/feed.test.ts
+++ b/apps/api/src/routes/feed.test.ts
@@ -1197,4 +1197,95 @@ describe('community feed', () => {
       expect(card?.commentCount).toBe(0)
     })
   })
+
+  describe('your own posts', () => {
+    async function mine(user: SignedUpUser, qs = '') {
+      return app.inject({
+        method: 'GET',
+        url: `/me/posts${qs ? `?${qs}` : ''}`,
+        headers: { cookie: user.cookie },
+      })
+    }
+
+    it('mixes both sections, newest first, and nobody else', async () => {
+      const author = await newUser('mine-author@example.com')
+      const other = await newUser('mine-other@example.com')
+
+      const corrected = (await post(author, 'I has a question.')).json<{ _id: string }>()._id
+      const asked = (await ask(author, 'squirrel')).json<{ _id: string }>()._id
+      const theirs = (await post(other, 'Not yours.')).json<{ _id: string }>()._id
+
+      const items = (await mine(author)).json<{ items: { _id: string; kind: string }[] }>().items
+      // Newest first: the pronunciation request was written second.
+      expect(items.map((i) => i._id)).toEqual([asked, corrected])
+      // Which is the point of the mix — the section is not a filter here.
+      expect(items.map((i) => i.kind)).toEqual(['pronunciation', 'correction'])
+      expect(items.map((i) => i._id)).not.toContain(theirs)
+
+      // And the other way round, so this is not just an ordering coincidence.
+      expect(
+        (await mine(other)).json<{ items: { _id: string }[] }>().items.map((i) => i._id),
+      ).toEqual([theirs])
+    })
+
+    it('carries what a card draws, for both kinds', async () => {
+      const author = await newUser('mine-card-author@example.com')
+      const helper = await newUser('mine-card-helper@example.com')
+
+      const corrected = (await post(author, 'I has been there.')).json<{ _id: string }>()._id
+      const asked = (await ask(author, 'thorough')).json<{ _id: string }>()._id
+      expect((await correct(helper, corrected, 'I have been there.')).statusCode).toBe(201)
+      expect((await answer(helper, asked)).statusCode).toBe(201)
+
+      const items = (await mine(author)).json<{
+        items: {
+          _id: string
+          author: { handle: string }
+          topCorrection: { corrected: string } | null
+          topAnswer: { _id: string } | null
+        }[]
+      }>().items
+
+      // The reason `hydratePosts` is asked for both summaries here: a list that
+      // mixes the sections needs the reply each kind shows.
+      expect(items.find((i) => i._id === corrected)?.topCorrection?.corrected).toBe(
+        'I have been there.',
+      )
+      expect(items.find((i) => i._id === asked)?.topAnswer).not.toBeNull()
+      expect(items[0]?.author.handle).toBeTruthy()
+    })
+
+    it('pages without repeating or dropping a post', async () => {
+      const author = await newUser('mine-paging@example.com')
+      const ids: string[] = []
+      for (let i = 0; i < 5; i++) {
+        ids.unshift((await post(author, `Sentence number ${i}.`)).json<{ _id: string }>()._id)
+      }
+
+      const first = (await mine(author, 'limit=2')).json<{
+        items: { _id: string }[]
+        nextCursor: string | null
+      }>()
+      expect(first.items.map((i) => i._id)).toEqual(ids.slice(0, 2))
+      expect(first.nextCursor).toBeTruthy()
+
+      const second = (
+        await mine(author, `limit=2&cursor=${encodeURIComponent(first.nextCursor ?? '')}`)
+      ).json<{ items: { _id: string }[]; nextCursor: string | null }>()
+      expect(second.items.map((i) => i._id)).toEqual(ids.slice(2, 4))
+
+      const third = (
+        await mine(author, `limit=2&cursor=${encodeURIComponent(second.nextCursor ?? '')}`)
+      ).json<{ items: { _id: string }[]; nextCursor: string | null }>()
+      expect(third.items.map((i) => i._id)).toEqual(ids.slice(4))
+      expect(third.nextCursor).toBeNull()
+    })
+
+    it('says nothing rather than everything when you have posted nothing', async () => {
+      const quiet = await newUser('mine-quiet@example.com')
+      const page = (await mine(quiet)).json<{ items: unknown[]; nextCursor: string | null }>()
+      expect(page.items).toEqual([])
+      expect(page.nextCursor).toBeNull()
+    })
+  })
 })

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -4,6 +4,7 @@ import {
   createPostSchema,
   createPronunciationAnswerSchema,
   listFeedQuerySchema,
+  listMyPostsQuerySchema,
   listPostCommentsQuerySchema,
   listPostCorrectionsQuerySchema,
   listPronunciationAnswersQuerySchema,
@@ -19,6 +20,7 @@ import {
   deleteCorrection,
   deletePost,
   listFeed,
+  listMyPosts,
   listPostCorrections,
 } from '../modules/feed/feed'
 import {
@@ -37,6 +39,22 @@ export const feedRoutes: FastifyPluginAsyncZod = async (app) => {
     { preHandler: requireAuth, schema: { querystring: listFeedQuerySchema } },
     async (request, reply) => {
       return reply.send(await listFeed(app.mongo.db, request.userId, request.query))
+    },
+  )
+
+  /**
+   * Your own posts, newest first.
+   *
+   * Hangs off `/me` for the same reason `/me/corrections` and `/me/starred` do:
+   * it is a read across the whole collection that names only you. Paged rather
+   * than capped, because the answer to "where is the thing I asked last month"
+   * has to still be reachable in a year.
+   */
+  app.get(
+    '/me/posts',
+    { preHandler: requireAuth, schema: { querystring: listMyPostsQuerySchema } },
+    async (request, reply) => {
+      return reply.send(await listMyPosts(app.mongo.db, request.userId, request.query))
     },
   )
 

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -150,6 +150,7 @@ export default function AppLayout() {
         <Tabs.Screen name="legal" options={FULL_SCREEN} />
         <Tabs.Screen name="streak" options={FULL_SCREEN} />
         <Tabs.Screen name="corrections" options={FULL_SCREEN} />
+        <Tabs.Screen name="my-posts" options={FULL_SCREEN} />
       </Tabs>
     </SafeAreaView>
   )

--- a/apps/mobile/app/(app)/me.tsx
+++ b/apps/mobile/app/(app)/me.tsx
@@ -174,6 +174,10 @@ export default function MeScreen() {
       */}
       <ActivityMap />
 
+      {/* First of the rows, because it is the one that answers a question
+          somebody actually arrives with: where the thing I asked went. */}
+      <ListRow title={t('me.myPosts')} onPress={() => router.push('/(app)/my-posts')} />
+
       {/* Free users get the count and a locked list; that contrast is the
           entire argument for Pro, so it is shown rather than hidden. */}
       <ListRow

--- a/apps/mobile/app/(app)/my-posts.tsx
+++ b/apps/mobile/app/(app)/my-posts.tsx
@@ -1,0 +1,130 @@
+import { useMemo } from 'react'
+import { ActivityIndicator, FlatList, Pressable, Text, View } from 'react-native'
+import type { FeedPost } from '../../src/api/types'
+import { useMyPosts } from '../../src/api/queries'
+import { EmptyState } from '../../src/components/ui/EmptyState'
+import { Screen } from '../../src/components/ui/Screen'
+import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
+import { useDisplayNames, useLocale, useT } from '../../src/i18n'
+import { dedupeById } from '../../src/lib/dedupeById'
+import { relativeTime } from '../../src/lib/format'
+import { listState } from '../../src/lib/listState'
+import { goBackTo, openPost } from '../../src/lib/navigation'
+import { makeStyles } from '../../src/lib/theme'
+
+/**
+ * Everything you have posted, newest first.
+ *
+ * A sentence you asked about used to be findable only by scrolling the feed
+ * until you met it again — which works for an hour and not for a week. The
+ * count on the profile had a screen behind it; the posts did not.
+ *
+ * Both sections in one list, because the split serves the person arriving to
+ * help, who wants one job at a time. You are not arriving to help: you
+ * remember asking, not which half of the screen you asked from.
+ *
+ * A compact row rather than the feed's card. The card carries a composer, a
+ * like button and a correction panel — all of them affordances for acting on
+ * *somebody else's* sentence, none of which belong on a list whose whole job is
+ * to get you back to your own. Tapping opens the post, where all of it is.
+ */
+export default function MyPostsScreen() {
+  const t = useT()
+  const styles = useStyles()
+  const page = useMyPosts()
+
+  const items = useMemo(
+    () => dedupeById(page.data?.pages.flatMap((p) => p.items) ?? []),
+    [page.data],
+  )
+  const state = listState({
+    isPending: page.isPending,
+    isError: page.isError,
+    itemCount: items.length,
+  })
+
+  return (
+    <Screen fluid>
+      <ScreenHeader title={t('myPosts.title')} onBack={() => goBackTo('/(app)/me')} />
+      {state === 'skeleton' ? (
+        <ActivityIndicator style={styles.loading} />
+      ) : state === 'empty' ? (
+        <EmptyState
+          icon="message-square"
+          title={t('myPosts.emptyTitle')}
+          body={t('myPosts.emptyBody')}
+        />
+      ) : (
+        <FlatList
+          data={items}
+          keyExtractor={(item) => String(item._id)}
+          onEndReached={() => {
+            if (page.hasNextPage && !page.isFetchingNextPage) void page.fetchNextPage()
+          }}
+          onEndReachedThreshold={0.4}
+          ListFooterComponent={
+            page.isFetchingNextPage ? <ActivityIndicator style={styles.loading} /> : null
+          }
+          renderItem={({ item }) => <Row post={item} styles={styles} />}
+        />
+      )}
+    </Screen>
+  )
+}
+
+function Row({ post, styles }: { post: FeedPost; styles: ReturnType<typeof useStyles> }) {
+  const t = useT()
+  const { locale } = useLocale()
+  const names = useDisplayNames()
+
+  /*
+   * Which number a row shows follows the post's own kind, not a screen-wide
+   * flag — this is the one list where the two sit next to each other, so the
+   * count and the word for it have to be read off the post.
+   */
+  const pronunciation = post.kind === 'pronunciation'
+  const replies = pronunciation ? post.answerCount : post.correctionCount
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={() => openPost(post._id, '/(app)/my-posts')}
+      style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+    >
+      <Text style={styles.body} numberOfLines={2}>
+        {post.body}
+      </Text>
+      <View style={styles.meta}>
+        <Text style={styles.kind}>
+          {t(pronunciation ? 'feed.pronunciationSection' : 'feed.correctionSection')}
+        </Text>
+        <Text style={styles.when}>· {names.language(post.language)}</Text>
+        <Text style={styles.when}>
+          ·{' '}
+          {replies > 0
+            ? t(pronunciation ? 'feed.answers' : 'feed.corrections', { count: replies })
+            : t(pronunciation ? 'feed.noAnswers' : 'feed.noCorrections')}
+        </Text>
+        <Text style={styles.when}>· {relativeTime(post.createdAt, { t, locale })}</Text>
+      </View>
+    </Pressable>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, spacing }) => ({
+  loading: { paddingVertical: spacing.lg },
+  row: {
+    borderBottomColor: colors.border,
+    borderBottomWidth: 1,
+    gap: 6,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: 14,
+  },
+  pressed: { opacity: 0.6 },
+  body: { ...font.body, color: colors.text, fontSize: 15, lineHeight: 22 },
+  // Wraps, because four facts and a long language name do not fit one line on
+  // a narrow phone — and truncating the middle of them tells the reader least.
+  meta: { alignItems: 'center', flexDirection: 'row', flexWrap: 'wrap', gap: 4 },
+  kind: { ...font.caption, color: colors.textMuted, fontWeight: '600' },
+  when: { ...font.caption, color: colors.textFaint },
+}))

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -102,6 +102,12 @@ export const keys = {
    * sites nothing while keeping the two sections' pages apart.
    */
   feed: (kind: string) => ['feed', kind] as const,
+  /*
+   * Under `feed` on purpose: writing or deleting a post already
+   * invalidates the whole `['feed']` prefix, so this list stays honest
+   * without a second invalidation to remember.
+   */
+  myPosts: () => ['feed', 'mine'] as const,
   postCorrections: (id: string) => ['postCorrections', id] as const,
   postComments: (id: string) => ['postComments', id] as const,
   postAnswers: (id: string) => ['postAnswers', id] as const,
@@ -647,6 +653,16 @@ export function useFeed(kind: PostKind) {
     getNextPageParam: (last) => last.nextCursor ?? undefined,
     // Same reason as `useDiscovery`: switching tab must not blank the list.
     placeholderData: keepPreviousData,
+  })
+}
+
+export function useMyPosts() {
+  return useInfiniteQuery({
+    queryKey: keys.myPosts(),
+    queryFn: ({ pageParam }) =>
+      api.get<FeedPage>(`/me/posts${pageParam ? `?cursor=${encodeURIComponent(pageParam)}` : ''}`),
+    initialPageParam: '',
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
   })
 }
 

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -445,6 +445,11 @@ export const ar: Localized<EnMessages> = {
     emptyTitle: 'لا تصحيحات بعد',
     emptyBody: 'اضغط مطولًا على رسالة واختر «صحّح» — أنفع ما يمكنك فعله هنا.',
   },
+  myPosts: {
+    title: 'المنشورات التي كتبتها',
+    emptyTitle: 'لم تسأل عن شيء بعد',
+    emptyBody: 'اسأل عن جملة لست متأكدًا منها، أو كلمة لا تستطيع نطقها — ستظهر هنا.',
+  },
   discover: {
     searchHandles: 'البحث باسم المستخدم',
     searchPlaceholder: 'اسم المستخدم',
@@ -859,6 +864,7 @@ export const ar: Localized<EnMessages> = {
     editProfile: 'تعديل الملف',
     settings: 'الإعدادات',
     corrections: 'التصحيحات',
+    myPosts: 'منشوراتك',
     wallet: 'المحفظة',
     previewProfile: 'معاينة ملفي الشخصي',
     previewProfileBody: 'شاهد ملفك كما يراه الآخرون',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -381,6 +381,12 @@ export const de: Localized<EnMessages> = {
     emptyBody:
       'Halte eine Nachricht gedrückt und wähle Korrigieren — das Nützlichste, was du hier tun kannst.',
   },
+  myPosts: {
+    title: 'Beiträge, die du geschrieben hast',
+    emptyTitle: 'Noch nichts gefragt',
+    emptyBody:
+      'Frag nach einem Satz, bei dem du unsicher bist, oder einem Wort, das du nicht aussprechen kannst — er erscheint hier.',
+  },
   discover: {
     searchHandles: 'Nach Benutzername suchen',
     searchPlaceholder: 'Benutzername',
@@ -716,6 +722,7 @@ export const de: Localized<EnMessages> = {
     editProfile: 'Profil bearbeiten',
     settings: 'Einstellungen',
     corrections: 'Korrekturen',
+    myPosts: 'Deine Beiträge',
     wallet: 'Geldbörse',
     previewProfile: 'Mein Profil ansehen',
     previewProfileBody: 'Sieh dein Profil so, wie andere es sehen',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -408,6 +408,12 @@ export const en = {
     emptyBody:
       'Hold a message in a chat and choose Correct — it is the most useful thing you can do here.',
   },
+  myPosts: {
+    title: 'Posts you wrote',
+    emptyTitle: 'Nothing asked yet',
+    emptyBody:
+      'Ask about a sentence you are unsure of, or a word you cannot say — it appears here.',
+  },
   discover: {
     searchHandles: 'Search by username',
     searchPlaceholder: 'Username',
@@ -736,6 +742,7 @@ export const en = {
     editProfile: 'Edit profile',
     settings: 'Settings',
     corrections: 'Corrections',
+    myPosts: 'Your posts',
     wallet: 'Wallet',
     previewProfile: 'Preview my profile',
     previewProfileBody: 'See your profile the way other people do',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -375,6 +375,12 @@ export const es: Localized<EnMessages> = {
     emptyTitle: 'Aún no hay correcciones',
     emptyBody: 'Mantén pulsado un mensaje y elige Corregir: es lo más útil que puedes hacer aquí.',
   },
+  myPosts: {
+    title: 'Publicaciones que escribiste',
+    emptyTitle: 'Todavía no has preguntado nada',
+    emptyBody:
+      'Pregunta por una frase que no tienes clara, o una palabra que no sabes decir — aparecerá aquí.',
+  },
   discover: {
     searchHandles: 'Buscar por nombre de usuario',
     searchPlaceholder: 'Nombre de usuario',
@@ -697,6 +703,7 @@ export const es: Localized<EnMessages> = {
     editProfile: 'Editar perfil',
     settings: 'Ajustes',
     corrections: 'Correcciones',
+    myPosts: 'Tus publicaciones',
     wallet: 'Cartera',
     previewProfile: 'Ver mi perfil',
     previewProfileBody: 'Mira tu perfil como lo ven los demás',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -378,6 +378,12 @@ export const fr: Localized<EnMessages> = {
     emptyTitle: 'Pas encore de corrections',
     emptyBody: 'Appuie longuement sur un message et choisis Corriger — c’est le plus utile ici.',
   },
+  myPosts: {
+    title: 'Publications que tu as écrites',
+    emptyTitle: 'Tu n’as encore rien demandé',
+    emptyBody:
+      'Pose une question sur une phrase dont tu n’es pas sûr, ou un mot que tu n’arrives pas à dire — elle apparaîtra ici.',
+  },
   discover: {
     searchHandles: 'Rechercher par nom d’utilisateur',
     searchPlaceholder: 'Nom d’utilisateur',
@@ -700,6 +706,7 @@ export const fr: Localized<EnMessages> = {
     editProfile: 'Modifier le profil',
     settings: 'Réglages',
     corrections: 'Corrections',
+    myPosts: 'Tes publications',
     wallet: 'Portefeuille',
     previewProfile: 'Aperçu de mon profil',
     previewProfileBody: 'Vois ton profil comme les autres le voient',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -372,6 +372,12 @@ export const ptBR: Localized<EnMessages> = {
     emptyBody:
       'Segure uma mensagem e escolha Corrigir — é a coisa mais útil que você pode fazer aqui.',
   },
+  myPosts: {
+    title: 'Publicações que você escreveu',
+    emptyTitle: 'Você ainda não perguntou nada',
+    emptyBody:
+      'Pergunte sobre uma frase da qual não tem certeza, ou uma palavra que não consegue dizer — ela aparece aqui.',
+  },
   discover: {
     searchHandles: 'Buscar por nome de usuário',
     searchPlaceholder: 'Nome de usuário',
@@ -691,6 +697,7 @@ export const ptBR: Localized<EnMessages> = {
     editProfile: 'Editar perfil',
     settings: 'Configurações',
     corrections: 'Correções',
+    myPosts: 'Suas publicações',
     wallet: 'Carteira',
     previewProfile: 'Ver meu perfil',
     previewProfileBody: 'Veja seu perfil como as outras pessoas veem',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -423,6 +423,12 @@ export const ru: Localized<EnMessages> = {
     emptyBody:
       'Задержи палец на сообщении и выбери «Исправить» — это самое полезное, что тут можно сделать.',
   },
+  myPosts: {
+    title: 'Твои публикации',
+    emptyTitle: 'Ты ещё ничего не спросил',
+    emptyBody:
+      'Спроси про предложение, в котором не уверен, или про слово, которое не можешь произнести — оно появится здесь.',
+  },
   discover: {
     searchHandles: 'Поиск по имени пользователя',
     searchPlaceholder: 'Имя пользователя',
@@ -812,6 +818,7 @@ export const ru: Localized<EnMessages> = {
     editProfile: 'Изменить профиль',
     settings: 'Настройки',
     corrections: 'Исправления',
+    myPosts: 'Твои публикации',
     wallet: 'Кошелёк',
     previewProfile: 'Посмотреть мой профиль',
     previewProfileBody: 'Взгляните на профиль глазами других',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -382,6 +382,11 @@ export const tr: Localized<EnMessages> = {
     emptyBody:
       'Bir sohbette mesaja basılı tut ve Düzelt’i seç — burada yapabileceğin en faydalı şey bu.',
   },
+  myPosts: {
+    title: 'Yazdığın gönderiler',
+    emptyTitle: 'Henüz bir şey sormadın',
+    emptyBody: 'Emin olmadığın bir cümleyi ya da söyleyemediğin bir kelimeyi sor — burada görünür.',
+  },
   discover: {
     searchHandles: 'Kullanıcı adıyla ara',
     searchPlaceholder: 'Kullanıcı adı',
@@ -707,6 +712,7 @@ export const tr: Localized<EnMessages> = {
     editProfile: 'Profili düzenle',
     settings: 'Ayarlar',
     corrections: 'Düzeltme',
+    myPosts: 'Gönderilerin',
     wallet: 'Cüzdan',
     previewProfile: 'Profilimi önizle',
     previewProfileBody: 'Profilini başkalarının gördüğü gibi gör',

--- a/packages/shared/src/feed.ts
+++ b/packages/shared/src/feed.ts
@@ -280,6 +280,20 @@ export const listFeedQuerySchema = z.object({
 })
 export type ListFeedQuery = z.infer<typeof listFeedQuerySchema>
 
+/**
+ * Your own posts, and deliberately without a `kind`.
+ *
+ * The feed is split into sections because a stranger arriving to help wants one
+ * job at a time. Looking for something you wrote yourself is the opposite
+ * errand — you remember asking, not which half of the screen you asked from —
+ * so this list mixes the two and sorts by when you wrote them.
+ */
+export const listMyPostsQuerySchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+})
+export type ListMyPostsQuery = z.infer<typeof listMyPostsQuerySchema>
+
 export const feedPageSchema = z.object({
   items: z.array(feedPostSchema),
   nextCursor: z.string().nullable(),


### PR DESCRIPTION
Asking the feed a question and finding it again were not the same problem, and only the first had been solved. A sentence you posted went into a queue sorted for the people arriving to help — fewest corrections first — so your own post drifted behind however many strangers had been answered since. There was **no screen, no route and no query** behind "where is the thing I asked", only scrolling until you met it.

### Two commits, on purpose

1. **`hydratePosts` extracted** from `listFeed` — behaviour unchanged, existing tests green. It is separate so the feature commit does not bury a refactor of the live feed's read path.
2. **The feature.**

### The read

`GET /me/posts` is a plain keyset over `{ authorId, createdAt }` — the `author` index the posts collection has carried all along and which until now only account deletion ever used. **No new index.**

A separate read rather than a filter on `listFeed`, because almost nothing they do is shared: no queue to drain, no section to choose, no audience to stitch two queries around, and no blocks — you cannot be hidden from yourself.

Deliberately **without a `kind`**. The feed splits corrections from pronunciation because a stranger with ten minutes wants one job at a time; somebody looking for their own sentence remembers asking, not which half of the screen they asked from. So the two sit together, newest first.

### The screen

A compact row rather than the feed's card. That card carries a composer, a like button and a correction panel — affordances for acting on *somebody else's* sentence, none of which belong on a list whose whole job is to get you back to your own. Tapping opens the post, where all of it already is.

Reached from a row on your own profile, above the viewers row. The query key sits under `feed`, so writing or deleting a post already invalidates it.

### Verified

`pnpm test`, `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` all green, plus 4 new route tests (both kinds mixed, isolation from other authors, paging across three pages, empty state).

Driven live in Expo web: the profile row opens the screen, both kinds appear newest-first with kind/language/reply-count/time, and tapping a row opens the right post.

That live pass caught something no test would have: adding `my-posts.tsx` put a **"my-posts" tab in the bottom tab bar**, because every full-screen route has to be registered in `_layout.tsx` with `FULL_SCREEN`. Fixed and re-verified — no tab, and no tab strip drawn under the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)