### PR TITLE
Count a recording as teaching, alongside written corrections

### DIFF
--- a/apps/api/src/modules/feed/pronunciation.ts
+++ b/apps/api/src/modules/feed/pronunciation.ts
@@ -153,9 +153,12 @@ function isDuplicate(error: unknown): boolean {
  * Paid at the same rate as a correction, under its own kind.
  *
  * The same rate because it is the same act in a different medium: somebody
- * spending their own time on a stranger's sentence. Its own kind because the
- * correction badges and cosmetic gates count corrections *written*, and folding
- * a different act into that number moves a threshold that names the other one.
+ * spending their own time on a stranger's sentence. Its own kind because
+ * `refId`, the token history and the daily pool all need to tell the two acts
+ * apart — not because the two are counted separately on a profile. They are
+ * not: `countCorrectionsWritten` reads this collection too, so a recording
+ * moves the correction tile, the badges and the cosmetic gates exactly as a
+ * written correction does.
  *
  * No `recordActivity`. The daily pool's weights are a published formula
  * mirrored on the website and in two GitBook pages, and adding a fourth term is

--- a/apps/api/src/modules/tokens/corrections.ts
+++ b/apps/api/src/modules/tokens/corrections.ts
@@ -2,7 +2,27 @@ import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 
 /**
- * How many corrections this user has ever written — in a thread or on a post.
+ * How much teaching this user has ever done: a correction in a thread, a
+ * correction on a post, or a recording left on a pronunciation request.
+ *
+ * The recordings were missing from this number for a long time, and the reason
+ * was real — they are paid under their own ledger kind so that a badge named
+ * after corrections keeps counting corrections. But the effect on the person
+ * was worse than the imprecision it avoided: somebody who mostly answers
+ * pronunciation requests spends exactly the same evening on exactly the same
+ * strangers, is paid exactly the same ten tokens for it, and had a profile
+ * saying they had helped nobody. Reading a sentence out loud for someone who
+ * cannot say it is teaching. The number says so now.
+ *
+ * The ledger keeps both kinds apart, which is still right — `refId`, the daily
+ * pool and every report need to tell the two acts apart. This is one number
+ * built from three sources, not a merge of the acts themselves.
+ *
+ * Note what this does *not* change: the daily pool. Answers do not call
+ * `recordActivity` (see `pronunciation.ts`), because the pool's weights are a
+ * published formula. So the lifetime number here counts recordings while the
+ * weekly chart beside it does not — deliberate, and the smaller of two wrongs
+ * until the pool is rebalanced on purpose.
  *
  * This used to count `correction` rows in the token ledger, which reads as the
  * same number and is not. `awardTokens` writes nothing at all when the amount
@@ -23,13 +43,17 @@ import { COLLECTIONS } from '../../db/collections'
  * not do.
  */
 export async function countCorrectionsWritten(db: Db, userId: string): Promise<number> {
-  const [posts, chat] = await Promise.all([
+  const [posts, chat, recordings] = await Promise.all([
     // `author_recent`. `post_author_unique` is `{postId, authorId}` — the wrong
     // prefix for "everything this person has corrected".
     db.collection(COLLECTIONS.postCorrections).countDocuments({ authorId: userId }),
     // `sender_type`. `sender_created` carries no `type`, so counting through it
     // would scan every message a heavy user ever sent.
     db.collection(COLLECTIONS.messages).countDocuments({ senderId: userId, type: 'correction' }),
+    // `author_recent` again, on the answers. One answer per person per request
+    // is enforced by `post_author_unique`, so this cannot double-count a
+    // request somebody recorded twice.
+    db.collection(COLLECTIONS.pronunciationAnswers).countDocuments({ authorId: userId }),
   ])
-  return posts + chat
+  return posts + chat + recordings
 }

--- a/apps/api/src/routes/feed.test.ts
+++ b/apps/api/src/routes/feed.test.ts
@@ -496,6 +496,47 @@ describe('community feed', () => {
     expect(paid).toBe(0)
   })
 
+  it('counts a recording as teaching, alongside written corrections', async () => {
+    // Reading a sentence out loud for somebody who cannot say it is the same
+    // act in a different medium, and it pays the same ten tokens. It used to
+    // leave the profile's number untouched, so an account that mostly answered
+    // pronunciation requests looked like it had never helped anyone.
+    const asker = await newUser('recording-asker@example.com')
+    const helper = await newUser('recording-helper@example.com')
+
+    const askId = (await ask(asker, 'squirrel')).json<{ _id: string }>()._id
+    expect((await answer(helper, askId)).statusCode).toBe(201)
+
+    const lifetime = async (user: SignedUpUser) => {
+      const summary = await app.inject({
+        method: 'GET',
+        url: '/me/tokens',
+        headers: { cookie: user.cookie },
+      })
+      expect(summary.statusCode).toBe(200)
+      return summary.json<{ lifetime: { corrections: number } }>().lifetime.corrections
+    }
+
+    expect(await lifetime(helper)).toBe(1)
+
+    // The two sources add up rather than replacing each other.
+    const postId = (await post(asker, 'I has been there.')).json<{ _id: string }>()._id
+    expect((await correct(helper, postId, 'I have been there.')).statusCode).toBe(201)
+    expect(await lifetime(helper)).toBe(2)
+
+    // Asking is not teaching. Only the person who recorded gets the number.
+    expect(await lifetime(asker)).toBe(0)
+
+    // Put the request back where it was found: the pronunciation section is
+    // small enough that another test asserts its exact contents.
+    const removed = await app.inject({
+      method: 'DELETE',
+      url: `/posts/${askId}`,
+      headers: { cookie: asker.cookie },
+    })
+    expect(removed.statusCode).toBe(204)
+  })
+
   it("pages a post's corrections oldest first, and carries the post", async () => {
     const author = await newUser('detail-author@example.com')
     const viewer = await newUser('detail-viewer@example.com')

--- a/packages/shared/src/token.ts
+++ b/packages/shared/src/token.ts
@@ -22,11 +22,14 @@ export const TOKEN_KINDS = [
   /**
    * A recorded answer to a pronunciation request.
    *
-   * Its own kind rather than `correction`, because the correction badges and
-   * the cosmetic gates count corrections written, and quietly folding a
-   * different act into that number moves a threshold that names the other one.
-   * It also earns its own line in the token history, which is the honest
-   * answer to "where did these come from".
+   * Its own kind rather than `correction`, because `refId` uniqueness, the
+   * daily pool and every report need the two acts distinguishable. It also
+   * earns its own line in the token history, which is the honest answer to
+   * "where did these come from".
+   *
+   * A separate kind, not a lesser one: the profile's correction count and the
+   * badges above it read recordings and written corrections together. See
+   * `countCorrectionsWritten`.
    */
   'pronunciation',
   'streak',


### PR DESCRIPTION
Answering a pronunciation request wrote to `pronunciationAnswers` and nowhere else a person can see. It pays the same ten tokens as a correction, for the same reason — somebody spending their evening on a stranger's sentence — but the profile's number, the correction badges and the cosmetic gates all read two collections and never that one. An account that mostly recorded answers had a token balance saying it had helped and a profile saying it had not.

### The tradeoff, stated plainly

The reason for the split was real, and written down in two places: the badges are named after corrections, so folding another act into that number moves a threshold that names the other one. Weighed against telling someone their teaching does not count, that is the smaller concern. Both comments are updated rather than left contradicting the code.

The ledger keeps the two kinds apart, which is still right — `refId`, the token history and every report need to tell the acts apart. This is one number built from three sources, not a merge of the acts themselves.

### Scope

- **No migration.** The count is computed on read, never stored.
- **No new index.** `pronunciationAnswers` already has `author_recent`.
- **The daily pool is untouched.** Answers still do not call `recordActivity`, because the pool's weights are a published formula mirrored on the site and in GitBook; adding a term is a rebalance, not a fix.

That last one has a visible consequence and it is deliberate: the lifetime number counts recordings while the weekly chart beside it does not. Stated in the comment rather than left to be found. Happy to revisit as its own change.

Badge and cosmetic thresholds shift retroactively for accounts that have recorded answers. Confirmed as acceptable — v2 is not live yet.

Docs updated in a matching PR on `langx/docs` (`docs/token/utility.md` described the Aurora gate as "corrections").

### Verified

`pnpm test`, `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` all green, plus a new route test. That test was checked against the unfixed counter first and fails there, so it measures the change rather than passing by accident.

Driven live: an account that had only ever recorded an answer showed **Corrections: 1** on its profile, and its weekly line still read "0 corrections" — the intended divergence above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)