### PR TITLE
Put the Chats search back beside the star, and stop the swipe actions showing through

### DIFF
--- a/apps/mobile/app/(app)/chats.tsx
+++ b/apps/mobile/app/(app)/chats.tsx
@@ -288,13 +288,22 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   filters: { paddingBottom: spacing.sm, paddingTop: spacing.md },
   // `zIndex` for the same reason Discover's copy of this row carries one:
   // the search results float, and a later sibling would paint over them.
+  //
+  // No `justifyContent`: the title's `flex: 1` is what holds the actions on the
+  // trailing edge. `space-between` was right while this row was the title and
+  // the star, and became wrong the moment search was dropped between them —
+  // with three content-sized children it splits the slack into both gaps and
+  // leaves the magnifier stranded in the middle of the row. `ScreenHeader` and
+  // `me.tsx` both pin their actions with a flexible middle instead; this is
+  // that. Discover's `marginStart: 'auto'` does the same job, but only while
+  // the element carrying it is rendered.
   titleRow: {
     alignItems: 'center',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    gap: spacing.md,
     zIndex: 2,
   },
-  title: { ...font.title, color: colors.text, fontSize: 34, paddingTop: spacing.md },
+  title: { ...font.title, color: colors.text, flex: 1, fontSize: 34, paddingTop: spacing.md },
   list: { paddingBottom: spacing.xxl, paddingTop: spacing.sm },
   footer: { paddingVertical: spacing.lg },
   row: {

--- a/apps/mobile/src/components/SwipeableRow.tsx
+++ b/apps/mobile/src/components/SwipeableRow.tsx
@@ -101,7 +101,16 @@ export function SwipeableRow({ right, left, children }: SwipeableRowProps) {
         <Action action={right} align="flex-start" styles={styles} />
         <Action action={left} align="flex-end" styles={styles} />
       </View>
-      <Animated.View style={{ transform: [{ translateX }] }} {...pan.panHandlers}>
+      {/*
+        Opaque, and that is not decoration. `behind` is a child of `wrap`, so it
+        paints over `wrap`'s background — the only one in the stack, since the
+        chat row itself sets none. Without a background of its own this layer is
+        glass, and the archive icon sits visible on every row at rest with the
+        timestamp printed on top of it. It has to be the layer that moves: a
+        background on `wrap` cannot travel with the row and would only mask the
+        actions the swipe is meant to reveal.
+      */}
+      <Animated.View style={[styles.moving, { transform: [{ translateX }] }]} {...pan.panHandlers}>
         {children}
       </Animated.View>
     </View>
@@ -129,6 +138,7 @@ function Action({
 
 const useStyles = makeStyles(({ colors, font, spacing }) => ({
   wrap: { backgroundColor: colors.bg, overflow: 'hidden' },
+  moving: { backgroundColor: colors.bg },
   behind: {
     ...({ position: 'absolute' } as const),
     alignItems: 'center',


### PR DESCRIPTION
Two layout defects on the Chats tab, both reported from a real iPhone and both invisible in the desktop-web dev loop.

## The search button sat in the middle of the header

`titleRow` was `justifyContent: 'space-between'` with three content-sized children and no flexible one, so the leftover width was split equally into both gaps: title hard-left, star hard-right, magnifier at the arithmetic midpoint.

That layout was correct while the row was the title and the star. `821cbcb5` made it three children by dropping `PeopleSearch` between them, and `0a2c3efd` moved Discover's copy of the row onto the newer idiom without bringing Chats along.

Fixed the way the rest of the app already does it — a flexible middle (`ScreenHeader`'s `title: { flex: 1 }`, `me.tsx`'s `heroText`) rather than Discover's `marginStart: 'auto'`, which only works while the element carrying it is rendered.

## Every row showed its archive action at rest

`SwipeableRow`'s moving layer had no background. `behind` is a child of `wrap`, so it paints over `wrap`'s `colors.bg` — the only background in the stack, since `chats.tsx`'s `row` sets none — leaving the row content as glass over the actions. The archive icon and label were visible on every row at all times, with the relative timestamp drawn on top of them, and the unread badge landing on the word "Archive".

The background has to go on the layer that moves: one on `wrap` cannot travel with the row and would only mask the actions the swipe exists to reveal.

## Why the browser could not show either

`rowSwipeEnabled` renders no action layer at all without a touchscreen, so the second defect cannot appear on desktop web. And inside `Screen`'s 720px web column, three spread-out header children read as deliberate rather than stranded.

## Verified

Screenshotted on a 390×844 touch-enabled viewport against a throwaway in-memory stack with seeded conversations: magnifier and star now sit together at the trailing edge, rows are clean, timestamps unobstructed. Note the action labels remain in the DOM (and so in `innerText`) — they are behind an opaque layer now, which is the point; this has to be checked visually, not by asserting on text.

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and `pnpm test` (1313 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)