### PR TITLE
Give the store privacy forms a box-by-box page, and tick a done prerequisite

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -395,11 +395,12 @@ of it runs together.
       so it gates the iOS release rather than merely improving it. Until both
       are set the sign-in screen simply does not draw the buttons
 - [x] `ascAppId` (6474187141) and `appleTeamId` (8F63M4JH8P) in `eas.json`
-- [ ] `EXPO_PUBLIC_API_URL` set on the `preview` and `production` build
-      profiles in `eas.json`. Only `development` sets it today, and only to
-      localhost — which a development build rewrites to the dev server's
-      address at runtime, but a released build has no dev server and would
-      ship pointing at the phone itself
+- [x] `EXPO_PUBLIC_API_URL` set on the `preview` and `production` build
+      profiles in `eas.json` — both point at `https://api2.langx.io`.
+      `development` still points at localhost, which a development build
+      rewrites to the dev server's address at runtime; a released build has no
+      dev server and would ship pointing at the phone itself, which is what
+      this item existed to prevent
 - [ ] `EXPO_PUBLIC_REVENUECAT_*` keys set, `react-native-purchases` wired into
       the paywall screen (which today states the offer and says purchase is not
       yet enabled — deliberately, rather than shipping a button that cannot work)
@@ -484,7 +485,10 @@ image configured for 16 KB before the rollout widens past 10%.
 
 Nearby (Polyglot) added the app's first location permission, so two answers that
 were "no" are now "yes", and a store form that still says otherwise is a false
-declaration rather than a stale one:
+declaration rather than a stale one. The box-by-box version of everything below,
+including two answers that are already live and wrong, is
+[`store/privacy-forms-checklist.md`](store/privacy-forms-checklist.md) — open it
+next to the Console rather than working from this section:
 
 - [ ] Play Data Safety → **Location → Approximate location**: collected, not
       shared, optional, purpose "App functionality". **Precise location stays

--- a/docs/store/privacy-forms-checklist.md
+++ b/docs/store/privacy-forms-checklist.md
@@ -1,0 +1,100 @@
+# Store privacy forms — what to select, field by field
+
+A transcription target, not an explanation: open Play Console and App Store
+Connect next to this page and copy the answers across. The reasoning for every
+answer is in [`privacy-data-safety.md`](privacy-data-safety.md); this file only
+says which box to tick. If the two disagree, `privacy-data-safety.md` is the
+source and this page is stale.
+
+Three things need to change in the same sitting. Two of them are corrections to
+answers that are already live and wrong; the third is the new location
+permission.
+
+## 1. Play Data Safety — corrections to what is live today
+
+Read off the published Data safety page on 31 August 2026 and compared against
+HelloTalk, Tandem and Hilokal.
+
+- [ ] **Personal info → Race and ethnicity: uncheck.** Nothing in the app asks
+      for it and nothing stores it — the profile holds gender, date of birth,
+      country, city and languages. None of the three comparable apps declares
+      it. Declaring data we do not collect is as wrong as omitting data we do.
+- [ ] **Security practices → "You can request that data be deleted": check.**
+      It is implemented — Settings → "Hesabımı sil" hides the account
+      immediately and purges it after 30 days, photos included. LangX is
+      currently the only one of the four without this line, and the line is
+      true.
+
+## 2. Play Data Safety — the new location answers
+
+Nearby (Polyglot) added the app's first location permission, so two answers
+that were "no" are now "yes".
+
+- [ ] **Location → Approximate location: collected.**
+  - Shared with third parties: **no**
+  - Required or optional: **optional** — the user turns it on in Settings or
+    from the Nearby tab's prompt; nothing writes it at sign-up or in the
+    background
+  - Purpose: **App functionality** (only)
+  - Processed ephemerally: **no** — it is stored on the profile until the user
+    turns it off
+- [ ] **Location → Precise location: leave unchecked.** The client asks the OS
+      for `Accuracy.Lowest` and the server rounds to two decimals (~1 km)
+      before storing, so no precise value is ever written.
+- [ ] Everything else on the form stays as it is. In particular **no analytics
+      row** — there is no PostHog SDK in the app and no opt-out control, so
+      declaring "App activity" would describe a system that does not exist.
+
+## 3. Apple App Privacy — the same change
+
+- [ ] **Location → Coarse Location: collected.**
+  - Linked to the user: **yes**
+  - Used for tracking: **no**
+  - Purpose: **App Functionality** (only)
+- [ ] **Location → Precise Location: leave unchecked.**
+- [ ] **Tracking: stays "no".** No IDFA, no ad SDK, no data broker, nothing
+      linked to other companies' data for advertising.
+
+## 4. The privacy policy has to say it too
+
+A form answer with no matching sentence in the policy is a finding waiting to
+happen. Four points, in plain words, source text in
+[`privacy-data-safety.md`](privacy-data-safety.md) → _Location_:
+
+- [ ] It is **optional** and off until turned on, and the permission is
+      **when-in-use only** — there is no background location.
+- [ ] What is stored is **rounded to about a kilometre before it is written**,
+      not at display time; the precise reading is never persisted anywhere.
+- [ ] **No one is shown a position** — other users see only a bucketed distance
+      ("under 5 km away") on the Nearby list.
+- [ ] **Turning it off deletes it**, which also removes the profile from
+      everyone else's Nearby results. No retention period to declare.
+
+## Reference — the rest of the Play form
+
+Unchanged by this pass; listed so a full re-verification does not need a second
+document. Every row is "collected, not shared".
+
+| Play category                                 | Ours                                                               |
+| --------------------------------------------- | ------------------------------------------------------------------ |
+| Personal info → Name, Email address           | display name, handle, sign-in email — required                     |
+| Personal info → User IDs                      | account id                                                         |
+| Personal info → Other info                    | date of birth (18+ gate; only the age is shown), gender, bio, city |
+| Location → Approximate location               | optional, see above                                                |
+| Photos and videos → Photos                    | avatar and gallery — optional                                      |
+| Messages → Other in-app messages              | chat bodies                                                        |
+| App info and performance                      | nothing                                                            |
+| Financial info                                | nothing — purchase state only, never a card number                 |
+| Contacts, Calendar, Health, Microphone, Ad ID | nothing                                                            |
+
+Target audience: **18+**, enforced server-side at profile creation. Do not
+declare a Families audience — it contradicts the age gate and changes which
+SDKs are permitted.
+
+> **City is collected, and that is all the form asks.** `privacy-data-safety.md`
+> describes it as "shown on profile", which is not true today — nothing renders
+> `profiles.city` — and there is an approved plan to derive it from location and
+> put it behind a privacy toggle. Neither the current gap nor the planned change
+> alters any answer above: the form asks what is _collected_, and it is, as an
+> optional field. Revisit this note if that work lands, since deriving city from
+> location would make it a second consumer of the location permission.


### PR DESCRIPTION
## Why

Two things were queued off the App Store / Play Store readiness pass.

`release-runbook.md` explains what the Nearby location permission means for the
two store privacy forms, but explaining is the wrong shape for the job — the
work is transcribing answers into two consoles, one checkbox at a time.

## What

**New: `docs/store/privacy-forms-checklist.md`.** A transcription target, not an
explanation: Play Data Safety and Apple App Privacy, field by field, with
`privacy-data-safety.md` left as the source for every "why". It covers

- two answers that are **already published and wrong** — "Race and ethnicity" is
  declared under Personal info although nothing in the app collects it, and "You
  can request that data be deleted" is missing although account deletion ships
  and works
- the new location answers on both forms (approximate/coarse: collected,
  optional, App Functionality; precise stays unchecked, since the client asks for
  `Accuracy.Lowest` and the server rounds to ~1 km before storing)
- the four points the privacy policy has to state in plain words
- a reference table for the rest of the Play form, so a full re-verification does
  not need a second document

City is listed as collected, with a note that `privacy-data-safety.md`'s "shown
on profile" does not match the app today and that deriving it from location is
still only a plan. The form asks what is *collected*, so neither value belongs
baked in.

**Ticked: the `EXPO_PUBLIC_API_URL` prerequisite.** `eas.json` has pointed both
`preview` and `production` at `https://api2.langx.io` for a while; left unticked
the item reads as an open release blocker.

## Notes

Docs only — no code, no behaviour change. Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)