### PR TITLE
Open a chat row's actions, and let one of them be delete

### DIFF
--- a/apps/api/src/modules/chat/conversations.ts
+++ b/apps/api/src/modules/chat/conversations.ts
@@ -31,6 +31,15 @@ export interface Conversation {
    */
   pinnedBy?: Record<string, true>
   archivedBy?: Record<string, true>
+  /**
+   * "I deleted this chat." A map for the same reason the two above are, and
+   * per-user because a thread is half of somebody else's: their copy, and
+   * every message in it, is untouched.
+   *
+   * Cleared when the next message arrives, so the thread comes back — empty on
+   * this side, because the messages it used to hold are in their `hiddenFor`.
+   */
+  deletedBy?: Record<string, true>
   /** One per conversation, replaced rather than appended — see `MAX_PINNED_PER_CONVERSATION`. */
   pinned?: { messageId: ObjectId; byUserId: string; at: Date }
   firstMessageBy: string

--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -101,6 +101,17 @@ async function recordMessage(
       // Riding the write that was already happening. The media gate reads this
       // and must not pay for a `countDocuments` on the send path.
       $inc: { messageCount: 1, ...(recipientId ? { [`unread.${recipientId}`]: 1 } : {}) },
+      /*
+       * A new message brings a deleted thread back, on both sides. Deleting is
+       * "I am done with this conversation", not "block me from it" — the other
+       * person knows nothing about it and writing again has to reach somebody.
+       *
+       * It comes back empty for whoever deleted it: the messages it used to
+       * hold carry their id in `hiddenFor`, and only the new one does not.
+       * Unconditional because `$unset` on an absent key is free, which is
+       * cheaper than reading the document to decide.
+       */
+      $unset: Object.fromEntries(conversation.participants.map((id) => [`deletedBy.${id}`, ''])),
     },
     { returnDocument: 'after' },
   )
@@ -563,6 +574,10 @@ export async function listConversations(
   const archivedPath = `archivedBy.${userId}`
   if (filter === 'archived') base[archivedPath] = true
   else base[archivedPath] = { $ne: true }
+
+  // Deleted threads are gone from every tab, archive included — `$ne: true`
+  // for the same reason as above, since coming back leaves the key unset.
+  base[`deletedBy.${userId}`] = { $ne: true }
 
   // "They spoke last." See `toConversationView` for why this is not `unread`.
   if (filter === 'unreplied') base['lastMessage.senderId'] = { $ne: userId }

--- a/apps/api/src/modules/chat/mutations.ts
+++ b/apps/api/src/modules/chat/mutations.ts
@@ -422,6 +422,66 @@ export async function listStarredMessages(
  * then un-archived" are the same document and the list's `$ne: true` reads
  * both the same way.
  */
+/**
+ * "Delete for me": the thread leaves this reader's list and its messages stop
+ * being shown to them. The other side is untouched — their copy of the thread,
+ * and every message in it, is exactly as it was.
+ *
+ * The same mechanism message-level "delete for me" already uses, applied to
+ * every message at once. Nothing is removed: a message is half of somebody
+ * else's conversation, so it is projected away rather than deleted.
+ *
+ * Writing to every message is unbounded work in principle. It is bounded in
+ * practice by `MAX_MESSAGES_PER_DELETE`, and a thread longer than that leaves
+ * its oldest messages visible — which is the failure that shows itself, rather
+ * than a request that times out halfway and leaves no way to tell how far it
+ * got. The caller can simply delete again.
+ */
+/**
+ * How many messages one delete will hide. Generous enough that no ordinary
+ * thread reaches it, small enough that the write cannot run long.
+ */
+const MAX_MESSAGES_PER_DELETE = 5000
+
+export async function deleteConversationForUser(
+  db: Db,
+  conversationId: string,
+  userId: string,
+): Promise<void> {
+  let _id: ObjectId
+  try {
+    _id = new ObjectId(conversationId)
+  } catch {
+    throw new ApiError(ERROR_CODES.NOT_FOUND, 'Conversation not found')
+  }
+  await assertConversationAccess(db, conversationId, userId)
+
+  const messages = db.collection<Message>(COLLECTIONS.messages)
+  const stale = await messages
+    .find({ conversationId: _id, hiddenFor: { $ne: userId } }, { projection: { _id: 1 } })
+    .limit(MAX_MESSAGES_PER_DELETE)
+    .toArray()
+  if (stale.length > 0) {
+    await messages.updateMany(
+      { _id: { $in: stale.map((row) => row._id) } },
+      { $addToSet: { hiddenFor: userId } },
+    )
+  }
+
+  /*
+   * The thread flag last. If the message pass fails halfway the thread is
+   * still listed, which is recoverable by deleting again; the other order
+   * would hide a thread whose messages are still there and give no way back
+   * to it.
+   */
+  const updated = await db
+    .collection<Conversation>(COLLECTIONS.conversations)
+    .updateOne({ _id }, { $set: { [`deletedBy.${userId}`]: true } })
+  if (updated.matchedCount === 0) {
+    throw new ApiError(ERROR_CODES.NOT_FOUND, 'Conversation not found')
+  }
+}
+
 export async function setConversationFlag(
   db: Db,
   conversationId: string,

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -1414,4 +1414,122 @@ describe('Faz 5 — conversation/message history REST', () => {
       ).rejects.toMatchObject({ code: 'VALIDATION_FAILED' })
     })
   })
+
+  describe('deleting a conversation', () => {
+    async function twoWay(prefix: string) {
+      const a = await newUser(`${prefix}-a@example.com`)
+      const b = await newUser(`${prefix}-b@example.com`)
+      const { _id: conversationId } = await startConversation(a, b.userId, 'from a')
+      const { sendTextMessage } = await import('../modules/chat/messages')
+      await sendTextMessage(handle.db, b.userId, { conversationId, body: 'from b' })
+      return { a, b, conversationId }
+    }
+
+    async function listFor(user: SignedUpUser, filter = 'all') {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/conversations?filter=${filter}`,
+        headers: { cookie: user.cookie },
+      })
+      expect(response.statusCode).toBe(200)
+      return response.json<{ items: { _id: string }[] }>().items
+    }
+
+    /**
+     * Hidden rows come back flagged rather than missing — `listMessages` says
+     * why, and `messageCache` is what drops them on the client — so "gone for
+     * me" is asserted on the flag.
+     */
+    async function messagesFor(user: SignedUpUser, conversationId: string) {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/conversations/${conversationId}/messages`,
+        headers: { cookie: user.cookie },
+      })
+      expect(response.statusCode).toBe(200)
+      return response.json<{ items: { body: string; hidden?: boolean }[] }>().items
+    }
+
+    const visible = (items: { body: string; hidden?: boolean }[]) =>
+      items.filter((row) => !row.hidden).map((row) => row.body)
+
+    it('takes the thread off my list and leaves theirs alone', async () => {
+      const { a, b, conversationId } = await twoWay('del-basic')
+
+      const deleted = await app.inject({
+        method: 'DELETE',
+        url: `/conversations/${conversationId}`,
+        headers: { cookie: a.cookie },
+      })
+      expect(deleted.statusCode).toBe(204)
+
+      expect(await listFor(a)).toHaveLength(0)
+      expect((await listFor(b)).map((row) => row._id)).toEqual([conversationId])
+      // Their copy is untouched — both messages, neither hidden.
+      expect(visible(await messagesFor(b, conversationId))).toEqual(['from a', 'from b'])
+    })
+
+    /** Gone means gone: the archive tab is not a hiding place for it either. */
+    it('is gone from the archive tab as well', async () => {
+      const { a, conversationId } = await twoWay('del-archived')
+      await app.inject({
+        method: 'PATCH',
+        url: `/conversations/${conversationId}/flags`,
+        headers: { cookie: a.cookie },
+        payload: { archived: true },
+      })
+      await app.inject({
+        method: 'DELETE',
+        url: `/conversations/${conversationId}`,
+        headers: { cookie: a.cookie },
+      })
+      expect(await listFor(a, 'archived')).toHaveLength(0)
+    })
+
+    /**
+     * The whole point of "for me": writing again has to reach somebody, so the
+     * thread comes back — carrying only what was said after the delete.
+     */
+    it('comes back empty when they write again', async () => {
+      const { a, b, conversationId } = await twoWay('del-revived')
+      await app.inject({
+        method: 'DELETE',
+        url: `/conversations/${conversationId}`,
+        headers: { cookie: a.cookie },
+      })
+
+      const { sendTextMessage } = await import('../modules/chat/messages')
+      await sendTextMessage(handle.db, b.userId, { conversationId, body: 'still there?' })
+
+      expect((await listFor(a)).map((row) => row._id)).toEqual([conversationId])
+      expect(visible(await messagesFor(a, conversationId))).toEqual(['still there?'])
+      // And nothing was taken from them.
+      expect(visible(await messagesFor(b, conversationId))).toEqual([
+        'from a',
+        'from b',
+        'still there?',
+      ])
+    })
+
+    it('refuses a conversation that is not mine', async () => {
+      const { conversationId } = await twoWay('del-outsider')
+      const outsider = await newUser('del-outsider-c@example.com')
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/conversations/${conversationId}`,
+        headers: { cookie: outsider.cookie },
+      })
+      expect(response.statusCode).toBe(404)
+    })
+
+    it('is a 404 for an id that is not one', async () => {
+      const a = await newUser('del-badid-a@example.com')
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/conversations/not-an-object-id',
+        headers: { cookie: a.cookie },
+      })
+      expect(response.statusCode).toBe(404)
+    })
+  })
 })

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -18,7 +18,11 @@ import {
 } from '../modules/chat/messages'
 import { toMessageView } from '../modules/chat/messageView'
 import { listCorrectionsWritten } from '../modules/chat/corrections'
-import { listStarredMessages, setConversationFlag } from '../modules/chat/mutations'
+import {
+  deleteConversationForUser,
+  listStarredMessages,
+  setConversationFlag,
+} from '../modules/chat/mutations'
 
 // eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
 export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
@@ -59,6 +63,24 @@ export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
       }
       if (!view) throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Nothing to change')
       return reply.send(view)
+    },
+  )
+
+  /*
+   * Its own route rather than a third flag: pinning and archiving are two
+   * states of a row that can be set either way, and this is neither. Nothing
+   * comes back — the thread is gone from every list, so there is no view left
+   * to return.
+   */
+  app.delete(
+    '/conversations/:id',
+    {
+      preHandler: requireAuth,
+      schema: { params: z.object({ id: z.string().trim().min(1) }) },
+    },
+    async (request, reply) => {
+      await deleteConversationForUser(app.mongo.db, request.params.id, request.userId)
+      return reply.code(204).send()
     },
   )
 

--- a/apps/mobile/app/(app)/chats.tsx
+++ b/apps/mobile/app/(app)/chats.tsx
@@ -11,7 +11,12 @@ import {
   Text,
   View,
 } from 'react-native'
-import { useConversationFlags, useConversations, useMe } from '../../src/api/queries'
+import {
+  useDeleteConversation,
+  useConversationFlags,
+  useConversations,
+  useMe,
+} from '../../src/api/queries'
 import { PeopleSearch } from '../../src/components/PeopleSearch'
 import { SwipeableRow } from '../../src/components/SwipeableRow'
 import { ConversationRowSkeleton } from '../../src/components/skeletons/ConversationRowSkeleton'
@@ -21,7 +26,8 @@ import { Screen } from '../../src/components/ui/Screen'
 import { SegmentedControl } from '../../src/components/ui/SegmentedControl'
 import { Skeleton } from '../../src/components/ui/Skeleton'
 import { useProfileCache } from '../../src/hooks/useProfileCache'
-import { chooseAlert } from '../../src/lib/alert'
+import { chooseAlert, confirmAlert, showAlert } from '../../src/lib/alert'
+import { showToast } from '../../src/lib/toast'
 import { dedupeById } from '../../src/lib/dedupeById'
 import { listState } from '../../src/lib/listState'
 import { makeStyles, useTheme } from '../../src/lib/theme'
@@ -52,6 +58,30 @@ export default function ChatsScreen() {
   const [searching, setSearching] = useState(false)
   const conversations = useConversations(filter)
   const flags = useConversationFlags()
+  const removeConversation = useDeleteConversation()
+  /** One row at a time: two open drawers is two sets of buttons and no way to tell them apart. */
+  const [openRow, setOpenRow] = useState<string | null>(null)
+
+  /**
+   * Confirmed, and destructive, because it cannot be undone from here — unlike
+   * archiving, which has a tab of its own to come back from. `profile`'s note
+   * on unfollow states the rule this follows.
+   */
+  async function confirmDelete(conversationId: string): Promise<void> {
+    const yes = await confirmAlert({
+      title: t('chats.deleteTitle'),
+      message: t('chats.deleteBody'),
+      confirmLabel: t('chats.delete'),
+      destructive: true,
+    })
+    if (!yes) return
+    removeConversation.mutate(conversationId, {
+      onSuccess: () => showToast(t('chats.deleted')),
+      // Said out loud: somebody who confirmed a destructive action and saw
+      // nothing has every reason to think it worked.
+      onError: () => void showAlert(t('chats.deleteTitle'), t('common.retry')),
+    })
+  }
 
   /*
    * Pinned first, then the rest. The server returns them as two lists because
@@ -182,24 +212,57 @@ export default function ChatsScreen() {
             const unread = item.unread
             const mine = item.lastMessage.senderId === me.data?._id
 
+            const pin = {
+              id: 'pin',
+              icon: item.pinned ? ('chevrons-down' as const) : ('chevrons-up' as const),
+              label: item.pinned ? t('chats.unpin') : t('chats.pin'),
+              colour: colors.accent,
+              onAction: () => {
+                setOpenRow(null)
+                flags.mutate({ conversationId: item._id, pinned: !item.pinned })
+              },
+            }
+            const archive = {
+              id: 'archive',
+              icon: item.archived ? ('inbox' as const) : ('archive' as const),
+              label: item.archived ? t('chats.unarchive') : t('chats.archive'),
+              colour: colors.textMuted,
+              onAction: () => {
+                setOpenRow(null)
+                flags.mutate({ conversationId: item._id, archived: !item.archived })
+              },
+            }
+            const remove = {
+              id: 'delete',
+              icon: 'trash-2' as const,
+              label: t('chats.delete'),
+              colour: colors.danger,
+              destructive: true,
+              onAction: () => {
+                setOpenRow(null)
+                void confirmDelete(item._id)
+              },
+            }
+
             return (
               <SwipeableRow
-                right={{
-                  icon: item.pinned ? 'chevrons-down' : 'chevrons-up',
-                  label: item.pinned ? t('chats.unpin') : t('chats.pin'),
-                  colour: colors.accent,
-                  onAction: () => flags.mutate({ conversationId: item._id, pinned: !item.pinned }),
-                }}
-                left={{
-                  icon: item.archived ? 'inbox' : 'archive',
-                  label: item.archived ? t('chats.unarchive') : t('chats.archive'),
-                  colour: colors.textMuted,
-                  onAction: () =>
-                    flags.mutate({ conversationId: item._id, archived: !item.archived }),
-                }}
+                // Delete is last, so it is the furthest thing from a thumb that
+                // opened the drawer meaning to archive.
+                right={[pin]}
+                left={[archive, remove]}
+                open={openRow === item._id}
+                onOpenChange={(open) => setOpenRow(open ? item._id : null)}
               >
                 <Pressable
-                  onPress={() => router.push(`/(app)/chat/${item._id}`)}
+                  /*
+                   * An open row closes rather than opening the thread. Tapping
+                   * the part of a row that is holding its own buttons open
+                   * means "never mind", and navigating away from a drawer that
+                   * was never closed leaves it open behind you.
+                   */
+                  onPress={() =>
+                    openRow === item._id ? setOpenRow(null) : router.push(`/(app)/chat/${item._id}`)
+                  }
                   /*
                   Long press rather than a swipe. `react-native-gesture-handler`
                   is deliberately absent from this package, and the app already
@@ -218,6 +281,10 @@ export default function ChatsScreen() {
                         label: item.archived ? t('chats.unarchive') : t('chats.archive'),
                         value: 'archive',
                       },
+                      // Also here, and not only behind the swipe: on a desktop
+                      // browser the gesture is not offered at all, so this menu
+                      // is the only way to reach any of them.
+                      { label: t('chats.delete'), value: 'delete' },
                     ]).then((choice) => {
                       if (choice === 'pin') {
                         flags.mutate({ conversationId: item._id, pinned: !item.pinned })
@@ -225,6 +292,7 @@ export default function ChatsScreen() {
                       if (choice === 'archive') {
                         flags.mutate({ conversationId: item._id, archived: !item.archived })
                       }
+                      if (choice === 'delete') void confirmDelete(item._id)
                     })
                   }}
                   style={({ pressed }) => [

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -625,6 +625,24 @@ export function useHandleSearch(term: string) {
  * the ones not on screen. Patching one and leaving the others is how the
  * archive tab ends up showing a thread the list already un-archived.
  */
+/**
+ * Deletes a conversation for the reader only.
+ *
+ * Unlike `useConversationFlags` below, a failure here is surfaced. Pinning
+ * silently is survivable — the row simply does not move — but somebody who
+ * confirmed a destructive action and was shown nothing has every reason to
+ * believe it worked.
+ */
+export function useDeleteConversation() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (conversationId: string) => api.delete<void>(`/conversations/${conversationId}`),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ['conversations'] })
+    },
+  })
+}
+
 export function useConversationFlags() {
   const client = useQueryClient()
   return useMutation({

--- a/apps/mobile/src/components/SwipeableRow.tsx
+++ b/apps/mobile/src/components/SwipeableRow.tsx
@@ -1,11 +1,21 @@
 import Feather from '@expo/vector-icons/Feather'
-import { useRef, type ReactNode } from 'react'
-import { Animated, PanResponder, Platform, Text, View } from 'react-native'
+import { useEffect, useRef, type ReactNode } from 'react'
+import {
+  Animated,
+  PanResponder,
+  Platform,
+  Pressable,
+  Text,
+  View,
+  type AccessibilityActionEvent,
+} from 'react-native'
 import { makeStyles } from '../lib/theme'
 import {
-  rowReleased,
+  ACTION_WIDTH_PX,
+  drawerWidth,
   rowSwipeEnabled,
   rowTranslation,
+  settleOffset,
   shouldCaptureRowSwipe,
 } from '../lib/swipeAction'
 
@@ -17,28 +27,37 @@ const HAS_TOUCH =
   Platform.OS !== 'web' || (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0)
 
 export interface SwipeableRowAction {
+  /** Also the accessibility action name, so it has to be stable and unique in the row. */
+  id: string
   icon: keyof typeof Feather.glyphMap
   label: string
   colour: string
+  /** Reads red, and is placed last so it is the furthest from a careless thumb. */
+  destructive?: boolean
   onAction: () => void
 }
 
 interface SwipeableRowProps {
-  /** Revealed by swiping right. */
-  right: SwipeableRowAction
-  /** Revealed by swiping left. */
-  left: SwipeableRowAction
+  /** Revealed by pulling the row to the right. */
+  right: SwipeableRowAction[]
+  /** Revealed by pulling the row to the left. */
+  left: SwipeableRowAction[]
+  /** The list owns this, so opening one row closes any other. */
+  open: boolean
+  onOpenChange: (open: boolean) => void
   children: ReactNode
 }
 
 /**
- * A list row that can be swiped either way to act on it.
+ * A list row whose actions are behind it.
  *
- * **Swipe and release, not a drawer that stays open.** A row that stays open
- * needs a shared "which row is open" across the whole list, and there is no
- * precedent for that here — `MessageBubble`'s swipe always springs back. This
- * is the same gesture that file already proved, given a second direction, and
- * it means a row can never be left in a state the reader has to undo.
+ * **The drawer stays open and the buttons are tapped**, where this used to
+ * commit on release. One action a side can be chosen by a gesture; two cannot,
+ * because a single swipe has no way to say which was meant. It also puts a
+ * destructive action behind a tap rather than behind a flick.
+ *
+ * Which row is open lives in the list, not here: two rows open at once is two
+ * sets of buttons and no way to tell which the next tap belongs to.
  *
  * RN's `PanResponder` and `Animated`, not gesture-handler and not Reanimated:
  * `react-native-gesture-handler` is not a dependency at all (only a transitive
@@ -46,16 +65,41 @@ interface SwipeableRowProps {
  * `ui/Skeleton.tsx` records why pulling Reanimated in would put its worklets
  * bundle into the shipped web build.
  *
- * Off for a mouse. `rowSwipeEnabled` states why; the long-press menu on the row
- * is the way in on a desktop, which it already was.
+ * Off for a mouse. `rowSwipeEnabled` states why; the actions are still reachable
+ * through `accessibilityActions` and through whatever menu the row itself
+ * offers, which on a desktop they always were.
  */
-export function SwipeableRow({ right, left, children }: SwipeableRowProps) {
+export function SwipeableRow({ right, left, open, onOpenChange, children }: SwipeableRowProps) {
   const styles = useStyles()
   const translateX = useRef(new Animated.Value(0)).current
-  // Read during the gesture without re-rendering the row on every frame.
-  const offset = useRef(0)
+  /**
+   * Where the row is resting. Read during the gesture without re-rendering,
+   * and — unlike the old version, which only ever started from zero — added to
+   * `gesture.dx`, because `dx` is measured from the start of *this* drag and an
+   * already-open row would otherwise jump back to nearly closed on the second.
+   */
+  const restingAt = useRef(0)
 
   const enabled = rowSwipeEnabled(Platform.OS, HAS_TOUCH)
+  const rightWidth = drawerWidth(right.length)
+  const leftWidth = drawerWidth(left.length)
+
+  /** Kept fresh for the responder, which is built once and closes over nothing else. */
+  const geometry = useRef({ rightWidth, leftWidth, onOpenChange })
+  geometry.current = { rightWidth, leftWidth, onOpenChange }
+
+  const settle = (to: number): void => {
+    restingAt.current = to
+    Animated.spring(translateX, { toValue: to, useNativeDriver: true, bounciness: 0 }).start()
+  }
+
+  // The list closes this row by flipping `open`; the row is what animates.
+  useEffect(() => {
+    // `settle` touches two refs and one `Animated.Value`, all stable, so it is
+    // deliberately not a dependency — listing it would rebuild this on every
+    // render and close the row mid-gesture.
+    if (!open && restingAt.current !== 0) settle(0)
+  }, [open])
 
   const pan = useRef(
     PanResponder.create({
@@ -67,89 +111,109 @@ export function SwipeableRow({ right, left, children }: SwipeableRowProps) {
       // The list asking for the responder back mid-scroll wins, always.
       onPanResponderTerminationRequest: () => true,
       onPanResponderMove: (_event, gesture) => {
-        offset.current = gesture.dx
-        translateX.setValue(rowTranslation(gesture.dx))
+        const { rightWidth: r, leftWidth: l } = geometry.current
+        translateX.setValue(rowTranslation(restingAt.current + gesture.dx, r, l))
       },
-      onPanResponderRelease: () => {
-        const fired = rowReleased(offset.current)
-        offset.current = 0
-        Animated.spring(translateX, {
-          toValue: 0,
-          useNativeDriver: true,
-          bounciness: 0,
-        }).start()
-        if (fired === 'right') right.onAction()
-        if (fired === 'left') left.onAction()
+      onPanResponderRelease: (_event, gesture) => {
+        const { rightWidth: r, leftWidth: l, onOpenChange: notify } = geometry.current
+        const to = settleOffset(restingAt.current + gesture.dx, r, l)
+        settle(to)
+        notify(to !== 0)
       },
       onPanResponderTerminate: () => {
-        offset.current = 0
-        Animated.spring(translateX, { toValue: 0, useNativeDriver: true, bounciness: 0 }).start()
+        settle(restingAt.current)
       },
     }),
   ).current
+
+  /**
+   * The actions again, for anyone not using a gesture. Swipe-only actions are
+   * invisible to a screen reader, and this row had no accessibility of any kind
+   * before.
+   */
+  const all = [...right, ...left]
+  const onAccessibilityAction = (event: AccessibilityActionEvent): void => {
+    all.find((action) => action.id === event.nativeEvent.actionName)?.onAction()
+  }
 
   if (!enabled) return <>{children}</>
 
   return (
     <View style={styles.wrap}>
-      {/*
-        Both actions sit behind the row at once, each pinned to the side it is
-        reached from. The row itself hides whichever one is not being pulled
-        towards, so there is nothing to toggle and nothing to get out of step.
-      */}
-      <View style={styles.behind} pointerEvents="none">
-        <Action action={right} align="flex-start" styles={styles} />
-        <Action action={left} align="flex-end" styles={styles} />
+      <View style={styles.behind}>
+        <View style={styles.drawer}>
+          {right.map((action) => (
+            <ActionButton key={action.id} action={action} styles={styles} />
+          ))}
+        </View>
+        <View style={styles.drawer}>
+          {left.map((action) => (
+            <ActionButton key={action.id} action={action} styles={styles} />
+          ))}
+        </View>
       </View>
       {/*
         Opaque, and that is not decoration. `behind` is a child of `wrap`, so it
         paints over `wrap`'s background — the only one in the stack, since the
         chat row itself sets none. Without a background of its own this layer is
-        glass, and the archive icon sits visible on every row at rest with the
-        timestamp printed on top of it. It has to be the layer that moves: a
-        background on `wrap` cannot travel with the row and would only mask the
-        actions the swipe is meant to reveal.
+        glass, and the buttons sit visible on every row at rest with the row's
+        own text printed on top of them.
       */}
-      <Animated.View style={[styles.moving, { transform: [{ translateX }] }]} {...pan.panHandlers}>
+      <Animated.View
+        accessibilityActions={all.map((action) => ({ name: action.id, label: action.label }))}
+        onAccessibilityAction={onAccessibilityAction}
+        style={[styles.moving, { transform: [{ translateX }] }]}
+        {...pan.panHandlers}
+      >
         {children}
       </Animated.View>
     </View>
   )
 }
 
-function Action({
+function ActionButton({
   action,
-  align,
   styles,
 }: {
   action: SwipeableRowAction
-  align: 'flex-start' | 'flex-end'
   styles: ReturnType<typeof useStyles>
 }) {
   return (
-    <View style={[styles.action, { alignItems: align }]}>
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={action.label}
+      onPress={action.onAction}
+      style={({ pressed }) => [styles.action, pressed && styles.actionPressed]}
+    >
       <Feather name={action.icon} size={18} color={action.colour} />
       <Text style={[styles.actionLabel, { color: action.colour }]} numberOfLines={1}>
         {action.label}
       </Text>
-    </View>
+    </Pressable>
   )
 }
 
-const useStyles = makeStyles(({ colors, font, spacing }) => ({
+const useStyles = makeStyles(({ colors, font }) => ({
   wrap: { backgroundColor: colors.bg, overflow: 'hidden' },
   moving: { backgroundColor: colors.bg },
   behind: {
     ...({ position: 'absolute' } as const),
-    alignItems: 'center',
     bottom: 0,
     flexDirection: 'row',
     justifyContent: 'space-between',
     left: 0,
-    paddingHorizontal: spacing.lg,
     right: 0,
     top: 0,
   },
-  action: { gap: 2, justifyContent: 'center' },
+  /** Each side's buttons, pinned to the edge they are reached from. */
+  drawer: { flexDirection: 'row' },
+  action: {
+    alignItems: 'center',
+    alignSelf: 'stretch',
+    gap: 3,
+    justifyContent: 'center',
+    width: ACTION_WIDTH_PX,
+  },
+  actionPressed: { opacity: 0.6 },
   actionLabel: { ...font.caption, fontSize: 11, fontWeight: '600' },
 }))

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -499,6 +499,10 @@ export const ar: Localized<EnMessages> = {
   },
 
   chats: {
+    delete: 'حذف',
+    deleteTitle: 'حذف هذه المحادثة؟',
+    deleteBody: 'تبقى لدى الطرف الآخر، وتعود هنا إن راسلك مجددًا.',
+    deleted: 'تم حذف المحادثة',
     tab_all: 'الكل',
     tab_unreplied: 'بلا رد',
     tab_archived: 'الأرشيف',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -441,6 +441,10 @@ export const de: Localized<EnMessages> = {
   },
 
   chats: {
+    delete: 'Löschen',
+    deleteTitle: 'Diesen Chat löschen?',
+    deleteBody: 'Bei ihnen bleibt er, und er kommt zurück, wenn sie wieder schreiben.',
+    deleted: 'Chat gelöscht',
     tab_all: 'Alle',
     tab_unreplied: 'Unbeantwortet',
     tab_archived: 'Archiv',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -466,6 +466,10 @@ export const en = {
   },
 
   chats: {
+    delete: 'Delete',
+    deleteTitle: 'Delete this chat?',
+    deleteBody: 'It stays on their side, and comes back here if they write again.',
+    deleted: 'Chat deleted',
     tab_all: 'All',
     tab_unreplied: 'Unreplied',
     tab_archived: 'Archived',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -434,6 +434,10 @@ export const es: Localized<EnMessages> = {
   },
 
   chats: {
+    delete: 'Eliminar',
+    deleteTitle: '¿Eliminar este chat?',
+    deleteBody: 'Se queda en su lado y vuelve aquí si escriben otra vez.',
+    deleted: 'Chat eliminado',
     tab_all: 'Todos',
     tab_unreplied: 'Sin responder',
     tab_archived: 'Archivados',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -438,6 +438,10 @@ export const fr: Localized<EnMessages> = {
   },
 
   chats: {
+    delete: 'Supprimer',
+    deleteTitle: 'Supprimer cette conversation ?',
+    deleteBody: 'Elle reste de leur côté et revient ici s’ils vous réécrivent.',
+    deleted: 'Conversation supprimée',
     tab_all: 'Tous',
     tab_unreplied: 'Sans réponse',
     tab_archived: 'Archivés',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -432,6 +432,10 @@ export const ptBR: Localized<EnMessages> = {
   },
 
   chats: {
+    delete: 'Excluir',
+    deleteTitle: 'Excluir esta conversa?',
+    deleteBody: 'Ela fica do lado deles e volta aqui se escreverem de novo.',
+    deleted: 'Conversa excluída',
     tab_all: 'Todos',
     tab_unreplied: 'Sem resposta',
     tab_archived: 'Arquivados',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -482,6 +482,10 @@ export const ru: Localized<EnMessages> = {
   },
 
   chats: {
+    delete: 'Удалить',
+    deleteTitle: 'Удалить этот чат?',
+    deleteBody: 'У собеседника он останется и вернётся сюда, если он напишет снова.',
+    deleted: 'Чат удалён',
     tab_all: 'Все',
     tab_unreplied: 'Без ответа',
     tab_archived: 'Архив',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -440,6 +440,10 @@ export const tr: Localized<EnMessages> = {
   },
 
   chats: {
+    delete: 'Sil',
+    deleteTitle: 'Bu sohbet silinsin mi?',
+    deleteBody: 'Karşı tarafta kalır; tekrar yazarsa burada yeniden açılır.',
+    deleted: 'Sohbet silindi',
     tab_all: 'Tümü',
     tab_unreplied: 'Cevapsız',
     tab_archived: 'Arşiv',

--- a/apps/mobile/src/lib/swipeAction.test.ts
+++ b/apps/mobile/src/lib/swipeAction.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import {
-  ACTION_ACTIVATE_PX,
   ACTION_LOCK_PX,
-  ACTION_MAX_PX,
-  rowReleased,
+  ACTION_WIDTH_PX,
+  drawerWidth,
   rowSwipeEnabled,
   rowTranslation,
+  settleOffset,
   shouldCaptureRowSwipe,
 } from './swipeAction'
+
+const ONE = drawerWidth(1)
+const TWO = drawerWidth(2)
 
 describe('shouldCaptureRowSwipe', () => {
   it('ignores movement that has not committed yet', () => {
@@ -30,32 +33,64 @@ describe('shouldCaptureRowSwipe', () => {
   })
 })
 
-describe('rowTranslation', () => {
-  it('follows the finger up to the limit, in both directions', () => {
-    expect(rowTranslation(50)).toBe(50)
-    expect(rowTranslation(-50)).toBe(-50)
-    expect(rowTranslation(ACTION_MAX_PX)).toBe(ACTION_MAX_PX)
+describe('drawerWidth', () => {
+  it('is one width per button', () => {
+    expect(drawerWidth(1)).toBe(ACTION_WIDTH_PX)
+    expect(drawerWidth(2)).toBe(ACTION_WIDTH_PX * 2)
   })
 
-  it('resists past the limit rather than stopping dead', () => {
-    const over = rowTranslation(ACTION_MAX_PX + 100)
-    expect(over).toBeGreaterThan(ACTION_MAX_PX)
-    expect(over).toBeLessThan(ACTION_MAX_PX + 100)
-    expect(rowTranslation(-(ACTION_MAX_PX + 100))).toBe(-over)
+  it('is nothing for a side with no actions', () => {
+    expect(drawerWidth(0)).toBe(0)
   })
 })
 
-describe('rowReleased', () => {
-  it('names the direction once it has gone far enough', () => {
-    expect(rowReleased(ACTION_ACTIVATE_PX)).toBe('right')
-    expect(rowReleased(-ACTION_ACTIVATE_PX)).toBe('left')
+describe('rowTranslation', () => {
+  it('follows the finger up to the drawer it is opening', () => {
+    expect(rowTranslation(50, ONE, TWO)).toBe(50)
+    expect(rowTranslation(-50, ONE, TWO)).toBe(-50)
+    expect(rowTranslation(ONE, ONE, TWO)).toBe(ONE)
   })
 
-  /** A short swipe springs back and does nothing — no accidental archiving. */
-  it('is null for a swipe that stopped short', () => {
-    expect(rowReleased(ACTION_ACTIVATE_PX - 1)).toBeNull()
-    expect(rowReleased(-(ACTION_ACTIVATE_PX - 1))).toBeNull()
-    expect(rowReleased(0)).toBeNull()
+  it('resists past a fully open drawer rather than stopping dead', () => {
+    const over = rowTranslation(ONE + 100, ONE, TWO)
+    expect(over).toBeGreaterThan(ONE)
+    expect(over).toBeLessThan(ONE + 100)
+  })
+
+  /** Two buttons is twice the room, so the same pull is still inside it. */
+  it('lets the wider side travel further before resisting', () => {
+    expect(rowTranslation(-TWO, ONE, TWO)).toBe(-TWO)
+    expect(rowTranslation(TWO, ONE, TWO)).toBeLessThan(TWO)
+  })
+
+  it('gives a side with no actions nothing but rubber', () => {
+    expect(rowTranslation(100, 0, TWO)).toBeLessThan(20)
+  })
+})
+
+describe('settleOffset', () => {
+  it('opens once the pull is far enough in', () => {
+    expect(settleOffset(-TWO, ONE, TWO)).toBe(-TWO)
+    expect(settleOffset(ONE, ONE, TWO)).toBe(ONE)
+  })
+
+  /** A short pull closes again — nothing is fired, and nothing is left ajar. */
+  it('closes again when it stopped short', () => {
+    expect(settleOffset(-10, ONE, TWO)).toBe(0)
+    expect(settleOffset(10, ONE, TWO)).toBe(0)
+    expect(settleOffset(0, ONE, TWO)).toBe(0)
+  })
+
+  /** Half-open is a row whose buttons are half-tappable. */
+  it('never rests part-way', () => {
+    for (const x of [-160, -80, -30, 30, 80, 160]) {
+      expect([0, ONE, -TWO]).toContain(settleOffset(x, ONE, TWO))
+    }
+  })
+
+  it('cannot open a side that has no actions', () => {
+    expect(settleOffset(300, 0, TWO)).toBe(0)
+    expect(settleOffset(-300, ONE, 0)).toBe(0)
   })
 })
 

--- a/apps/mobile/src/lib/swipeAction.ts
+++ b/apps/mobile/src/lib/swipeAction.ts
@@ -1,23 +1,29 @@
 /**
- * Swiping a row in a list to act on it.
+ * Swiping a row in a list to reach its actions.
  *
  * A sibling of `swipeToReply`, and deliberately the same shape: the thresholds
- * live here as plain numbers and the gesture logic is a pure function, so the
- * two things that are easy to get wrong — when a diagonal flick stops being a
- * scroll, and how far the row may travel — are testable without a renderer.
+ * live here as plain numbers and the geometry is pure functions, so the two
+ * things that are easy to get wrong — when a diagonal flick stops being a
+ * scroll, and where the row is allowed to come to rest — are testable without
+ * a renderer.
  *
- * Unlike swipe-to-reply this is **two-directional**, because a chat row has two
- * actions and a list has no second axis to spend.
+ * **The row rests open.** It used to commit on release: swipe far enough and
+ * the action fired as the row sprang back. That is fine for one action a side
+ * and impossible for two, since a single gesture cannot say which of them was
+ * meant. Opening a drawer and letting the reader tap costs a second gesture and
+ * buys the thing they already expect from every other list on their phone —
+ * and it makes a destructive action reachable without ever being reachable by
+ * accident.
  */
 
-/** Past this, releasing performs the action. */
-export const ACTION_ACTIVATE_PX = 72
-/** Where the row stops following the finger one-to-one. */
-export const ACTION_MAX_PX = 96
+/** One action button's width, and therefore the unit the row opens in. */
+export const ACTION_WIDTH_PX = 84
 /** Movement below this is still undecided. */
 export const ACTION_LOCK_PX = 12
-/** How much of the overshoot past `ACTION_MAX_PX` still moves the row. */
+/** How much of the overshoot past a fully open drawer still moves the row. */
 const RUBBER = 0.15
+/** Past this much of a drawer's width, releasing opens it rather than closing. */
+const OPEN_AT = 0.4
 /**
  * How much more horizontal than vertical the movement has to be.
  *
@@ -34,23 +40,34 @@ export function shouldCaptureRowSwipe(dx: number, dy: number): boolean {
   return Math.abs(dx) > ACTION_LOCK_PX && Math.abs(dx) > Math.abs(dy) * HORIZONTAL_BIAS
 }
 
-/** Follows the finger, then resists — so the limit is felt, not hit. */
-export function rowTranslation(dx: number): number {
-  const sign = dx < 0 ? -1 : 1
-  const distance = Math.abs(dx)
-  const eased =
-    distance <= ACTION_MAX_PX ? distance : ACTION_MAX_PX + (distance - ACTION_MAX_PX) * RUBBER
-  return sign * eased
+/** How wide the drawer on one side is, given how many buttons it holds. */
+export function drawerWidth(actionCount: number): number {
+  return Math.max(0, actionCount) * ACTION_WIDTH_PX
 }
 
 /**
- * Which action a release fires, or `null` for a swipe that did not go far
- * enough — which springs back and does nothing.
+ * Follows the finger, then resists — so the limit is felt, not hit.
+ *
+ * `right` is the drawer revealed by pulling the row to the right, `left` the
+ * one revealed by pulling it to the left; a side with no actions cannot be
+ * opened at all, and the rubber band is all that is left of the gesture there.
  */
-export function rowReleased(dx: number): SwipeDirection | null {
-  if (dx >= ACTION_ACTIVATE_PX) return 'right'
-  if (dx <= -ACTION_ACTIVATE_PX) return 'left'
-  return null
+export function rowTranslation(x: number, right: number, left: number): number {
+  const limit = x >= 0 ? right : left
+  const distance = Math.abs(x)
+  const eased = distance <= limit ? distance : limit + (distance - limit) * RUBBER
+  return x < 0 ? -eased : eased
+}
+
+/**
+ * Where the row comes to rest when the finger lifts: closed, or one of the two
+ * drawers fully open. Never anywhere in between — a half-open row is a row
+ * whose buttons are half-tappable.
+ */
+export function settleOffset(x: number, right: number, left: number): number {
+  if (x > 0) return right > 0 && x >= right * OPEN_AT ? right : 0
+  if (x < 0) return left > 0 && -x >= left * OPEN_AT ? -left : 0
+  return 0
 }
 
 /**

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -395,11 +395,12 @@ of it runs together.
       so it gates the iOS release rather than merely improving it. Until both
       are set the sign-in screen simply does not draw the buttons
 - [x] `ascAppId` (6474187141) and `appleTeamId` (8F63M4JH8P) in `eas.json`
-- [ ] `EXPO_PUBLIC_API_URL` set on the `preview` and `production` build
-      profiles in `eas.json`. Only `development` sets it today, and only to
-      localhost — which a development build rewrites to the dev server's
-      address at runtime, but a released build has no dev server and would
-      ship pointing at the phone itself
+- [x] `EXPO_PUBLIC_API_URL` set on the `preview` and `production` build
+      profiles in `eas.json` — both point at `https://api2.langx.io`.
+      `development` still points at localhost, which a development build
+      rewrites to the dev server's address at runtime; a released build has no
+      dev server and would ship pointing at the phone itself, which is what
+      this item existed to prevent
 - [ ] `EXPO_PUBLIC_REVENUECAT_*` keys set, `react-native-purchases` wired into
       the paywall screen (which today states the offer and says purchase is not
       yet enabled — deliberately, rather than shipping a button that cannot work)
@@ -484,7 +485,10 @@ image configured for 16 KB before the rollout widens past 10%.
 
 Nearby (Polyglot) added the app's first location permission, so two answers that
 were "no" are now "yes", and a store form that still says otherwise is a false
-declaration rather than a stale one:
+declaration rather than a stale one. The box-by-box version of everything below,
+including two answers that are already live and wrong, is
+[`store/privacy-forms-checklist.md`](store/privacy-forms-checklist.md) — open it
+next to the Console rather than working from this section:
 
 - [ ] Play Data Safety → **Location → Approximate location**: collected, not
       shared, optional, purpose "App functionality". **Precise location stays

--- a/docs/store/privacy-forms-checklist.md
+++ b/docs/store/privacy-forms-checklist.md
@@ -1,0 +1,100 @@
+# Store privacy forms — what to select, field by field
+
+A transcription target, not an explanation: open Play Console and App Store
+Connect next to this page and copy the answers across. The reasoning for every
+answer is in [`privacy-data-safety.md`](privacy-data-safety.md); this file only
+says which box to tick. If the two disagree, `privacy-data-safety.md` is the
+source and this page is stale.
+
+Three things need to change in the same sitting. Two of them are corrections to
+answers that are already live and wrong; the third is the new location
+permission.
+
+## 1. Play Data Safety — corrections to what is live today
+
+Read off the published Data safety page on 31 August 2026 and compared against
+HelloTalk, Tandem and Hilokal.
+
+- [ ] **Personal info → Race and ethnicity: uncheck.** Nothing in the app asks
+      for it and nothing stores it — the profile holds gender, date of birth,
+      country, city and languages. None of the three comparable apps declares
+      it. Declaring data we do not collect is as wrong as omitting data we do.
+- [ ] **Security practices → "You can request that data be deleted": check.**
+      It is implemented — Settings → "Hesabımı sil" hides the account
+      immediately and purges it after 30 days, photos included. LangX is
+      currently the only one of the four without this line, and the line is
+      true.
+
+## 2. Play Data Safety — the new location answers
+
+Nearby (Polyglot) added the app's first location permission, so two answers
+that were "no" are now "yes".
+
+- [ ] **Location → Approximate location: collected.**
+  - Shared with third parties: **no**
+  - Required or optional: **optional** — the user turns it on in Settings or
+    from the Nearby tab's prompt; nothing writes it at sign-up or in the
+    background
+  - Purpose: **App functionality** (only)
+  - Processed ephemerally: **no** — it is stored on the profile until the user
+    turns it off
+- [ ] **Location → Precise location: leave unchecked.** The client asks the OS
+      for `Accuracy.Lowest` and the server rounds to two decimals (~1 km)
+      before storing, so no precise value is ever written.
+- [ ] Everything else on the form stays as it is. In particular **no analytics
+      row** — there is no PostHog SDK in the app and no opt-out control, so
+      declaring "App activity" would describe a system that does not exist.
+
+## 3. Apple App Privacy — the same change
+
+- [ ] **Location → Coarse Location: collected.**
+  - Linked to the user: **yes**
+  - Used for tracking: **no**
+  - Purpose: **App Functionality** (only)
+- [ ] **Location → Precise Location: leave unchecked.**
+- [ ] **Tracking: stays "no".** No IDFA, no ad SDK, no data broker, nothing
+      linked to other companies' data for advertising.
+
+## 4. The privacy policy has to say it too
+
+A form answer with no matching sentence in the policy is a finding waiting to
+happen. Four points, in plain words, source text in
+[`privacy-data-safety.md`](privacy-data-safety.md) → _Location_:
+
+- [ ] It is **optional** and off until turned on, and the permission is
+      **when-in-use only** — there is no background location.
+- [ ] What is stored is **rounded to about a kilometre before it is written**,
+      not at display time; the precise reading is never persisted anywhere.
+- [ ] **No one is shown a position** — other users see only a bucketed distance
+      ("under 5 km away") on the Nearby list.
+- [ ] **Turning it off deletes it**, which also removes the profile from
+      everyone else's Nearby results. No retention period to declare.
+
+## Reference — the rest of the Play form
+
+Unchanged by this pass; listed so a full re-verification does not need a second
+document. Every row is "collected, not shared".
+
+| Play category                                 | Ours                                                               |
+| --------------------------------------------- | ------------------------------------------------------------------ |
+| Personal info → Name, Email address           | display name, handle, sign-in email — required                     |
+| Personal info → User IDs                      | account id                                                         |
+| Personal info → Other info                    | date of birth (18+ gate; only the age is shown), gender, bio, city |
+| Location → Approximate location               | optional, see above                                                |
+| Photos and videos → Photos                    | avatar and gallery — optional                                      |
+| Messages → Other in-app messages              | chat bodies                                                        |
+| App info and performance                      | nothing                                                            |
+| Financial info                                | nothing — purchase state only, never a card number                 |
+| Contacts, Calendar, Health, Microphone, Ad ID | nothing                                                            |
+
+Target audience: **18+**, enforced server-side at profile creation. Do not
+declare a Families audience — it contradicts the age gate and changes which
+SDKs are permitted.
+
+> **City is collected, and that is all the form asks.** `privacy-data-safety.md`
+> describes it as "shown on profile", which is not true today — nothing renders
+> `profiles.city` — and there is an approved plan to derive it from location and
+> put it behind a privacy toggle. Neither the current gap nor the planned change
+> alters any answer above: the form asks what is _collected_, and it is, as an
+> optional field. Revisit this note if that work lands, since deriving city from
+> location would make it a second consumer of the location permission.


### PR DESCRIPTION
> Stacked on #1057, which is where the `SwipeableRow` background fix comes from. Review that one first; this branch's base is set to it so the diff here is only the rework.

## The gesture

Swiping a row committed on release: pull far enough and the action fired as the row sprang back. That works for one action a side and is impossible for two, because a single gesture cannot say which was meant — and it put every action behind a flick, which is the wrong place for one that cannot be undone.

The drawer now rests open and the buttons are tapped.

- **Which row is open lives in the list**, not the row. Two open drawers is two sets of buttons and no way to tell which the next tap belongs to.
- **Tapping an open row closes it** rather than opening the thread. Navigating away from a drawer nobody closed leaves it open behind you.
- **`gesture.dx` is measured from the start of the current drag**, so an already-open row is dragged from where it is. The old version only ever started from closed, so it had no second drag to get wrong.
- `rowReleased` becomes `settleOffset`, and it only ever returns closed or fully open — a half-open row is a row whose buttons are half-tappable.

## Deleting a conversation

Did not exist anywhere: no route, no schema, no menu item, nothing in `packages/shared`.

It is **delete for me**, which is the mechanism message-level deletion already uses, applied to a whole thread. Messages keep their rows — each is half of somebody else's conversation — and carry the reader's id in `hiddenFor`. `deletedBy` is a map keyed by user id rather than an array, for the reason `archivedBy` records in its own comment: `participants` is already multikey and MongoDB will not compound two array fields in one index.

**A new message clears it on both sides.** Deleting is "I am done with this conversation", not "you cannot reach me": the other person knows nothing about it and writing again has to arrive somewhere. The thread comes back empty for whoever deleted it, because only the new message is missing from their `hiddenFor`.

The message pass is capped at 5000 and runs *before* the thread flag. A thread longer than that leaves its oldest messages visible — a failure that shows itself, and that deleting again fixes — rather than a request that times out halfway with no way to tell how far it got. If the pass failed and the flag were written first, the thread would be hidden with its messages still there and no way back to it.

Confirmed and red, because archiving has a tab to come back from and this has nothing. A failure is surfaced rather than swallowed the way `useConversationFlags` swallows its own: somebody who confirmed a destructive action and saw nothing has every reason to think it worked.

## Reachable without the gesture

Delete is in the long-press menu too — on a desktop browser `rowSwipeEnabled` offers no swipe at all, so that menu is the only way to reach any of these. And the row finally has `accessibilityActions`: before this, everything behind the gesture was invisible to a screen reader, and the row `Pressable` had no label of its own.

## Verified

Five new API tests: the thread leaves my list and not theirs, their messages are untouched, it is gone from the archive tab too, it comes back carrying only what was said afterwards, an outsider gets a 404, and so does a malformed id.

15 unit tests on the geometry, including that the row never rests part-way and that a side with no actions cannot be opened.

End to end with Playwright on a touch context, dispatching real multi-step touch drags through CDP:

```
after swipe left:                    [Archive, Delete]   (both exposed)
after swipe right on another row:    [Pin]               (the first row closed itself)
tap Delete                        →  "Delete this chat?"
confirm                           →  DELETE 204, row gone from the list
```

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and `pnpm test` (1324 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)