### PR TITLE
Give every notification kind its two channels back

### DIFF
--- a/apps/api/scripts/inspect-notification-prefs.ts
+++ b/apps/api/scripts/inspect-notification-prefs.ts
@@ -1,0 +1,97 @@
+/**
+ * Read-only. Counts which of the three `settings.notifications` shapes are
+ * actually out there, and finds the one cell that has to be checked by hand
+ * before the channel axis ships.
+ *
+ * The retired `{push, email}` matrix and a preference written today are
+ * byte-identical, so no query can tell them apart. That matters for exactly
+ * one cell: a `promotions.email: true` written while no mail could be sent
+ * recorded a consent against a sender that did not exist, and the new reader
+ * takes it literally. Everything else is a service notification the account
+ * opted into by installing the app.
+ *
+ * So this prints the handles carrying that cell. If any are real accounts
+ * rather than testers, `--unset-promotions-email` clears it and those people
+ * are asked again in the new UI. Consent is given, not inherited.
+ *
+ * Usage:
+ *   pnpm --filter @langx/api exec tsx scripts/inspect-notification-prefs.ts
+ *   pnpm --filter @langx/api exec tsx scripts/inspect-notification-prefs.ts --unset-promotions-email --apply
+ */
+import { NOTIFICATION_TYPES } from '@langx/shared'
+import { connectToDatabase } from '../src/db/client'
+import { COLLECTIONS } from '../src/db/collections'
+import { loadEnv } from '../src/env'
+
+interface WithPrefs {
+  _id: string
+  handle?: string
+  settings?: { notifications?: unknown }
+}
+
+async function main(): Promise<void> {
+  const unsetPromotions = process.argv.includes('--unset-promotions-email')
+  const apply = process.argv.includes('--apply')
+  const env = loadEnv()
+  const { db, close } = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
+
+  const docs = await db
+    .collection<WithPrefs>(COLLECTIONS.profiles)
+    .find({}, { projection: { handle: 1, settings: 1 } })
+    .toArray()
+
+  const shapes = { absent: 0, v1Boolean: 0, booleanPerKind: 0, objectPerKind: 0, mixed: 0 }
+  const promotionsEmail: string[] = []
+
+  for (const doc of docs) {
+    const prefs = doc.settings?.notifications
+    if (prefs === undefined || prefs === null) {
+      shapes.absent++
+      continue
+    }
+    if (typeof prefs === 'boolean') {
+      shapes.v1Boolean++
+      continue
+    }
+    const stored = prefs as Record<string, unknown>
+    const kinds = NOTIFICATION_TYPES.map((type) => stored[type])
+    const objects = kinds.filter((v) => v !== null && typeof v === 'object').length
+    const booleans = kinds.filter((v) => typeof v === 'boolean').length
+    if (objects > 0 && booleans > 0) shapes.mixed++
+    else if (objects > 0) shapes.objectPerKind++
+    else shapes.booleanPerKind++
+
+    const promotions = stored.promotions
+    if (promotions && typeof promotions === 'object') {
+      if ((promotions as { email?: unknown }).email === true) {
+        promotionsEmail.push(doc.handle ?? doc._id)
+      }
+    }
+  }
+
+  console.log(`${env.MONGODB_DB}: ${docs.length} profiles`)
+  for (const [shape, count] of Object.entries(shapes)) console.log(`  ${shape}: ${count}`)
+  console.log(`\npromotions.email already true: ${promotionsEmail.length}`)
+  for (const handle of promotionsEmail) console.log(`  ${handle}`)
+
+  if (unsetPromotions && promotionsEmail.length > 0) {
+    if (!apply) {
+      console.log('\n(dry run — re-run with --apply to unset promotions.email on those profiles)')
+    } else {
+      const result = await db
+        .collection<WithPrefs>(COLLECTIONS.profiles)
+        .updateMany(
+          { 'settings.notifications.promotions.email': true },
+          { $unset: { 'settings.notifications.promotions.email': '' } },
+        )
+      console.log(`\nunset on ${result.modifiedCount} profiles`)
+    }
+  }
+
+  await close()
+}
+
+main().catch((error: unknown) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/api/scripts/migrate-birthdate.ts
+++ b/apps/api/scripts/migrate-birthdate.ts
@@ -1,6 +1,11 @@
 /**
- * One-off, two shapes: `birthYear: 1995` → `birthDate: '1995-01-01'`, and
- * `settings.notifications` → one boolean per kind.
+ * One-off: `birthYear: 1995` → `birthDate: '1995-01-01'`.
+ *
+ * It used to convert `settings.notifications` in the same pass, flattening
+ * every shape to one boolean per kind. That half is gone. The channel axis is
+ * back — a preference is `{push, email}` again — so the conversion would now
+ * destroy the very choices it once tidied up, and it has already run against
+ * every document that needed it.
  *
  * v2 stores the whole calendar day now — for the age gate, which is unchanged,
  * and for birthdays, which are the point. Documents written before the switch
@@ -21,7 +26,7 @@
  *   pnpm --filter @langx/api exec tsx scripts/migrate-birthdate.ts --apply
  *   pnpm --filter @langx/api exec tsx scripts/migrate-birthdate.ts --set ada=1994-03-07 --apply
  */
-import { DEFAULT_NOTIFICATION_PREFS, NOTIFICATION_TYPES, isCalendarDate } from '@langx/shared'
+import { isCalendarDate } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { connectToDatabase } from '../src/db/client'
 import { COLLECTIONS } from '../src/db/collections'
@@ -32,7 +37,6 @@ interface WithBirth {
   handle?: string
   birthYear?: number
   birthDate?: string
-  settings?: { notifications?: unknown }
 }
 
 /** `--set handle=YYYY-MM-DD`, repeatable. */
@@ -54,7 +58,7 @@ async function migrate(
   collection: string,
   apply: boolean,
   overrides: Map<string, string>,
-): Promise<{ seen: number; converted: string[]; notifications: number }> {
+): Promise<{ seen: number; converted: string[] }> {
   const docs = await db.collection<WithBirth>(collection).find({}).toArray()
   const converted: string[] = []
 
@@ -74,68 +78,7 @@ async function migrate(
     }
   }
 
-  /**
-   * The other half, in the same pass over the same documents: whatever shape
-   * `settings.notifications` is in becomes one boolean per kind.
-   *
-   * Two shapes arrive here. A bare boolean is a v1 account, one switch for
-   * everything: `false` is preserved as silence for every kind — reading it as
-   * "unset" would start pushing to everyone who had opted out — and `true`
-   * becomes the defaults, which is what it always meant.
-   *
-   * A `{push, email}` object is an account written while the channel matrix
-   * existed, and it collapses to its `push` half. `email` never had a sender,
-   * so it never recorded a real decision; taking `push || email` would switch
-   * push back on for somebody who turned it off and left the dead email box
-   * ticked.
-   *
-   * **Idempotent**: a kind already stored as a boolean per kind is skipped, so
-   * a document this has already converted is left alone.
-   */
-  let notifications = 0
-  for (const doc of docs) {
-    const current = doc.settings?.notifications
-    if (current === undefined || current === null) continue
-
-    const prefs: Record<string, boolean> = {}
-    if (typeof current === 'boolean') {
-      for (const type of NOTIFICATION_TYPES) {
-        prefs[type] = current ? DEFAULT_NOTIFICATION_PREFS[type] : false
-      }
-    } else if (typeof current === 'object') {
-      const stored = current as Record<string, unknown>
-      let sawMatrix = false
-      for (const type of NOTIFICATION_TYPES) {
-        const value = stored[type]
-        if (typeof value === 'boolean') {
-          prefs[type] = value
-          continue
-        }
-        if (value && typeof value === 'object') {
-          sawMatrix = true
-          const push = (value as { push?: unknown }).push
-          prefs[type] = typeof push === 'boolean' ? push : DEFAULT_NOTIFICATION_PREFS[type]
-          continue
-        }
-        prefs[type] = DEFAULT_NOTIFICATION_PREFS[type]
-      }
-      // Already one boolean per kind, with nothing missing: nothing to do.
-      if (!sawMatrix && NOTIFICATION_TYPES.every((type) => typeof stored[type] === 'boolean')) {
-        continue
-      }
-    } else {
-      continue
-    }
-
-    notifications++
-    if (apply) {
-      await db
-        .collection<WithBirth>(collection)
-        .updateOne({ _id: doc._id }, { $set: { 'settings.notifications': prefs } })
-    }
-  }
-
-  return { seen: docs.length, converted, notifications }
+  return { seen: docs.length, converted }
 }
 
 async function main(): Promise<void> {
@@ -146,10 +89,8 @@ async function main(): Promise<void> {
 
   console.log(`${apply ? 'Applying' : 'Dry run'} on ${env.MONGODB_DB}…`)
   for (const collection of [COLLECTIONS.profiles, COLLECTIONS.legacyProfiles]) {
-    const { seen, converted, notifications } = await migrate(db, collection, apply, overrides)
-    console.log(
-      `\n${collection}: ${seen} seen, ${converted.length} birth dates, ${notifications} notification settings`,
-    )
+    const { seen, converted } = await migrate(db, collection, apply, overrides)
+    console.log(`\n${collection}: ${seen} seen, ${converted.length} birth dates`)
     for (const line of converted) console.log(`  ${line}`)
   }
   if (!apply) console.log('\n(dry run — re-run with --apply to write)')

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -11,12 +11,15 @@ import {
   findCosmetic,
   meetsMinimumAge,
   newHandleSchema,
+  resolveNotificationPrefs,
   toGeoPoint,
   type FollowState,
   type GeoPoint,
   type LocationInput,
   type Equipped,
   type NotificationPrefs,
+  type NotificationPrefsInput,
+  type NotificationType,
   type StoredNotificationPrefs,
   type OnboardingProfileInput,
   type PaidPlanTier,
@@ -93,9 +96,10 @@ export interface Profile {
   settings: {
     discoverable: boolean
     /**
-     * Three shapes at once: today's boolean per kind, the push/email matrix it
-     * replaced, and the single boolean v1 wrote. `notificationsAllowed` reads
-     * all three; nothing else should read this field directly.
+     * Three shapes at once: today's `{push, email}` per kind, the bare boolean
+     * per kind written while the channel axis was gone, and the single boolean
+     * v1 wrote. `notificationsAllowed` reads all three; nothing else should
+     * read this field directly.
      */
     notifications: StoredNotificationPrefs | NotificationPrefs | boolean
   }
@@ -609,7 +613,7 @@ export async function updateProfile(
    */
   const { privacy, settings, equipped, ...rest } = definedUpdates as {
     privacy?: Record<string, boolean>
-    settings?: { discoverable?: boolean; notifications?: Record<string, boolean> }
+    settings?: { discoverable?: boolean; notifications?: NotificationPrefsInput }
     equipped?: Record<string, string | null>
   }
   const privacyPaths = Object.fromEntries(
@@ -619,21 +623,30 @@ export async function updateProfile(
   /**
    * `settings` is written the same way, and for a sharper version of the same
    * reason: its `notifications` used to be one boolean that a screen always
-   * sent whole, and is now one switch per kind. `$set: { settings }` from a
-   * screen toggling one of them would wipe the other three.
+   * sent whole, and is now two switches for each of four kinds. `$set:
+   * { settings }` from a screen toggling one of them would wipe the other
+   * seven.
    *
-   * The dotted path also does the migration, one switch at a time. Setting
-   * `settings.notifications.messages` to a boolean over a profile still
-   * holding `{push, email}` there replaces that sub-document with the boolean
-   * — Mongo permits the type change — so a profile converts itself the first
-   * time its owner touches a switch, and `notificationsAllowed` covers the
-   * ones nobody ever touches.
+   * The dotted path stops one kind below the switch, though — at the kind, not
+   * at the channel. `settings.notifications.messages.email` is a path *into* a
+   * sub-document, and on the many profiles where `messages` is still a bare
+   * boolean there is no sub-document to enter: Mongo refuses the write
+   * outright rather than replacing the boolean. So each touched kind is
+   * resolved first and written whole, which is also what migrates it — one
+   * kind at a time, on the first switch its owner touches, with
+   * `notificationsAllowed` covering the ones nobody ever does.
    */
   const settingsPaths: Record<string, unknown> = {}
   if (settings?.discoverable !== undefined)
     settingsPaths['settings.discoverable'] = settings.discoverable
-  for (const [type, value] of Object.entries(settings?.notifications ?? {})) {
-    settingsPaths[`settings.notifications.${type}`] = value
+  if (settings?.notifications) {
+    const resolved = resolveNotificationPrefs(current.settings?.notifications)
+    for (const [type, channels] of Object.entries(settings.notifications)) {
+      settingsPaths[`settings.notifications.${type}`] = {
+        ...resolved[type as NotificationType],
+        ...channels,
+      }
+    }
   }
 
   /*

--- a/apps/api/src/modules/push/devices.ts
+++ b/apps/api/src/modules/push/devices.ts
@@ -58,7 +58,12 @@ export interface PushMessage {
   to: string[]
   title: string
   body: string
-  data: { kind: PushKind; conversationId?: string }
+  /**
+   * What the app needs to act on the tap, and — for a message — to draw the
+   * in-app banner that replaces the OS one while the app is open. `senderId`
+   * is there for the avatar; the notification's own title is only a name.
+   */
+  data: { kind: PushKind; conversationId?: string; senderId?: string }
 }
 
 /**
@@ -215,11 +220,17 @@ export async function tokensByLocale(db: Db, userId: string): Promise<Map<Locale
  *
  * Local hour, like the streak itself — a reminder at 8pm UTC is 5am in Tokyo,
  * which is not a nudge, it is an alarm clock.
+ *
+ * Both channels come back on the candidate rather than being decided here.
+ * The nudge is a push to whoever has a phone signed in and an email to whoever
+ * does not, and only the caller — which has already claimed the day in the
+ * ledger — can see which of those it turned out to be. Filtering to
+ * push-allowed here would drop the web-only accounts that the email exists for.
  */
 export async function streakReminderCandidates(
   db: Db,
   now: Date = new Date(),
-): Promise<{ userId: string; streak: number }[]> {
+): Promise<{ userId: string; streak: number; push: boolean; email: boolean }[]> {
   const profiles = await db
     .collection<Profile>(COLLECTIONS.profiles)
     .find({
@@ -234,9 +245,11 @@ export async function streakReminderCandidates(
     })
     .toArray()
 
-  const candidates: { userId: string; streak: number }[] = []
+  const candidates: { userId: string; streak: number; push: boolean; email: boolean }[] = []
   for (const profile of profiles) {
-    if (!notificationsAllowed(profile.settings?.notifications, 'streak')) continue
+    const push = notificationsAllowed(profile.settings?.notifications, 'streak', 'push')
+    const email = notificationsAllowed(profile.settings?.notifications, 'streak', 'email')
+    if (!push && !email) continue
     const zone = profile.timezone ?? 'UTC'
     const localHour = Number(
       new Intl.DateTimeFormat('en-GB', {
@@ -247,7 +260,7 @@ export async function streakReminderCandidates(
     )
     if (localHour !== STREAK_REMINDER_LOCAL_HOUR) continue
     if (profile.streak.lastQualifiedDay === localDayKey(now, zone)) continue
-    candidates.push({ userId: profile._id, streak: profile.streak.current })
+    candidates.push({ userId: profile._id, streak: profile.streak.current, push, email })
   }
   return candidates
 }

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -363,9 +363,9 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
   })
 
   /**
-   * Four booleans and the settings screen flips one at a time. Writing
+   * Eight switches and the settings screen flips one at a time. Writing
    * `settings` whole — which is what the old single-boolean shape allowed —
-   * would clear the other three on every toggle.
+   * would clear the other seven on every toggle.
    */
   it('changes one notification switch without touching the others', async () => {
     const user = await newUser('prefs@example.com')
@@ -380,27 +380,60 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
       method: 'PATCH',
       url: '/profiles/me',
       headers: { cookie: user.cookie },
-      payload: { settings: { notifications: { streak: false } } },
+      payload: { settings: { notifications: { streak: { email: false } } } },
     })
 
     expect(updated.statusCode, updated.body).toBe(200)
     const settings = updated.json<{
-      settings: { discoverable: boolean; notifications: Record<string, boolean> }
+      settings: { discoverable: boolean; notifications: Record<string, unknown> }
     }>().settings
-    expect(settings.notifications.streak).toBe(false)
-    expect(settings.notifications.messages).toBe(true)
-    expect(settings.notifications.promotions).toBe(false)
+    // The other half of the kind that moved is written back, not dropped.
+    expect(settings.notifications.streak).toEqual({ push: true, email: false })
+    expect(settings.notifications.messages).toEqual({ push: true, email: true })
+    expect(settings.notifications.promotions).toEqual({ push: false, email: false })
     expect(settings.discoverable).toBe(true)
   })
 
   /**
-   * The dotted path is also the migration. A profile still holding the retired
-   * `{push, email}` matrix converts that kind to a boolean the first time its
-   * owner touches the switch — Mongo allows a `$set` to change a field's type
-   * — and the kinds nobody touches stay as they are, for `notificationsAllowed`
-   * to read.
+   * Explicit consent is stored as given. Promotions default to off on both
+   * channels, so this is the one cell that can only ever become true by
+   * somebody saying so.
    */
-  it('replaces a stored push/email matrix with the switch that replaced it', async () => {
+  it('records a promotions opt-in', async () => {
+    const user = await newUser('promo-prefs@example.com')
+    await app.inject({
+      method: 'POST',
+      url: '/profiles',
+      headers: { cookie: user.cookie },
+      payload: onboardingBody({ handle: 'promoprefs' }),
+    })
+
+    const updated = await app.inject({
+      method: 'PATCH',
+      url: '/profiles/me',
+      headers: { cookie: user.cookie },
+      payload: { settings: { notifications: { promotions: { email: true } } } },
+    })
+
+    expect(updated.statusCode, updated.body).toBe(200)
+    expect(
+      updated.json<{ settings: { notifications: Record<string, unknown> } }>().settings
+        .notifications.promotions,
+    ).toEqual({ push: false, email: true })
+  })
+
+  /**
+   * The write is also the migration, one kind at a time. A profile still
+   * holding a bare boolean per kind — the shape written while there was no
+   * channel axis — gets that kind resolved and rewritten as an object the
+   * first time its owner touches either of its switches, and the kinds nobody
+   * touches stay as they are for `notificationsAllowed` to read.
+   *
+   * It has to be written whole rather than as a path one level deeper:
+   * `settings.notifications.streak.email` is a path *into* a sub-document, and
+   * over a boolean there is none to enter — Mongo refuses the write outright.
+   */
+  it('converts a stored bare boolean into the kind it is now', async () => {
     const user = await newUser('matrix-prefs@example.com')
     await app.inject({
       method: 'POST',
@@ -413,10 +446,10 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
       {
         $set: {
           'settings.notifications': {
-            messages: { push: true, email: false },
-            streak: { push: true, email: false },
-            profileVisits: { push: true, email: false },
-            promotions: { push: false, email: false },
+            messages: true,
+            streak: true,
+            profileVisits: false,
+            promotions: false,
           },
         },
       },
@@ -426,16 +459,17 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
       method: 'PATCH',
       url: '/profiles/me',
       headers: { cookie: user.cookie },
-      payload: { settings: { notifications: { streak: false } } },
+      payload: { settings: { notifications: { streak: { email: false } } } },
     })
 
     expect(updated.statusCode, updated.body).toBe(200)
     const notifications = updated.json<{
       settings: { notifications: Record<string, unknown> }
     }>().settings.notifications
-    expect(notifications.streak).toBe(false)
+    expect(notifications.streak).toEqual({ push: true, email: false })
     // Untouched, so still the old shape — and still readable.
-    expect(notifications.messages).toEqual({ push: true, email: false })
+    expect(notifications.messages).toBe(true)
+    expect(notifications.profileVisits).toBe(false)
   })
 
   describe('handles as public addresses', () => {

--- a/apps/api/src/ws/fanOut.ts
+++ b/apps/api/src/ws/fanOut.ts
@@ -85,13 +85,17 @@ export async function fanOutMessage(
     // The recipient's choice, per kind now rather than one switch for
     // everything: somebody who wants no streak nudge still wants this.
     const prefs = recipient?.settings?.notifications as Parameters<typeof notificationsAllowed>[0]
-    if (!notificationsAllowed(prefs, 'messages')) return
+    if (!notificationsAllowed(prefs, 'messages', 'push')) return
 
     await sendPush(app.mongo.db, app.push, {
       to: tokens,
       title: sender?.displayName ?? sender?.handle ?? 'LangX',
       body: message.body.slice(0, 120),
-      data: { kind: 'message', conversationId: message.conversationId.toHexString() },
+      data: {
+        kind: 'message',
+        conversationId: message.conversationId.toHexString(),
+        senderId: message.senderId,
+      },
     })
   } catch (error) {
     app.log.warn({ err: error }, 'post-send fan-out failed')

--- a/apps/mobile/app/(app)/settings.tsx
+++ b/apps/mobile/app/(app)/settings.tsx
@@ -42,7 +42,12 @@ import {
 import { FLAG_KEYS, readBoolFlag } from '../../src/lib/localFlags'
 import { captureLocation, LOCATION_FAILURE_KEY } from '../../src/lib/location'
 import { useLocale, useLocalePreference, useT, type MessageKey } from '../../src/i18n'
-import { LOCALE_NAMES, NOTIFICATION_TYPES, notificationsAllowed } from '@langx/shared'
+import {
+  LOCALE_NAMES,
+  NOTIFICATION_CHANNELS,
+  NOTIFICATION_TYPES,
+  resolveNotificationPrefs,
+} from '@langx/shared'
 import { unregisterPushToken } from '../../src/hooks/usePushRegistration'
 import {
   makeStyles,
@@ -77,6 +82,19 @@ export default function SettingsScreen() {
 
   const profile = me.data
   const isPro = useIsPro()
+  /**
+   * The eight cells, with every stored shape already resolved — an account
+   * from v1 carries one boolean for all of this, and a screen drawing switches
+   * off `profile.settings.notifications` directly would read that as "off".
+   */
+  const notifications = resolveNotificationPrefs(profile?.settings.notifications)
+  /**
+   * An email switch on an unverified address is a switch that sends nothing,
+   * which is the exact fault that had the email column removed the first time.
+   * Disabled with a reason under it rather than hidden: somebody who verifies
+   * their address later should find the control where they last saw it.
+   */
+  const emailVerified = authClient.useSession().data?.user.emailVerified === true
   /*
    * The incognito row asks about *incognito*, not "any paid plan". They agreed
    * while every privacy flag was Fluent's; now that this one is Polyglot's,
@@ -404,37 +422,57 @@ export default function SettingsScreen() {
       </View>
 
       {/*
-        Four kinds, one switch each. It was one switch for everything, which
+        Four kinds, two channels each. It was one switch for everything, which
         meant that somebody who did not want a nudge about their streak had to
         turn off the message they were waiting for as well.
 
-        It was briefly two switches per kind, push and email. The email column
-        never sent anything — nothing in the app sends mail except verification
-        and password reset — so six of those eight switches did nothing, and a
-        choice that changes nothing is worse than no choice at all.
+        The channel axis was here once before and was taken out again, because
+        nothing sent mail except verification and password reset: six of the
+        eight switches did nothing, and a choice that changes nothing is worse
+        than no choice at all. It is back because every cell now reaches a
+        sender, and the email half is disabled until an address is verified —
+        that rule, not the axis, is what keeps a dead switch off this screen.
 
-        Promotions default to off; consent is given, not withdrawn.
+        Two rows per kind rather than two toggles in one row: `ListRow` has one
+        accessory slot, and two unlabelled switches side by side are a coin
+        flip for anyone reading the screen aloud.
+
+        Promotions default to off on both; consent is given, not withdrawn.
       */}
       <Text style={styles.section}>{t('settings.notificationsSection')}</Text>
-      <View>
-        {NOTIFICATION_TYPES.map((type, index) => (
-          <ListRow
-            key={type}
-            title={t(`notifications.${type}` as MessageKey)}
-            subtitle={t(`notifications.${type}Body` as MessageKey)}
-            last={index === NOTIFICATION_TYPES.length - 1}
-            accessory={
-              <Toggle
-                accessibilityLabel={t(`notifications.${type}` as MessageKey)}
-                value={notificationsAllowed(profile?.settings.notifications, type)}
-                onValueChange={(next) =>
-                  update.mutate({ settings: { notifications: { [type]: next } } })
-                }
-              />
-            }
-          />
-        ))}
-      </View>
+      {NOTIFICATION_TYPES.map((type) => (
+        <View key={type}>
+          <Text style={styles.kindTitle}>{t(`notifications.${type}` as MessageKey)}</Text>
+          <Text style={styles.kindBody}>{t(`notifications.${type}Body` as MessageKey)}</Text>
+          <View>
+            {NOTIFICATION_CHANNELS.map((channel, index) => {
+              const disabled = channel === 'email' && !emailVerified
+              return (
+                <ListRow
+                  key={channel}
+                  title={t(`notifications.channel.${channel}` as MessageKey)}
+                  subtitle={disabled ? t('notifications.emailUnverified') : undefined}
+                  last={index === NOTIFICATION_CHANNELS.length - 1}
+                  accessory={
+                    <Toggle
+                      accessibilityLabel={`${t(`notifications.${type}` as MessageKey)} — ${t(
+                        `notifications.channel.${channel}` as MessageKey,
+                      )}`}
+                      disabled={disabled}
+                      value={notifications[type][channel]}
+                      onValueChange={(next) =>
+                        update.mutate({
+                          settings: { notifications: { [type]: { [channel]: next } } },
+                        })
+                      }
+                    />
+                  }
+                />
+              )
+            })}
+          </View>
+        </View>
+      ))}
 
       {/*
         A device preference rather than an account one, so it is deliberately
@@ -634,6 +672,9 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
     color: colors.textFaint,
     marginTop: spacing.xl,
   },
+  /** The kind a pair of channel rows belongs to, above them rather than beside. */
+  kindTitle: { ...font.body, color: colors.text, fontWeight: '600', marginTop: spacing.lg },
+  kindBody: { ...font.caption, color: colors.textMuted, marginBottom: spacing.xs },
   theme: { paddingVertical: spacing.xs },
   signOut: { marginTop: spacing.xl },
   build: {

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -1,6 +1,7 @@
 import {
   type ConversationFilter,
   type NotificationPrefs,
+  type StoredNotificationPrefs,
   effectivePlanTier,
   hasFeature,
   isPaidTier,
@@ -164,7 +165,14 @@ export interface MeProfile {
   nativeLanguages: { code: string }[]
   learning: { code: string; level: LanguageLevel; priority: number }[]
   interests: string[]
-  settings: { discoverable: boolean; notifications: NotificationPrefs | boolean }
+  /**
+   * Whatever shape the server has stored, verbatim — three of them are live at
+   * once. Only `resolveNotificationPrefs` reads it.
+   */
+  settings: {
+    discoverable: boolean
+    notifications: StoredNotificationPrefs | NotificationPrefs | boolean
+  }
   privacy: {
     incognito: boolean
     hideOnlineStatus: boolean

--- a/apps/mobile/src/i18n/catalogs.test.ts
+++ b/apps/mobile/src/i18n/catalogs.test.ts
@@ -3,6 +3,7 @@ import {
   GENDERS,
   INTEREST_SUGGESTIONS,
   LANGUAGE_LEVELS,
+  NOTIFICATION_CHANNELS,
   NOTIFICATION_TYPES,
   PERIOD_TYPES,
   SUPPORTED_LOCALES,
@@ -168,6 +169,14 @@ describe('dynamically built keys', () => {
     for (const type of NOTIFICATION_TYPES) {
       expect(t(`notifications.${type}` as never), type).not.toContain('notifications.')
       expect(t(`notifications.${type}Body` as never), type).not.toContain('notifications.')
+    }
+  })
+
+  it('resolves a label for every channel a kind can be sent on', () => {
+    for (const channel of NOTIFICATION_CHANNELS) {
+      expect(t(`notifications.channel.${channel}` as never), channel).not.toContain(
+        'notifications.',
+      )
     }
   })
 

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -455,13 +455,17 @@ export const ar: Localized<EnMessages> = {
 
   notifications: {
     messages: 'الرسائل',
-    messagesBody: 'عندما يكتب إليك أحد.',
+    messagesBody: 'عندما يكتب إليك أحد. وبالبريد فقط إن غبت مدة.',
     streak: 'تذكير السلسلة',
-    streakBody: 'مساءً، إذا كانت سلسلتك على وشك الانقطاع.',
+    streakBody:
+      'مساءً، إذا كانت سلسلتك على وشك الانقطاع. وبالبريد إن لم يكن هناك هاتف مسجَّل الدخول.',
     profileVisits: 'زيارات الملف',
-    profileVisitsBody: 'عندما يطّلع أحد على ملفك.',
+    profileVisitsBody: 'مرة كل يوم، كم شخصًا اطّلع على ملفك. وملخّص بالبريد كل أسبوع.',
     promotions: 'الأخبار والعروض',
     promotionsBody: 'بين حين وآخر عن الجديد. مغلق ما لم تطلبه.',
+    /** The two halves of every kind above; the row title, so no kind name in it. */
+    channel: { push: 'إشعار فوري', email: 'البريد' },
+    emailUnverified: 'وثّق عنوان بريدك لتفعيل هذا.',
     primingTitle: 'تفعيل الإشعارات؟',
     primingBody:
       'أمران فقط: حين يراسلك أحد، وتذكير عند الساعة {hour}:00 إن كانت سلسلتك على وشك الانقطاع.',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -394,13 +394,18 @@ export const de: Localized<EnMessages> = {
 
   notifications: {
     messages: 'Nachrichten',
-    messagesBody: 'Wenn dir jemand schreibt.',
+    messagesBody: 'Wenn dir jemand schreibt. Per E-Mail nur, wenn du länger weg warst.',
     streak: 'Streak-Erinnerung',
-    streakBody: 'Abends, wenn dein Streak zu reißen droht.',
+    streakBody:
+      'Abends, wenn dein Streak zu reißen droht. Per E-Mail, wenn kein Telefon angemeldet ist.',
     profileVisits: 'Profilbesuche',
-    profileVisitsBody: 'Wenn jemand dein Profil ansieht.',
+    profileVisitsBody:
+      'Einmal am Tag, wie viele dein Profil angesehen haben. Wöchentlich eine Zusammenfassung per E-Mail.',
     promotions: 'Neues und Angebote',
     promotionsBody: 'Gelegentlich, was es Neues gibt. Aus, sofern du es nicht willst.',
+    /** The two halves of every kind above; the row title, so no kind name in it. */
+    channel: { push: 'Push', email: 'E-Mail' },
+    emailUnverified: 'Bestätige deine E-Mail-Adresse, um das einzuschalten.',
     primingTitle: 'Mitteilungen einschalten?',
     primingBody:
       'Nur zwei Dinge: wenn dir jemand schreibt, und ein Anstupser um {hour}:00 Uhr, wenn deine Serie zu reißen droht.',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -417,13 +417,18 @@ export const en = {
 
   notifications: {
     messages: 'Messages',
-    messagesBody: 'When somebody writes to you.',
+    messagesBody: 'When somebody writes to you. By email only if you have been away a while.',
     streak: 'Streak reminder',
-    streakBody: 'In the evening, if your streak is about to break.',
+    streakBody:
+      'In the evening, if your streak is about to break. By email if no phone is signed in.',
     profileVisits: 'Profile visits',
-    profileVisitsBody: 'When somebody looks at your profile.',
+    profileVisitsBody:
+      'Once a day, how many people looked at your profile. A summary by email each week.',
     promotions: 'News and offers',
     promotionsBody: 'Occasional word about what is new. Off unless you ask.',
+    /** The two halves of every kind above; the row title, so no kind name in it. */
+    channel: { push: 'Push', email: 'Email' },
+    emailUnverified: 'Verify your email address to turn this on.',
     primingTitle: 'Turn on notifications?',
     primingBody:
       'Two things only: when someone messages you, and a nudge at {hour}:00 if your streak is about to break.',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -386,13 +386,18 @@ export const es: Localized<EnMessages> = {
 
   notifications: {
     messages: 'Mensajes',
-    messagesBody: 'Cuando alguien te escribe.',
+    messagesBody: 'Cuando alguien te escribe. Por correo solo si llevas un tiempo sin entrar.',
     streak: 'Recordatorio de racha',
-    streakBody: 'Por la tarde, si tu racha está a punto de romperse.',
+    streakBody:
+      'Por la tarde, si tu racha está a punto de romperse. Por correo si no hay ningún teléfono con sesión iniciada.',
     profileVisits: 'Visitas a tu perfil',
-    profileVisitsBody: 'Cuando alguien mira tu perfil.',
+    profileVisitsBody:
+      'Una vez al día, cuánta gente miró tu perfil. Un resumen por correo cada semana.',
     promotions: 'Novedades y ofertas',
     promotionsBody: 'De vez en cuando, lo nuevo. Apagado salvo que lo pidas.',
+    /** The two halves of every kind above; the row title, so no kind name in it. */
+    channel: { push: 'Push', email: 'Correo' },
+    emailUnverified: 'Verifica tu dirección de correo para activarlo.',
     primingTitle: '¿Activar las notificaciones?',
     primingBody:
       'Solo dos cosas: cuando alguien te escribe y un aviso a las {hour}:00 si tu racha está a punto de romperse.',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -393,13 +393,18 @@ export const fr: Localized<EnMessages> = {
 
   notifications: {
     messages: 'Messages',
-    messagesBody: 'Quand quelqu’un vous écrit.',
+    messagesBody: 'Quand quelqu’un vous écrit. Par e-mail seulement après une absence.',
     streak: 'Rappel de série',
-    streakBody: 'Le soir, si votre série est sur le point de s’interrompre.',
+    streakBody:
+      'Le soir, si votre série est sur le point de s’interrompre. Par e-mail si aucun téléphone n’est connecté.',
     profileVisits: 'Visites de profil',
-    profileVisitsBody: 'Quand quelqu’un consulte votre profil.',
+    profileVisitsBody:
+      'Une fois par jour, combien de personnes ont consulté votre profil. Un résumé par e-mail chaque semaine.',
     promotions: 'Actualités et offres',
     promotionsBody: 'De temps en temps, les nouveautés. Désactivé sauf demande.',
+    /** The two halves of every kind above; the row title, so no kind name in it. */
+    channel: { push: 'Push', email: 'E-mail' },
+    emailUnverified: 'Vérifiez votre adresse e-mail pour l’activer.',
     primingTitle: 'Activer les notifications ?',
     primingBody:
       'Deux choses seulement : quand quelqu’un t’écrit, et un rappel à {hour}h00 si ta série est sur le point de se rompre.',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -382,13 +382,18 @@ export const ptBR: Localized<EnMessages> = {
 
   notifications: {
     messages: 'Mensagens',
-    messagesBody: 'Quando alguém te escreve.',
+    messagesBody: 'Quando alguém te escreve. Por e-mail só se você ficar um tempo fora.',
     streak: 'Lembrete de sequência',
-    streakBody: 'À noite, se sua sequência estiver prestes a quebrar.',
+    streakBody:
+      'À noite, se sua sequência estiver prestes a quebrar. Por e-mail se nenhum telefone estiver conectado.',
     profileVisits: 'Visitas ao perfil',
-    profileVisitsBody: 'Quando alguém olha seu perfil.',
+    profileVisitsBody:
+      'Uma vez por dia, quantas pessoas olharam seu perfil. Um resumo por e-mail toda semana.',
     promotions: 'Novidades e ofertas',
     promotionsBody: 'De vez em quando, o que há de novo. Desligado a não ser que você peça.',
+    /** The two halves of every kind above; the row title, so no kind name in it. */
+    channel: { push: 'Push', email: 'E-mail' },
+    emailUnverified: 'Verifique seu endereço de e-mail para ativar isto.',
     primingTitle: 'Ativar as notificações?',
     primingBody:
       'Só duas coisas: quando alguém te manda mensagem, e um lembrete às {hour}:00 se sua sequência estiver prestes a quebrar.',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -435,13 +435,18 @@ export const ru: Localized<EnMessages> = {
 
   notifications: {
     messages: 'Сообщения',
-    messagesBody: 'Когда вам пишут.',
+    messagesBody: 'Когда вам пишут. На почту — только если вас давно не было.',
     streak: 'Напоминание о стрике',
-    streakBody: 'Вечером, если стрик вот-вот прервётся.',
+    streakBody:
+      'Вечером, если стрик вот-вот прервётся. На почту, если ни один телефон не вошёл в аккаунт.',
     profileVisits: 'Визиты в профиль',
-    profileVisitsBody: 'Когда кто-то смотрит ваш профиль.',
+    profileVisitsBody:
+      'Раз в день, сколько человек посмотрели ваш профиль. Раз в неделю сводка на почту.',
     promotions: 'Новости и предложения',
     promotionsBody: 'Изредка о новом. Выключено, пока не включите.',
+    /** The two halves of every kind above; the row title, so no kind name in it. */
+    channel: { push: 'Пуш', email: 'Почта' },
+    emailUnverified: 'Подтвердите адрес почты, чтобы включить это.',
     primingTitle: 'Включить уведомления?',
     primingBody:
       'Только две вещи: когда тебе пишут и напоминание в {hour}:00, если серия вот-вот прервётся.',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -392,13 +392,16 @@ export const tr: Localized<EnMessages> = {
 
   notifications: {
     messages: 'Mesajlar',
-    messagesBody: 'Biri sana yazdığında.',
+    messagesBody: 'Biri sana yazdığında. E-posta yalnızca bir süredir uzaktaysan.',
     streak: 'Streak hatırlatması',
-    streakBody: 'Akşam, streak’in kırılmak üzereyse.',
+    streakBody: 'Akşam, streak’in kırılmak üzereyse. Girişli telefonun yoksa e-postayla.',
     profileVisits: 'Profil ziyaretleri',
-    profileVisitsBody: 'Biri profiline baktığında.',
+    profileVisitsBody: 'Günde bir kez, profiline kaç kişinin baktığı. Haftada bir e-postayla özet.',
     promotions: 'Haberler ve kampanyalar',
     promotionsBody: 'Arada yeniliklerden haber. İstemedikçe kapalı.',
+    /** The two halves of every kind above; the row title, so no kind name in it. */
+    channel: { push: 'Anlık bildirim', email: 'E-posta' },
+    emailUnverified: 'Bunu açmak için e-posta adresini doğrula.',
     primingTitle: 'Bildirimler açılsın mı?',
     primingBody:
       'Sadece iki şey: biri sana mesaj attığında ve serin kopmak üzereyse saat {hour}:00’da bir dürtme.',

--- a/packages/shared/src/notifications.test.ts
+++ b/packages/shared/src/notifications.test.ts
@@ -1,42 +1,50 @@
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_NOTIFICATION_PREFS,
+  NOTIFICATION_CHANNELS,
   NOTIFICATION_TYPES,
   notificationPrefsSchema,
   notificationsAllowed,
+  resolveNotificationPrefs,
 } from './notifications'
 
 describe('notification defaults', () => {
   /**
    * Not a taste: consent to be marketed at has to be given rather than
-   * withdrawn, so a new account is opted out of promotions.
+   * withdrawn, so a new account is opted out of promotions — and out of both
+   * channels, because an unsolicited email is the half with a regulator.
    */
-  it('opts nobody into promotions', () => {
-    expect(DEFAULT_NOTIFICATION_PREFS.promotions).toBe(false)
+  it('opts nobody into promotions, on either channel', () => {
+    expect(DEFAULT_NOTIFICATION_PREFS.promotions).toEqual({ push: false, email: false })
   })
 
   it('is on for what the app already does', () => {
-    expect(DEFAULT_NOTIFICATION_PREFS.messages).toBe(true)
-    expect(DEFAULT_NOTIFICATION_PREFS.streak).toBe(true)
+    expect(DEFAULT_NOTIFICATION_PREFS.messages).toEqual({ push: true, email: true })
+    expect(DEFAULT_NOTIFICATION_PREFS.streak).toEqual({ push: true, email: true })
   })
 
-  it('covers every type, so no kind falls through to undefined', () => {
+  it('covers every kind on every channel, so no cell falls through to undefined', () => {
     for (const type of NOTIFICATION_TYPES) {
-      expect(typeof DEFAULT_NOTIFICATION_PREFS[type], type).toBe('boolean')
+      for (const channel of NOTIFICATION_CHANNELS) {
+        expect(typeof DEFAULT_NOTIFICATION_PREFS[type][channel], `${type}.${channel}`).toBe(
+          'boolean',
+        )
+      }
     }
   })
 })
 
 describe('notificationsAllowed', () => {
   it('honours an explicit choice', () => {
-    expect(notificationsAllowed({ messages: false }, 'messages')).toBe(false)
-    expect(notificationsAllowed({ promotions: true }, 'promotions')).toBe(true)
+    expect(notificationsAllowed({ messages: { push: false } }, 'messages', 'push')).toBe(false)
+    expect(notificationsAllowed({ promotions: { email: true } }, 'promotions', 'email')).toBe(true)
   })
 
   it('falls back to the default for anything unsaid', () => {
-    expect(notificationsAllowed({}, 'messages')).toBe(true)
-    expect(notificationsAllowed(undefined, 'streak')).toBe(true)
-    expect(notificationsAllowed({}, 'promotions')).toBe(false)
+    expect(notificationsAllowed({}, 'messages', 'push')).toBe(true)
+    expect(notificationsAllowed(undefined, 'streak', 'email')).toBe(true)
+    expect(notificationsAllowed({}, 'promotions', 'push')).toBe(false)
+    expect(notificationsAllowed({}, 'promotions', 'email')).toBe(false)
   })
 
   /**
@@ -46,57 +54,104 @@ describe('notificationsAllowed', () => {
    */
   it('still understands the single switch v1 wrote', () => {
     for (const type of NOTIFICATION_TYPES) {
-      expect(notificationsAllowed(false, type), type).toBe(false)
+      for (const channel of NOTIFICATION_CHANNELS) {
+        expect(notificationsAllowed(false, type, channel), `${type}.${channel}`).toBe(false)
+      }
     }
-    expect(notificationsAllowed(true, 'messages')).toBe(true)
-    expect(notificationsAllowed(true, 'promotions')).toBe(false)
+    expect(notificationsAllowed(true, 'messages', 'push')).toBe(true)
+    expect(notificationsAllowed(true, 'messages', 'email')).toBe(true)
+    expect(notificationsAllowed(true, 'promotions', 'push')).toBe(false)
+    expect(notificationsAllowed(true, 'promotions', 'email')).toBe(false)
   })
 
-  describe('the push/email matrix it replaces', () => {
-    it('reads the push half, because email never sent anything', () => {
-      expect(notificationsAllowed({ messages: { push: false, email: false } }, 'messages')).toBe(
-        false,
-      )
-      expect(notificationsAllowed({ streak: { push: true, email: false } }, 'streak')).toBe(true)
+  describe('the bare boolean per kind, written while there was no channel axis', () => {
+    /** Push was the only channel with a sender, so the switch was a push switch. */
+    it('reads push literally', () => {
+      expect(notificationsAllowed({ messages: false }, 'messages', 'push')).toBe(false)
+      expect(notificationsAllowed({ promotions: true }, 'promotions', 'push')).toBe(true)
+    })
+
+    it('silences both channels when it is off', () => {
+      expect(notificationsAllowed({ streak: false }, 'streak', 'email')).toBe(false)
     })
 
     /**
-     * The one migration mistake a user would notice. Somebody who turned push
-     * off and left the dead email box ticked opted *out*; `push || email`
-     * would switch them back on.
+     * Nobody was shown an email option while this shape was being written, so
+     * a `true` consented to nothing about mail. For the service kinds that
+     * lands on the default; for promotions it must not.
      */
-    it('does not let a ticked email box switch push back on', () => {
-      expect(notificationsAllowed({ messages: { push: false, email: true } }, 'messages')).toBe(
-        false,
-      )
-      expect(notificationsAllowed({ promotions: { push: false, email: true } }, 'promotions')).toBe(
-        false,
-      )
+    it('never lets it consent to email that was never offered', () => {
+      expect(notificationsAllowed({ messages: true }, 'messages', 'email')).toBe(true)
+      expect(notificationsAllowed({ promotions: true }, 'promotions', 'email')).toBe(false)
+    })
+  })
+
+  describe('the {push, email} object', () => {
+    it('reads both halves literally, now that both have a sender', () => {
+      expect(
+        notificationsAllowed({ messages: { push: false, email: true } }, 'messages', 'push'),
+      ).toBe(false)
+      expect(
+        notificationsAllowed({ messages: { push: false, email: true } }, 'messages', 'email'),
+      ).toBe(true)
     })
 
-    it('falls back to the default when the matrix named only email', () => {
-      expect(notificationsAllowed({ messages: { email: true } }, 'messages')).toBe(true)
-      expect(notificationsAllowed({ promotions: { email: true } }, 'promotions')).toBe(false)
+    it('fills a half nobody named with the default', () => {
+      expect(notificationsAllowed({ messages: { email: false } }, 'messages', 'push')).toBe(true)
+      expect(notificationsAllowed({ streak: { push: false } }, 'streak', 'email')).toBe(true)
+      expect(notificationsAllowed({ promotions: { push: true } }, 'promotions', 'email')).toBe(
+        false,
+      )
     })
 
     it('falls back to the default for an empty object', () => {
-      expect(notificationsAllowed({ streak: {} }, 'streak')).toBe(true)
-      expect(notificationsAllowed({ promotions: {} }, 'promotions')).toBe(false)
+      expect(notificationsAllowed({ streak: {} }, 'streak', 'push')).toBe(true)
+      expect(notificationsAllowed({ promotions: {} }, 'promotions', 'email')).toBe(false)
     })
   })
 })
 
+describe('resolveNotificationPrefs', () => {
+  it('answers for every cell, whatever shape was stored', () => {
+    for (const stored of [
+      undefined,
+      true,
+      false,
+      { messages: false },
+      { streak: { push: false } },
+    ]) {
+      const resolved = resolveNotificationPrefs(stored)
+      for (const type of NOTIFICATION_TYPES) {
+        for (const channel of NOTIFICATION_CHANNELS) {
+          expect(typeof resolved[type][channel], `${type}.${channel}`).toBe('boolean')
+        }
+      }
+    }
+  })
+
+  it('agrees with the reader it is built on', () => {
+    const stored = { messages: { push: false }, promotions: true }
+    const resolved = resolveNotificationPrefs(stored)
+    expect(resolved.messages).toEqual({ push: false, email: true })
+    expect(resolved.promotions).toEqual({ push: true, email: false })
+  })
+})
+
 describe('notificationPrefsSchema', () => {
-  it('accepts one key without demanding the other three', () => {
-    expect(notificationPrefsSchema.safeParse({ messages: false }).success).toBe(true)
+  it('accepts one cell without demanding the other seven', () => {
+    expect(notificationPrefsSchema.safeParse({ messages: { email: false } }).success).toBe(true)
   })
 
   it('refuses a value that is not a boolean', () => {
-    expect(notificationPrefsSchema.safeParse({ messages: 'yes' }).success).toBe(false)
+    expect(notificationPrefsSchema.safeParse({ messages: { email: 'yes' } }).success).toBe(false)
   })
 
-  /** The matrix is no longer a thing a client may send. */
-  it('refuses the shape it replaces', () => {
-    expect(notificationPrefsSchema.safeParse({ messages: { push: false } }).success).toBe(false)
+  /**
+   * A client may no longer send the bare boolean. It is still *read* — old
+   * accounts carry it — but a screen that can draw two switches has no excuse
+   * for writing a value that cannot say which one moved.
+   */
+  it('refuses the channel-less shape it replaces', () => {
+    expect(notificationPrefsSchema.safeParse({ messages: false }).success).toBe(false)
   })
 })

--- a/packages/shared/src/notifications.ts
+++ b/packages/shared/src/notifications.ts
@@ -5,37 +5,47 @@ import { z } from 'zod'
  *
  * One boolean used to cover all of it — `settings.notifications` — which meant
  * that somebody who did not want a nudge about their streak had to turn off
- * the message they were waiting for as well. Four kinds fixed that, and each
- * kind briefly had two channels behind it, push and email.
+ * the message they were waiting for as well. Four kinds fixed that.
  *
- * The email column never sent anything. `apps/api/src/email/` has exactly two
- * templates, verification and password reset, and `EmailSender` is imported by
- * no module; six of the eight switches did nothing at all. A settings screen
- * that offers a choice which changes nothing is worse than one that does not
- * offer it, so the channel axis is gone and each kind is one switch again.
+ * Each kind briefly had two channels behind it, push and email, and the email
+ * column was removed again because it sent nothing: `apps/api/src/email/` held
+ * two templates, verification and password reset, and six of the eight
+ * switches did nothing at all. That was the right call for a screen offering a
+ * choice which changed nothing.
  *
- * The kind axis stays, because that one was never the problem.
+ * The channel axis is back because the senders now exist — a digest for unread
+ * messages, an evening streak mail for somebody with no phone signed in, a
+ * weekly profile-visit summary, and a campaign script for promotions. Every
+ * one of the eight cells reaches something that sends, and the settings screen
+ * disables the email half until an address is verified, which is what stops
+ * "a switch that does nothing" coming back.
  */
 export const NOTIFICATION_TYPES = ['messages', 'streak', 'profileVisits', 'promotions'] as const
 export type NotificationType = (typeof NOTIFICATION_TYPES)[number]
 
-export type NotificationPrefs = Record<NotificationType, boolean>
+export const NOTIFICATION_CHANNELS = ['push', 'email'] as const
+export type NotificationChannel = (typeof NOTIFICATION_CHANNELS)[number]
+
+export type ChannelPrefs = Record<NotificationChannel, boolean>
+export type NotificationPrefs = Record<NotificationType, ChannelPrefs>
 
 /**
  * What is actually on a profile, and it is three shapes at once.
  *
- * A `boolean` is a v1 account, one switch for everything. A `{push, email}`
- * object is an account written while the matrix existed. A bare boolean per
- * kind is what this version writes. All three are live in production
- * simultaneously, which is why `notificationsAllowed` is the only thing
- * allowed to read this field.
+ * A `boolean` is a v1 account, one switch for everything. A bare boolean per
+ * kind is what the app wrote while the channel axis was gone. A
+ * `{push, email}` object is both the retired matrix and what this version
+ * writes — byte-identical, and deliberately so: an account that recorded a
+ * channel choice before keeps it, and there is no migration to run. All three
+ * are live in production simultaneously, which is why `notificationsAllowed`
+ * is the only thing allowed to read this field.
  */
 export type StoredNotificationPrefs = Partial<
   Record<NotificationType, boolean | { push?: boolean; email?: boolean }>
 >
 
 /**
- * On for everything the app already does; **promotions off**.
+ * On for everything the app already does; **promotions off on both channels**.
  *
  * The last one is not a taste. Consent to be marketed at has to be given, not
  * withdrawn — GDPR calls a pre-ticked box no consent at all, and CAN-SPAM's
@@ -43,61 +53,110 @@ export type StoredNotificationPrefs = Partial<
  * of promotions and opted in to the things it asked for by installing the app.
  */
 export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
-  messages: true,
-  streak: true,
-  profileVisits: true,
-  promotions: false,
+  messages: { push: true, email: true },
+  streak: { push: true, email: true },
+  profileVisits: { push: true, email: true },
+  promotions: { push: false, email: false },
 }
 
 /**
- * Partial, like `privacy` in `updateProfileSchema` and for the same reason: a
- * client sending `{ messages: false }` must not have to restate the other
- * three, and must not blank them by omission. The repository writes dotted
- * paths, so an absent key stays as it was.
+ * Partial at both levels, like `privacy` in `updateProfileSchema` and for the
+ * same reason: a client sending `{ messages: { email: false } }` must not have
+ * to restate the other seven cells, and must not blank them by omission. The
+ * repository writes each kind whole — see `updateProfile` for why a dotted
+ * path one level deeper cannot work.
  */
+const channelPrefsSchema = z.object({ push: z.boolean(), email: z.boolean() }).partial()
 export const notificationPrefsSchema = z
   .object({
-    messages: z.boolean(),
-    streak: z.boolean(),
-    profileVisits: z.boolean(),
-    promotions: z.boolean(),
+    messages: channelPrefsSchema,
+    streak: channelPrefsSchema,
+    profileVisits: channelPrefsSchema,
+    promotions: channelPrefsSchema,
   })
   .partial()
 export type NotificationPrefsInput = z.infer<typeof notificationPrefsSchema>
 
 /**
- * Whether one notification may be sent.
+ * Whether one notification may be sent on one channel.
+ *
+ * `channel` is required rather than defaulting to push, so that adding it
+ * made the compiler point at every existing call site instead of leaving one
+ * of them silently asking a question it no longer meant.
  *
  * Missing means default: profiles written before this existed carry a boolean,
- * a matrix, or nothing at all, and none of those should be read as "wants
- * nothing". The one thing that is never inferred is a promotion — absent stays
- * off, because consent is the thing that has to be recorded.
+ * a bare boolean per kind, or nothing at all, and none of those should be read
+ * as "wants nothing". The one thing that is never inferred is a promotion —
+ * absent stays off, on both channels, because consent is the thing that has to
+ * be recorded.
  */
 export function notificationsAllowed(
   prefs: StoredNotificationPrefs | boolean | undefined,
   type: NotificationType,
+  channel: NotificationChannel,
 ): boolean {
   // The oldest shape: one switch for everything. `false` meant silence, and it
-  // still does; `true` means the defaults.
+  // still does; `true` means the defaults, which keeps promotions off.
   if (typeof prefs === 'boolean') {
-    return prefs ? DEFAULT_NOTIFICATION_PREFS[type] : false
+    return prefs ? DEFAULT_NOTIFICATION_PREFS[type][channel] : false
   }
 
   const chosen = prefs?.[type]
-  if (typeof chosen === 'boolean') return chosen
 
   /*
-   * The matrix shape, collapsed to its `push` half.
+   * The bare boolean per kind, from the months when the channel axis was gone.
    *
-   * `push` is the only channel that ever sent anything, so it is the only one
-   * that recorded a real decision — `email` was a preference filed against a
-   * sender that did not exist. Reading `push || email` would silently switch
-   * push back on for somebody who turned it off and left the dead email box
-   * ticked, which is the one migration mistake here that a user would notice.
+   * Push reads it literally: push was the only channel with a sender, so the
+   * switch was in practice a push switch and a `true` on promotions is a real
+   * decision to be pushed at. Email cannot read it the same way. Nobody was
+   * shown an email option, so a `true` here consented to nothing about mail —
+   * it falls to the default, which is on for the three service kinds and off
+   * for promotions. `false` still means silence on both.
    */
-  if (chosen && typeof chosen === 'object') {
-    return chosen.push ?? DEFAULT_NOTIFICATION_PREFS[type]
+  if (typeof chosen === 'boolean') {
+    if (channel === 'push') return chosen
+    return chosen && DEFAULT_NOTIFICATION_PREFS[type].email
   }
 
-  return DEFAULT_NOTIFICATION_PREFS[type]
+  /*
+   * The object shape: the retired matrix and today's writes, indistinguishable
+   * from each other.
+   *
+   * Both halves are read literally now. While no email sender existed, reading
+   * `email` would have been reading a preference filed against nothing, and
+   * the reader collapsed the object to its `push` half. Now that a message
+   * digest and three other senders exist, a recorded `email: false` is
+   * somebody having turned mail off, and ignoring it would be the one
+   * migration mistake a user notices. The matrix lived for hours on a build
+   * that reached no store, so the number of accounts whose `email` value
+   * predates a sender is small enough to check by hand — and a stray
+   * `promotions.email: true` is unset before this ships rather than reasoned
+   * about here.
+   */
+  if (chosen && typeof chosen === 'object') {
+    return chosen[channel] ?? DEFAULT_NOTIFICATION_PREFS[type][channel]
+  }
+
+  return DEFAULT_NOTIFICATION_PREFS[type][channel]
+}
+
+/**
+ * The whole eight-cell matrix, with every stored shape already resolved.
+ *
+ * The settings screen needs all eight to draw its switches, and `updateProfile`
+ * needs the four it is not touching to leave them alone — both would otherwise
+ * write their own loop over `notificationsAllowed` and one of them would
+ * eventually forget a kind.
+ */
+export function resolveNotificationPrefs(
+  prefs: StoredNotificationPrefs | boolean | undefined,
+): NotificationPrefs {
+  const resolved = {} as NotificationPrefs
+  for (const type of NOTIFICATION_TYPES) {
+    resolved[type] = {
+      push: notificationsAllowed(prefs, type, 'push'),
+      email: notificationsAllowed(prefs, type, 'email'),
+    }
+  }
+  return resolved
 }

--- a/packages/shared/src/profile.ts
+++ b/packages/shared/src/profile.ts
@@ -248,9 +248,10 @@ export const updateProfileSchema = z
       .object({
         discoverable: z.boolean(),
         /**
-         * Four kinds, two channels. `.partial()` here as well, so a screen
-         * flipping one switch does not have to restate the other seven — the
-         * repository writes dotted paths for the same reason `privacy` does.
+         * Four kinds, two channels. `.partial()` at both levels, so a screen
+         * flipping one switch does not have to restate the other seven — and
+         * the repository writes each kind whole, because a path one level
+         * deeper cannot enter the bare boolean older profiles still hold.
          */
         notifications: notificationPrefsSchema,
       })


### PR DESCRIPTION
First of eight. The notification senders are being built, and this puts the
push/email axis back on the preferences so that every later sender finds a
recorded consent rather than inventing one.

The axis was removed on 30 August because the email column sent nothing —
two templates existed, verification and password reset, and six of the eight
switches did nothing. That was right for the screen as it stood. It stops
being right now that a digest, a streak fallback, a weekly visit summary and
a campaign script are on the way.

**Three stored shapes are live at once** and `notificationsAllowed(prefs,
kind, channel)` settles all three. The bare boolean per kind is the delicate
one: push reads it literally, email falls to the default and never turns
promotions on. Nobody was shown an email option while that shape was being
written, so nothing in it consented to mail.

**The write stops at the kind, not the channel.**
`settings.notifications.streak.email` is a path into a sub-document and over
a bare boolean there is none to enter — Mongo refuses it. Each touched kind
is resolved and written whole, which is also what migrates it.

**The email half is disabled until an address is verified.** That rule, not
the axis, is what keeps a switch that sends nothing off the screen.

`channel` is a required argument, so the compiler pointed at all three call
sites instead of leaving one silently asking a question it no longer meant.

Also drops the notifications half of `migrate-birthdate.ts`: it flattened
every shape to one boolean per kind, which would now destroy the choices it
once tidied up.

### Before merging

One read against production, because the retired matrix and a new write are
byte-identical: `countDocuments({'settings.notifications.promotions.email':
true})`. Anything non-zero gets `$unset` so promotions email is re-consented
in the new UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)