### PR TITLE
Send the streak nudge to people who have no phone

### DIFF
--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -1,4 +1,4 @@
-import type { Locale } from '@langx/shared'
+import { webUrl, type Locale } from '@langx/shared'
 import { translator } from '../i18n'
 
 /**
@@ -119,5 +119,34 @@ export function resetPasswordEmail(url: string, locale: Locale): Email {
        <p style="font-size: 12px; color: #888;">${t('email.orPaste', { url })}</p>`,
     ),
     text: t('email.resetText', { url }),
+  }
+}
+
+/**
+ * The streak nudge, for somebody with no phone signed in.
+ *
+ * Deliberately the same two sentences as the push — `push.streakTitle` and
+ * `push.streakBody`, not a second wording. One person may have a phone this
+ * month and only the web the next, and a reminder that changes its voice
+ * depending on how it arrived reads as two different features.
+ */
+export function streakReminderEmail(
+  locale: Locale,
+  { count, unsubscribe }: { count: number; unsubscribe: string },
+): Email {
+  const t = translator(locale)
+  const title = t('push.streakTitle', { count })
+  const body = t('push.streakBody')
+  const cta = { url: webUrl('/chats'), label: t('email.openChats') }
+  return {
+    subject: title,
+    html: notificationEmail(locale, {
+      preheader: body,
+      bodyHtml: `<p><strong>${title}</strong></p><p>${body}</p>`,
+      cta,
+      unsubscribeUrl: unsubscribe,
+      manageUrl: webUrl('/settings'),
+    }).html,
+    text: notificationText(locale, [title, body, '', cta.url], unsubscribe),
   }
 }

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -35,6 +35,8 @@ export const ar: Localized<ServerMessages> = {
     unsubscribeLink: 'أوقف هذه الرسائل',
     unsubscribeText: 'أوقف هذه الرسائل: {url}',
     managePrefs: 'كل إعدادات الإشعارات',
+    /** The one button a streak email has. */
+    openChats: 'أرسل رسالة',
 
     unsubscribeTitle: 'إيقاف هذه الرسائل؟',
     unsubscribeBody: 'لن تصلك {kind} عبر البريد بعد الآن. إشعارات الهاتف لا تتأثر.',

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -28,6 +28,8 @@ export const de: Localized<ServerMessages> = {
     unsubscribeLink: 'Diese E-Mails abstellen',
     unsubscribeText: 'Diese E-Mails abstellen: {url}',
     managePrefs: 'Alle Benachrichtigungseinstellungen',
+    /** The one button a streak email has. */
+    openChats: 'Nachricht senden',
 
     unsubscribeTitle: 'Diese E-Mails abstellen?',
     unsubscribeBody:

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -39,6 +39,8 @@ export const en = {
     unsubscribeLink: 'Turn these emails off',
     unsubscribeText: 'Turn these emails off: {url}',
     managePrefs: 'All notification settings',
+    /** The one button a streak email has. */
+    openChats: 'Send a message',
 
     unsubscribeTitle: 'Turn off these emails?',
     unsubscribeBody:

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -27,6 +27,8 @@ export const es: Localized<ServerMessages> = {
     unsubscribeLink: 'Desactivar estos correos',
     unsubscribeText: 'Desactivar estos correos: {url}',
     managePrefs: 'Todos los ajustes de notificaciones',
+    /** The one button a streak email has. */
+    openChats: 'Enviar un mensaje',
 
     unsubscribeTitle: '¿Desactivar estos correos?',
     unsubscribeBody:

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -29,6 +29,8 @@ export const fr: Localized<ServerMessages> = {
     unsubscribeLink: 'Désactiver ces e-mails',
     unsubscribeText: 'Désactiver ces e-mails : {url}',
     managePrefs: 'Tous les réglages de notifications',
+    /** The one button a streak email has. */
+    openChats: 'Envoyer un message',
 
     unsubscribeTitle: 'Désactiver ces e-mails ?',
     unsubscribeBody:

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -27,6 +27,8 @@ export const ptBR: Localized<ServerMessages> = {
     unsubscribeLink: 'Desativar estes e-mails',
     unsubscribeText: 'Desativar estes e-mails: {url}',
     managePrefs: 'Todas as configurações de notificações',
+    /** The one button a streak email has. */
+    openChats: 'Enviar uma mensagem',
 
     unsubscribeTitle: 'Desativar estes e-mails?',
     unsubscribeBody:

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -37,6 +37,8 @@ export const ru: Localized<ServerMessages> = {
     unsubscribeLink: 'Отключить эти письма',
     unsubscribeText: 'Отключить эти письма: {url}',
     managePrefs: 'Все настройки уведомлений',
+    /** The one button a streak email has. */
+    openChats: 'Отправить сообщение',
 
     unsubscribeTitle: 'Отключить эти письма?',
     unsubscribeBody:

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -27,6 +27,8 @@ export const tr: Localized<ServerMessages> = {
     unsubscribeLink: 'Bu e-postaları kapat',
     unsubscribeText: 'Bu e-postaları kapat: {url}',
     managePrefs: 'Tüm bildirim ayarları',
+    /** The one button a streak email has. */
+    openChats: 'Mesaj gönder',
 
     unsubscribeTitle: 'Bu e-postalar kapatılsın mı?',
     unsubscribeBody: '{kind} artık e-postayla gelmeyecek. Telefonundaki bildirimler etkilenmez.',

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,12 +5,13 @@ import { connectToDatabase } from './db/client'
 import { ensureIndexes } from './db/indexes'
 import { createEmailSender } from './email/sender'
 import { attachSentryErrorHandler, initSentry } from './observability/sentry'
-import { loadEnv } from './env'
+import { loadEnv, publicApiUrl, unsubscribeSecret } from './env'
 import { createStorageProvider } from './storage/createStorageProvider'
 import { createTranslationProvider } from './translation/createTranslationProvider'
 import { createRevenueCatClientFromEnv } from './modules/billing/createRevenueCatClient'
 import { startPurgeScheduler } from './modules/account/purgeScheduler'
 import { ExpoPushSender } from './modules/push/devices'
+import type { NotificationEmailContext } from './email/notify'
 import { AppwriteLegacyVerifier, DisabledLegacyVerifier } from './modules/handles/legacyLogin'
 import { startLegacyImportScheduler } from './modules/handles/legacyImportScheduler'
 import { startStreakReminderScheduler } from './modules/push/reminderScheduler'
@@ -36,6 +37,18 @@ async function main(): Promise<void> {
   const translation = createTranslationProvider(env)
 
   const push = new ExpoPushSender(env.EXPO_ACCESS_TOKEN)
+
+  /**
+   * What every notification sender needs: an outbox, the secret its
+   * unsubscribe links are signed with, and the address those links point back
+   * at. Built once so no scheduler assembles its own and gets one of the three
+   * subtly wrong.
+   */
+  const notificationEmail: NotificationEmailContext = {
+    sender: emailSender,
+    unsubscribeSecret: unsubscribeSecret(env),
+    apiBaseUrl: publicApiUrl(env),
+  }
 
   // The bridge only exists while v1 is still running. Without APPWRITE_* it is
   // simply off, and a returning user goes through the normal reset-password
@@ -72,7 +85,7 @@ async function main(): Promise<void> {
   const schedulers = [
     startDailyPoolScheduler(db, app.log),
     startPurgeScheduler(db, app.log, { storage }),
-    startStreakReminderScheduler(db, push, app.log),
+    startStreakReminderScheduler(db, push, notificationEmail, app.log),
     startLegacyImportScheduler(db, app.log),
   ]
 

--- a/apps/api/src/modules/push/reminderScheduler.test.ts
+++ b/apps/api/src/modules/push/reminderScheduler.test.ts
@@ -1,0 +1,184 @@
+import { STREAK_REMINDER_LOCAL_HOUR } from '@langx/shared'
+import { ObjectId } from 'mongodb'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import type { NotificationEmailContext } from '../../email/notify'
+import { authId } from '../../lib/authId'
+import { CapturingEmailSender } from '../../testSupport/authFlow'
+import { LoggingPushSender, type Device } from './devices'
+import { runStreakReminderTick } from './reminderScheduler'
+
+const SECRET = 'c'.repeat(40)
+
+/**
+ * A fixed zone in which `now` is the reminder hour.
+ *
+ * `Etc/GMT+n` runs *behind* UTC by n hours despite the plus — a POSIX
+ * inversion, not a typo — so this picks the offset that puts the local clock
+ * on `STREAK_REMINDER_LOCAL_HOUR` and nothing depends on when the suite runs.
+ */
+function zoneWhereItIsReminderHour(now: Date): string {
+  const offset = (now.getUTCHours() - STREAK_REMINDER_LOCAL_HOUR + 24) % 24
+  if (offset === 0) return 'UTC'
+  return offset <= 12 ? `Etc/GMT+${offset}` : `Etc/GMT-${24 - offset}`
+}
+
+describe('the streak reminder pass', () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+  let push: LoggingPushSender
+  let sender: CapturingEmailSender
+  let email: NotificationEmailContext
+  const now = new Date('2026-09-03T14:00:00Z')
+  const zone = zoneWhereItIsReminderHour(now)
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'streak_reminder_test')
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    for (const name of [
+      COLLECTIONS.profiles,
+      COLLECTIONS.user,
+      COLLECTIONS.devices,
+      COLLECTIONS.streakReminders,
+    ]) {
+      await handle.db.collection(name).deleteMany({})
+    }
+    push = new LoggingPushSender()
+    sender = new CapturingEmailSender()
+    email = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api2.langx.io' }
+  })
+
+  async function seed(
+    opts: {
+      notifications?: unknown
+      withDevice?: boolean
+      verified?: boolean
+      streak?: number
+      lastQualifiedDay?: string
+      timezone?: string
+    } = {},
+  ): Promise<string> {
+    const userId = new ObjectId().toHexString()
+    await handle.db.collection(COLLECTIONS.profiles).insertOne({
+      _id: userId,
+      timezone: opts.timezone ?? zone,
+      streak: {
+        current: opts.streak ?? 3,
+        longest: 9,
+        // Yesterday: today's chance has not been taken, which is the whole
+        // reason the nudge is worth sending.
+        lastQualifiedDay: opts.lastQualifiedDay ?? '2026-09-02',
+      },
+      settings: { discoverable: true, notifications: opts.notifications ?? {} },
+    } as never)
+    await handle.db.collection(COLLECTIONS.user).insertOne({
+      _id: authId(userId),
+      email: `${userId}@example.com`,
+      emailVerified: opts.verified ?? true,
+    })
+    if (opts.withDevice) {
+      await handle.db.collection<Device>(COLLECTIONS.devices).insertOne({
+        userId,
+        pushToken: `ExponentPushToken[${userId}]`,
+        platform: 'ios',
+        createdAt: now,
+        updatedAt: now,
+      } as never)
+    }
+    return userId
+  }
+
+  it('pushes to a phone and sends no email', async () => {
+    await seed({ withDevice: true })
+    const result = await runStreakReminderTick(handle.db, push, email, now)
+
+    expect(result).toEqual({ pushed: 1, emailed: 0 })
+    expect(push.sent).toHaveLength(1)
+    expect(push.sent[0]?.data.kind).toBe('streakReminder')
+    expect(sender.messages).toHaveLength(0)
+  })
+
+  /**
+   * The web audience, and anyone who declined the permission. Before this
+   * they were found, ledgered and then silently skipped.
+   */
+  it('emails somebody with no phone signed in', async () => {
+    await seed()
+    const result = await runStreakReminderTick(handle.db, push, email, now)
+
+    expect(result).toEqual({ pushed: 0, emailed: 1 })
+    expect(push.sent).toHaveLength(0)
+    expect(sender.messages).toHaveLength(1)
+    // The same words as the push, with the streak count filled in.
+    expect(sender.messages[0]?.subject).toContain('3')
+    expect(sender.messages[0]?.headers?.['List-Unsubscribe-Post']).toBe(
+      'List-Unsubscribe=One-Click',
+    )
+  })
+
+  it('nudges once a day however many times it runs', async () => {
+    await seed()
+    await runStreakReminderTick(handle.db, push, email, now)
+    const second = await runStreakReminderTick(handle.db, push, email, now)
+
+    expect(second).toEqual({ pushed: 0, emailed: 0 })
+    expect(sender.messages).toHaveLength(1)
+  })
+
+  it('says nothing to somebody who turned both channels off', async () => {
+    await seed({ notifications: { streak: { push: false, email: false } } })
+    await runStreakReminderTick(handle.db, push, email, now)
+
+    expect(sender.messages).toHaveLength(0)
+    expect(push.sent).toHaveLength(0)
+    // Not even claimed: the day should still be free if they change their mind.
+    expect(await handle.db.collection(COLLECTIONS.streakReminders).countDocuments({})).toBe(0)
+  })
+
+  it('emails somebody who wants mail but not a push', async () => {
+    await seed({ withDevice: true, notifications: { streak: { push: false, email: true } } })
+    const result = await runStreakReminderTick(handle.db, push, email, now)
+
+    expect(result).toEqual({ pushed: 0, emailed: 1 })
+    expect(push.sent).toHaveLength(0)
+  })
+
+  /**
+   * The day is claimed before the send is attempted, so a person the mail
+   * cannot reach is not retried thirty minutes later — and again the next
+   * evening after that.
+   */
+  it('still claims the day when the address is unverified', async () => {
+    await seed({ verified: false })
+    const result = await runStreakReminderTick(handle.db, push, email, now)
+
+    expect(result).toEqual({ pushed: 0, emailed: 0 })
+    expect(sender.messages).toHaveLength(0)
+    expect(await handle.db.collection(COLLECTIONS.streakReminders).countDocuments({})).toBe(1)
+  })
+
+  it('leaves alone anyone for whom it is not the reminder hour', async () => {
+    await seed({ timezone: 'Etc/GMT+1' === zone ? 'Etc/GMT+2' : 'Etc/GMT+1' })
+    const result = await runStreakReminderTick(handle.db, push, email, now)
+    expect(result).toEqual({ pushed: 0, emailed: 0 })
+  })
+
+  it('leaves alone anyone who has already kept the streak today', async () => {
+    const today = new Intl.DateTimeFormat('en-CA', { timeZone: zone }).format(now)
+    await seed({ lastQualifiedDay: today })
+    expect(await runStreakReminderTick(handle.db, push, email, now)).toEqual({
+      pushed: 0,
+      emailed: 0,
+    })
+  })
+})

--- a/apps/api/src/modules/push/reminderScheduler.ts
+++ b/apps/api/src/modules/push/reminderScheduler.ts
@@ -1,6 +1,8 @@
 import { localDayKey } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
+import { sendNotificationEmail, type NotificationEmailContext } from '../../email/notify'
+import { streakReminderEmail } from '../../email/templates'
 import type { Profile } from '../profiles/profiles'
 import type { SchedulerLogger } from '../tokens/poolScheduler'
 import { sendPush, streakReminderCandidates, tokensByLocale, type PushSender } from './devices'
@@ -19,16 +21,85 @@ export interface ReminderLedgerEntry {
 }
 
 /**
- * Sends the "keep your streak" nudge at 20:00 in each user's own timezone.
+ * One pass of the "keep your streak" nudge, at 20:00 in each user's own
+ * timezone.
  *
  * De-duplicated per user per local day by an `_id` of `<userId>:<localDay>`:
  * two ticks land inside the same target hour, and being nagged twice about the
  * same streak is how a notification permission gets revoked. The insert
  * failing on a duplicate key *is* the check — no read-then-write race.
+ *
+ * Split from the timer around it so a test can drive one pass at a chosen
+ * `now`, the way `runDailyPool` is driven; the scheduler below is then only a
+ * clock.
+ *
+ * A phone gets the push. Somebody with none — the whole web audience, and
+ * anyone who declined the permission — gets the same words as an email, in the
+ * *same iteration*, because the ledger insert above has already claimed the
+ * day for them. A second pass would need either a second ledger or a re-read
+ * of this one, and both put back the read-then-write race the `_id` insert was
+ * chosen to avoid.
  */
+export async function runStreakReminderTick(
+  db: Db,
+  sender: PushSender,
+  email: NotificationEmailContext,
+  now: Date = new Date(),
+): Promise<{ pushed: number; emailed: number }> {
+  const candidates = await streakReminderCandidates(db, now)
+  let pushed = 0
+  let emailed = 0
+
+  for (const candidate of candidates) {
+    const profile = await db
+      .collection<Profile>(COLLECTIONS.profiles)
+      .findOne({ _id: candidate.userId }, { projection: { timezone: 1 } })
+    const day = localDayKey(now, profile?.timezone ?? 'UTC')
+
+    try {
+      await db
+        .collection<ReminderLedgerEntry>(COLLECTIONS.streakReminders)
+        .insertOne({ _id: `${candidate.userId}:${day}`, sentOn: now })
+    } catch {
+      continue // already nudged today
+    }
+
+    const byLocale = candidate.push
+      ? await tokensByLocale(db, candidate.userId)
+      : new Map<never, never>()
+    if (byLocale.size > 0) {
+      for (const [locale, tokens] of byLocale) {
+        const t = translator(locale)
+        await sendPush(db, sender, {
+          to: tokens,
+          title: t('push.streakTitle', { count: candidate.streak }),
+          body: t('push.streakBody'),
+          data: { kind: 'streakReminder' },
+        })
+      }
+      pushed++
+      continue
+    }
+
+    // Not a second notification, a fallback for the one that had nowhere to
+    // go. Somebody holding both a phone and an inbox gets exactly one nudge.
+    if (!candidate.email) continue
+    const outcome = await sendNotificationEmail(db, email, {
+      userId: candidate.userId,
+      type: 'streak',
+      build: (locale, unsubscribe) =>
+        streakReminderEmail(locale, { count: candidate.streak, unsubscribe }),
+    })
+    if (outcome === 'sent') emailed++
+  }
+
+  return { pushed, emailed }
+}
+
 export function startStreakReminderScheduler(
   db: Db,
   sender: PushSender,
+  email: NotificationEmailContext,
   logger: SchedulerLogger,
   options: { intervalMs?: number } = {},
 ): { stop: () => void } {
@@ -39,39 +110,8 @@ export function startStreakReminderScheduler(
     if (running) return
     running = true
     try {
-      const now = new Date()
-      const candidates = await streakReminderCandidates(db, now)
-      let sent = 0
-
-      for (const candidate of candidates) {
-        const profile = await db
-          .collection<Profile>(COLLECTIONS.profiles)
-          .findOne({ _id: candidate.userId }, { projection: { timezone: 1 } })
-        const day = localDayKey(now, profile?.timezone ?? 'UTC')
-
-        try {
-          await db
-            .collection<ReminderLedgerEntry>(COLLECTIONS.streakReminders)
-            .insertOne({ _id: `${candidate.userId}:${day}`, sentOn: now })
-        } catch {
-          continue // already nudged today
-        }
-
-        const byLocale = await tokensByLocale(db, candidate.userId)
-        if (byLocale.size === 0) continue
-        for (const [locale, tokens] of byLocale) {
-          const t = translator(locale)
-          await sendPush(db, sender, {
-            to: tokens,
-            title: t('push.streakTitle', { count: candidate.streak }),
-            body: t('push.streakBody'),
-            data: { kind: 'streakReminder' },
-          })
-        }
-        sent++
-      }
-
-      if (sent > 0) logger.info({ sent }, 'streak reminders sent')
+      const { pushed, emailed } = await runStreakReminderTick(db, sender, email, new Date())
+      if (pushed > 0 || emailed > 0) logger.info({ pushed, emailed }, 'streak reminders sent')
     } catch (error) {
       logger.error({ err: error }, 'streak reminder run failed')
     } finally {


### PR DESCRIPTION
Stacked on #1068.

The pass already found these people, claimed their day in the ledger, and
then dropped them: `tokensByLocale` came back empty and the loop moved on.
That is the entire web audience plus everyone who declined the permission.

- **Same iteration, not a second pass.** The ledger insert has already
  claimed the day; re-reading it later reintroduces the race the `_id` insert
  exists to prevent.
- **Same words as the push.** One person may have a phone this month and only
  the web the next.
- **A fallback, not a second notification.** Somebody with both gets one nudge.
- The tick is split from the timer, like `runDailyPool`, which gives this
  scheduler its first test — eight of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)