### PR TITLE
Mail people who have unread messages and have gone

### DIFF
--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -114,6 +114,16 @@ export const COLLECTIONS = {
   /** A single document (`_id: 'current'`) — maintenance, min versions, feature flags. */
   appConfig: 'appConfig',
   jobRuns: 'jobRuns',
+  /**
+   * "We already told them." One row per notification a scheduled pass has
+   * sent, keyed `<job>:<userId>:<periodKey>`.
+   *
+   * One collection rather than one per sender: they are the same document with
+   * the same TTL, and the job name is already the first thing in the `_id`.
+   * `streakReminders` predates it and stays where it is — renaming a live
+   * collection is a migration for nothing.
+   */
+  notificationLedger: 'notificationLedger',
 } as const
 
 export type CollectionName = (typeof COLLECTIONS)[keyof typeof COLLECTIONS]

--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -90,6 +90,13 @@ export const INDEXES: Partial<IndexSpec> = {
       name: 'discovery_learning_active',
     },
     { key: { displayName: 'text', bio: 'text' }, name: 'profile_text' },
+    /*
+     * "Who has been away long enough to email?" — a bare range over one field.
+     * The two discovery indexes above both lead with a language array, so
+     * neither can serve it, and without this the digest pass is a collection
+     * scan every half hour.
+     */
+    { key: { 'stats.lastActiveAt': 1 }, name: 'last_active' },
     /**
      * The Pro city filter, on the canonical id.
      *
@@ -498,6 +505,14 @@ export const INDEXES: Partial<IndexSpec> = {
     // stops the collection growing forever — a nudge from last month proves
     // nothing today.
     { key: { sentOn: 1 }, name: 'ttl_7d', expireAfterSeconds: 7 * 24 * 60 * 60 },
+  ],
+
+  [COLLECTIONS.notificationLedger]: [
+    // `_id` is `<job>:<userId>:<periodKey>` and carries the uniqueness — the
+    // insert failing *is* the check that nobody is told twice. This only stops
+    // the collection growing forever, and it is thirty days rather than seven
+    // because a weekly period key has to outlive its own week.
+    { key: { sentOn: 1 }, name: 'ttl_30d', expireAfterSeconds: 30 * 24 * 60 * 60 },
   ],
 
   [COLLECTIONS.jobRuns]: [

--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -150,3 +150,53 @@ export function streakReminderEmail(
     text: notificationText(locale, [title, body, '', cta.url], unsubscribe),
   }
 }
+
+/**
+ * "You have unread messages", naming who wrote and how many — and nothing
+ * they said.
+ *
+ * That restriction is the design. The privacy sheet describes notification
+ * mail as counts and display names; a line of somebody's message sitting in
+ * Resend's logs, and in an inbox that may not be private, is a different
+ * disclosure than the one anyone agreed to.
+ */
+export function unreadDigestEmail(
+  locale: Locale,
+  {
+    count,
+    names,
+    moreThreads,
+    url,
+    unsubscribe,
+  }: { count: number; names: string[]; moreThreads: number; url: string; unsubscribe: string },
+): Email {
+  const t = translator(locale)
+  const subject = t('email.digestSubject', { count })
+  // `Intl.ListFormat` because "Ada, Bo and Cy" is not "Ada, Bo, Cy" in most of
+  // the eight languages, and joining with a comma is wrong in all of them.
+  const joined = formatList(locale, names)
+  const body = t('email.digestBody', { count, names: joined })
+  const more = moreThreads > 0 ? t('email.digestMore', { count: moreThreads }) : ''
+  const cta = { url, label: t('email.digestButton') }
+
+  return {
+    subject,
+    html: notificationEmail(locale, {
+      preheader: t('email.digestPreheader'),
+      bodyHtml: `<p>${body}</p>${more ? `<p style="color:#888;">${more}</p>` : ''}`,
+      cta,
+      unsubscribeUrl: unsubscribe,
+      manageUrl: webUrl('/settings'),
+    }).html,
+    text: notificationText(locale, [body, ...(more ? [more] : []), '', cta.url], unsubscribe),
+  }
+}
+
+/** Falls back to a comma join where the runtime has no list formatter. */
+function formatList(locale: Locale, items: string[]): string {
+  try {
+    return new Intl.ListFormat(locale, { type: 'conjunction' }).format(items)
+  } catch {
+    return items.join(', ')
+  }
+}

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -38,6 +38,18 @@ export const ar: Localized<ServerMessages> = {
     /** The one button a streak email has. */
     openChats: 'أرسل رسالة',
 
+    digestSubject: {
+      one: 'رسالة واحدة غير مقروءة في LangX',
+      other: '{count} رسائل غير مقروءة في LangX',
+    },
+    digestPreheader: 'هناك من ينتظر ردّك',
+    digestBody: {
+      one: 'راسلك {names} أثناء غيابك.',
+      other: 'لديك {count} رسائل غير مقروءة من {names}.',
+    },
+    digestMore: { one: 'ومحادثة أخرى.', other: 'و{count} محادثات أخرى.' },
+    digestButton: 'اقرأ وردّ',
+
     unsubscribeTitle: 'إيقاف هذه الرسائل؟',
     unsubscribeBody: 'لن تصلك {kind} عبر البريد بعد الآن. إشعارات الهاتف لا تتأثر.',
     unsubscribeConfirm: 'أوقفها',

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -31,6 +31,21 @@ export const de: Localized<ServerMessages> = {
     /** The one button a streak email has. */
     openChats: 'Nachricht senden',
 
+    digestSubject: {
+      one: '1 ungelesene Nachricht auf LangX',
+      other: '{count} ungelesene Nachrichten auf LangX',
+    },
+    digestPreheader: 'Da wartet jemand auf deine Antwort',
+    digestBody: {
+      one: '{names} hat dir geschrieben, während du weg warst.',
+      other: 'Du hast {count} ungelesene Nachrichten, von {names}.',
+    },
+    digestMore: {
+      one: 'Und eine weitere Unterhaltung.',
+      other: 'Und {count} weitere Unterhaltungen.',
+    },
+    digestButton: 'Lesen und antworten',
+
     unsubscribeTitle: 'Diese E-Mails abstellen?',
     unsubscribeBody:
       '{kind} bekommst du dann nicht mehr per E-Mail. Mitteilungen auf dem Telefon bleiben davon unberührt.',

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -42,6 +42,15 @@ export const en = {
     /** The one button a streak email has. */
     openChats: 'Send a message',
 
+    digestSubject: { one: '1 unread message on LangX', other: '{count} unread messages on LangX' },
+    digestPreheader: 'People are waiting to hear back from you',
+    digestBody: {
+      one: '{names} wrote to you while you were away.',
+      other: 'You have {count} unread messages, from {names}.',
+    },
+    digestMore: { one: 'And 1 more conversation.', other: 'And {count} more conversations.' },
+    digestButton: 'Read and reply',
+
     unsubscribeTitle: 'Turn off these emails?',
     unsubscribeBody:
       'You will stop getting {kind} by email. Notifications on your phone are not affected.',

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -30,6 +30,18 @@ export const es: Localized<ServerMessages> = {
     /** The one button a streak email has. */
     openChats: 'Enviar un mensaje',
 
+    digestSubject: {
+      one: '1 mensaje sin leer en LangX',
+      other: '{count} mensajes sin leer en LangX',
+    },
+    digestPreheader: 'Hay quien espera tu respuesta',
+    digestBody: {
+      one: '{names} te escribió mientras no estabas.',
+      other: 'Tienes {count} mensajes sin leer, de {names}.',
+    },
+    digestMore: { one: 'Y una conversación más.', other: 'Y {count} conversaciones más.' },
+    digestButton: 'Leer y responder',
+
     unsubscribeTitle: '¿Desactivar estos correos?',
     unsubscribeBody:
       'Dejarás de recibir {kind} por correo. Las notificaciones del teléfono no cambian.',

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -32,6 +32,18 @@ export const fr: Localized<ServerMessages> = {
     /** The one button a streak email has. */
     openChats: 'Envoyer un message',
 
+    digestSubject: {
+      one: '1 message non lu sur LangX',
+      other: '{count} messages non lus sur LangX',
+    },
+    digestPreheader: 'On attend votre réponse',
+    digestBody: {
+      one: '{names} vous a écrit pendant votre absence.',
+      other: 'Vous avez {count} messages non lus, de {names}.',
+    },
+    digestMore: { one: 'Et une autre conversation.', other: 'Et {count} autres conversations.' },
+    digestButton: 'Lire et répondre',
+
     unsubscribeTitle: 'Désactiver ces e-mails ?',
     unsubscribeBody:
       'Vous ne recevrez plus {kind} par e-mail. Les notifications sur votre téléphone ne changent pas.',

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -30,6 +30,18 @@ export const ptBR: Localized<ServerMessages> = {
     /** The one button a streak email has. */
     openChats: 'Enviar uma mensagem',
 
+    digestSubject: {
+      one: '1 mensagem não lida no LangX',
+      other: '{count} mensagens não lidas no LangX',
+    },
+    digestPreheader: 'Tem gente esperando sua resposta',
+    digestBody: {
+      one: '{names} te escreveu enquanto você esteve fora.',
+      other: 'Você tem {count} mensagens não lidas, de {names}.',
+    },
+    digestMore: { one: 'E mais uma conversa.', other: 'E mais {count} conversas.' },
+    digestButton: 'Ler e responder',
+
     unsubscribeTitle: 'Desativar estes e-mails?',
     unsubscribeBody:
       'Você deixará de receber {kind} por e-mail. As notificações no telefone não mudam.',

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -40,6 +40,18 @@ export const ru: Localized<ServerMessages> = {
     /** The one button a streak email has. */
     openChats: 'Отправить сообщение',
 
+    digestSubject: {
+      one: '1 непрочитанное сообщение в LangX',
+      other: 'Непрочитанных сообщений в LangX: {count}',
+    },
+    digestPreheader: 'Вам ждут ответа',
+    digestBody: {
+      one: '{names} написал(а) вам, пока вас не было.',
+      other: 'У вас {count} непрочитанных сообщений — от {names}.',
+    },
+    digestMore: { one: 'И ещё один диалог.', other: 'И ещё диалогов: {count}.' },
+    digestButton: 'Прочитать и ответить',
+
     unsubscribeTitle: 'Отключить эти письма?',
     unsubscribeBody:
       'Вы перестанете получать {kind} на почту. Уведомления на телефоне не изменятся.',

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -30,6 +30,15 @@ export const tr: Localized<ServerMessages> = {
     /** The one button a streak email has. */
     openChats: 'Mesaj gönder',
 
+    digestSubject: { one: 'LangX’te 1 okunmamış mesaj', other: 'LangX’te {count} okunmamış mesaj' },
+    digestPreheader: 'Senden haber bekleyenler var',
+    digestBody: {
+      one: 'Sen yokken {names} sana yazdı.',
+      other: '{names} tarafından yazılmış {count} okunmamış mesajın var.',
+    },
+    digestMore: { one: 'Bir sohbet daha var.', other: '{count} sohbet daha var.' },
+    digestButton: 'Oku ve yanıtla',
+
     unsubscribeTitle: 'Bu e-postalar kapatılsın mı?',
     unsubscribeBody: '{kind} artık e-postayla gelmeyecek. Telefonundaki bildirimler etkilenmez.',
     unsubscribeConfirm: 'Kapat',

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,6 +15,7 @@ import type { NotificationEmailContext } from './email/notify'
 import { AppwriteLegacyVerifier, DisabledLegacyVerifier } from './modules/handles/legacyLogin'
 import { startLegacyImportScheduler } from './modules/handles/legacyImportScheduler'
 import { startStreakReminderScheduler } from './modules/push/reminderScheduler'
+import { startNotificationScheduler } from './modules/notifications/scheduler'
 import { startDailyPoolScheduler } from './modules/tokens/poolScheduler'
 
 async function main(): Promise<void> {
@@ -87,6 +88,7 @@ async function main(): Promise<void> {
     startPurgeScheduler(db, app.log, { storage }),
     startStreakReminderScheduler(db, push, notificationEmail, app.log),
     startLegacyImportScheduler(db, app.log),
+    startNotificationScheduler(db, notificationEmail, app.log),
   ]
 
   const shutdown = async (signal: string): Promise<void> => {

--- a/apps/api/src/modules/notifications/ledger.ts
+++ b/apps/api/src/modules/notifications/ledger.ts
@@ -1,0 +1,64 @@
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+
+/** Which scheduled pass a row belongs to; first component of the `_id`. */
+export type NotificationJob = 'unreadDigest' | 'profileVisitsPush' | 'profileVisitsEmail'
+
+export interface NotificationLedgerEntry {
+  _id: string
+  sentOn: Date
+}
+
+function ledgerId(job: NotificationJob, userId: string, periodKey: string): string {
+  return `${job}:${userId}:${periodKey}`
+}
+
+/**
+ * Claims the right to notify one person once, for one job, in one period.
+ *
+ * The insert failing on a duplicate `_id` *is* the check — the same trick the
+ * streak reminder uses, and for the same reason: a read followed by a write
+ * has a gap, and two ticks landing in that gap is somebody being told the same
+ * thing twice. Which, for a notification, is how a permission gets revoked.
+ *
+ * Claimed *before* the send, deliberately. A send that then fails is one
+ * notification nobody got; a send that succeeds after a claim that failed to
+ * record is one they get again every half hour until the hour passes.
+ */
+export async function claimOnce(
+  db: Db,
+  job: NotificationJob,
+  userId: string,
+  periodKey: string,
+): Promise<boolean> {
+  try {
+    await db
+      .collection<NotificationLedgerEntry>(COLLECTIONS.notificationLedger)
+      .insertOne({ _id: ledgerId(job, userId, periodKey), sentOn: new Date() })
+    return true
+  } catch (error) {
+    // 11000 is a duplicate key: somebody else got there, which is the answer.
+    // Anything else is a database problem and must not read as "already done".
+    if ((error as { code?: number }).code === 11000) return false
+    throw error
+  }
+}
+
+/**
+ * The cheap look before the expensive work.
+ *
+ * `claimOnce` alone is correct, but a pass that claims first would have to do
+ * every count and lookup for people it is going to skip. This is a hint, not a
+ * lock: the claim is still what decides.
+ */
+export async function alreadyClaimed(
+  db: Db,
+  job: NotificationJob,
+  userId: string,
+  periodKey: string,
+): Promise<boolean> {
+  const existing = await db
+    .collection<NotificationLedgerEntry>(COLLECTIONS.notificationLedger)
+    .findOne({ _id: ledgerId(job, userId, periodKey) }, { projection: { _id: 1 } })
+  return existing !== null
+}

--- a/apps/api/src/modules/notifications/scheduler.ts
+++ b/apps/api/src/modules/notifications/scheduler.ts
@@ -1,0 +1,52 @@
+import type { Db } from 'mongodb'
+import type { NotificationEmailContext } from '../../email/notify'
+import type { SchedulerLogger } from '../tokens/poolScheduler'
+import { runUnreadDigestPass } from './unreadDigest'
+
+/**
+ * Every thirty minutes, like the streak reminder — and for the same reason.
+ * These passes fire on a whole local hour, and every IANA offset is a whole or
+ * half hour, so a half-hourly tick catches all of them.
+ */
+export const NOTIFICATION_INTERVAL_MS = 30 * 60 * 1000
+
+/**
+ * One timer for the scheduled notification passes rather than one each.
+ *
+ * They share an interval, a `running` guard and a shutdown, and three separate
+ * schedulers would be three chances for one of them to be left out of
+ * `index.ts`. Each pass is caught on its own, though: a pass that throws must
+ * not starve the ones after it, which is exactly what a single try/catch
+ * around the sequence would do.
+ */
+export function startNotificationScheduler(
+  db: Db,
+  email: NotificationEmailContext,
+  logger: SchedulerLogger,
+  options: { intervalMs?: number } = {},
+): { stop: () => void } {
+  const intervalMs = options.intervalMs ?? NOTIFICATION_INTERVAL_MS
+  let running = false
+
+  async function tick(): Promise<void> {
+    if (running) return
+    running = true
+    try {
+      const digest = await runUnreadDigestPass(db, email, new Date())
+      if (digest.sent > 0) logger.info({ sent: digest.sent }, 'unread digests sent')
+    } catch (error) {
+      logger.error({ err: error }, 'unread digest pass failed')
+    } finally {
+      running = false
+    }
+  }
+
+  void tick()
+  const timer = setInterval(() => void tick(), intervalMs)
+  timer.unref?.()
+  return {
+    stop: () => {
+      clearInterval(timer)
+    },
+  }
+}

--- a/apps/api/src/modules/notifications/unreadDigest.test.ts
+++ b/apps/api/src/modules/notifications/unreadDigest.test.ts
@@ -1,0 +1,219 @@
+import { UNREAD_DIGEST_MAX_SENDERS } from '@langx/shared'
+import { ObjectId } from 'mongodb'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import type { NotificationEmailContext } from '../../email/notify'
+import { authId } from '../../lib/authId'
+import { CapturingEmailSender } from '../../testSupport/authFlow'
+import { runUnreadDigestPass } from './unreadDigest'
+
+const SECRET = 'd'.repeat(40)
+const HOUR = 60 * 60 * 1000
+
+/** A zone in which `now` reads as noon, safely inside the send window. */
+function zoneWhereItIsNoon(now: Date): string {
+  const offset = (now.getUTCHours() - 12 + 24) % 24
+  if (offset === 0) return 'UTC'
+  return offset <= 12 ? `Etc/GMT+${offset}` : `Etc/GMT-${24 - offset}`
+}
+
+describe('the unread-message digest', () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+  let sender: CapturingEmailSender
+  let ctx: NotificationEmailContext
+  const now = new Date('2026-09-03T15:00:00Z')
+  const zone = zoneWhereItIsNoon(now)
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'unread_digest_test')
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    for (const name of [
+      COLLECTIONS.profiles,
+      COLLECTIONS.user,
+      COLLECTIONS.conversations,
+      COLLECTIONS.notificationLedger,
+      COLLECTIONS.blocks,
+    ]) {
+      await handle.db.collection(name).deleteMany({})
+    }
+    sender = new CapturingEmailSender()
+    ctx = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api2.langx.io' }
+  })
+
+  async function newProfile(
+    opts: { awayHours?: number; notifications?: unknown; timezone?: string; name?: string } = {},
+  ): Promise<string> {
+    const userId = new ObjectId().toHexString()
+    await handle.db.collection(COLLECTIONS.profiles).insertOne({
+      _id: userId,
+      handle: `h${userId.slice(0, 8)}`,
+      displayName: opts.name ?? `User ${userId.slice(0, 4)}`,
+      timezone: opts.timezone ?? zone,
+      settings: { discoverable: true, notifications: opts.notifications ?? {} },
+      stats: {
+        lastActiveAt: new Date(now.getTime() - (opts.awayHours ?? 12) * HOUR),
+        messagesSent: 3,
+      },
+    } as never)
+    await handle.db
+      .collection(COLLECTIONS.user)
+      .insertOne({ _id: authId(userId), email: `${userId}@example.com`, emailVerified: true })
+    return userId
+  }
+
+  async function thread(
+    reader: string,
+    writer: string,
+    opts: { unread?: number; minutesAgo?: number } = {},
+  ): Promise<ObjectId> {
+    const _id = new ObjectId()
+    await handle.db.collection(COLLECTIONS.conversations).insertOne({
+      _id,
+      pairKey: `${reader}:${writer}:${_id.toHexString()}`,
+      participants: [reader, writer],
+      lastMessage: {
+        body: 'a secret nobody should see in an inbox',
+        senderId: writer,
+        createdAt: new Date(now.getTime() - (opts.minutesAgo ?? 60) * 60_000),
+      },
+      unread: { [reader]: opts.unread ?? 2, [writer]: 0 },
+    })
+    return _id
+  }
+
+  it('names who wrote, counts what is waiting, and quotes nobody', async () => {
+    const reader = await newProfile()
+    const writer = await newProfile({ name: 'Ada Lovelace' })
+    await thread(reader, writer, { unread: 2 })
+
+    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 1 })
+    const message = sender.messages[0]
+    expect(message?.subject).toContain('2')
+    expect(message?.html).toContain('Ada Lovelace')
+    // The one thing a digest must never carry.
+    expect(message?.text).not.toContain('a secret nobody should see')
+    expect(message?.html).not.toContain('a secret nobody should see')
+  })
+
+  /**
+   * The period key is `lastActiveAt`, so a fortnight away is one email. A
+   * daily key would have made this a daily nag.
+   */
+  it('sends once for one absence, however often it runs', async () => {
+    const reader = await newProfile()
+    await thread(reader, await newProfile())
+
+    await runUnreadDigestPass(handle.db, ctx, now)
+    expect(await runUnreadDigestPass(handle.db, ctx, new Date(now.getTime() + HOUR))).toEqual({
+      sent: 0,
+    })
+    expect(sender.messages).toHaveLength(1)
+  })
+
+  it('sends again after they came back, left, and were written to once more', async () => {
+    const reader = await newProfile()
+    const id = await thread(reader, await newProfile())
+    await runUnreadDigestPass(handle.db, ctx, now)
+
+    // They opened the app, went away again, and a new message arrived after
+    // that — which is a fresh `lastActiveAt`, so a fresh period key.
+    const later = new Date(now.getTime() + 48 * HOUR)
+    const cameBack = new Date(later.getTime() - 12 * HOUR)
+    await handle.db
+      .collection(COLLECTIONS.profiles)
+      .updateOne({ _id: reader as never }, { $set: { 'stats.lastActiveAt': cameBack } })
+    await handle.db
+      .collection(COLLECTIONS.conversations)
+      .updateOne(
+        { _id: id },
+        { $set: { 'lastMessage.createdAt': new Date(cameBack.getTime() + HOUR) } },
+      )
+
+    expect(await runUnreadDigestPass(handle.db, ctx, later)).toEqual({ sent: 1 })
+    expect(sender.messages).toHaveLength(2)
+  })
+
+  it('leaves alone somebody who was here an hour ago', async () => {
+    const reader = await newProfile({ awayHours: 1 })
+    await thread(reader, await newProfile())
+    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+  })
+
+  it('leaves alone somebody gone longer than a fortnight', async () => {
+    const reader = await newProfile({ awayHours: 24 * 20 })
+    await thread(reader, await newProfile())
+    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+  })
+
+  it('respects the switch for message email', async () => {
+    const reader = await newProfile({ notifications: { messages: { email: false } } })
+    await thread(reader, await newProfile())
+    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+  })
+
+  /** 3am mail is a phone buzzing, whatever it says on the label. */
+  it('waits for waking hours in the reader’s own timezone', async () => {
+    const middleOfTheNight = (now.getUTCHours() - 3 + 24) % 24
+    const reader = await newProfile({
+      timezone: middleOfTheNight === 0 ? 'UTC' : `Etc/GMT+${middleOfTheNight}`,
+    })
+    await thread(reader, await newProfile())
+
+    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+    // And nothing was claimed, so the 9am tick still gets to send it.
+    expect(await handle.db.collection(COLLECTIONS.notificationLedger).countDocuments({})).toBe(0)
+  })
+
+  it('says nothing when the only unread thread is from somebody blocked', async () => {
+    const reader = await newProfile()
+    const writer = await newProfile()
+    await thread(reader, writer)
+    await handle.db
+      .collection(COLLECTIONS.blocks)
+      .insertOne({ blockerId: reader, blockedId: writer, createdAt: now })
+
+    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+  })
+
+  it('ignores a thread the reader archived', async () => {
+    const reader = await newProfile()
+    const id = await thread(reader, await newProfile())
+    await handle.db
+      .collection(COLLECTIONS.conversations)
+      .updateOne({ _id: id }, { $set: { [`archivedBy.${reader}`]: true } })
+
+    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+  })
+
+  it('ignores a thread whose last word was the reader’s own', async () => {
+    const reader = await newProfile()
+    const writer = await newProfile()
+    const id = await thread(reader, writer)
+    await handle.db
+      .collection(COLLECTIONS.conversations)
+      .updateOne({ _id: id }, { $set: { 'lastMessage.senderId': reader } })
+
+    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+  })
+
+  it('says how many more there are once it has named enough', async () => {
+    const reader = await newProfile()
+    for (let i = 0; i < UNREAD_DIGEST_MAX_SENDERS + 1; i++) {
+      await thread(reader, await newProfile(), { unread: 1, minutesAgo: 60 + i })
+    }
+
+    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 1 })
+    expect(sender.messages[0]?.text).toContain('1 more')
+  })
+})

--- a/apps/api/src/modules/notifications/unreadDigest.ts
+++ b/apps/api/src/modules/notifications/unreadDigest.ts
@@ -1,0 +1,138 @@
+import {
+  NOTIFICATION_EMAIL_LOCAL_HOURS,
+  UNREAD_DIGEST_AWAY_HOURS,
+  UNREAD_DIGEST_MAX_AWAY_DAYS,
+  UNREAD_DIGEST_MAX_SENDERS,
+  localHour,
+  notificationsAllowed,
+  webUrl,
+} from '@langx/shared'
+import type { Db, Filter } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { sendNotificationEmail, type NotificationEmailContext } from '../../email/notify'
+import { unreadDigestEmail } from '../../email/templates'
+import type { Conversation } from '../chat/conversations'
+import { blockedUserIds } from '../moderation/blocks'
+import { alreadyClaimed, claimOnce } from './ledger'
+import type { Profile } from '../profiles/profiles'
+
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+/**
+ * "You have unread messages", for somebody who has not opened the app since
+ * they arrived.
+ *
+ * The period key is `stats.lastActiveAt`, not the local day. While a person
+ * stays away that timestamp does not move, so the key does not change and a
+ * fortnight of absence is **one** email rather than fourteen. Coming back and
+ * leaving again produces a new key, which is exactly when a second digest is
+ * worth sending. A daily key would have made this a daily nag, which is the
+ * thing an unread-message email is most often guilty of.
+ *
+ * Counts and names only — never a line of anybody's message. The privacy sheet
+ * describes notification mail as exactly that, and message text sitting in a
+ * third party's logs is a different disclosure than the one users agreed to.
+ */
+export async function runUnreadDigestPass(
+  db: Db,
+  ctx: NotificationEmailContext,
+  now: Date = new Date(),
+): Promise<{ sent: number }> {
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  const conversations = db.collection<Conversation>(COLLECTIONS.conversations)
+
+  const candidates = await profiles
+    .find(
+      {
+        'stats.lastActiveAt': {
+          $lte: new Date(now.getTime() - UNREAD_DIGEST_AWAY_HOURS * HOUR_MS),
+          $gte: new Date(now.getTime() - UNREAD_DIGEST_MAX_AWAY_DAYS * DAY_MS),
+        },
+        deletedAt: { $exists: false },
+        // Bounds the scan only; `notificationsAllowed` decides. The other two
+        // stored shapes are objects this cannot read into — see the same
+        // filter in `streakReminderCandidates`.
+        'settings.notifications': { $ne: false },
+      },
+      { projection: { timezone: 1, settings: 1, stats: 1 } },
+    )
+    .toArray()
+
+  let sent = 0
+  for (const profile of candidates) {
+    if (!notificationsAllowed(profile.settings?.notifications, 'messages', 'email')) continue
+
+    const hour = localHour(now, profile.timezone ?? 'UTC')
+    if (hour < NOTIFICATION_EMAIL_LOCAL_HOURS.earliest) continue
+    if (hour > NOTIFICATION_EMAIL_LOCAL_HOURS.latest) continue
+
+    const lastActiveAt = profile.stats?.lastActiveAt
+    if (!lastActiveAt) continue
+    const periodKey = new Date(lastActiveAt).toISOString()
+
+    if (await alreadyClaimed(db, 'unreadDigest', profile._id, periodKey)) continue
+
+    const filter: Filter<Conversation> = {
+      participants: profile._id,
+      'lastMessage.createdAt': { $gt: new Date(lastActiveAt) },
+      'lastMessage.senderId': { $ne: profile._id },
+      [`unread.${profile._id}`]: { $gt: 0 },
+      [`archivedBy.${profile._id}`]: { $exists: false },
+      [`deletedBy.${profile._id}`]: { $exists: false },
+    }
+
+    // One more than we name, so "and N more" is answerable without a second
+    // count for the overwhelming majority who have three threads or fewer.
+    const threads = await conversations
+      .find(filter, { projection: { participants: 1, unread: 1, lastMessage: 1 } })
+      .sort({ 'lastMessage.createdAt': -1 })
+      .limit(UNREAD_DIGEST_MAX_SENDERS + 1)
+      .toArray()
+    if (threads.length === 0) continue
+
+    const hidden = new Set(await blockedUserIds(db, profile._id))
+    const visible = threads.filter((thread) =>
+      thread.participants.every((id) => id === profile._id || !hidden.has(id)),
+    )
+    if (visible.length === 0) continue
+
+    const named = visible.slice(0, UNREAD_DIGEST_MAX_SENDERS)
+    const partnerIds = named
+      .map((thread) => thread.participants.find((id) => id !== profile._id))
+      .filter((id): id is string => Boolean(id))
+
+    const partners = await profiles
+      .find(
+        { _id: { $in: partnerIds }, deletedAt: { $exists: false } },
+        { projection: { displayName: 1, handle: 1 } },
+      )
+      .toArray()
+    const nameOf = new Map(partners.map((p) => [p._id, p.displayName ?? p.handle]))
+    const names = partnerIds
+      .map((id) => nameOf.get(id))
+      .filter((name): name is string => Boolean(name))
+    if (names.length === 0) continue
+
+    const count = visible.reduce((total, thread) => total + (thread.unread[profile._id] ?? 0), 0)
+    const moreThreads = Math.max(0, visible.length - named.length)
+    // One thread has somewhere specific to land; several do not, and a link to
+    // the wrong conversation is worse than a link to the list.
+    const url =
+      visible.length === 1 && visible[0]
+        ? webUrl(`/chat/${visible[0]._id.toHexString()}`)
+        : webUrl('/chats')
+
+    if (!(await claimOnce(db, 'unreadDigest', profile._id, periodKey))) continue
+
+    const outcome = await sendNotificationEmail(db, ctx, {
+      userId: profile._id,
+      type: 'messages',
+      build: (locale, unsubscribe) =>
+        unreadDigestEmail(locale, { count, names, moreThreads, url, unsubscribe }),
+    })
+    if (outcome === 'sent') sent++
+  }
+
+  return { sent }
+}

--- a/apps/api/src/modules/push/devices.ts
+++ b/apps/api/src/modules/push/devices.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_LOCALE,
   STREAK_REMINDER_LOCAL_HOUR,
   localDayKey,
+  localHour,
   type Locale,
   type PushKind,
   type PushPlatform,
@@ -267,14 +268,7 @@ export async function streakReminderCandidates(
     const email = notificationsAllowed(profile.settings?.notifications, 'streak', 'email')
     if (!push && !email) continue
     const zone = profile.timezone ?? 'UTC'
-    const localHour = Number(
-      new Intl.DateTimeFormat('en-GB', {
-        timeZone: zone,
-        hour: '2-digit',
-        hour12: false,
-      }).format(now),
-    )
-    if (localHour !== STREAK_REMINDER_LOCAL_HOUR) continue
+    if (localHour(now, zone) !== STREAK_REMINDER_LOCAL_HOUR) continue
     if (profile.streak.lastQualifiedDay === localDayKey(now, zone)) continue
     candidates.push({ userId: profile._id, streak: profile.streak.current, push, email })
   }

--- a/packages/shared/src/notifications.ts
+++ b/packages/shared/src/notifications.ts
@@ -160,3 +160,33 @@ export function resolveNotificationPrefs(
   }
   return resolved
 }
+
+/**
+ * How long somebody has to have been gone before unread mail is worth sending.
+ *
+ * Eight hours rather than one: the point is a person who is not going to see
+ * the message today, and anything shorter competes with the push that already
+ * went to their phone. Long enough to have slept through it, short enough that
+ * the answer is still useful.
+ */
+export const UNREAD_DIGEST_AWAY_HOURS = 8
+
+/**
+ * And the far end. Somebody gone a fortnight has had their one digest; mailing
+ * them again is not a reminder, it is a campaign, and there is a separate
+ * switch for those.
+ */
+export const UNREAD_DIGEST_MAX_AWAY_DAYS = 14
+
+/** Named in the digest before it says "and N more". */
+export const UNREAD_DIGEST_MAX_SENDERS = 3
+
+/**
+ * The window a notification email may be sent in, on the reader's own clock.
+ *
+ * A push is a phone buzzing and is worth an exact hour; an email is read
+ * whenever the inbox is opened. But a phone shows mail too, and a 3am arrival
+ * is the same buzz — so the send is fenced into waking hours rather than
+ * fired the moment the condition is met.
+ */
+export const NOTIFICATION_EMAIL_LOCAL_HOURS = { earliest: 9, latest: 21 } as const

--- a/packages/shared/src/periods.ts
+++ b/packages/shared/src/periods.ts
@@ -88,6 +88,23 @@ export function localDayKey(date: Date, timeZone: string): string {
   }
 }
 
+/**
+ * The hour on the user's own clock, 0-23.
+ *
+ * Every scheduled notification fires on a local hour rather than a UTC one:
+ * 20:00 UTC is 5am in Tokyo, which is not a nudge, it is an alarm clock. Falls
+ * back to UTC for an unknown zone, like `localDayKey` and for the same reason.
+ */
+export function localHour(date: Date, timeZone: string): number {
+  try {
+    return Number(
+      new Intl.DateTimeFormat('en-GB', { timeZone, hour: '2-digit', hour12: false }).format(date),
+    )
+  } catch {
+    return date.getUTCHours()
+  }
+}
+
 /** Shift a `YYYY-MM-DD` key by whole days. */
 export function shiftDayKey(dayKey: string, days: number): string {
   const ms = Date.parse(`${dayKey}T00:00:00Z`)


### PR DESCRIPTION
Stacked on #1069.

- **Once per absence, not per day.** The period key is `stats.lastActiveAt`,
  which does not move while somebody is away. A fortnight of silence is one
  email; coming back and leaving again is a new key.
- **Counts and names, never message text.** The privacy sheet describes
  notification mail as exactly that. A test asserts the body does not appear.
- **Waking hours on the reader's clock**, and nothing is claimed outside the
  window, so the 9am tick still sends it.
- **Starts from profiles, not conversations**: `unread` is a map keyed by user
  id and its dotted path cannot be queried across users. Needs a new
  `stats.lastActiveAt` index — both discovery indexes lead with a language
  array and cannot serve a bare range.
- **`notificationLedger`** is one collection for every scheduled sender, keyed
  `<job>:<userId>:<periodKey>`, claimed before the send.

Eleven tests, including a blocked sender, an archived thread, a thread whose
last word was the reader's own, and the 3am case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)