### PR TITLE
Show a message arriving without buzzing the phone

### DIFF
--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -7,7 +7,7 @@ import {
   TOKEN_RULES,
 } from '@langx/shared'
 import { useQueryClient } from '@tanstack/react-query'
-import { useLocalSearchParams } from 'expo-router'
+import { useFocusEffect, useLocalSearchParams } from 'expo-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ActivityIndicator,
@@ -22,6 +22,7 @@ import {
   type TextInputKeyPressEventData,
 } from 'react-native'
 import {
+  markConversationRead,
   uploadMessageMedia,
   useMe,
   useMessages,
@@ -31,7 +32,7 @@ import {
   type MessageDto,
 } from '../../../src/api/queries'
 import * as Clipboard from 'expo-clipboard'
-import { api } from '../../../src/api/client'
+import { setActiveConversation } from '../../../src/lib/activeConversation'
 import { PresenceLine } from '../../../src/components/PresenceLine'
 import { ComposerHint } from '../../../src/components/ComposerHint'
 import { Tip } from '../../../src/components/Tip'
@@ -205,14 +206,24 @@ export default function ChatScreen() {
   const partners = useProfileCache(partnerId ? [partnerId] : [])
   const partner = partners[partnerId]
 
-  // Opening the thread is the read receipt. Doing it here rather than on a
-  // scroll-to-bottom keeps it honest for short threads that never scroll.
-  useEffect(() => {
-    if (!conversationId) return
-    void api.post(`/conversations/${conversationId}/read`).then(() => {
-      void queryClient.invalidateQueries({ queryKey: ['conversations'] })
-    })
-  }, [conversationId, queryClient])
+  /**
+   * Opening the thread is the read receipt — and *focusing* it, not mounting
+   * it. This screen is a hidden tab route, so it stays mounted after the user
+   * navigates away: on mount alone, coming back to a thread already open
+   * posted nothing, and the app went on believing this conversation was being
+   * read for the rest of the session.
+   *
+   * Which also matters to the in-app banner: `activeConversation` is what
+   * stops a message buzzing at somebody who is looking straight at it.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      if (!conversationId) return
+      setActiveConversation(conversationId)
+      void markConversationRead(conversationId, queryClient)
+      return () => setActiveConversation(null)
+    }, [conversationId, queryClient]),
+  )
 
   useEffect(() => {
     let cancelled = false

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -22,6 +22,7 @@ import { MessageMenuHost } from '../src/components/MessageMenuHost'
 import { AppGate } from '../src/components/AppGate'
 import { AppSplash, SplashFill } from '../src/components/AppSplash'
 import { Button } from '../src/components/ui/Button'
+import { MessageBannerHost } from '../src/components/MessageBannerHost'
 import { ToastHost } from '../src/components/ToastHost'
 import { authClient } from '../src/lib/auth-client'
 import { useGuestSessionReset } from '../src/hooks/useGuestSessionReset'
@@ -256,6 +257,12 @@ function RootShell() {
               is a matter of coming later in the tree.
             */}
             <ToastHost />
+            {/*
+              Last, so it paints over the toast as well: a message arriving is
+              the more urgent of the two, and both at once is rare enough that
+              the toast losing four seconds costs nothing.
+            */}
+            <MessageBannerHost />
           </AppGate>
         )}
         {/*

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -50,6 +50,7 @@ import {
   useMutation,
   useQuery,
   useQueryClient,
+  type QueryClient,
 } from '@tanstack/react-query'
 import type { InfiniteData } from '@tanstack/react-query'
 import { api } from './client'
@@ -126,6 +127,28 @@ export const keys = {
  * to call it for: signed out, `/profiles/me` is a 401, and the gate reads
  * "no profile" off a 404. Every other caller is already behind the session.
  */
+/**
+ * "I have seen this thread."
+ *
+ * Here rather than in the chat screen because two places post it now: opening
+ * the thread, and a message arriving while it is already open. Two copies
+ * would be two chances for one of them to forget the invalidation and leave a
+ * stale unread count on the list behind.
+ */
+export async function markConversationRead(
+  conversationId: string,
+  queryClient: QueryClient,
+): Promise<void> {
+  if (!conversationId) return
+  try {
+    await api.post(`/conversations/${conversationId}/read`)
+    await queryClient.invalidateQueries({ queryKey: ['conversations'] })
+  } catch {
+    // Best-effort: failing to clear an unread badge must never surface as an
+    // error over a conversation the user is reading perfectly happily.
+  }
+}
+
 export function useMe(enabled = true) {
   return useQuery({
     queryKey: keys.me,

--- a/apps/mobile/src/components/MessageBannerHost.tsx
+++ b/apps/mobile/src/components/MessageBannerHost.tsx
@@ -1,0 +1,125 @@
+import { router } from 'expo-router'
+import { useEffect, useRef, useState } from 'react'
+import { Animated, Pressable, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useT, type MessageKey } from '../i18n'
+import { useProfileCache } from '../hooks/useProfileCache'
+import {
+  dismissMessageBanner,
+  MESSAGE_BANNER_DURATION_MS,
+  subscribeToMessageBanner,
+  type MessageBanner,
+} from '../lib/inAppNotifications'
+import { makeStyles, useTheme } from '../lib/theme'
+import { Avatar } from './ui/Avatar'
+
+/**
+ * "Somebody wrote to you", while the app is open.
+ *
+ * Mounted at the root beside `ToastHost` and after the navigator, so it paints
+ * over whichever screen is up and survives that screen going away. A plain
+ * positioned view rather than a `Modal`, for the same reason the toast is one:
+ * a `Modal` takes the touches of the whole screen, and this must not stop
+ * anybody carrying on with what they were doing.
+ *
+ * Inside `QueryClientProvider`, because the avatar and the name come from the
+ * same profile cache the chat list reads — a banner that fetched its own would
+ * flash an empty circle for a person already on screen behind it.
+ */
+export function MessageBannerHost() {
+  const { spacing } = useTheme()
+  const styles = useStyles()
+  const t = useT()
+  const insets = useSafeAreaInsets()
+
+  const [banner, setBanner] = useState<MessageBanner | null>(null)
+  const slide = useRef(new Animated.Value(0)).current
+
+  useEffect(() => subscribeToMessageBanner(setBanner), [])
+
+  const profiles = useProfileCache(banner ? [banner.senderId] : [])
+  const sender = banner ? profiles[banner.senderId] : undefined
+
+  useEffect(() => {
+    if (!banner) return
+    slide.setValue(0)
+    Animated.timing(slide, { toValue: 1, duration: 180, useNativeDriver: true }).start()
+    // Keyed on the id, so a message replacing another restarts the clock for
+    // itself rather than inheriting what was left of the first one's.
+    const timer = setTimeout(() => dismissMessageBanner(banner.id), MESSAGE_BANNER_DURATION_MS)
+    return () => clearTimeout(timer)
+  }, [banner, slide])
+
+  if (!banner) return null
+
+  const name = sender?.displayName ?? sender?.handle ?? t('chats.someone')
+  const preview =
+    banner.preview === 'text' ? banner.body : t(`chats.preview.${banner.preview}` as MessageKey)
+
+  return (
+    <Animated.View
+      pointerEvents="box-none"
+      style={[
+        styles.layer,
+        {
+          paddingTop: insets.top + spacing.sm,
+          opacity: slide,
+          transform: [
+            { translateY: slide.interpolate({ inputRange: [0, 1], outputRange: [-16, 0] }) },
+          ],
+        },
+      ]}
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={t('chats.bannerA11y', { name })}
+        onPress={() => {
+          dismissMessageBanner(banner.id)
+          router.push(`/(app)/chat/${banner.conversationId}`)
+        }}
+        style={styles.card}
+      >
+        <Avatar url={sender?.avatarUrl} name={name} size={36} />
+        <View style={styles.text}>
+          <Text style={styles.name} numberOfLines={1}>
+            {name}
+          </Text>
+          <Text style={styles.preview} numberOfLines={1}>
+            {preview}
+          </Text>
+        </View>
+      </Pressable>
+    </Animated.View>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
+  // Top, like the toast, and for the same reason: the bottom of every
+  // signed-in screen is where the tab bar is, and this one is tappable.
+  layer: {
+    alignItems: 'center',
+    left: 0,
+    paddingHorizontal: spacing.lg,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  // A surface card rather than the toast's solid yellow: this is somebody
+  // else's message, not the app reporting on itself, and it carries a face.
+  card: {
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: spacing.md,
+    maxWidth: 420,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.md,
+    width: '100%',
+  },
+  text: { flex: 1 },
+  name: { ...font.body, color: colors.text, fontWeight: '600' },
+  preview: { ...font.caption, color: colors.textMuted },
+}))

--- a/apps/mobile/src/hooks/useNotificationRouting.ts
+++ b/apps/mobile/src/hooks/useNotificationRouting.ts
@@ -1,6 +1,11 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { router } from 'expo-router'
 import { useEffect } from 'react'
-import { Platform } from 'react-native'
+import { AppState, Platform } from 'react-native'
+import { markConversationRead } from '../api/queries'
+import { getActiveConversation } from '../lib/activeConversation'
+import { presentationFor } from '../lib/foregroundPush'
+import { previewOf, showMessageBanner } from '../lib/inAppNotifications'
 import { configureNotifications } from '../lib/notifications'
 import { notificationRoute } from '../lib/notificationRoute'
 
@@ -19,11 +24,14 @@ import { notificationRoute } from '../lib/notificationRoute'
  * usually read on a locked phone.
  */
 export function useNotificationRouting({ enabled = true }: { enabled?: boolean } = {}): void {
+  const queryClient = useQueryClient()
+
   useEffect(() => {
     if (!enabled) return
     if (Platform.OS === 'web') return
     let cancelled = false
     let subscription: { remove: () => void } | undefined
+    let received: { remove: () => void } | undefined
 
     void (async () => {
       await configureNotifications()
@@ -34,6 +42,35 @@ export function useNotificationRouting({ enabled = true }: { enabled?: boolean }
         subscription = Notifications.addNotificationResponseReceivedListener((response) => {
           const href = notificationRoute(response.notification.request.content.data)
           if (href) router.push(href)
+        })
+
+        /**
+         * The other half of suppressing the OS banner: something has to draw
+         * the message instead. Only reached when the socket is down while the
+         * app is open, since the server skips the push entirely for anyone
+         * holding one — so this and `useSocket` cannot both fire for the same
+         * message.
+         */
+        received = Notifications.addNotificationReceivedListener((notification) => {
+          const { content } = notification.request
+          if (presentationFor(content.data, AppState.currentState === 'active') !== 'suppress') {
+            return
+          }
+          const { conversationId, senderId } = content.data as {
+            conversationId?: unknown
+            senderId?: unknown
+          }
+          if (typeof conversationId !== 'string' || typeof senderId !== 'string') return
+          if (getActiveConversation() === conversationId) {
+            void markConversationRead(conversationId, queryClient)
+            return
+          }
+          showMessageBanner({
+            conversationId,
+            senderId,
+            preview: previewOf('text'),
+            body: content.body ?? '',
+          })
         })
 
         const initial = await Notifications.getLastNotificationResponseAsync()
@@ -51,6 +88,7 @@ export function useNotificationRouting({ enabled = true }: { enabled?: boolean }
     return () => {
       cancelled = true
       subscription?.remove()
+      received?.remove()
     }
-  }, [enabled])
+  }, [enabled, queryClient])
 }

--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -1,9 +1,12 @@
-import { PRESENCE_HEARTBEAT_MS } from '@langx/shared'
+import { notificationsAllowed, PRESENCE_HEARTBEAT_MS } from '@langx/shared'
 import type { InfiniteData } from '@tanstack/react-query'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
-import type { MessageDto } from '../api/queries'
-import { keys } from '../api/queries'
+import { AppState } from 'react-native'
+import type { MeProfile, MessageDto } from '../api/queries'
+import { keys, markConversationRead } from '../api/queries'
+import { getActiveConversation } from '../lib/activeConversation'
+import { previewOf, shouldShowIncomingBanner, showMessageBanner } from '../lib/inAppNotifications'
 import { applyIncomingMessage, type ConversationPageDto } from '../lib/conversationCache'
 import {
   appendIncomingMessage,
@@ -97,6 +100,33 @@ export function useSocket({ enabled = true }: { enabled?: boolean } = {}): void 
         )
         if (!patched) void queryClient.invalidateQueries({ queryKey: ['conversations'] })
         void queryClient.invalidateQueries({ queryKey: keys.tokens })
+
+        /**
+         * And then say so, if there is anybody to say it to.
+         *
+         * The server sends no push while this socket is in the user's room —
+         * see `fanOut.ts` — so without this, somebody reading their settings
+         * learns nothing about a message arriving in another thread until they
+         * happen to open the chat list. On the web, where there is no push at
+         * all, this is the only notice there is.
+         */
+        const prefs = queryClient.getQueryData<MeProfile>(keys.me)?.settings.notifications
+        const decision = shouldShowIncomingBanner({
+          message,
+          meId,
+          activeConversationId: getActiveConversation(),
+          appActive: AppState.currentState === 'active',
+          messagesPushAllowed: notificationsAllowed(prefs, 'messages', 'push'),
+        })
+        if (decision === 'markRead') void markConversationRead(conversationId, queryClient)
+        else if (decision === 'banner') {
+          showMessageBanner({
+            conversationId,
+            senderId: message.senderId,
+            preview: previewOf(message.type),
+            body: message.body,
+          })
+        }
       })
 
       /**

--- a/apps/mobile/src/i18n/catalogs.test.ts
+++ b/apps/mobile/src/i18n/catalogs.test.ts
@@ -105,9 +105,17 @@ describe.each(SUPPORTED_LOCALES.filter((l) => l !== 'en'))('%s', (locale: Locale
     // A locale wired to `en` as a placeholder is the failure this branch went
     // through twice; identical sentences here would mean it happened again.
     const mine = leaves(catalogs[locale])
-    const same = [...leaves(en)].filter(([path, text]) => mine.get(path) === text)
-    // Brand names, emoji labels and a few short words legitimately match.
-    expect(same.length).toBeLessThan(60)
+    const english = [...leaves(en)]
+    const same = english.filter(([path, text]) => mine.get(path) === text)
+    /*
+     * A share rather than a count. Brand names, emoji labels and short words
+     * like "Push" or "Photo" legitimately match, and there are more of them
+     * every time the catalogue grows — a fixed ceiling turns into a number
+     * somebody raises by one whenever it fails, which is a dead test. A
+     * placeholder locale scores 1.0; the worst real one here is well under a
+     * fifth.
+     */
+    expect(same.length / english.length).toBeLessThan(0.2)
   })
 })
 

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -533,6 +533,10 @@ export const ar: Localized<EnMessages> = {
   },
 
   chats: {
+    /** The in-app banner: a face, a name and one line that is never the body. */
+    someone: 'شخص ما',
+    bannerA11y: 'رسالة جديدة من {name}',
+    preview: { image: '📷 صورة', audio: '🎤 رسالة صوتية', correction: '✍️ تصحيح' },
     delete: 'حذف',
     deleteTitle: 'حذف هذه المحادثة؟',
     deleteBody: 'تبقى لدى الطرف الآخر، وتعود هنا إن راسلك مجددًا.',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -479,6 +479,10 @@ export const de: Localized<EnMessages> = {
   },
 
   chats: {
+    /** The in-app banner: a face, a name and one line that is never the body. */
+    someone: 'Jemand',
+    bannerA11y: 'Neue Nachricht von {name}',
+    preview: { image: '📷 Foto', audio: '🎤 Sprachnachricht', correction: '✍️ Korrektur' },
     delete: 'Löschen',
     deleteTitle: 'Diesen Chat löschen?',
     deleteBody: 'Bei ihnen bleibt er, und er kommt zurück, wenn sie wieder schreiben.',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -501,6 +501,10 @@ export const en = {
   },
 
   chats: {
+    /** The in-app banner: a face, a name and one line that is never the body. */
+    someone: 'Someone',
+    bannerA11y: 'New message from {name}',
+    preview: { image: '📷 Photo', audio: '🎤 Voice message', correction: '✍️ Correction' },
     delete: 'Delete',
     deleteTitle: 'Delete this chat?',
     deleteBody: 'It stays on their side, and comes back here if they write again.',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -470,6 +470,10 @@ export const es: Localized<EnMessages> = {
   },
 
   chats: {
+    /** The in-app banner: a face, a name and one line that is never the body. */
+    someone: 'Alguien',
+    bannerA11y: 'Nuevo mensaje de {name}',
+    preview: { image: '📷 Foto', audio: '🎤 Mensaje de voz', correction: '✍️ Corrección' },
     delete: 'Eliminar',
     deleteTitle: '¿Eliminar este chat?',
     deleteBody: 'Se queda en su lado y vuelve aquí si escriben otra vez.',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -477,6 +477,10 @@ export const fr: Localized<EnMessages> = {
   },
 
   chats: {
+    /** The in-app banner: a face, a name and one line that is never the body. */
+    someone: 'Quelqu’un',
+    bannerA11y: 'Nouveau message de {name}',
+    preview: { image: '📷 Photo', audio: '🎤 Message vocal', correction: '✍️ Correction' },
     delete: 'Supprimer',
     deleteTitle: 'Supprimer cette conversation ?',
     deleteBody: 'Elle reste de leur côté et revient ici s’ils vous réécrivent.',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -467,6 +467,10 @@ export const ptBR: Localized<EnMessages> = {
   },
 
   chats: {
+    /** The in-app banner: a face, a name and one line that is never the body. */
+    someone: 'Alguém',
+    bannerA11y: 'Nova mensagem de {name}',
+    preview: { image: '📷 Foto', audio: '🎤 Mensagem de voz', correction: '✍️ Correção' },
     delete: 'Excluir',
     deleteTitle: 'Excluir esta conversa?',
     deleteBody: 'Ela fica do lado deles e volta aqui se escreverem de novo.',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -520,6 +520,10 @@ export const ru: Localized<EnMessages> = {
   },
 
   chats: {
+    /** The in-app banner: a face, a name and one line that is never the body. */
+    someone: 'Кто-то',
+    bannerA11y: 'Новое сообщение от {name}',
+    preview: { image: '📷 Фото', audio: '🎤 Голосовое сообщение', correction: '✍️ Исправление' },
     delete: 'Удалить',
     deleteTitle: 'Удалить этот чат?',
     deleteBody: 'У собеседника он останется и вернётся сюда, если он напишет снова.',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -473,6 +473,10 @@ export const tr: Localized<EnMessages> = {
   },
 
   chats: {
+    /** The in-app banner: a face, a name and one line that is never the body. */
+    someone: 'Biri',
+    bannerA11y: '{name} kişisinden yeni mesaj',
+    preview: { image: '📷 Fotoğraf', audio: '🎤 Sesli mesaj', correction: '✍️ Düzeltme' },
     delete: 'Sil',
     deleteTitle: 'Bu sohbet silinsin mi?',
     deleteBody: 'Karşı tarafta kalır; tekrar yazarsa burada yeniden açılır.',

--- a/apps/mobile/src/lib/activeConversation.test.ts
+++ b/apps/mobile/src/lib/activeConversation.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  getActiveConversation,
+  resetActiveConversationForTest,
+  setActiveConversation,
+} from './activeConversation'
+
+describe('the conversation on screen', () => {
+  afterEach(() => {
+    resetActiveConversationForTest()
+  })
+
+  it('is nothing until a thread says otherwise', () => {
+    expect(getActiveConversation()).toBeNull()
+  })
+
+  it('remembers the last thread focused', () => {
+    setActiveConversation('c1')
+    expect(getActiveConversation()).toBe('c1')
+  })
+
+  /**
+   * The blur half of `useFocusEffect`. Without it the app believes a thread is
+   * still being read after the user leaves it — this screen is a hidden tab
+   * route and never unmounts.
+   */
+  it('clears when the thread is left', () => {
+    setActiveConversation('c1')
+    setActiveConversation(null)
+    expect(getActiveConversation()).toBeNull()
+  })
+})

--- a/apps/mobile/src/lib/activeConversation.ts
+++ b/apps/mobile/src/lib/activeConversation.ts
@@ -1,0 +1,27 @@
+/**
+ * Which conversation is on screen right now, if any.
+ *
+ * A module variable rather than context, for the reason `toast.ts` gives: the
+ * one thing that needs to read it is a socket handler, which is not a
+ * component and cannot use a hook. Keeping it in `src/lib` also keeps it
+ * inside the only directory the mobile test setup can load.
+ *
+ * Set from `useFocusEffect`, not from mount. `chat/[id]` is a hidden tab
+ * screen, so it stays mounted after the user navigates away — a mount effect
+ * would leave the app believing the thread is still being read for the rest
+ * of the session, and silently swallow every banner for it.
+ */
+let activeConversationId: string | null = null
+
+export function setActiveConversation(conversationId: string | null): void {
+  activeConversationId = conversationId
+}
+
+export function getActiveConversation(): string | null {
+  return activeConversationId
+}
+
+/** Test seam. */
+export function resetActiveConversationForTest(): void {
+  activeConversationId = null
+}

--- a/apps/mobile/src/lib/foregroundPush.test.ts
+++ b/apps/mobile/src/lib/foregroundPush.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { presentationFor } from './foregroundPush'
+
+describe('what to do with a push that arrives while the app is open', () => {
+  it('hands a message to the in-app banner', () => {
+    expect(presentationFor({ kind: 'message', conversationId: 'c1' }, true)).toBe('suppress')
+  })
+
+  it('lets the OS draw it once the app is in the background', () => {
+    expect(presentationFor({ kind: 'message', conversationId: 'c1' }, false)).toBe('os')
+  })
+
+  /**
+   * These arrive once a day, have no in-app equivalent, and are the sort of
+   * thing somebody swipes away and looks for again in the shade.
+   */
+  it('leaves the once-a-day kinds to the OS even in the foreground', () => {
+    for (const kind of ['streakReminder', 'badgeEarned', 'profileVisits']) {
+      expect(presentationFor({ kind }, true), kind).toBe('os')
+    }
+  })
+
+  /** An unrecognised payload must still be shown, not swallowed. */
+  it('shows anything it does not recognise', () => {
+    expect(presentationFor({ kind: 'somethingNew' }, true)).toBe('os')
+    expect(presentationFor({}, true)).toBe('os')
+    expect(presentationFor(null, true)).toBe('os')
+    expect(presentationFor(undefined, true)).toBe('os')
+    expect(presentationFor('message', true)).toBe('os')
+  })
+})

--- a/apps/mobile/src/lib/foregroundPush.ts
+++ b/apps/mobile/src/lib/foregroundPush.ts
@@ -1,0 +1,26 @@
+import { PUSH_KINDS, type PushKind } from '@langx/shared'
+
+/**
+ * Whether an arriving notification should be drawn by the OS, or handed to the
+ * in-app banner instead.
+ *
+ * Only a message, and only while the app is in front. A heads-up banner
+ * sliding over the app somebody is already using is the most irritating thing
+ * a notification can do, and it is redundant: the socket has already put the
+ * message in the chat list, and the in-app banner says the same thing without
+ * covering the status bar.
+ *
+ * Streak and badge and profile-visit notifications keep the OS presentation.
+ * They arrive once a day, have no in-app equivalent, and are exactly the sort
+ * of thing somebody might want to swipe away and find again in the shade.
+ *
+ * Pure and free of `react-native` so the unit tests can load it: `appActive`
+ * is passed in rather than read from `AppState` here.
+ */
+export function presentationFor(data: unknown, appActive: boolean): 'suppress' | 'os' {
+  if (!appActive) return 'os'
+  if (typeof data !== 'object' || data === null) return 'os'
+  const { kind } = data as { kind?: unknown }
+  if (typeof kind !== 'string' || !(PUSH_KINDS as readonly string[]).includes(kind)) return 'os'
+  return (kind as PushKind) === 'message' ? 'suppress' : 'os'
+}

--- a/apps/mobile/src/lib/inAppNotifications.test.ts
+++ b/apps/mobile/src/lib/inAppNotifications.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  dismissMessageBanner,
+  previewOf,
+  resetMessageBannersForTest,
+  shouldShowIncomingBanner,
+  showMessageBanner,
+  subscribeToMessageBanner,
+} from './inAppNotifications'
+
+const ME = 'me'
+const THEM = 'them'
+
+function incoming(overrides: Record<string, unknown> = {}) {
+  return {
+    message: { senderId: THEM, conversationId: 'c1', type: 'text', ...overrides },
+    meId: ME,
+    activeConversationId: null,
+    appActive: true,
+    messagesPushAllowed: true,
+  }
+}
+
+describe('shouldShowIncomingBanner', () => {
+  it('shows one for somebody else’s message in a thread nobody is reading', () => {
+    expect(shouldShowIncomingBanner(incoming())).toBe('banner')
+  })
+
+  it('says nothing about your own message arriving back', () => {
+    expect(
+      shouldShowIncomingBanner({ ...incoming(), message: { ...incoming().message, senderId: ME } }),
+    ).toBe('ignore')
+  })
+
+  /** The cache has not answered yet, or this is a guest. */
+  it('says nothing when it does not know who you are', () => {
+    expect(shouldShowIncomingBanner({ ...incoming(), meId: undefined })).toBe('ignore')
+  })
+
+  it('says nothing about a withdrawn or hidden message', () => {
+    expect(shouldShowIncomingBanner(incoming({ deleted: true }))).toBe('ignore')
+    expect(shouldShowIncomingBanner(incoming({ hidden: true }))).toBe('ignore')
+  })
+
+  /**
+   * Looking straight at the thread. Marking it read here is what the chat
+   * screen cannot do for itself: it posts on focus, and it is already focused.
+   */
+  it('marks read instead of interrupting when the thread is open', () => {
+    expect(shouldShowIncomingBanner({ ...incoming(), activeConversationId: 'c1' })).toBe('markRead')
+  })
+
+  /**
+   * Android keeps the JS thread alive in the background, so the chat screen
+   * can still be the focused route with nobody looking at it. Clearing an
+   * unread badge there is clearing it for a message never seen.
+   */
+  it('does not mark read while the app is in the background', () => {
+    expect(
+      shouldShowIncomingBanner({ ...incoming(), activeConversationId: 'c1', appActive: false }),
+    ).toBe('banner')
+  })
+
+  it('shows one for a different thread even while a chat is open', () => {
+    expect(shouldShowIncomingBanner({ ...incoming(), activeConversationId: 'other' })).toBe(
+      'banner',
+    )
+  })
+
+  /**
+   * The banner is the foreground face of the push channel: one switch has to
+   * silence every unsolicited "somebody wrote", wherever it is drawn.
+   */
+  it('obeys the messages push switch', () => {
+    expect(shouldShowIncomingBanner({ ...incoming(), messagesPushAllowed: false })).toBe('ignore')
+  })
+
+  /** But a message in the open thread is still read, switch or no switch. */
+  it('still marks read for somebody who turned notifications off', () => {
+    expect(
+      shouldShowIncomingBanner({
+        ...incoming(),
+        activeConversationId: 'c1',
+        messagesPushAllowed: false,
+      }),
+    ).toBe('markRead')
+  })
+})
+
+describe('the banner queue', () => {
+  afterEach(() => {
+    resetMessageBannersForTest()
+  })
+
+  it('tells a subscriber what is showing, and what replaced it', () => {
+    const seen = vi.fn()
+    subscribeToMessageBanner(seen)
+    showMessageBanner({ conversationId: 'c1', senderId: THEM, preview: 'text', body: 'hi' })
+
+    expect(seen).toHaveBeenLastCalledWith(expect.objectContaining({ conversationId: 'c1' }))
+  })
+
+  /**
+   * Replaces rather than queues, unlike `toast.ts`. A toast reports an outcome
+   * and has to be seen; this points at a chat list that already shows every
+   * one of these. Three quick messages must not hold the screen for fifteen
+   * seconds.
+   */
+  it('replaces rather than queueing behind', () => {
+    const seen = vi.fn()
+    subscribeToMessageBanner(seen)
+    showMessageBanner({ conversationId: 'c1', senderId: THEM, preview: 'text', body: 'one' })
+    showMessageBanner({ conversationId: 'c2', senderId: THEM, preview: 'text', body: 'two' })
+
+    expect(seen).toHaveBeenLastCalledWith(expect.objectContaining({ conversationId: 'c2' }))
+  })
+
+  it('ignores a dismissal for a banner already replaced', () => {
+    const seen = vi.fn()
+    subscribeToMessageBanner(seen)
+    showMessageBanner({ conversationId: 'c1', senderId: THEM, preview: 'text', body: 'one' })
+    const stale = seen.mock.calls.at(-1)?.[0] as { id: number }
+    showMessageBanner({ conversationId: 'c2', senderId: THEM, preview: 'text', body: 'two' })
+
+    dismissMessageBanner(stale.id)
+    expect(seen).toHaveBeenLastCalledWith(expect.objectContaining({ conversationId: 'c2' }))
+  })
+
+  it('clears on its own dismissal', () => {
+    const seen = vi.fn()
+    subscribeToMessageBanner(seen)
+    showMessageBanner({ conversationId: 'c1', senderId: THEM, preview: 'text', body: 'one' })
+    const shown = seen.mock.calls.at(-1)?.[0] as { id: number }
+
+    dismissMessageBanner(shown.id)
+    expect(seen).toHaveBeenLastCalledWith(null)
+  })
+
+  it('stops telling an unsubscribed listener anything', () => {
+    const seen = vi.fn()
+    const unsubscribe = subscribeToMessageBanner(seen)
+    unsubscribe()
+    showMessageBanner({ conversationId: 'c1', senderId: THEM, preview: 'text', body: 'one' })
+
+    expect(seen).toHaveBeenCalledTimes(1) // the initial null, and nothing since
+  })
+})
+
+describe('previewOf', () => {
+  it('keeps the three kinds that have no text to show', () => {
+    expect(previewOf('image')).toBe('image')
+    expect(previewOf('audio')).toBe('audio')
+    expect(previewOf('correction')).toBe('correction')
+  })
+
+  /** A kind added to the server later must not render as a dotted path. */
+  it('falls back to text for anything else', () => {
+    expect(previewOf('text')).toBe('text')
+    expect(previewOf('somethingNew')).toBe('text')
+  })
+})

--- a/apps/mobile/src/lib/inAppNotifications.ts
+++ b/apps/mobile/src/lib/inAppNotifications.ts
@@ -1,0 +1,126 @@
+/**
+ * A message that arrived while the app was open, drawn as a banner the user
+ * can tap.
+ *
+ * The OS banner is deliberately suppressed for these — see `foregroundPush.ts`.
+ * Somebody looking at the app does not need their phone to buzz at them about
+ * a thread two taps away; they need to be able to see it and get to it.
+ */
+export interface MessageBanner {
+  id: number
+  conversationId: string
+  senderId: string
+  /** Chosen here so the host can word it; the wire carries a raw message type. */
+  preview: MessagePreview
+  body: string
+}
+
+export type MessagePreview = 'text' | 'image' | 'audio' | 'correction'
+
+/** Long enough to read a name and glance at a line, short enough to ignore. */
+export const MESSAGE_BANNER_DURATION_MS = 5000
+
+type Listener = (banner: MessageBanner | null) => void
+
+let nextId = 1
+let current: MessageBanner | null = null
+let listener: Listener | null = null
+
+export function subscribeToMessageBanner(next: Listener): () => void {
+  listener = next
+  next(current)
+  return () => {
+    if (listener === next) listener = null
+  }
+}
+
+/**
+ * Replaces whatever was showing, rather than queueing behind it — the opposite
+ * of `toast.ts`, and worth saying why.
+ *
+ * A toast reports the outcome of something the user did, and each one has to
+ * be seen or the app has silently swallowed an answer. A banner is a pointer
+ * to the chat list, which already shows every one of these messages with an
+ * unread count beside it. Three quick messages must not hold the top of the
+ * screen for fifteen seconds to tell somebody something the next screen tells
+ * them anyway.
+ */
+export function showMessageBanner(input: Omit<MessageBanner, 'id'>): void {
+  current = { ...input, id: nextId++ }
+  listener?.(current)
+}
+
+export function dismissMessageBanner(id: number): void {
+  if (current?.id !== id) return
+  current = null
+  listener?.(null)
+}
+
+export function resetMessageBannersForTest(): void {
+  current = null
+  listener = null
+  nextId = 1
+}
+
+/** The wire's message type, narrowed to the four the banner can word. */
+export function previewOf(type: string): MessagePreview {
+  if (type === 'image' || type === 'audio' || type === 'correction') return type
+  return 'text'
+}
+
+interface IncomingDecision {
+  message: {
+    senderId: string
+    conversationId: string
+    type: string
+    deleted?: boolean
+    hidden?: boolean
+  }
+  meId: string | undefined
+  activeConversationId: string | null
+  appActive: boolean
+  /** `notificationsAllowed(prefs, 'messages', 'push')` — see below. */
+  messagesPushAllowed: boolean
+}
+
+/**
+ * What to do about a message that just arrived over the socket.
+ *
+ * A pure function taking everything it needs, so the mobile test setup — node,
+ * no renderer, `src/lib` only — can exercise every branch. `appActive` is
+ * passed in rather than read here for the same reason: `AppState` comes from
+ * `react-native`, which this file must not import.
+ *
+ * That flag is not a formality. On Android the JS thread keeps running in the
+ * background, so a message can arrive while the chat screen is still the
+ * focused route and nobody is looking at it — marking it read there would
+ * clear an unread badge for a message the user has never seen.
+ *
+ * The banner obeys the **messages/push** switch, deliberately. It is the
+ * foreground face of that channel: one switch labelled "Messages — Push" has
+ * to silence every unsolicited "somebody wrote to you", wherever it is drawn.
+ * The chat list and its unread counts still update, because that is data
+ * arriving rather than a notification being sent — and on the web, where no
+ * push exists, this is the only thing that switch does.
+ */
+export function shouldShowIncomingBanner({
+  message,
+  meId,
+  activeConversationId,
+  appActive,
+  messagesPushAllowed,
+}: IncomingDecision): 'banner' | 'markRead' | 'ignore' {
+  // No `meId` means the cache has not answered yet, or this is a guest. Either
+  // way there is nobody to decide "not mine" against.
+  if (!meId) return 'ignore'
+  if (message.senderId === meId) return 'ignore'
+  if (message.deleted || message.hidden) return 'ignore'
+
+  // Reading the thread it arrived in *is* the read receipt, which the chat
+  // screen only posts on focus — so a message arriving while it sits open
+  // would otherwise stay unread until the user left and came back.
+  if (activeConversationId === message.conversationId && appActive) return 'markRead'
+
+  if (!messagesPushAllowed) return 'ignore'
+  return 'banner'
+}

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -1,4 +1,5 @@
-import { Platform } from 'react-native'
+import { AppState, Platform } from 'react-native'
+import { presentationFor } from './foregroundPush'
 
 /**
  * Two things that have to be set before the first notification arrives, and
@@ -19,15 +20,29 @@ export async function configureNotifications(): Promise<void> {
      * delivered to the JS layer and shown nowhere — so someone reading one
      * conversation never learns about a message in another. Both platforms
      * default to silence here; it is a decision, not a default.
+     *
+     * The exception is a *message* while the app is in front, which becomes
+     * the in-app banner instead. A heads-up notification sliding over the app
+     * somebody is already using is the most irritating thing this system can
+     * do, and it says nothing the banner does not. The badge still ticks, so
+     * the count on the icon stays honest.
+     *
+     * In practice this path only fires when the socket is down while the app
+     * is open — the server sends no push to somebody holding a live socket —
+     * so the two cannot draw a banner for the same message.
      */
     Notifications.setNotificationHandler({
-      handleNotification: () =>
-        Promise.resolve({
-          shouldShowBanner: true,
-          shouldShowList: true,
-          shouldPlaySound: true,
+      handleNotification: (notification) => {
+        const suppress =
+          presentationFor(notification.request.content.data, AppState.currentState === 'active') ===
+          'suppress'
+        return Promise.resolve({
+          shouldShowBanner: !suppress,
+          shouldShowList: !suppress,
+          shouldPlaySound: !suppress,
           shouldSetBadge: true,
-        }),
+        })
+      },
     })
 
     if (Platform.OS === 'android') {


### PR DESCRIPTION
Stacked on #1072. The thing asked for first: an in-app notice, not a push,
while the app is open.

The server already skips the push for anyone holding a live socket — a phone
should not buzz about a thread two taps away — but nothing took its place. On
the web, where there is no push at all, that was the entire notification
story.

- **Replaces rather than queues**, unlike the toast beside it. A toast reports
  an outcome and has to be seen; this points at a chat list that already shows
  every one of these.
- **Obeys the messages/push switch.** It is that channel's foreground face.
  The list and its unread counts still update — data arriving, not a
  notification being sent.
- **The foreground OS banner is suppressed** for messages and handed to the
  same component; the badge still ticks. Streak, badge and profile-visit
  notifications keep the OS presentation.
- **The read receipt moves from mount to focus**, fixing an existing bug:
  `chat/[id]` is a hidden tab route and never unmounts, so returning to a
  thread posted nothing.
- **`appActive` is checked**, because Android keeps JS alive in the background
  and marking a message read there clears a badge for something never seen.

The catalogue guard becomes a share rather than a fixed count of 60 — short
labels like "Push" and "Photo" legitimately match English, and a fixed ceiling
becomes a number somebody raises by one whenever it fails.

23 new tests across the three pure modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)