### PR TITLE
Give promotions a sender that cannot mail anyone twice

### DIFF
--- a/apps/api/scripts/send-campaign.ts
+++ b/apps/api/scripts/send-campaign.ts
@@ -1,0 +1,173 @@
+/**
+ * Sends one promotional email to everybody who asked for them.
+ *
+ * A script rather than a scheduled sender, because a campaign is a decision
+ * somebody makes on a particular day about a particular message — there is
+ * nothing to compute. And a script rather than Resend's own Audiences,
+ * because that would keep a second copy of the addresses and their consent
+ * outside this database: every deletion and every toggle would have to be
+ * synchronised into it, and the day the two disagree is a complaint rather
+ * than a bug.
+ *
+ * **Consent is read at send time**, from `settings.notifications.promotions`,
+ * and it must be exactly true. Nothing here infers it.
+ *
+ * **A re-run cannot mail anybody twice.** Recipients are claimed into
+ * `emailCampaigns` before the batch goes out, and the unique index on
+ * `{campaignId, userId}` is what enforces it; a batch that fails releases its
+ * own claim so the next run retries exactly those people.
+ *
+ * The HTML and text files must both contain `{{unsubscribeUrl}}`. The script
+ * refuses to send otherwise — a promotional email without a way out is the one
+ * mistake here with a regulator attached.
+ *
+ * Usage:
+ *   pnpm --filter @langx/api exec tsx scripts/send-campaign.ts \
+ *     --campaign 2026-09-launch --subject "LangX v2 is here" \
+ *     --html-file ./campaigns/launch.html [--text-file ./campaigns/launch.txt] \
+ *     [--locale tr] [--limit 500] [--confirm]
+ *
+ * Without `--confirm` it counts and prints and sends nothing. Without
+ * RESEND_API_KEY it prints each message instead of sending it, which is the
+ * way to read one before it goes anywhere.
+ */
+import { readFileSync } from 'node:fs'
+import { createEmailSender, EMAIL_BATCH_SIZE, type EmailMessage } from '../src/email/sender'
+import { unsubscribeHeaders } from '../src/email/notify'
+import { signUnsubscribeToken, unsubscribeUrl } from '../src/email/unsubscribeToken'
+import { connectToDatabase } from '../src/db/client'
+import { loadEnv, publicApiUrl, unsubscribeSecret } from '../src/env'
+import {
+  campaignRecipients,
+  claimCampaignRecipients,
+  releaseCampaignRecipients,
+} from '../src/modules/notifications/campaign'
+
+/** Resend's default is two requests a second; this stays comfortably under. */
+const BATCH_DELAY_MS = 700
+
+const PLACEHOLDER = '{{unsubscribeUrl}}'
+
+function flag(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`)
+  return index === -1 ? undefined : process.argv[index + 1]
+}
+
+function mask(email: string): string {
+  const [user = '', domain = ''] = email.split('@')
+  return `${user.slice(0, 2)}***@${domain}`
+}
+
+async function main(): Promise<void> {
+  const campaignId = flag('campaign')
+  const subject = flag('subject')
+  const htmlFile = flag('html-file')
+  const textFile = flag('text-file')
+  const locale = flag('locale')
+  const limit = flag('limit') ? Number(flag('limit')) : undefined
+  const confirm = process.argv.includes('--confirm')
+
+  if (!campaignId || !subject || !htmlFile) {
+    throw new Error('--campaign, --subject and --html-file are all required')
+  }
+
+  const html = readFileSync(htmlFile, 'utf8')
+  // Stripping tags rather than demanding a second file: a text part is
+  // required by every deliverability guide, and one that is missing is a
+  // worse default than one that is plain.
+  const text = textFile
+    ? readFileSync(textFile, 'utf8')
+    : html
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+
+  for (const [name, body] of [
+    ['html', html],
+    ['text', text],
+  ] as const) {
+    if (!body.includes(PLACEHOLDER)) {
+      throw new Error(`the ${name} body must contain ${PLACEHOLDER} — refusing to send without one`)
+    }
+  }
+
+  const env = loadEnv()
+  const { db, close } = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
+  const sender = createEmailSender(env, console)
+  const secret = unsubscribeSecret(env)
+  const apiBaseUrl = publicApiUrl(env)
+
+  try {
+    const audience = await campaignRecipients(db, campaignId, {
+      ...(locale ? { locale } : {}),
+      ...(limit ? { limit } : {}),
+    })
+    console.log(`campaign ${campaignId} on ${env.MONGODB_DB}`)
+    console.log(`  recipients: ${audience.recipients.length}`)
+    console.log(`  skipped: ${JSON.stringify(audience.skipped)}`)
+    for (const recipient of audience.recipients.slice(0, 5)) {
+      console.log(`    ${mask(recipient.email)} (${recipient.locale})`)
+    }
+    if (audience.recipients.length > 5)
+      console.log(`    …and ${audience.recipients.length - 5} more`)
+
+    if (!confirm) {
+      console.log('\n(dry run — re-run with --confirm to send)')
+      return
+    }
+    if (!env.RESEND_API_KEY) {
+      console.log('\nRESEND_API_KEY is not set — every message will be printed, not sent')
+    }
+
+    let sent = 0
+    for (let index = 0; index < audience.recipients.length; index += EMAIL_BATCH_SIZE) {
+      const batch = audience.recipients.slice(index, index + EMAIL_BATCH_SIZE)
+      const claimed = await claimCampaignRecipients(
+        db,
+        campaignId,
+        batch.map((recipient) => recipient.userId),
+      )
+      const claimedSet = new Set(claimed)
+      const messages: EmailMessage[] = batch
+        .filter((recipient) => claimedSet.has(recipient.userId))
+        .map((recipient) => {
+          const url = unsubscribeUrl(
+            apiBaseUrl,
+            signUnsubscribeToken(secret, recipient.userId, 'promotions'),
+          )
+          return {
+            to: recipient.email,
+            subject,
+            html: html.replaceAll(PLACEHOLDER, url),
+            text: text.replaceAll(PLACEHOLDER, url),
+            headers: unsubscribeHeaders(url),
+          }
+        })
+      if (messages.length === 0) continue
+
+      try {
+        if (sender.sendBatch) await sender.sendBatch(messages)
+        else for (const message of messages) await sender.send(message)
+        sent += messages.length
+      } catch (error) {
+        // Release, so a re-run picks up exactly these people rather than
+        // recording a send that never happened.
+        await releaseCampaignRecipients(db, campaignId, claimed)
+        throw error
+      }
+
+      if (index + EMAIL_BATCH_SIZE < audience.recipients.length) {
+        await new Promise((resolve) => setTimeout(resolve, BATCH_DELAY_MS))
+      }
+    }
+
+    console.log(`\nsent ${sent}`)
+  } finally {
+    await close()
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -124,6 +124,12 @@ export const COLLECTIONS = {
    * collection is a migration for nothing.
    */
   notificationLedger: 'notificationLedger',
+  /**
+   * One row per person per campaign, written *before* the send. The unique
+   * index on `{campaignId, userId}` is the only thing that makes re-running a
+   * half-finished campaign safe.
+   */
+  emailCampaigns: 'emailCampaigns',
 } as const
 
 export type CollectionName = (typeof COLLECTIONS)[keyof typeof COLLECTIONS]

--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -515,6 +515,14 @@ export const INDEXES: Partial<IndexSpec> = {
     { key: { sentOn: 1 }, name: 'ttl_30d', expireAfterSeconds: 30 * 24 * 60 * 60 },
   ],
 
+  [COLLECTIONS.emailCampaigns]: [
+    // The invariant that makes a re-run unable to mail somebody twice — the
+    // same doctrine as `jobRuns`, in the database rather than in the script's
+    // care. No TTL: "we already sent them the launch email" has to be true
+    // next year, or a second campaign with a reused id would go out again.
+    { key: { campaignId: 1, userId: 1 }, name: 'campaign_user_unique', unique: true },
+  ],
+
   [COLLECTIONS.jobRuns]: [
     // The only defence against a double-run cron distributing the pool twice.
     { key: { job: 1, periodKey: 1 }, name: 'job_period_unique', unique: true },

--- a/apps/api/src/modules/notifications/campaign.test.ts
+++ b/apps/api/src/modules/notifications/campaign.test.ts
@@ -1,0 +1,179 @@
+import { ObjectId } from 'mongodb'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import { ensureIndexes } from '../../db/indexes'
+import { authId } from '../../lib/authId'
+import type { Device } from '../push/devices'
+import { campaignRecipients, claimCampaignRecipients, releaseCampaignRecipients } from './campaign'
+
+const CAMPAIGN = '2026-09-launch'
+
+describe('who a campaign may be sent to', () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'campaign_test')
+    await ensureIndexes(handle.db)
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    for (const name of [
+      COLLECTIONS.profiles,
+      COLLECTIONS.user,
+      COLLECTIONS.devices,
+      COLLECTIONS.emailCampaigns,
+    ]) {
+      await handle.db.collection(name).deleteMany({})
+    }
+  })
+
+  async function newProfile(
+    opts: {
+      notifications?: unknown
+      verified?: boolean
+      email?: boolean
+      deleted?: boolean
+      locale?: string
+    } = {},
+  ): Promise<string> {
+    const userId = new ObjectId().toHexString()
+    await handle.db.collection(COLLECTIONS.profiles).insertOne({
+      _id: userId,
+      handle: `h${userId.slice(-12)}`,
+      settings: { discoverable: true, notifications: opts.notifications ?? {} },
+      ...(opts.deleted ? { deletedAt: new Date() } : {}),
+    } as never)
+    if (opts.email !== false) {
+      await handle.db.collection(COLLECTIONS.user).insertOne({
+        _id: authId(userId),
+        email: `${userId}@example.com`,
+        emailVerified: opts.verified ?? true,
+      })
+    }
+    if (opts.locale) {
+      await handle.db.collection<Device>(COLLECTIONS.devices).insertOne({
+        userId,
+        pushToken: `t-${userId}`,
+        platform: 'ios',
+        locale: opts.locale as never,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as never)
+    }
+    return userId
+  }
+
+  const optedIn = { promotions: { push: false, email: true } }
+
+  it('includes only people who said yes', async () => {
+    const yes = await newProfile({ notifications: optedIn })
+    await newProfile()
+    await newProfile({ notifications: { promotions: { email: false } } })
+
+    const audience = await campaignRecipients(handle.db, CAMPAIGN)
+    expect(audience.recipients.map((r) => r.userId)).toEqual([yes])
+    expect(audience.skipped.optedOut).toBe(2)
+  })
+
+  /**
+   * The one cell that is never inferred. Every other kind falls back to a
+   * default when nobody has said; consent to be marketed at has to be given.
+   */
+  it('never infers consent from an older stored shape', async () => {
+    await newProfile({ notifications: true })
+    await newProfile({ notifications: { promotions: true } })
+
+    const audience = await campaignRecipients(handle.db, CAMPAIGN)
+    expect(audience.recipients).toHaveLength(0)
+  })
+
+  it('excludes an unverified address and one that does not exist', async () => {
+    await newProfile({ notifications: optedIn, verified: false })
+    await newProfile({ notifications: optedIn, email: false })
+
+    const audience = await campaignRecipients(handle.db, CAMPAIGN)
+    expect(audience.recipients).toHaveLength(0)
+    expect(audience.skipped).toMatchObject({ unverified: 1, noEmail: 1 })
+  })
+
+  it('excludes somebody on their way out', async () => {
+    await newProfile({ notifications: optedIn, deleted: true })
+    expect((await campaignRecipients(handle.db, CAMPAIGN)).recipients).toHaveLength(0)
+  })
+
+  it('excludes anybody this campaign already reached', async () => {
+    const userId = await newProfile({ notifications: optedIn })
+    await claimCampaignRecipients(handle.db, CAMPAIGN, [userId])
+
+    const audience = await campaignRecipients(handle.db, CAMPAIGN)
+    expect(audience.recipients).toHaveLength(0)
+    expect(audience.skipped.alreadySent).toBe(1)
+    // A different campaign is a different question.
+    expect((await campaignRecipients(handle.db, 'other')).recipients).toHaveLength(1)
+  })
+
+  it('can be narrowed to one language', async () => {
+    const turkish = await newProfile({ notifications: optedIn, locale: 'tr' })
+    await newProfile({ notifications: optedIn, locale: 'de' })
+
+    const audience = await campaignRecipients(handle.db, CAMPAIGN, { locale: 'tr' })
+    expect(audience.recipients.map((r) => r.userId)).toEqual([turkish])
+  })
+
+  it('stops at a limit', async () => {
+    for (let i = 0; i < 3; i++) await newProfile({ notifications: optedIn })
+    expect((await campaignRecipients(handle.db, CAMPAIGN, { limit: 2 })).recipients).toHaveLength(2)
+  })
+})
+
+describe('claiming a batch', () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'campaign_claim_test')
+    await ensureIndexes(handle.db)
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    await handle.db.collection(COLLECTIONS.emailCampaigns).deleteMany({})
+  })
+
+  it('claims everybody the first time', async () => {
+    expect(await claimCampaignRecipients(handle.db, CAMPAIGN, ['a', 'b'])).toEqual(['a', 'b'])
+  })
+
+  /**
+   * The whole safety story of a re-run after a crash: the unique index refuses
+   * the second insert, so the second send cannot happen either.
+   */
+  it('claims only the newcomers when a batch overlaps', async () => {
+    await claimCampaignRecipients(handle.db, CAMPAIGN, ['a'])
+    const claimed = await claimCampaignRecipients(handle.db, CAMPAIGN, ['a', 'b', 'c'])
+
+    expect(claimed.sort()).toEqual(['b', 'c'])
+    expect(await handle.db.collection(COLLECTIONS.emailCampaigns).countDocuments({})).toBe(3)
+  })
+
+  it('gives them back when the send fails', async () => {
+    const claimed = await claimCampaignRecipients(handle.db, CAMPAIGN, ['a', 'b'])
+    await releaseCampaignRecipients(handle.db, CAMPAIGN, claimed)
+
+    expect(await claimCampaignRecipients(handle.db, CAMPAIGN, ['a', 'b'])).toEqual(['a', 'b'])
+  })
+})

--- a/apps/api/src/modules/notifications/campaign.test.ts
+++ b/apps/api/src/modules/notifications/campaign.test.ts
@@ -170,6 +170,26 @@ describe('claiming a batch', () => {
     expect(await handle.db.collection(COLLECTIONS.emailCampaigns).countDocuments({})).toBe(3)
   })
 
+  /**
+   * The first version read the claim back by `sentAt`, which is the same
+   * millisecond for two batches on a fast machine — so the second call
+   * reported having claimed people the first one had, and the script would
+   * have mailed them twice. Pinning the timestamp is what makes that failure
+   * deterministic rather than a matter of how quick the runner is.
+   */
+  it('does not claim somebody just because they share a timestamp', async () => {
+    const sameInstant = new Date('2026-09-03T00:00:00.000Z')
+    await claimCampaignRecipients(handle.db, CAMPAIGN, ['a'], sameInstant)
+    const claimed = await claimCampaignRecipients(handle.db, CAMPAIGN, ['a', 'b'], sameInstant)
+
+    expect(claimed).toEqual(['b'])
+  })
+
+  it('claims nobody when the whole batch was already sent', async () => {
+    await claimCampaignRecipients(handle.db, CAMPAIGN, ['a', 'b'])
+    expect(await claimCampaignRecipients(handle.db, CAMPAIGN, ['a', 'b'])).toEqual([])
+  })
+
   it('gives them back when the send fails', async () => {
     const claimed = await claimCampaignRecipients(handle.db, CAMPAIGN, ['a', 'b'])
     await releaseCampaignRecipients(handle.db, CAMPAIGN, claimed)

--- a/apps/api/src/modules/notifications/campaign.ts
+++ b/apps/api/src/modules/notifications/campaign.ts
@@ -1,0 +1,136 @@
+import { notificationsAllowed } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { emailFor } from '../profiles/emailFor'
+import { localeFor } from '../push/devices'
+import type { Profile } from '../profiles/profiles'
+
+export interface CampaignSend {
+  campaignId: string
+  userId: string
+  sentAt: Date
+}
+
+export interface CampaignRecipient {
+  userId: string
+  email: string
+  locale: string
+}
+
+export interface CampaignAudience {
+  recipients: CampaignRecipient[]
+  skipped: { optedOut: number; unverified: number; noEmail: number; alreadySent: number }
+}
+
+/**
+ * Who may be sent a campaign, read from the only place consent is recorded.
+ *
+ * Not a list held anywhere else, which is the argument against Resend's own
+ * Audiences: a second copy of the addresses and their consent would need
+ * every account deletion and every toggle synchronised into it, and the day
+ * the two disagree is a complaint rather than a bug.
+ *
+ * `promotions.email` must be exactly true. Every other kind falls back to a
+ * default when nobody has said; this one never does — consent to be marketed
+ * at has to have been given.
+ */
+export async function campaignRecipients(
+  db: Db,
+  campaignId: string,
+  options: { locale?: string; limit?: number } = {},
+): Promise<CampaignAudience> {
+  const profiles = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .find(
+      { deletedAt: { $exists: false }, 'settings.notifications': { $ne: false } },
+      { projection: { settings: 1 } },
+    )
+    .toArray()
+
+  const already = new Set(
+    (
+      await db
+        .collection<CampaignSend>(COLLECTIONS.emailCampaigns)
+        .find({ campaignId }, { projection: { userId: 1 } })
+        .toArray()
+    ).map((row) => row.userId),
+  )
+
+  const recipients: CampaignRecipient[] = []
+  const skipped = { optedOut: 0, unverified: 0, noEmail: 0, alreadySent: 0 }
+
+  for (const profile of profiles) {
+    if (!notificationsAllowed(profile.settings?.notifications, 'promotions', 'email')) {
+      skipped.optedOut++
+      continue
+    }
+    if (already.has(profile._id)) {
+      skipped.alreadySent++
+      continue
+    }
+    const address = await emailFor(db, profile._id)
+    if (!address) {
+      skipped.noEmail++
+      continue
+    }
+    if (!address.verified) {
+      skipped.unverified++
+      continue
+    }
+    const locale = await localeFor(db, profile._id)
+    if (options.locale && locale !== options.locale) continue
+
+    recipients.push({ userId: profile._id, email: address.email, locale })
+    if (options.limit && recipients.length >= options.limit) break
+  }
+
+  return { recipients, skipped }
+}
+
+/**
+ * Claims a batch before it is sent.
+ *
+ * The unique index on `{campaignId, userId}` is what makes a re-run after a
+ * crash safe: the second attempt cannot insert the rows the first one already
+ * did, so it cannot send to them either. Same doctrine as `jobRuns` — the
+ * invariant is in the database rather than in the caller's care.
+ *
+ * Returns whoever was claimed. `ordered: false` so one duplicate in a batch of
+ * a hundred does not abandon the other ninety-nine.
+ */
+export async function claimCampaignRecipients(
+  db: Db,
+  campaignId: string,
+  userIds: string[],
+  at: Date = new Date(),
+): Promise<string[]> {
+  if (userIds.length === 0) return []
+  const rows = userIds.map((userId) => ({ campaignId, userId, sentAt: at }))
+  try {
+    await db.collection<CampaignSend>(COLLECTIONS.emailCampaigns).insertMany(rows, {
+      ordered: false,
+    })
+    return userIds
+  } catch (error) {
+    // A duplicate-key error still inserts everything else. Ask the database
+    // which of them landed rather than guessing from the error shape.
+    if ((error as { code?: number }).code !== 11000) throw error
+    const inserted = await db
+      .collection<CampaignSend>(COLLECTIONS.emailCampaigns)
+      .find({ campaignId, userId: { $in: userIds }, sentAt: at }, { projection: { userId: 1 } })
+      .toArray()
+    return inserted.map((row) => row.userId)
+  }
+}
+
+/** Undoes a claim whose send then failed, so a re-run retries exactly those. */
+export async function releaseCampaignRecipients(
+  db: Db,
+  campaignId: string,
+  userIds: string[],
+): Promise<void> {
+  if (userIds.length === 0) return
+  await db
+    .collection<CampaignSend>(COLLECTIONS.emailCampaigns)
+    .deleteMany({ campaignId, userId: { $in: userIds } })
+}

--- a/apps/api/src/modules/notifications/campaign.ts
+++ b/apps/api/src/modules/notifications/campaign.ts
@@ -95,8 +95,15 @@ export async function campaignRecipients(
  * did, so it cannot send to them either. Same doctrine as `jobRuns` — the
  * invariant is in the database rather than in the caller's care.
  *
- * Returns whoever was claimed. `ordered: false` so one duplicate in a batch of
- * a hundred does not abandon the other ninety-nine.
+ * Returns whoever *this call* claimed. `ordered: false` so one duplicate in a
+ * batch of a hundred does not abandon the other ninety-nine, and the answer is
+ * read from the write errors' positions rather than from the rows afterwards.
+ *
+ * Reading it back by timestamp was the obvious version and it was wrong: two
+ * claims inside the same millisecond — which is every batch on a fast machine
+ * — share a `sentAt`, so the second call reported having claimed people the
+ * first one had, and the script would have mailed them twice. CI caught it;
+ * a local run did not, because it was slower.
  */
 export async function claimCampaignRecipients(
   db: Db,
@@ -107,19 +114,20 @@ export async function claimCampaignRecipients(
   if (userIds.length === 0) return []
   const rows = userIds.map((userId) => ({ campaignId, userId, sentAt: at }))
   try {
-    await db.collection<CampaignSend>(COLLECTIONS.emailCampaigns).insertMany(rows, {
-      ordered: false,
-    })
+    await db
+      .collection<CampaignSend>(COLLECTIONS.emailCampaigns)
+      .insertMany(rows, { ordered: false })
     return userIds
   } catch (error) {
-    // A duplicate-key error still inserts everything else. Ask the database
-    // which of them landed rather than guessing from the error shape.
     if ((error as { code?: number }).code !== 11000) throw error
-    const inserted = await db
-      .collection<CampaignSend>(COLLECTIONS.emailCampaigns)
-      .find({ campaignId, userId: { $in: userIds }, sentAt: at }, { projection: { userId: 1 } })
-      .toArray()
-    return inserted.map((row) => row.userId)
+    // Each write error carries the index of the row it rejected, which points
+    // straight back into `userIds`. Everything else in the batch did land.
+    const rejected = new Set(
+      ((error as { writeErrors?: { index?: number }[] }).writeErrors ?? [])
+        .map((writeError) => writeError.index)
+        .filter((index): index is number => typeof index === 'number'),
+    )
+    return userIds.filter((_, index) => !rejected.has(index))
   }
 }
 


### PR DESCRIPTION
Stacked on #1073. The last of the eight switches to get a sender.

- **A script, not a scheduled pass.** A campaign is a decision about a
  particular message on a particular day; there is nothing to compute.
- **Not Resend Audiences.** That keeps a second copy of addresses and consent
  outside this database — every deletion and toggle would need syncing into
  it, and the day they disagree is a complaint rather than a bug.
- **`promotions.email` must be exactly true.** A test asserts an account
  carrying the old single boolean, even a `true` one, is not in the audience.
- **A re-run cannot mail anybody twice.** Recipients are claimed before the
  batch; the unique `{campaignId, userId}` index enforces it. A failed batch
  releases its own claim so the next run retries exactly those people.
- **Both bodies must contain `{{unsubscribeUrl}}`** or it refuses to run.

Ten tests on the audience and the claim; the script itself is argument
parsing and I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)