### PR TITLE
Write down what the notifications do and why

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,9 +187,11 @@ A public repo puts four items on the plan:
 - Validation: zod + `fastify-type-provider-zod`. Indexes are declared in
   `src/db/indexes.ts` and applied at boot by `ensureIndexes()`.
 - `socket.io`, `pino`, Sentry.
-- **Scheduled work:** the daily token pool, account purging and streak reminders.
-  A unique `{job, periodKey}` in `jobRuns` makes a double run physically
-  impossible.
+- **Scheduled work:** the daily token pool, account purging, streak reminders,
+  and the notification passes (unread digest, profile visits, badge round-up).
+  A unique `{job, periodKey}` in `jobRuns` makes a double run of the pool
+  physically impossible; the notification passes use `notificationLedger`,
+  whose `_id` is `<job>:<userId>:<periodKey>`, for the same reason.
 
 **Infrastructure:** MongoDB Atlas · one container on Railway/Render ·
 Backblaze B2 (R2 by config) · Resend · RevenueCat + Stripe · a translation provider. No Redis
@@ -581,7 +583,7 @@ write to them directly and never change their shape.
   nativeLanguages: [{ code: 'tr' }],
   learning: [{ code: 'en', level: 'B1', priority: 1 }],
   interests: ['music', 'tech'],
-  settings: { discoverable, notifications },
+  settings: { discoverable, notifications: { <kind>: { push, email } } },
   locationUpdatedAt,
   privacy: { incognito: false },
   entitlement: { tier: 'free' | 'pro', expiresAt?, willRenew?, store?, updatedAt },
@@ -1001,7 +1003,8 @@ only thing that matters is preserving store identity.
    quota, paid filters, who-viewed-me + incognito
 8. **Gamification:** streak, token ledger, daily pool, 4 leaderboards, streak
    freeze + cosmetic sinks
-9. Push notifications (message / streak reminder)
+9. Notifications: push, email and in-app (message / streak / badge / profile
+   visits / promotions)
 10. Block + report
 11. **Account deletion + data export**
 12. Web: same code, responsive, working URLs

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2198,3 +2198,160 @@ would never have removed on its own.
 The city list is GeoNames' `cities15000`, CC BY 4.0. The attribution is a
 licence condition and lives in three places; `docs/data-sources.md` is the one
 that explains why.
+
+## The notification matrix is back, because every cell has a sender now
+
+The channel axis was removed on 30 August with a good argument: nothing in the
+app sent mail except verification and password reset, so six of the eight
+switches did nothing, and a screen offering a choice which changes nothing is
+worse than one that does not offer it.
+
+That argument was about the senders, not about the shape. Building them —
+a digest for unread messages, an evening streak mail, a weekly profile-visit
+summary, a badge round-up, a campaign script — makes the same reasoning point
+the other way. The axis returns, and the rule that keeps a dead switch off the
+screen is written down rather than implied: **the email half of a row is
+disabled until the address is verified.**
+
+Three stored shapes are live at once and `notificationsAllowed(prefs, kind,
+channel)` is the only thing allowed to read them.
+
+- A bare `boolean` for everything is a v1 account. `false` is silence;
+  `true` is the defaults, which keeps promotions off.
+- A bare boolean per kind is what the app wrote in between. **Push reads it
+  literally** — push was the only channel with a sender, so the switch was in
+  practice a push switch and a `true` on promotions is a real decision to be
+  pushed at. **Email cannot.** Nobody was shown an email option while that
+  shape was being written, so nothing in it consented to mail; email falls to
+  the default, which is off for promotions.
+- A `{push, email}` object is both the retired matrix and what this version
+  writes, byte-identical, and both halves are read literally. While no sender
+  existed, reading `email` would have been reading a preference filed against
+  nothing; now it is somebody's decision. The matrix lived for hours on a build
+  that reached no store, so the accounts whose `email` predates a sender were
+  counted by hand before this shipped rather than reasoned about in code —
+  `scripts/inspect-notification-prefs.ts`.
+
+The write stops at the kind, not the channel.
+`settings.notifications.streak.email` is a path _into_ a sub-document, and over
+the bare boolean older profiles still hold there is none to enter: Mongo
+refuses it outright rather than replacing the boolean. So each touched kind is
+resolved and written whole, which is also what migrates it — one kind at a
+time, on the first switch its owner touches.
+
+## A message in the foreground is an in-app banner, not an OS one
+
+Phase 10 decided that a push only goes out if the recipient has no live socket:
+somebody with the thread open does not need their phone to buzz. What it left
+was a gap — somebody with the app open and a message arriving in a _different_
+thread was told nothing at all, and on the web, where there is no push, that
+was the whole notification story.
+
+The banner fills it, and three things about it were decided rather than
+defaulted.
+
+_It replaces rather than queues_, unlike `toast.ts` beside it. A toast reports
+the outcome of something the user did and has to be seen, or the app has
+silently swallowed an answer. A banner points at the chat list, which already
+shows every one of these messages with an unread count. Three quick messages
+must not hold the top of the screen for fifteen seconds.
+
+_It obeys the messages/push switch._ It is that channel's foreground face, and
+one switch labelled "Messages — Push" has to silence every unsolicited
+"somebody wrote to you", wherever it happens to be drawn. The chat list and its
+counts still update, because that is data arriving rather than a notification
+being sent — and on the web this is the only thing that switch does.
+
+_An OS notification for a message while the app is in front is suppressed and
+handed to the same banner._ A heads-up sliding over the app somebody is already
+using is the most irritating thing this system can do, and it says nothing the
+banner does not. The badge still ticks. Streak, badge and profile-visit
+notifications keep the OS presentation: once a day, no in-app equivalent, and
+worth swiping away and finding again in the shade.
+
+The read receipt moved from mount to **focus** at the same time, which fixed a
+bug that was already there: `chat/[id]` is a hidden tab route and never
+unmounts, so returning to an open thread posted nothing and the app went on
+believing it was being read. `appActive` is checked separately, because Android
+keeps the JS thread alive in the background — the chat screen can be the
+focused route with nobody looking at it, and marking a message read there
+clears a badge for something never seen.
+
+## Scheduled notifications claim before they send
+
+Every pass writes a row into `notificationLedger` — `_id` is
+`<job>:<userId>:<periodKey>` — and the insert failing on a duplicate key _is_
+the check. A read followed by a write has a gap, and two half-hourly ticks
+landing in that gap is somebody told the same thing twice, which is how a
+notification permission gets revoked.
+
+The claim happens **before** the send, deliberately. A send that then fails is
+one notification nobody got. A claim that fails to record is one they get again
+every thirty minutes until the hour passes.
+
+The period key is not always a day. The unread digest keys on
+`stats.lastActiveAt`, which does not move while somebody is away — so a
+fortnight of absence is one email rather than fourteen, and coming back and
+leaving again is a new key, which is exactly when a second digest is worth
+sending. A daily key would have made it the thing an unread-message email is
+usually guilty of.
+
+Badges are the exception, and they are on the profile instead:
+`stats.notifiedBadgeIds`. The ledger expires its rows after thirty days, which
+is right for "already nudged them today" and catastrophic for "they have had
+this badge since March" — an expiring row would re-announce every badge every
+month. That field is a log of what was sent rather than a second copy of the
+badges: it grants nothing and cannot disagree with them. An account it has
+never seen is **seeded, not congratulated**, so nobody was notified about a
+year of past achievements the day it shipped.
+
+## Profile visits are batched, and the count is the free half
+
+The viewer _list_ is Polyglot's; the count is free. So a push on every view
+would hand a free user the paywall's argument several times an afternoon, and
+any name in it would give away the thing being sold.
+
+One push a day, carrying a number and naming nobody, landing on `/viewers` —
+which draws the free/Pro line itself. One email a week, which may name people,
+for the tier allowed to see them. `viewSummarySince` decides that, not either
+sender, so the line is drawn in one module; there is a test that Fluent, which
+buys other things, still does not get the names in writing.
+
+The daily push has no email fallback, unlike the streak nudge. Somebody with no
+phone gets the weekly summary _instead of_ a daily notification, not as well as.
+
+Noon local, eight hours from the streak nudge at 20:00 and two from the badge
+round-up at 18:00. The fastest way to make somebody turn all three off is to
+let them arrive together.
+
+## Unsubscribe is a signed, non-expiring token on a POST
+
+The link in the footer of a notification email carries its own authority. No
+session, no login: somebody who left the app, forgot the password and still
+gets mail must be able to stop it, and RFC 8058's one-click is a mail server
+following a link with no way to sign in at all.
+
+**It never expires.** A footer sits in an inbox for years and has to keep
+working; CAN-SPAM's thirty days is a floor, not a design. The safety is the
+HMAC — 256 bits keyed by a 32-character secret, and the worst a replay achieves
+is switching off mail its holder already receives.
+
+**Its secret is its own**, not `BETTER_AUTH_SECRET`. The auth secret is what
+you rotate the morning a session store leaks, and doing that must not silently
+break the legal way out of every email ever sent. `EMAIL_UNSUBSCRIBE_SECRET` is
+generated once and never rotated; unset, it falls back and inherits the problem.
+
+**The GET only asks.** Scanners, link previewers and click-protection proxies
+all fetch a URL before a human sees the message, so a GET that acted would
+unsubscribe people who never opened the mail. The change is on the POST, which
+also parses a form body — one-click clients send an empty one, and Fastify
+answers 415 for a content-type nothing can read.
+
+**Unsubscribing touches email only.** Somebody stopping mail said nothing about
+their phone, and silencing that too would be answering a question they were not
+asked.
+
+Everything a notification sender does goes through `sendNotificationEmail`,
+which checks deleted, then the preference, then the address, in that order — a
+consent check that lives in five places is one that four of them will
+eventually get wrong.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -253,6 +253,53 @@ not the token. The API prunes tokens that come back with it, so a
 misconfigured send also quietly empties the devices collection — fix the
 credentials before running the streak reminder against real users.
 
+## Email needs a verified sender and a secret that is never rotated
+
+Push reaches a phone once Apple and Google are configured. Notification email
+reaches an inbox once three things are true, and the first is the one that
+takes days rather than minutes.
+
+- [ ] **A verified sending domain.** Resend → Domains → `langx.io`, then the
+      SPF, DKIM and DMARC records it prints, in Cloudflare DNS. Until this is
+      done `EMAIL_FROM` has to stay on `onboarding@resend.dev`, which works but
+      puts a stranger's domain on every email the app sends.
+- [ ] **`EMAIL_FROM` pointed at it**, e.g. `LangX <hello@langx.io>`. The TODO
+      in `env.ts` comes out with it.
+- [ ] **`EMAIL_UNSUBSCRIBE_SECRET` set**, `openssl rand -base64 32`.
+      **Generate once and never rotate it.** It signs the unsubscribe link in
+      every notification email ever sent, and those links live in inboxes for
+      years — rotating it breaks all of them at once, which is the legal way
+      out of the mail. Unset, the app falls back to `BETTER_AUTH_SECRET` and
+      inherits exactly that problem.
+
+Read one before anybody else does: leave `RESEND_API_KEY` unset locally and the
+sender prints each message to the log instead, headers included.
+
+### Sending a campaign
+
+The only notification that is not automatic, and the only one that can annoy
+several thousand people at once.
+
+```bash
+# Counts and prints; sends nothing.
+pnpm --filter @langx/api exec tsx scripts/send-campaign.ts \
+  --campaign 2026-09-launch --subject "LangX v2 is here" \
+  --html-file ./campaigns/launch.html
+
+# Same command, plus --confirm.
+```
+
+- The dry run is not optional in practice: it prints the recipient count and
+  five masked addresses, and a count that surprises you is the cheapest bug
+  report available.
+- Both bodies must contain `{{unsubscribeUrl}}`; the script refuses otherwise.
+- A re-run after a crash cannot mail anybody twice — recipients are claimed in
+  `emailCampaigns` before the batch, and the unique index enforces it.
+- Watch Resend's dashboard afterwards. A complaint rate above 0.1% means stop
+  and work out why before the next one.
+- One campaign is one language. For a bilingual send, run it twice with
+  different ids and `--locale`.
+
 ## Actions that succeed silently
 
 `src/lib/alert.ts` and `AlertHost` give the app a dialog that works in the

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -13,10 +13,11 @@ nothing here phones home.
 | An S3-compatible bucket | avatars, gallery photos                                                                                                                         | Cloudflare R2 (no egress fees), Backblaze B2                                                     |
 
 Everything else is optional and the app boots without it: no email provider
-means verification links are printed to the log, no translation credentials
-means `/translate` returns a clear "not configured" error, no RevenueCat means
-everyone stays on the free tier, no push credentials means notifications are
-logged instead of sent. That is deliberate — a self-hoster should be able to
+means verification links and notification mail are printed to the log, no
+unsubscribe secret means those links are signed with the auth secret instead,
+no translation credentials means `/translate` returns a clear "not configured"
+error, no RevenueCat means everyone stays on the free tier, no push credentials
+means notifications are logged instead of sent. That is deliberate — a self-hoster should be able to
 get a working instance before deciding which paid services they want.
 
 ## Quick start
@@ -54,7 +55,7 @@ whole collection.
 
 ## Background work
 
-Three schedulers start with the API. None of them is a cron expression — each
+Four schedulers start with the API. None of them is a cron expression — each
 asks "is there unfinished work?" on an interval, so a process that was down
 during the window catches up on its next tick instead of skipping silently.
 
@@ -62,10 +63,18 @@ during the window catches up on its next tick instead of skipping silently.
 | ---------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Daily token pool | 15 min   | Distributes a closed day's token pool. Idempotent twice over: a `jobRuns` lock, and the ledger's unique index. Catches up 7 days. |
 | Account purge    | 1 hour   | Hard-deletes accounts past their 30-day grace period.                                                                             |
-| Streak reminder  | 30 min   | Sends the nudge at 20:00 in each user's own timezone, once per local day.                                                         |
+| Streak reminder  | 30 min   | Sends the nudge at 20:00 in each user's own timezone, once per local day — as a push, or as email to somebody with no phone.      |
+| Notifications    | 30 min   | Three passes: the unread-message digest, the profile-visit round-up (daily push, weekly email) and the badge round-up at 18:00.   |
 
 Running several API instances is safe. The pool's `jobRuns` unique index means
-only one instance can own a given day.
+only one instance can own a given day, and every notification pass claims a row
+in `notificationLedger` before it sends, so nobody is told the same thing twice.
+
+Without `RESEND_API_KEY` the notification email is printed to the log rather
+than sent, exactly like the verification link. Without `EMAIL_UNSUBSCRIBE_SECRET`
+the unsubscribe links are signed with `BETTER_AUTH_SECRET` instead — which
+works, but means rotating that secret breaks every unsubscribe link already
+sitting in somebody's inbox.
 
 ## Deploying
 

--- a/docs/store/privacy-data-safety.md
+++ b/docs/store/privacy-data-safety.md
@@ -29,6 +29,7 @@ Both stores treat a wrong answer here as a policy violation, and both accept
 > Answer the form's location questions with both in mind.
 
 | Push token | `devices.pushToken` | Sending notifications | Only if you grant permission |
+| Notification record | `notificationLedger`, `stats.notifiedBadgeIds`, `emailCampaigns` | Not telling you the same thing twice — which day you were nudged, which badges you have been told about, which campaigns reached you | Automatic; the ledger is deleted after 30 days (TTL index) |
 | Purchase state | `subscriptions` | Knowing whether you have Pro | Only if you subscribe |
 | Profile views | `profileViews` | "Who viewed me". Not written at all if the viewer has incognito on | Automatic; deleted after 90 days (TTL index) |
 | Reports you file | `reports` | Moderation | Only if you report someone |
@@ -134,14 +135,14 @@ not through a second SDK in the app.
 
 ## Sharing with third parties
 
-| Recipient                    | What it receives                                                           | Why                                                                       |
-| ---------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Resend                       | Your email address and the message body                                    | Sending verification and password-reset mail                              |
-| Google Cloud Translation     | The text you asked to translate                                            | Machine translation. Results are cached by a hash of the source text      |
-| RevenueCat                   | Your user id and purchase events                                           | Subscription state                                                        |
-| Expo push service            | Your push token and the notification text                                  | Delivering notifications                                                  |
-| Cloudflare R2 / Backblaze B2 | Your photos                                                                | Hosting them                                                              |
-| ~~PostHog (EU Cloud)~~       | _Nothing — not integrated. Listed only so it is not forgotten when it is._ | _See "Analytics" above: not built, and must not be declared until it is._ |
+| Recipient                    | What it receives                                                                                                                                               | Why                                                                                    |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Resend                       | Your email address, and — for notification mail — how many messages are waiting and the display names of who wrote or looked. **Never the text of a message.** | Verification and password-reset mail, and the notification emails you have switched on |
+| Google Cloud Translation     | The text you asked to translate                                                                                                                                | Machine translation. Results are cached by a hash of the source text                   |
+| RevenueCat                   | Your user id and purchase events                                                                                                                               | Subscription state                                                                     |
+| Expo push service            | Your push token and the notification text                                                                                                                      | Delivering notifications                                                               |
+| Cloudflare R2 / Backblaze B2 | Your photos                                                                                                                                                    | Hosting them                                                                           |
+| ~~PostHog (EU Cloud)~~       | _Nothing — not integrated. Listed only so it is not forgotten when it is._                                                                                     | _See "Analytics" above: not built, and must not be declared until it is._              |
 
 None of these receive data for their own advertising or profiling. There are no
 data brokers.


### PR DESCRIPTION
Stacked on #1074. Last of the set.

Five entries in `decisions.md`, because each looks arbitrary from the code
and one reverses a note written a week ago — the channel axis is back, and
the argument that removed it is the same one that brings it back.

- The matrix returns, with the reading rules for all three stored shapes.
- A foreground message is an in-app banner, not an OS one.
- Every scheduled pass claims a ledger row before it sends, and why badges
  are the exception.
- Profile visits are batched, and the count is the free half.
- Unsubscribe is a signed, non-expiring token on a POST.

`privacy-data-safety.md` gains the notification record and a sharper Resend
row: counts and display names, never message text. `self-host.md` gains the
fourth scheduler. `release-runbook.md` gains the email half of the release,
which is the slow half — a sending domain takes days to verify — plus the
campaign runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)