### PR TITLE
Build the one door notification email leaves by

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,13 @@ RESEND_API_KEY=
 # resend.dev needs no domain verification, so this works immediately. Point
 # it at a verified langx.io sender before Faz 13's launch.
 EMAIL_FROM=LangX <onboarding@resend.dev>
+# Signs the unsubscribe link in every notification email. Its own secret, not
+# BETTER_AUTH_SECRET, because rotating the auth secret must not break links
+# that sit in inboxes for years — those links are the legal way out of the
+# mail. Generate once and NEVER rotate: openssl rand -base64 32
+# Unset, it falls back to BETTER_AUTH_SECRET, which works and inherits that
+# problem.
+EMAIL_UNSUBSCRIBE_SECRET=
 
 # ─── API: storage (Faz 2 / 11) ───────────────────────────────────────────────
 # S3-compatible; the published app runs on Backblaze B2 (same account as v1,

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,6 +14,7 @@ import type { Env } from './env'
 import { ApiError } from './lib/ApiError'
 import { registerMaintenanceGate } from './middleware/maintenance'
 import { accountRoutes } from './routes/account'
+import { emailRoutes } from './routes/email'
 import { appConfigRoutes } from './routes/appConfig'
 import { loginRoutes } from './routes/login'
 import { registerAuthRoutes } from './routes/auth'
@@ -39,6 +40,7 @@ import { xpRoutes } from './routes/tokens'
 import { wellKnownRoutes } from './routes/wellKnown'
 import type { RevenueCatClient } from './modules/billing/revenueCatClient'
 import { LoggingPushSender, type PushSender } from './modules/push/devices'
+import { ConsoleEmailSender, type EmailSender } from './email/sender'
 import { DisabledLegacyVerifier, type LegacyVerifier } from './modules/handles/legacyLogin'
 import type { StorageProvider } from './storage/StorageProvider'
 import type { TranslationProvider } from './translation/TranslationProvider'
@@ -54,6 +56,12 @@ declare module 'fastify' {
     translation: TranslationProvider
     revenueCat: RevenueCatClient
     push: PushSender
+    /**
+     * The same sender Better Auth was handed, so that one array in a test
+     * holds both the verification mail and the notification mail — they are
+     * one outbox from the reader's side, and were two from ours.
+     */
+    email: EmailSender
     legacyVerifier: LegacyVerifier
     appVersion: string
     /**
@@ -81,6 +89,11 @@ export interface BuildAppOptions {
    */
   push?: PushSender
   /**
+   * Defaults to the console sender for the same reason `push` defaults to the
+   * logging one: a test that never sends mail should not have to name it.
+   */
+  email?: EmailSender
+  /**
    * Checks a v1 password against the still-running Appwrite. Defaults to the
    * disabled one, so tests and any instance without APPWRITE_* simply never
    * take the bridge path.
@@ -98,6 +111,7 @@ export async function buildApp({
   translation,
   revenueCat,
   push = new LoggingPushSender(),
+  email = new ConsoleEmailSender(console),
   legacyVerifier = new DisabledLegacyVerifier(),
   version = '2.0.0',
 }: BuildAppOptions): Promise<FastifyInstance> {
@@ -127,6 +141,7 @@ export async function buildApp({
   app.decorate('translation', translation)
   app.decorate('revenueCat', revenueCat)
   app.decorate('push', push)
+  app.decorate('email', email)
   app.decorate('legacyVerifier', legacyVerifier)
   app.decorate('appVersion', version)
 
@@ -237,6 +252,7 @@ export async function buildApp({
   await app.register(leaderboardRoutes)
   await app.register(moderationRoutes)
   await app.register(accountRoutes)
+  await app.register(emailRoutes)
 
   // Attached last: Socket.io only needs `app.server` (Fastify creates the
   // underlying http.Server synchronously at construction) plus the

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -11,7 +11,7 @@ import { recordTermsAcceptance } from './modules/account/terms'
 import type { EmailSender } from './email/sender'
 import { resetPasswordEmail, verificationEmail } from './email/templates'
 import { localeFromHeader } from './i18n'
-import type { Env } from './env'
+import { publicApiUrl, type Env } from './env'
 import type { RevenueCatClient } from './modules/billing/revenueCatClient'
 
 export interface CreateAuthOptions {
@@ -33,8 +33,7 @@ export interface CreateAuthOptions {
  * JWT first (see auth/appleClientSecret.ts), so construction is async.
  */
 export async function createAuth({ env, db, client, emailSender, revenueCat }: CreateAuthOptions) {
-  const baseURL =
-    env.BETTER_AUTH_URL ?? `http://${env.HOST === '0.0.0.0' ? 'localhost' : env.HOST}:${env.PORT}`
+  const baseURL = publicApiUrl(env)
 
   const socialProviders: NonNullable<Parameters<typeof betterAuth>[0]['socialProviders']> = {}
 

--- a/apps/api/src/email/notify.test.ts
+++ b/apps/api/src/email/notify.test.ts
@@ -1,0 +1,192 @@
+import { ObjectId } from 'mongodb'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../db/client'
+import { COLLECTIONS } from '../db/collections'
+import { authId } from '../lib/authId'
+import type { Device } from '../modules/push/devices'
+import { CapturingEmailSender } from '../testSupport/authFlow'
+import { sendNotificationEmail, type NotificationEmailContext } from './notify'
+import { verifyUnsubscribeToken } from './unsubscribeToken'
+
+const SECRET = 'an-unsubscribe-secret-of-adequate-length'
+
+describe('sendNotificationEmail', () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+  let sender: CapturingEmailSender
+  let ctx: NotificationEmailContext
+  /** A real ObjectId hex: `authId` parses ids to cross into Better Auth's world. */
+  let u1: string
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'notify_test')
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    for (const name of [COLLECTIONS.profiles, COLLECTIONS.user, COLLECTIONS.devices]) {
+      await handle.db.collection(name).deleteMany({})
+    }
+    u1 = new ObjectId().toHexString()
+    sender = new CapturingEmailSender()
+    ctx = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api2.langx.io' }
+  })
+
+  async function seed(
+    userId: string,
+    opts: {
+      notifications?: unknown
+      email?: string | null
+      verified?: boolean
+      deleted?: boolean
+      deviceLocale?: string
+    } = {},
+  ): Promise<void> {
+    await handle.db.collection(COLLECTIONS.profiles).insertOne({
+      _id: userId,
+      settings: { discoverable: true, notifications: opts.notifications ?? {} },
+      ...(opts.deleted ? { deletedAt: new Date() } : {}),
+    } as never)
+    if (opts.email !== null) {
+      await handle.db.collection(COLLECTIONS.user).insertOne({
+        _id: authId(userId),
+        email: opts.email ?? `${userId}@example.com`,
+        emailVerified: opts.verified ?? true,
+      })
+    }
+    if (opts.deviceLocale) {
+      await handle.db.collection<Device>(COLLECTIONS.devices).insertOne({
+        userId,
+        pushToken: `token-${userId}`,
+        platform: 'ios',
+        locale: opts.deviceLocale as never,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as never)
+    }
+  }
+
+  const build = (locale: string, unsubscribe: string) => ({
+    subject: `subject in ${locale}`,
+    html: `<p>hello</p><a href="${unsubscribe}">out</a>`,
+    text: `hello\nout: ${unsubscribe}`,
+  })
+
+  it('sends to a verified address that has not opted out', async () => {
+    await seed(u1)
+    const outcome = await sendNotificationEmail(handle.db, ctx, {
+      userId: u1,
+      type: 'messages',
+      build,
+    })
+    expect(outcome).toBe('sent')
+    expect(sender.messages).toHaveLength(1)
+    expect(sender.messages[0]?.to).toBe(`${u1}@example.com`)
+  })
+
+  /**
+   * The header pair is what a mailbox provider reads; without it the same mail
+   * is judged as bulk sending that made leaving hard, however good the footer.
+   */
+  it('carries a one-click unsubscribe header signed for that person and kind', async () => {
+    await seed(u1)
+    await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'streak', build })
+
+    const headers = sender.messages[0]?.headers ?? {}
+    expect(headers['List-Unsubscribe-Post']).toBe('List-Unsubscribe=One-Click')
+    const url = headers['List-Unsubscribe']?.slice(1, -1) ?? ''
+    const token = new URL(url).searchParams.get('token')
+    expect(verifyUnsubscribeToken(SECRET, token ?? undefined)).toEqual({
+      userId: u1,
+      scope: 'streak',
+    })
+  })
+
+  /** The same URL has to reach the body too, for a client that strips headers. */
+  it('hands the same url to the template', async () => {
+    await seed(u1)
+    await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'messages', build })
+    const message = sender.messages[0]
+    const header = message?.headers?.['List-Unsubscribe']?.slice(1, -1)
+    expect(message?.text).toContain(header)
+    expect(message?.html).toContain(header)
+  })
+
+  it('words it in the language of the newest device', async () => {
+    await seed(u1, { deviceLocale: 'tr' })
+    await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'messages', build })
+    expect(sender.messages[0]?.subject).toBe('subject in tr')
+  })
+
+  it('falls back to English when there is no phone signed in', async () => {
+    await seed(u1)
+    await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'messages', build })
+    expect(sender.messages[0]?.subject).toBe('subject in en')
+  })
+
+  it('respects an opt-out on that kind alone', async () => {
+    await seed(u1, { notifications: { messages: { email: false } } })
+    expect(
+      await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'messages', build }),
+    ).toBe('opted-out')
+    expect(await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'streak', build })).toBe(
+      'sent',
+    )
+  })
+
+  /** Never inferred: nobody is marketed at without having said yes. */
+  it('never sends promotions to somebody who did not ask', async () => {
+    await seed(u1)
+    expect(
+      await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'promotions', build }),
+    ).toBe('opted-out')
+    await handle.db
+      .collection(COLLECTIONS.profiles)
+      .updateOne(
+        { _id: u1 as never },
+        { $set: { 'settings.notifications.promotions': { push: false, email: true } } },
+      )
+    expect(
+      await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'promotions', build }),
+    ).toBe('sent')
+  })
+
+  it('refuses an address nobody has proved', async () => {
+    await seed(u1, { verified: false })
+    expect(
+      await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'messages', build }),
+    ).toBe('unverified')
+    expect(sender.messages).toHaveLength(0)
+  })
+
+  it('has nothing to write to when there is no account row', async () => {
+    await seed(u1, { email: null })
+    expect(
+      await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'messages', build }),
+    ).toBe('no-email')
+  })
+
+  it('says nothing to somebody on their way out', async () => {
+    await seed(u1, { deleted: true })
+    expect(
+      await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'messages', build }),
+    ).toBe('deleted')
+    expect(sender.messages).toHaveLength(0)
+  })
+
+  it('reports a user with no profile rather than throwing', async () => {
+    expect(
+      await sendNotificationEmail(handle.db, ctx, {
+        userId: new ObjectId().toHexString(),
+        type: 'messages',
+        build,
+      }),
+    ).toBe('no-profile')
+  })
+})

--- a/apps/api/src/email/notify.ts
+++ b/apps/api/src/email/notify.ts
@@ -1,0 +1,92 @@
+import { notificationsAllowed, webUrl, type Locale, type NotificationType } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../db/collections'
+import { localeFor } from '../modules/push/devices'
+import { emailFor } from '../modules/profiles/emailFor'
+import type { Profile } from '../modules/profiles/profiles'
+import type { Email } from './templates'
+import type { EmailSender } from './sender'
+import { signUnsubscribeToken, unsubscribeUrl } from './unsubscribeToken'
+
+/** What every notification sender needs, built once in `index.ts`. */
+export interface NotificationEmailContext {
+  sender: EmailSender
+  unsubscribeSecret: string
+  apiBaseUrl: string
+}
+
+/**
+ * Why a mail was not sent, which is worth naming rather than returning a
+ * boolean: a scheduler counting sends wants to know the difference between
+ * "they said no" and "we have no address for them".
+ */
+export type NotificationEmailOutcome =
+  'sent' | 'no-profile' | 'deleted' | 'opted-out' | 'no-email' | 'unverified'
+
+/**
+ * The only way a notification email leaves this app.
+ *
+ * Every sender goes through here and none of them repeats the consent check,
+ * because a consent check that lives in four places is a consent check that
+ * three of them will eventually get wrong. The order is also the point:
+ * deleted first, then the preference, then the address. Somebody who opted out
+ * should never have their address looked up at all.
+ *
+ * `build` is handed the locale and the finished unsubscribe URL — the URL is
+ * needed *inside* the body as well as in the header, and a sender that had to
+ * assemble it would be a sender that could forget to.
+ */
+export async function sendNotificationEmail(
+  db: Db,
+  ctx: NotificationEmailContext,
+  input: {
+    userId: string
+    type: NotificationType
+    build: (locale: Locale, unsubscribe: string) => Email
+  },
+): Promise<NotificationEmailOutcome> {
+  const profile = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .findOne({ _id: input.userId }, { projection: { settings: 1, deletedAt: 1 } })
+  if (!profile) return 'no-profile'
+  if (profile.deletedAt) return 'deleted'
+  if (!notificationsAllowed(profile.settings?.notifications, input.type, 'email')) {
+    return 'opted-out'
+  }
+
+  const address = await emailFor(db, input.userId)
+  if (!address) return 'no-email'
+  // Never to an unproved address. Somebody who typed a stranger's email at
+  // sign-up and never clicked the link has not agreed to anything, and the
+  // stranger certainly has not.
+  if (!address.verified) return 'unverified'
+
+  const locale = await localeFor(db, input.userId)
+  const url = unsubscribeUrl(
+    ctx.apiBaseUrl,
+    signUnsubscribeToken(ctx.unsubscribeSecret, input.userId, input.type),
+  )
+
+  await ctx.sender.send({
+    to: address.email,
+    ...input.build(locale, url),
+    headers: unsubscribeHeaders(url),
+  })
+  return 'sent'
+}
+
+/**
+ * RFC 8058. The `-Post` header is what tells a client it may unsubscribe with
+ * one POST and no confirmation page — Gmail and Outlook draw their own button
+ * from the pair, and mail without them is judged as bulk sending that made
+ * leaving hard.
+ */
+export function unsubscribeHeaders(url: string): Record<string, string> {
+  return {
+    'List-Unsubscribe': `<${url}>`,
+    'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+  }
+}
+
+/** Where the footer's second link goes: the screen with all eight switches. */
+export const MANAGE_PREFS_URL = webUrl('/settings')

--- a/apps/api/src/email/sender.ts
+++ b/apps/api/src/email/sender.ts
@@ -15,13 +15,30 @@ export interface EmailMessage {
   subject: string
   html: string
   text: string
+  /**
+   * `List-Unsubscribe` and its one-click companion, on every notification
+   * mail. Gmail and Outlook draw their own unsubscribe control from these and
+   * treat their absence as a spam signal on bulk sending — the link in the
+   * footer satisfies the law, the header is what keeps the mail arriving.
+   */
+  headers?: Record<string, string>
 }
 
 export interface EmailSender {
   send(message: EmailMessage): Promise<void>
+  /**
+   * Optional: only the campaign script sends enough at once to care, and a
+   * sender that cannot batch is not broken, just slower. Resend takes 100 per
+   * request, each item carrying its own recipient and headers — which it must,
+   * since the unsubscribe token is per person.
+   */
+  sendBatch?(messages: EmailMessage[]): Promise<void>
 }
 
-class ResendEmailSender implements EmailSender {
+/** Resend rejects a batch larger than this. */
+export const EMAIL_BATCH_SIZE = 100
+
+export class ResendEmailSender implements EmailSender {
   readonly #client: Resend
   readonly #from: string
 
@@ -30,10 +47,37 @@ class ResendEmailSender implements EmailSender {
     this.#from = from
   }
 
-  async send({ to, subject, html, text }: EmailMessage): Promise<void> {
-    const { error } = await this.#client.emails.send({ from: this.#from, to, subject, html, text })
+  async send({ to, subject, html, text, headers }: EmailMessage): Promise<void> {
+    const { error } = await this.#client.emails.send({
+      from: this.#from,
+      to,
+      subject,
+      html,
+      text,
+      ...(headers ? { headers } : {}),
+    })
     if (error) {
       throw new Error(`Resend failed to send "${subject}" to ${to}: ${error.message}`)
+    }
+  }
+
+  async sendBatch(messages: EmailMessage[]): Promise<void> {
+    for (let index = 0; index < messages.length; index += EMAIL_BATCH_SIZE) {
+      const batch = messages.slice(index, index + EMAIL_BATCH_SIZE)
+      const { error } = await this.#client.batch.send(
+        batch.map(({ to, subject, html, text, headers }) => ({
+          from: this.#from,
+          to,
+          subject,
+          html,
+          text,
+          ...(headers ? { headers } : {}),
+        })),
+      )
+      // Thrown rather than logged: the caller claimed these recipients in the
+      // ledger before sending, and only an error tells it to release them.
+      if (error)
+        throw new Error(`Resend failed to send a batch of ${batch.length}: ${error.message}`)
     }
   }
 }
@@ -44,19 +88,23 @@ class ResendEmailSender implements EmailSender {
  * instead of an inbox. This is what makes `pnpm dev` work before anyone has
  * gone and created a Resend account.
  */
-class ConsoleEmailSender implements EmailSender {
+export class ConsoleEmailSender implements EmailSender {
   readonly #logger: EmailSenderLogger
 
   constructor(logger: EmailSenderLogger) {
     this.#logger = logger
   }
 
-  send({ to, subject, text }: EmailMessage): Promise<void> {
+  send({ to, subject, text, headers }: EmailMessage): Promise<void> {
     this.#logger.warn(
-      { to, subject, text },
+      { to, subject, text, headers },
       'RESEND_API_KEY not set — printing email instead of sending it',
     )
     return Promise.resolve()
+  }
+
+  async sendBatch(messages: EmailMessage[]): Promise<void> {
+    for (const message of messages) await this.send(message)
   }
 }
 

--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -37,6 +37,61 @@ export interface Email {
   text: string
 }
 
+/**
+ * The shell for mail somebody *chose* to receive, as opposed to the two above,
+ * which answer something they just did.
+ *
+ * The difference is the footer, and it is not decoration. A notification email
+ * has to say why it arrived and how to stop it — the law's floor, and the
+ * thing that keeps a mailbox provider delivering the rest. `wrap`'s footer
+ * says "ignore this if you didn't ask for it", which is exactly wrong here:
+ * they did ask, once, and want the way back out.
+ */
+export function notificationEmail(
+  locale: Locale,
+  options: {
+    preheader: string
+    bodyHtml: string
+    cta?: { url: string; label: string }
+    unsubscribeUrl: string
+    manageUrl: string
+  },
+): { html: string } {
+  const t = translator(locale)
+  const dir = locale === 'ar' ? 'rtl' : 'ltr'
+  const cta = options.cta ? `<p>${button(options.cta.url, options.cta.label)}</p>` : ''
+  return {
+    html: `<!doctype html>
+<html lang="${locale}" dir="${dir}">
+  <body style="font-family: -apple-system, system-ui, sans-serif; color: #111; background: #f7f7f7; padding: 24px;">
+    <span style="display:none">${options.preheader}</span>
+    <div style="max-width: 480px; margin: 0 auto; background: #fff; border-radius: 12px; padding: 32px;">
+      <h1 style="font-size: 20px; margin: 0 0 16px;">LangX</h1>
+      ${options.bodyHtml}
+      ${cta}
+      <p style="color: #888; font-size: 12px; margin-top: 32px;">
+        ${t('email.whyThisMail')}<br />
+        <a href="${options.unsubscribeUrl}" style="color:#888;">${t('email.unsubscribeLink')}</a>
+        &middot;
+        <a href="${options.manageUrl}" style="color:#888;">${t('email.managePrefs')}</a>
+      </p>
+    </div>
+  </body>
+</html>`,
+  }
+}
+
+/**
+ * The plain-text half, which carries the unsubscribe URL in full.
+ *
+ * Not a nicety: a client that strips HTML would otherwise show mail with no
+ * way out of it, and the way out is the part that has to survive.
+ */
+export function notificationText(locale: Locale, lines: string[], unsubscribeUrl: string): string {
+  const t = translator(locale)
+  return [...lines, '', t('email.unsubscribeText', { url: unsubscribeUrl })].join('\n')
+}
+
 export function verificationEmail(url: string, locale: Locale): Email {
   const t = translator(locale)
   return {

--- a/apps/api/src/email/unsubscribeToken.test.ts
+++ b/apps/api/src/email/unsubscribeToken.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { signUnsubscribeToken, unsubscribeUrl, verifyUnsubscribeToken } from './unsubscribeToken'
+
+const SECRET = 'a-secret-at-least-thirty-two-characters'
+
+describe('unsubscribe tokens', () => {
+  it('round-trips a scope', () => {
+    const token = signUnsubscribeToken(SECRET, 'user-1', 'messages')
+    expect(verifyUnsubscribeToken(SECRET, token)).toEqual({ userId: 'user-1', scope: 'messages' })
+  })
+
+  it('round-trips the everything scope', () => {
+    const token = signUnsubscribeToken(SECRET, 'user-1', 'all')
+    expect(verifyUnsubscribeToken(SECRET, token)?.scope).toBe('all')
+  })
+
+  it('refuses a tampered signature', () => {
+    const token = signUnsubscribeToken(SECRET, 'user-1', 'messages')
+    expect(verifyUnsubscribeToken(SECRET, `${token}x`)).toBeNull()
+  })
+
+  /**
+   * The part that matters: the user id is in the clear, so without this a
+   * link to one inbox would unsubscribe anybody whose id you could guess.
+   */
+  it('refuses a token signed for somebody else', () => {
+    const token = signUnsubscribeToken(SECRET, 'user-1', 'messages')
+    const forged = token.replace('user-1', 'user-2')
+    expect(verifyUnsubscribeToken(SECRET, forged)).toBeNull()
+  })
+
+  it('refuses a scope swapped after signing', () => {
+    const token = signUnsubscribeToken(SECRET, 'user-1', 'messages')
+    expect(verifyUnsubscribeToken(SECRET, token.replace('messages', 'promotions'))).toBeNull()
+  })
+
+  it('refuses a token from another secret', () => {
+    const token = signUnsubscribeToken('another-secret-of-adequate-length', 'user-1', 'streak')
+    expect(verifyUnsubscribeToken(SECRET, token)).toBeNull()
+  })
+
+  it('refuses a scope that is not a kind', () => {
+    expect(verifyUnsubscribeToken(SECRET, 'v1.user-1.everything.abc')).toBeNull()
+  })
+
+  /** `timingSafeEqual` throws on a length mismatch; a short token must not 500. */
+  it('survives rubbish without throwing', () => {
+    for (const junk of ['', 'x', 'v1.user-1', 'v1.user-1.messages.', 'a.b.c.d.e']) {
+      expect(verifyUnsubscribeToken(SECRET, junk)).toBeNull()
+    }
+    expect(verifyUnsubscribeToken(SECRET, undefined)).toBeNull()
+  })
+
+  it('builds a url that survives a token in a query string', () => {
+    const token = signUnsubscribeToken(SECRET, 'user/1', 'messages')
+    const url = unsubscribeUrl('https://api2.langx.io/', token)
+    expect(url.startsWith('https://api2.langx.io/email/unsubscribe?token=')).toBe(true)
+    const parsed = new URL(url)
+    expect(verifyUnsubscribeToken(SECRET, parsed.searchParams.get('token') ?? undefined)).toEqual({
+      userId: 'user/1',
+      scope: 'messages',
+    })
+  })
+})

--- a/apps/api/src/email/unsubscribeToken.ts
+++ b/apps/api/src/email/unsubscribeToken.ts
@@ -1,0 +1,59 @@
+import { NOTIFICATION_TYPES, type NotificationType } from '@langx/shared'
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+/** Every kind, plus the "stop all of it" the confirmation page also offers. */
+export type UnsubscribeScope = NotificationType | 'all'
+
+const VERSION = 'v1'
+
+function signature(secret: string, userId: string, scope: UnsubscribeScope): string {
+  return createHmac('sha256', secret).update(`${VERSION}:${userId}:${scope}`).digest('base64url')
+}
+
+/**
+ * The credential in the footer of every notification email.
+ *
+ * It carries its own authority — no session, no login — because that is what
+ * an unsubscribe link has to be. Somebody who left the app, forgot the
+ * password and still gets mail must be able to stop it, and RFC 8058's
+ * one-click is a machine following the link with no way to sign in at all.
+ *
+ * **It never expires.** A footer sits in an inbox for years and has to keep
+ * working; CAN-SPAM's floor is thirty days after the send, which is a floor
+ * rather than a design. The safety comes from the HMAC instead: 256 bits over
+ * a 32-character secret, unguessable, and the worst it can be replayed to do
+ * is switch off mail its holder already receives.
+ */
+export function signUnsubscribeToken(
+  secret: string,
+  userId: string,
+  scope: UnsubscribeScope,
+): string {
+  return `${VERSION}.${userId}.${scope}.${signature(secret, userId, scope)}`
+}
+
+export function verifyUnsubscribeToken(
+  secret: string,
+  token: string | undefined,
+): { userId: string; scope: UnsubscribeScope } | null {
+  if (!token) return null
+  const parts = token.split('.')
+  if (parts.length !== 4) return null
+  const [version, userId, scope, provided] = parts as [string, string, string, string]
+  if (version !== VERSION || !userId) return null
+  if (scope !== 'all' && !NOTIFICATION_TYPES.includes(scope as NotificationType)) return null
+
+  const expected = signature(secret, userId, scope as UnsubscribeScope)
+  // `timingSafeEqual` throws on a length mismatch rather than returning false,
+  // and a token is attacker-supplied — the length check is not an optimisation.
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return null
+  if (!timingSafeEqual(a, b)) return null
+
+  return { userId, scope: scope as UnsubscribeScope }
+}
+
+export function unsubscribeUrl(apiBaseUrl: string, token: string): string {
+  return `${apiBaseUrl.replace(/\/$/, '')}/email/unsubscribe?token=${encodeURIComponent(token)}`
+}

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -50,6 +50,19 @@ const envSchema = z.object({
   // resend.dev requires no domain verification, so this works immediately;
   // point it at a verified langx.io sender before Faz 13's launch.
   EMAIL_FROM: z.string().min(1).default('LangX <onboarding@resend.dev>'),
+  /**
+   * Signs the unsubscribe link in the footer of every notification email.
+   *
+   * Its own secret rather than `BETTER_AUTH_SECRET`, and the difference is
+   * rotation: the auth secret is what you change the morning a session store
+   * leaks, and doing that must not silently break the unsubscribe link in
+   * every email ever sent — those links live in inboxes for years and are the
+   * legal way out of the mail. **Generate once and never rotate.**
+   *
+   * Optional, so the app still boots without it: unset, it falls back to the
+   * auth secret, which works and merely inherits that rotation problem.
+   */
+  EMAIL_UNSUBSCRIBE_SECRET: emptyToUndefined(z.string().min(32).optional()),
 
   // OAuth. Each provider activates only once both of its variables are set —
   // see socialProviders() in auth.ts — so leaving these blank still boots a
@@ -167,6 +180,31 @@ const envSchema = z.object({
 })
 
 export type Env = z.infer<typeof envSchema>
+
+/**
+ * Where this API answers from the outside, which is what an unsubscribe link
+ * in an email has to point at.
+ *
+ * The same resolution `createAuth` does for its `baseURL`, extracted so the
+ * two cannot drift: a link built against a different host than the one Better
+ * Auth thinks it is serving is a 404 in somebody's inbox.
+ */
+export function publicApiUrl(env: Env): string {
+  return (
+    env.BETTER_AUTH_URL ?? `http://${env.HOST === '0.0.0.0' ? 'localhost' : env.HOST}:${env.PORT}`
+  )
+}
+
+/**
+ * The secret the unsubscribe links are signed with.
+ *
+ * Falls back to the auth secret so an instance without its own still sends
+ * working links — at the cost of those links dying the day that secret is
+ * rotated, which is the whole reason `EMAIL_UNSUBSCRIBE_SECRET` exists.
+ */
+export function unsubscribeSecret(env: Env): string {
+  return env.EMAIL_UNSUBSCRIBE_SECRET ?? env.BETTER_AUTH_SECRET
+}
 
 export function loadEnv(source: NodeJS.ProcessEnv = process.env): Env {
   const parsed = envSchema.safeParse(source)

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -30,5 +30,26 @@ export const ar: Localized<ServerMessages> = {
     resetBody: 'طلب أحدهم إعادة تعيين كلمة المرور لهذا الحساب. إذا كنت أنت:',
     resetButton: 'إعادة تعيين كلمة المرور',
     resetText: 'إعادة تعيين كلمة مرور LangX: {url}',
+
+    whyThisMail: 'تصلك هذه الرسالة بسبب إعدادات الإشعارات في LangX.',
+    unsubscribeLink: 'أوقف هذه الرسائل',
+    unsubscribeText: 'أوقف هذه الرسائل: {url}',
+    managePrefs: 'كل إعدادات الإشعارات',
+
+    unsubscribeTitle: 'إيقاف هذه الرسائل؟',
+    unsubscribeBody: 'لن تصلك {kind} عبر البريد بعد الآن. إشعارات الهاتف لا تتأثر.',
+    unsubscribeConfirm: 'أوقفها',
+    unsubscribeAll: 'أو أوقف كل رسائل LangX',
+    unsubscribedTitle: 'تم — لن تصلك بعد الآن.',
+    unsubscribedBody: 'يمكنك تشغيلها متى شئت من LangX في الإعدادات ← الإشعارات.',
+    unsubscribeInvalid: 'هذا الرابط غير صالح. افتح LangX وغيّره من الإعدادات ← الإشعارات.',
+
+    kind: {
+      messages: 'ملخّصات الرسائل',
+      streak: 'تذكيرات السلسلة',
+      profileVisits: 'ملخّصات زيارات الملف',
+      promotions: 'الأخبار والعروض',
+      all: 'رسائل LangX',
+    },
   },
 }

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -23,5 +23,29 @@ export const de: Localized<ServerMessages> = {
       'Jemand hat für dieses Konto eine Passwortzurücksetzung angefordert. Wenn du das warst:',
     resetButton: 'Passwort zurücksetzen',
     resetText: 'Setze dein LangX-Passwort zurück: {url}',
+
+    whyThisMail: 'Du bekommst das wegen deiner LangX-Benachrichtigungseinstellungen.',
+    unsubscribeLink: 'Diese E-Mails abstellen',
+    unsubscribeText: 'Diese E-Mails abstellen: {url}',
+    managePrefs: 'Alle Benachrichtigungseinstellungen',
+
+    unsubscribeTitle: 'Diese E-Mails abstellen?',
+    unsubscribeBody:
+      '{kind} bekommst du dann nicht mehr per E-Mail. Mitteilungen auf dem Telefon bleiben davon unberührt.',
+    unsubscribeConfirm: 'Abstellen',
+    unsubscribeAll: 'Oder jede E-Mail von LangX abstellen',
+    unsubscribedTitle: 'Erledigt — nichts mehr davon.',
+    unsubscribedBody:
+      'Du kannst sie jederzeit in LangX unter Einstellungen → Mitteilungen wieder einschalten.',
+    unsubscribeInvalid:
+      'Dieser Link ist ungültig. Öffne LangX und ändere es unter Einstellungen → Mitteilungen.',
+
+    kind: {
+      messages: 'Nachrichtenübersichten',
+      streak: 'Streak-Erinnerungen',
+      profileVisits: 'Übersichten zu Profilbesuchen',
+      promotions: 'Neues und Angebote',
+      all: 'E-Mails von LangX',
+    },
   },
 }

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -1,6 +1,6 @@
 /**
- * Everything the **server** words for a user: two emails and one push
- * notification.
+ * Everything the **server** words for a user: the mail it sends and the
+ * notifications it pushes.
  *
  * Deliberately not the app's catalogue. The two have almost nothing in common
  * — the app words screens, this words things that arrive when the app is
@@ -29,6 +29,35 @@ export const en = {
     resetBody: 'Someone requested a password reset for this account. If that was you:',
     resetButton: 'Reset password',
     resetText: 'Reset your LangX password: {url}',
+
+    /*
+     * The footer every notification email carries, and the page its link
+     * leads to. Not the same as `ignore` above: this mail was asked for, so it
+     * says why it came and how to stop it rather than how to disregard it.
+     */
+    whyThisMail: 'You’re getting this because of your LangX notification settings.',
+    unsubscribeLink: 'Turn these emails off',
+    unsubscribeText: 'Turn these emails off: {url}',
+    managePrefs: 'All notification settings',
+
+    unsubscribeTitle: 'Turn off these emails?',
+    unsubscribeBody:
+      'You will stop getting {kind} by email. Notifications on your phone are not affected.',
+    unsubscribeConfirm: 'Turn them off',
+    unsubscribeAll: 'Or turn off every LangX email',
+    unsubscribedTitle: 'Done — no more of these.',
+    unsubscribedBody: 'You can turn them back on any time in LangX under Settings → Notifications.',
+    unsubscribeInvalid:
+      'This link is not valid. Open LangX and change it under Settings → Notifications.',
+
+    /** Named in the sentence above, so they read as objects, not headings. */
+    kind: {
+      messages: 'message summaries',
+      streak: 'streak reminders',
+      profileVisits: 'profile-visit summaries',
+      promotions: 'news and offers',
+      all: 'email from LangX',
+    },
   },
 } as const
 

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -22,5 +22,29 @@ export const es: Localized<ServerMessages> = {
     resetBody: 'Alguien ha solicitado restablecer la contraseña de esta cuenta. Si has sido tú:',
     resetButton: 'Restablecer contraseña',
     resetText: 'Restablece tu contraseña de LangX: {url}',
+
+    whyThisMail: 'Recibes esto por tus ajustes de notificaciones de LangX.',
+    unsubscribeLink: 'Desactivar estos correos',
+    unsubscribeText: 'Desactivar estos correos: {url}',
+    managePrefs: 'Todos los ajustes de notificaciones',
+
+    unsubscribeTitle: '¿Desactivar estos correos?',
+    unsubscribeBody:
+      'Dejarás de recibir {kind} por correo. Las notificaciones del teléfono no cambian.',
+    unsubscribeConfirm: 'Desactivarlos',
+    unsubscribeAll: 'O desactivar todos los correos de LangX',
+    unsubscribedTitle: 'Listo, no llegarán más.',
+    unsubscribedBody:
+      'Puedes volver a activarlos cuando quieras en LangX, en Ajustes → Notificaciones.',
+    unsubscribeInvalid:
+      'Este enlace no es válido. Abre LangX y cámbialo en Ajustes → Notificaciones.',
+
+    kind: {
+      messages: 'los resúmenes de mensajes',
+      streak: 'los recordatorios de racha',
+      profileVisits: 'los resúmenes de visitas a tu perfil',
+      promotions: 'las novedades y ofertas',
+      all: 'el correo de LangX',
+    },
   },
 }

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -24,5 +24,29 @@ export const fr: Localized<ServerMessages> = {
       'Quelqu’un a demandé la réinitialisation du mot de passe de ce compte. S’il s’agit de vous :',
     resetButton: 'Réinitialiser le mot de passe',
     resetText: 'Réinitialisez votre mot de passe LangX : {url}',
+
+    whyThisMail: 'Vous recevez ceci en raison de vos réglages de notifications LangX.',
+    unsubscribeLink: 'Désactiver ces e-mails',
+    unsubscribeText: 'Désactiver ces e-mails : {url}',
+    managePrefs: 'Tous les réglages de notifications',
+
+    unsubscribeTitle: 'Désactiver ces e-mails ?',
+    unsubscribeBody:
+      'Vous ne recevrez plus {kind} par e-mail. Les notifications sur votre téléphone ne changent pas.',
+    unsubscribeConfirm: 'Les désactiver',
+    unsubscribeAll: 'Ou désactiver tous les e-mails de LangX',
+    unsubscribedTitle: 'C’est fait — vous n’en recevrez plus.',
+    unsubscribedBody:
+      'Vous pouvez les réactiver à tout moment dans LangX, sous Réglages → Notifications.',
+    unsubscribeInvalid:
+      'Ce lien n’est pas valide. Ouvrez LangX et modifiez-le dans Réglages → Notifications.',
+
+    kind: {
+      messages: 'les résumés de messages',
+      streak: 'les rappels de série',
+      profileVisits: 'les résumés de visites de profil',
+      promotions: 'les actualités et offres',
+      all: 'les e-mails de LangX',
+    },
   },
 }

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -22,5 +22,28 @@ export const ptBR: Localized<ServerMessages> = {
     resetBody: 'Alguém pediu para redefinir a senha desta conta. Se foi você:',
     resetButton: 'Redefinir senha',
     resetText: 'Redefina sua senha do LangX: {url}',
+
+    whyThisMail: 'Você recebe isto por causa das suas configurações de notificações do LangX.',
+    unsubscribeLink: 'Desativar estes e-mails',
+    unsubscribeText: 'Desativar estes e-mails: {url}',
+    managePrefs: 'Todas as configurações de notificações',
+
+    unsubscribeTitle: 'Desativar estes e-mails?',
+    unsubscribeBody:
+      'Você deixará de receber {kind} por e-mail. As notificações no telefone não mudam.',
+    unsubscribeConfirm: 'Desativar',
+    unsubscribeAll: 'Ou desativar todos os e-mails do LangX',
+    unsubscribedTitle: 'Pronto — não chegam mais.',
+    unsubscribedBody: 'Você pode reativar quando quiser no LangX, em Configurações → Notificações.',
+    unsubscribeInvalid:
+      'Este link não é válido. Abra o LangX e altere em Configurações → Notificações.',
+
+    kind: {
+      messages: 'os resumos de mensagens',
+      streak: 'os lembretes de sequência',
+      profileVisits: 'os resumos de visitas ao perfil',
+      promotions: 'as novidades e ofertas',
+      all: 'os e-mails do LangX',
+    },
   },
 }

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -32,5 +32,28 @@ export const ru: Localized<ServerMessages> = {
     resetBody: 'Кто-то запросил сброс пароля для этого аккаунта. Если это были вы:',
     resetButton: 'Сбросить пароль',
     resetText: 'Сброс пароля LangX: {url}',
+
+    whyThisMail: 'Вы получаете это из-за настроек уведомлений в LangX.',
+    unsubscribeLink: 'Отключить эти письма',
+    unsubscribeText: 'Отключить эти письма: {url}',
+    managePrefs: 'Все настройки уведомлений',
+
+    unsubscribeTitle: 'Отключить эти письма?',
+    unsubscribeBody:
+      'Вы перестанете получать {kind} на почту. Уведомления на телефоне не изменятся.',
+    unsubscribeConfirm: 'Отключить',
+    unsubscribeAll: 'Или отключить все письма от LangX',
+    unsubscribedTitle: 'Готово — больше не придут.',
+    unsubscribedBody: 'Включить обратно можно в любой момент в LangX: Настройки → Уведомления.',
+    unsubscribeInvalid:
+      'Ссылка недействительна. Откройте LangX и измените это в Настройках → Уведомления.',
+
+    kind: {
+      messages: 'сводки сообщений',
+      streak: 'напоминания о стрике',
+      profileVisits: 'сводки визитов в профиль',
+      promotions: 'новости и предложения',
+      all: 'письма от LangX',
+    },
   },
 }

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -22,5 +22,27 @@ export const tr: Localized<ServerMessages> = {
     resetBody: 'Bu hesap için bir parola sıfırlama isteği geldi. Bu sensen:',
     resetButton: 'Parolayı sıfırla',
     resetText: 'LangX parolanı sıfırla: {url}',
+
+    whyThisMail: 'Bunu LangX bildirim ayarların yüzünden alıyorsun.',
+    unsubscribeLink: 'Bu e-postaları kapat',
+    unsubscribeText: 'Bu e-postaları kapat: {url}',
+    managePrefs: 'Tüm bildirim ayarları',
+
+    unsubscribeTitle: 'Bu e-postalar kapatılsın mı?',
+    unsubscribeBody: '{kind} artık e-postayla gelmeyecek. Telefonundaki bildirimler etkilenmez.',
+    unsubscribeConfirm: 'Kapat',
+    unsubscribeAll: 'Ya da LangX’ten gelen tüm e-postaları kapat',
+    unsubscribedTitle: 'Tamam — artık gelmeyecek.',
+    unsubscribedBody: 'İstediğin zaman LangX’te Ayarlar → Bildirimler’den geri açabilirsin.',
+    unsubscribeInvalid:
+      'Bu bağlantı geçerli değil. LangX’i açıp Ayarlar → Bildirimler’den değiştir.',
+
+    kind: {
+      messages: 'mesaj özetleri',
+      streak: 'streak hatırlatmaları',
+      profileVisits: 'profil ziyareti özetleri',
+      promotions: 'haberler ve kampanyalar',
+      all: 'LangX’ten gelen e-postalar',
+    },
   },
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -54,6 +54,7 @@ async function main(): Promise<void> {
     translation,
     revenueCat,
     push,
+    email: emailSender,
     legacyVerifier,
   })
 

--- a/apps/api/src/modules/profiles/emailFor.ts
+++ b/apps/api/src/modules/profiles/emailFor.ts
@@ -1,0 +1,31 @@
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { authId } from '../../lib/authId'
+
+/**
+ * The address to write to, and whether it has been proved.
+ *
+ * A leaf module beside `emailVerified.ts` and for the same reason: `profiles.ts`
+ * imports the referral repository, the referral repository needs the user
+ * document, and a function on `profiles.ts` would close that loop into an
+ * import cycle whose symptom is `undefined is not a function` at boot.
+ *
+ * `authId` because the address lives in Better Auth's `user` collection, where
+ * ids are ObjectId — a string matches nothing and would report every account
+ * as having no email at all.
+ *
+ * Guests hold an address too, at a domain that resolves nowhere, and it is
+ * never verified. Nothing here special-cases them: every caller sends only to
+ * a verified address, which excludes them by the same rule that excludes
+ * anyone who has not clicked their link.
+ */
+export async function emailFor(
+  db: Db,
+  userId: string,
+): Promise<{ email: string; verified: boolean } | null> {
+  const user = await db
+    .collection<{ email?: string; emailVerified?: boolean }>(COLLECTIONS.user)
+    .findOne({ _id: authId(userId) }, { projection: { email: 1, emailVerified: 1 } })
+  if (!user?.email) return null
+  return { email: user.email, verified: user.emailVerified === true }
+}

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -10,6 +10,7 @@ import {
   isOnlineAt,
   findCosmetic,
   meetsMinimumAge,
+  NOTIFICATION_TYPES,
   newHandleSchema,
   resolveNotificationPrefs,
   toGeoPoint,
@@ -720,6 +721,40 @@ export async function updateProfile(
  * and, worse, that a client could park coordinates in a request whose visible
  * subject was something else entirely.
  */
+/**
+ * Turns the email half of one kind — or of all four — off, for somebody who
+ * clicked the footer of a message rather than opening the app.
+ *
+ * A repository function rather than a call to `updateProfile`, because there
+ * is no session here: an unsubscribe link is followed by a mail client, or by
+ * a person who left months ago and cannot sign in. The token is the authority.
+ *
+ * Push is deliberately untouched. Somebody stopping email said nothing about
+ * their phone, and silencing that too would be answering a question they were
+ * not asked.
+ */
+export async function setEmailNotifications(
+  db: Db,
+  userId: string,
+  scope: NotificationType | 'all',
+  enabled: boolean,
+): Promise<boolean> {
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  const current = await profiles.findOne({ _id: userId }, { projection: { settings: 1 } })
+  if (!current) return false
+
+  const resolved = resolveNotificationPrefs(current.settings?.notifications)
+  const kinds = scope === 'all' ? NOTIFICATION_TYPES : [scope]
+  const paths: Record<string, unknown> = {}
+  // Whole per kind, for the reason `updateProfile` gives: the path one level
+  // deeper cannot enter the bare boolean older profiles still carry.
+  for (const type of kinds)
+    paths[`settings.notifications.${type}`] = { ...resolved[type], email: enabled }
+
+  await profiles.updateOne({ _id: userId }, { $set: paths })
+  return true
+}
+
 export async function setLocation(db: Db, userId: string, input: LocationInput): Promise<Profile> {
   const now = new Date()
   const point = toGeoPoint(input)

--- a/apps/api/src/modules/push/devices.ts
+++ b/apps/api/src/modules/push/devices.ts
@@ -214,6 +214,22 @@ export async function tokensByLocale(db: Db, userId: string): Promise<Map<Locale
 }
 
 /**
+ * What language to word something for this person in, when there is no request
+ * to read it off.
+ *
+ * The newest device wins: re-registering stamps `updatedAt`, so the most
+ * recently opened app is the phone they actually use. There is no account
+ * language to fall back on — deliberately, see `tokensByLocale` — so somebody
+ * who only ever uses the web gets English.
+ */
+export async function localeFor(db: Db, userId: string): Promise<Locale> {
+  const device = await db
+    .collection<Device>(COLLECTIONS.devices)
+    .findOne({ userId }, { sort: { updatedAt: -1 }, projection: { locale: 1 } })
+  return device?.locale ?? DEFAULT_LOCALE
+}
+
+/**
  * Users who should get tonight's "keep your streak" nudge: it is
  * `STREAK_REMINDER_LOCAL_HOUR` **where they are**, they have a streak worth
  * saving, and they have not already acted today.

--- a/apps/api/src/routes/email.test.ts
+++ b/apps/api/src/routes/email.test.ts
@@ -1,0 +1,197 @@
+import type { FastifyInstance } from 'fastify'
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { buildApp } from '../app'
+import { createAuth } from '../auth'
+import { connectToDatabase, type DbHandle } from '../db/client'
+import { COLLECTIONS } from '../db/collections'
+import { ensureIndexes } from '../db/indexes'
+import { loadEnv } from '../env'
+import { signUnsubscribeToken } from '../email/unsubscribeToken'
+import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
+import type { Profile } from '../modules/profiles/profiles'
+import { createStorageProvider } from '../storage/createStorageProvider'
+import { createTranslationProvider } from '../translation/createTranslationProvider'
+import { CapturingEmailSender, signUpAndSignIn } from '../testSupport/authFlow'
+
+const PASSWORD = 'correct horse battery staple'
+const SECRET = 'b'.repeat(40)
+
+function onboardingBody(overrides: Record<string, unknown> = {}) {
+  return {
+    handle: `user${Math.random().toString(36).slice(2, 10)}`,
+    displayName: 'Test User',
+    birthDate: '1995-06-15',
+    gender: 'undisclosed',
+    nativeLanguages: [{ code: 'tr' }],
+    learning: [{ code: 'en', level: 'intermediate', priority: 1 }],
+    ...overrides,
+  }
+}
+
+describe('unsubscribing from a link in an email', () => {
+  let replSet: MongoMemoryReplSet
+  let handle: DbHandle
+  let app: FastifyInstance
+  let emailSender: CapturingEmailSender
+  let userId: string
+
+  async function notificationsOf(id: string): Promise<Record<string, unknown>> {
+    const profile = await handle.db.collection<Profile>(COLLECTIONS.profiles).findOne({ _id: id })
+    return profile?.settings.notifications as Record<string, unknown>
+  }
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+    handle = await connectToDatabase(replSet.getUri(), 'langx_email_test')
+    const env = loadEnv({
+      NODE_ENV: 'test',
+      MONGODB_URI: replSet.getUri(),
+      MONGODB_DB: 'langx_email_test',
+      LOG_LEVEL: 'silent',
+      BETTER_AUTH_SECRET: 'a'.repeat(32),
+      BETTER_AUTH_URL: 'http://localhost:4000',
+      EMAIL_UNSUBSCRIBE_SECRET: SECRET,
+    })
+    await ensureIndexes(handle.db)
+    emailSender = new CapturingEmailSender()
+    const auth = await createAuth({ env, db: handle.db, client: handle.client, emailSender })
+    app = await buildApp({
+      env,
+      client: handle.client,
+      db: handle.db,
+      auth,
+      storage: createStorageProvider(env),
+      translation: createTranslationProvider(env),
+      revenueCat: createRevenueCatClientFromEnv(env),
+      email: emailSender,
+    })
+    await app.ready()
+
+    // Better Auth's first transaction against a cold replica set loses a race
+    // with index creation; chat.test.ts warms up the same way.
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      const warmUp = await app.inject({
+        method: 'POST',
+        url: '/api/auth/sign-up/email',
+        payload: { email: `warmup-${attempt}@example.com`, password: PASSWORD, name: 'Warm Up' },
+      })
+      if (warmUp.statusCode === 200) break
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+    emailSender.messages.length = 0
+  }, 120_000)
+
+  afterAll(async () => {
+    await app.close()
+    await handle.close()
+    await replSet.stop()
+  })
+
+  beforeEach(async () => {
+    const user = await signUpAndSignIn(app, emailSender, {
+      email: `unsub-${Math.random().toString(36).slice(2, 10)}@example.com`,
+      password: PASSWORD,
+      name: 'Test',
+    })
+    const created = await app.inject({
+      method: 'POST',
+      url: '/profiles',
+      headers: { cookie: user.cookie },
+      payload: onboardingBody(),
+    })
+    expect(created.statusCode, created.body).toBe(201)
+    userId = user.userId
+  })
+
+  /**
+   * Scanners, previewers and "protect the click" proxies all fetch a link
+   * before a human sees it. A GET that acted would unsubscribe people who
+   * never opened the mail.
+   */
+  it('asks on GET and changes nothing', async () => {
+    const token = signUnsubscribeToken(SECRET, userId, 'messages')
+    const response = await app.inject({ method: 'GET', url: `/email/unsubscribe?token=${token}` })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['content-type']).toContain('text/html')
+    expect(response.body).toContain('<form method="post"')
+    expect(await notificationsOf(userId)).toMatchObject({ messages: { push: true, email: true } })
+  })
+
+  it('turns one kind off on POST and leaves the phone alone', async () => {
+    const token = signUnsubscribeToken(SECRET, userId, 'messages')
+    const response = await app.inject({ method: 'POST', url: `/email/unsubscribe?token=${token}` })
+
+    expect(response.statusCode).toBe(200)
+    const notifications = await notificationsOf(userId)
+    expect(notifications).toMatchObject({
+      messages: { push: true, email: false },
+      streak: { push: true, email: true },
+    })
+  })
+
+  /** RFC 8058: an empty form body, and the token that counts is in the URL. */
+  it('honours a one-click POST from a mail client', async () => {
+    const token = signUnsubscribeToken(SECRET, userId, 'promotions')
+    const response = await app.inject({
+      method: 'POST',
+      url: `/email/unsubscribe?token=${token}`,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: 'List-Unsubscribe=One-Click',
+    })
+
+    expect(response.statusCode, response.body).toBe(200)
+    expect(await notificationsOf(userId)).toMatchObject({
+      promotions: { push: false, email: false },
+    })
+  })
+
+  it('takes the token from a form body when the URL has none', async () => {
+    const token = signUnsubscribeToken(SECRET, userId, 'streak')
+    const response = await app.inject({
+      method: 'POST',
+      url: '/email/unsubscribe',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: `token=${encodeURIComponent(token)}`,
+    })
+
+    expect(response.statusCode, response.body).toBe(200)
+    expect(await notificationsOf(userId)).toMatchObject({ streak: { push: true, email: false } })
+  })
+
+  it('stops every kind when the scope is all', async () => {
+    const token = signUnsubscribeToken(SECRET, userId, 'all')
+    await app.inject({ method: 'POST', url: `/email/unsubscribe?token=${token}` })
+
+    const notifications = await notificationsOf(userId)
+    for (const kind of ['messages', 'streak', 'profileVisits', 'promotions']) {
+      expect((notifications[kind] as { email: boolean }).email, kind).toBe(false)
+    }
+    // Push is a different question, and nobody asked it.
+    expect(notifications.messages).toMatchObject({ push: true })
+  })
+
+  /** A mail client may retry; the second press must not be an error page. */
+  it('is idempotent', async () => {
+    const token = signUnsubscribeToken(SECRET, userId, 'messages')
+    await app.inject({ method: 'POST', url: `/email/unsubscribe?token=${token}` })
+    const second = await app.inject({ method: 'POST', url: `/email/unsubscribe?token=${token}` })
+    expect(second.statusCode).toBe(200)
+  })
+
+  it('refuses a token it did not sign', async () => {
+    const forged = signUnsubscribeToken('a-different-secret-of-adequate-length', userId, 'messages')
+    const get = await app.inject({ method: 'GET', url: `/email/unsubscribe?token=${forged}` })
+    const post = await app.inject({ method: 'POST', url: `/email/unsubscribe?token=${forged}` })
+
+    expect(get.statusCode).toBe(400)
+    expect(post.statusCode).toBe(400)
+    expect(await notificationsOf(userId)).toMatchObject({ messages: { email: true } })
+  })
+
+  it('refuses a missing token without throwing', async () => {
+    expect((await app.inject({ method: 'GET', url: '/email/unsubscribe' })).statusCode).toBe(400)
+    expect((await app.inject({ method: 'POST', url: '/email/unsubscribe' })).statusCode).toBe(400)
+  })
+})

--- a/apps/api/src/routes/email.ts
+++ b/apps/api/src/routes/email.ts
@@ -1,0 +1,135 @@
+import { webUrl } from '@langx/shared'
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { publicApiUrl, unsubscribeSecret } from '../env'
+import { localeFromHeader, translator } from '../i18n'
+import { setEmailNotifications } from '../modules/profiles/profiles'
+import {
+  signUnsubscribeToken,
+  unsubscribeUrl,
+  verifyUnsubscribeToken,
+} from '../email/unsubscribeToken'
+import type { Locale } from '@langx/shared'
+
+/** Enough of a page to read on a phone, with no stylesheet to fetch. */
+function page(locale: Locale, title: string, bodyHtml: string): string {
+  const dir = locale === 'ar' ? 'rtl' : 'ltr'
+  return `<!doctype html>
+<html lang="${locale}" dir="${dir}">
+  <head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>LangX</title></head>
+  <body style="font-family: -apple-system, system-ui, sans-serif; color: #111; background: #f7f7f7; margin: 0; padding: 24px;">
+    <div style="max-width: 420px; margin: 48px auto; background: #fff; border-radius: 12px; padding: 32px;">
+      <h1 style="font-size: 20px; margin: 0 0 16px;">${title}</h1>
+      ${bodyHtml}
+    </div>
+  </body>
+</html>`
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`)
+}
+
+/**
+ * The way out of every notification email, and the only route in this app that
+ * acts for somebody holding no session.
+ *
+ * That is not a gap. An unsubscribe link is followed months after the app was
+ * deleted, by someone who cannot sign in and should not have to — and RFC
+ * 8058's one-click is a mail server, which has no way to sign in at all. The
+ * signed token is the authority; see `unsubscribeToken.ts`.
+ */
+// eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
+export const emailRoutes: FastifyPluginAsyncZod = async (app) => {
+  /**
+   * One-click sends `application/x-www-form-urlencoded`, which Fastify rejects
+   * with a 415 before any handler runs unless something can read it. Scoped to
+   * this plugin and written with `URLSearchParams` rather than pulling in
+   * `@fastify/formbody` for two routes that read at most one field.
+   */
+  app.addContentTypeParser(
+    'application/x-www-form-urlencoded',
+    { parseAs: 'string' },
+    (_request, body, done) => {
+      try {
+        done(null, Object.fromEntries(new URLSearchParams(body as string)))
+      } catch {
+        done(null, {})
+      }
+    },
+  )
+
+  /**
+   * Link previewers, spam scanners and "protect the click" proxies all follow
+   * a GET before any human sees the message. So the GET only asks — the change
+   * is on the POST below, which nothing follows by accident.
+   */
+  app.get('/email/unsubscribe', async (request, reply) => {
+    const locale = localeFromHeader(request.headers['accept-language'])
+    const t = translator(locale)
+    const token = (request.query as { token?: string }).token
+    const claim = verifyUnsubscribeToken(unsubscribeSecret(app.env), token)
+
+    if (!claim) {
+      return reply
+        .code(400)
+        .type('text/html; charset=utf-8')
+        .send(page(locale, 'LangX', `<p>${t('email.unsubscribeInvalid')}</p>`))
+    }
+
+    const kind = t(`email.kind.${claim.scope}` as never)
+    const allToken = signUnsubscribeToken(unsubscribeSecret(app.env), claim.userId, 'all')
+    const allUrl = unsubscribeUrl(publicApiUrl(app.env), allToken)
+    return reply.type('text/html; charset=utf-8').send(
+      page(
+        locale,
+        t('email.unsubscribeTitle'),
+        `<p>${escapeHtml(t('email.unsubscribeBody', { kind }))}</p>
+         <form method="post" action="/email/unsubscribe?token=${encodeURIComponent(token ?? '')}">
+           <button type="submit" style="background:#111;color:#fff;border:0;border-radius:8px;padding:12px 20px;font-weight:600;font-size:15px;cursor:pointer;">
+             ${escapeHtml(t('email.unsubscribeConfirm'))}
+           </button>
+         </form>
+         ${claim.scope === 'all' ? '' : `<p style="margin-top:24px;"><a href="${allUrl}" style="color:#888;font-size:13px;">${escapeHtml(t('email.unsubscribeAll'))}</a></p>`}`,
+      ),
+    )
+  })
+
+  /**
+   * The one-click target. A client honouring `List-Unsubscribe-Post` sends an
+   * empty form body here, so the token that matters is the one in the URL —
+   * the body is parsed only because a POST with a content-type Fastify cannot
+   * read is a 415 before any handler runs.
+   */
+  app.post(
+    '/email/unsubscribe',
+    { config: { rateLimit: { max: 30, timeWindow: '1 minute' } } },
+    async (request, reply) => {
+      const locale = localeFromHeader(request.headers['accept-language'])
+      const t = translator(locale)
+      const fromQuery = (request.query as { token?: string }).token
+      const fromBody = (request.body as { token?: string } | undefined)?.token
+      const claim = verifyUnsubscribeToken(unsubscribeSecret(app.env), fromQuery ?? fromBody)
+
+      if (!claim) {
+        return reply
+          .code(400)
+          .type('text/html; charset=utf-8')
+          .send(page(locale, 'LangX', `<p>${t('email.unsubscribeInvalid')}</p>`))
+      }
+
+      // Idempotent on purpose: a mail client may retry, and a second press of
+      // the button must not be an error page for something already done.
+      await setEmailNotifications(app.mongo.db, claim.userId, claim.scope, false)
+      request.log.info({ scope: claim.scope }, 'unsubscribed from notification email')
+
+      return reply.type('text/html; charset=utf-8').send(
+        page(
+          locale,
+          t('email.unsubscribedTitle'),
+          `<p>${escapeHtml(t('email.unsubscribedBody'))}</p>
+         <p style="margin-top:24px;"><a href="${webUrl('/settings')}" style="color:#888;font-size:13px;">${escapeHtml(t('email.managePrefs'))}</a></p>`,
+        ),
+      )
+    },
+  )
+}

--- a/packages/shared/src/appIdentity.ts
+++ b/packages/shared/src/appIdentity.ts
@@ -59,6 +59,18 @@ export const APP_LINK_HOST = 'app.langx.io'
 export const WEB_HOST = 'app2.langx.io'
 
 /**
+ * Any screen of the web build, as a link a mail client can follow.
+ *
+ * Every deep link in a notification email goes through here rather than being
+ * written out: the app claims these paths through `/.well-known/*`, so on a
+ * phone with LangX installed the same URL opens the screen rather than the
+ * browser — and there is one place to change when the host does.
+ */
+export function webUrl(path: string): string {
+  return `https://${WEB_HOST}${path.startsWith('/') ? path : `/${path}`}`
+}
+
+/**
  * The link somebody shares for their own profile.
  *
  * Root-level, so it is short enough to say out loud, which is the whole point


### PR DESCRIPTION
Replaces #1068, which was merged into its stack base rather than into `main` —
its base branch was `notif/prefs-channels`, so GitHub marked it merged while
none of this reached `main`. Same commit, same content, correct target.

No mail is sent yet. This is the plumbing the next PRs use, put in first so
four senders cannot each invent their own idea of consent.

- **`sendNotificationEmail` is the only way out.** Deleted, then preference,
  then address, in that order. It hands the template a locale and a finished
  unsubscribe URL, because a sender that assembles its own is one that can
  forget to.
- **The token never expires and has its own secret.** A footer sits in an
  inbox for years; rotating `BETTER_AUTH_SECRET` must not break the legal way
  out of every email ever sent. Unset, it falls back.
- **GET asks, POST acts.** Scanners follow links before humans do. The POST
  also parses a form body, since RFC 8058 clients send an empty one and
  Fastify answers 415 otherwise.
- **Unsubscribing touches email only.** Nobody asked about their phone.
- **`app.email` joins `app.push`**, so a test holds one outbox.
- Locale comes from the newest registered device; there is no account
  language, deliberately.

29 tests: token forgery and truncation, every outcome of the gate, and the two
routes end to end including a one-click POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)