### PR TITLE
Stop one unreadable profile from silencing everybody's badges

### DIFF
--- a/apps/api/src/modules/notifications/badges.test.ts
+++ b/apps/api/src/modules/notifications/badges.test.ts
@@ -1,7 +1,7 @@
 import { BADGE_ROUND_UP_LOCAL_HOUR } from '@langx/shared'
 import { ObjectId } from 'mongodb'
 import { MongoMemoryServer } from 'mongodb-memory-server'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { connectToDatabase, type DbHandle } from '../../db/client'
 import { COLLECTIONS } from '../../db/collections'
 import type { NotificationEmailContext } from '../../email/notify'
@@ -114,7 +114,7 @@ describe('the badge round-up', () => {
     const userId = await newProfile({ messagesSent: 5000, withDevice: true })
 
     const result = await runBadgeRoundUpPass(handle.db, senders, now)
-    expect(result).toEqual({ sent: 0, seeded: 1 })
+    expect(result).toEqual({ sent: 0, seeded: 1, failed: 0 })
     expect(push.sent).toHaveLength(0)
     expect((await notifiedIdsOf(userId))?.length).toBeGreaterThan(0)
   })
@@ -203,11 +203,46 @@ describe('the badge round-up', () => {
     expect(await notifiedIdsOf(userId)).toContain('messages.100')
   })
 
+  /**
+   * The pass is the first thing that walks every profile in the database
+   * rather than the one that just asked for its own badges, and
+   * `getBadgeSummary` reads `streak.longest` without a guard. One row written
+   * by an import that no longer exists must not stop everybody else's badges
+   * — forever, thirty minutes at a time.
+   */
+  it('skips a profile it cannot read and carries on with the rest', async () => {
+    const broken = new ObjectId().toHexString()
+    await handle.db.collection(COLLECTIONS.profiles).insertOne({
+      _id: broken,
+      handle: `h${broken.slice(-12)}`,
+      timezone: zone,
+      entitlement: { tier: 'free' },
+      // No `streak`, which is what an old import can leave behind.
+      settings: { discoverable: true, notifications: {} },
+      stats: { lastActiveAt: now, messagesSent: 0, notifiedBadgeIds: [] },
+      createdAt: new Date('2026-09-01T00:00:00Z'),
+    } as never)
+    const healthy = await newProfile({ messagesSent: 5000, withDevice: true })
+
+    const warn = vi.fn()
+    const result = await runBadgeRoundUpPass(handle.db, senders, now, { warn })
+
+    expect(result.failed).toBe(1)
+    expect(warn).toHaveBeenCalledOnce()
+    // The healthy profile was still reached, which is the whole point.
+    expect(result.seeded).toBe(1)
+    expect(await notifiedIdsOf(healthy)).toBeDefined()
+  })
+
   it('leaves alone anyone for whom it is not the round-up hour', async () => {
     await newProfile({
       withDevice: true,
       timezone: zone === 'Etc/GMT+1' ? 'Etc/GMT+2' : 'Etc/GMT+1',
     })
-    expect(await runBadgeRoundUpPass(handle.db, senders, now)).toEqual({ sent: 0, seeded: 0 })
+    expect(await runBadgeRoundUpPass(handle.db, senders, now)).toEqual({
+      sent: 0,
+      seeded: 0,
+      failed: 0,
+    })
   })
 })

--- a/apps/api/src/modules/notifications/badges.ts
+++ b/apps/api/src/modules/notifications/badges.ts
@@ -11,6 +11,7 @@ import { sendNotificationEmail, type NotificationEmailContext } from '../../emai
 import { badgeEarnedEmail } from '../../email/templates'
 import { translator } from '../../i18n'
 import type { Profile } from '../profiles/profiles'
+import type { SchedulerLogger } from '../tokens/poolScheduler'
 import { sendPush, tokensByLocale, type PushSender } from '../push/devices'
 import { getBadgeSummary } from '../tokens/badges'
 import { claimOnce } from './ledger'
@@ -44,7 +45,8 @@ export async function runBadgeRoundUpPass(
   db: Db,
   senders: { push: PushSender; email: NotificationEmailContext },
   now: Date = new Date(),
-): Promise<{ sent: number; seeded: number }> {
+  logger?: Pick<SchedulerLogger, 'warn'>,
+): Promise<{ sent: number; seeded: number; failed: number }> {
   const profiles = db.collection<Profile>(COLLECTIONS.profiles)
   const candidates = await profiles
     .find({
@@ -57,10 +59,37 @@ export async function runBadgeRoundUpPass(
 
   let sent = 0
   let seeded = 0
+  let failed = 0
 
   for (const profile of candidates) {
+    /*
+     * One profile at a time, and one profile's failure is its own.
+     *
+     * `getBadgeSummary` reads `profile.streak.longest` without a guard,
+     * because every path that writes a profile writes a streak — but this is
+     * the first thing to walk *every* profile in the database rather than the
+     * one that just asked for its own badges. A single row written by an old
+     * import, or by a migration that has since been deleted, would throw here
+     * and take the whole pass with it; the scheduler would log it, wait thirty
+     * minutes and do exactly the same thing again, forever, and nobody would
+     * ever get a badge notification.
+     *
+     * Same doctrine as `fanOutMessage`: a notification that fails must never
+     * be able to stop the ones behind it.
+     */
+    try {
+      await notifyOne(profile)
+    } catch (error) {
+      failed++
+      logger?.warn({ err: error, userId: profile._id }, 'badge round-up skipped one profile')
+    }
+  }
+
+  return { sent, seeded, failed }
+
+  async function notifyOne(profile: Profile): Promise<void> {
     const zone = profile.timezone ?? 'UTC'
-    if (localHour(now, zone) !== BADGE_ROUND_UP_LOCAL_HOUR) continue
+    if (localHour(now, zone) !== BADGE_ROUND_UP_LOCAL_HOUR) return
 
     const wantsPush = notificationsAllowed(profile.settings?.notifications, 'badges', 'push')
     const wantsEmail = notificationsAllowed(profile.settings?.notifications, 'badges', 'email')
@@ -74,19 +103,19 @@ export async function runBadgeRoundUpPass(
       // the news starts from here.
       await profiles.updateOne({ _id: profile._id }, { $set: { 'stats.notifiedBadgeIds': earned } })
       seeded++
-      continue
+      return
     }
 
     const knownSet = new Set(known)
     const fresh = earned.filter((id) => !knownSet.has(id))
-    if (fresh.length === 0) continue
+    if (fresh.length === 0) return
 
     // Recorded before the send, like every ledger claim in this app: a
     // notification nobody got is better than one that arrives every evening
     // because the write that would have stopped it never happened.
     await profiles.updateOne({ _id: profile._id }, { $set: { 'stats.notifiedBadgeIds': earned } })
-    if (!wantsPush && !wantsEmail) continue
-    if (!(await claimOnce(db, 'badgeEarned', profile._id, localDayKey(now, zone)))) continue
+    if (!wantsPush && !wantsEmail) return
+    if (!(await claimOnce(db, 'badgeEarned', profile._id, localDayKey(now, zone)))) return
 
     // The label is English in the catalogue — `BADGES` builds it from the
     // threshold — so the notification names it only when there is exactly one,
@@ -108,10 +137,10 @@ export async function runBadgeRoundUpPass(
         })
       }
       sent++
-      continue
+      return
     }
 
-    if (!wantsEmail) continue
+    if (!wantsEmail) return
     const outcome = await sendNotificationEmail(db, senders.email, {
       userId: profile._id,
       type: 'badges',
@@ -124,6 +153,4 @@ export async function runBadgeRoundUpPass(
     })
     if (outcome === 'sent') sent++
   }
-
-  return { sent, seeded }
 }

--- a/apps/api/src/modules/notifications/scheduler.ts
+++ b/apps/api/src/modules/notifications/scheduler.ts
@@ -40,7 +40,7 @@ export function startNotificationScheduler(
         run('unread digest', () => runUnreadDigestPass(db, senders.email, now)),
         run('profile visit push', () => runProfileVisitsPushPass(db, senders.push, now)),
         run('profile visit email', () => runProfileVisitsEmailPass(db, senders.email, now)),
-        run('badge round-up', () => runBadgeRoundUpPass(db, senders, now)),
+        run('badge round-up', () => runBadgeRoundUpPass(db, senders, now, logger)),
       ])
     } finally {
       running = false
@@ -48,10 +48,14 @@ export function startNotificationScheduler(
   }
 
   /** Each pass on its own, so one throwing does not starve the two after it. */
-  async function run(name: string, pass: () => Promise<{ sent: number }>): Promise<void> {
+  async function run(
+    name: string,
+    pass: () => Promise<{ sent: number; failed?: number }>,
+  ): Promise<void> {
     try {
-      const { sent } = await pass()
+      const { sent, failed } = await pass()
       if (sent > 0) logger.info({ sent, pass: name }, 'notifications sent')
+      if (failed) logger.warn({ failed, pass: name }, 'notifications skipped')
     } catch (error) {
       logger.error({ err: error, pass: name }, 'notification pass failed')
     }

--- a/apps/api/src/modules/tokens/poolScheduler.ts
+++ b/apps/api/src/modules/tokens/poolScheduler.ts
@@ -4,6 +4,8 @@ import { runDailyPool } from './pool'
 
 export interface SchedulerLogger {
   info: (obj: object, msg: string) => void
+  /** For the half-failures: a pass that finished, having skipped something. */
+  warn: (obj: object, msg: string) => void
   error: (obj: object, msg: string) => void
 }
 


### PR DESCRIPTION
Found while verifying the production deploy, not by a failure.

The badge round-up walks every profile in the database — the first thing here
that does — and `getBadgeSummary` reads `profile.streak.longest` with no
guard. That is reasonable for the endpoint it was written for, where the
caller has just asked about their own badges.

A row left by an import that no longer exists throws there and takes the whole
pass with it. The scheduler logs it, waits thirty minutes, and repeats,
forever, and nobody ever gets a badge notification.

Each profile is its own now; a failure is counted and logged rather than
propagated. Same doctrine as `fanOutMessage`.

`SchedulerLogger` gains `warn`, because a pass that finished having skipped
something is neither the `info` on success nor the `error` when it could not
run at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)