### PR TITLE
Let a campaign supply only HTML, as the usage says it can

### DIFF
--- a/apps/api/scripts/send-campaign.ts
+++ b/apps/api/scripts/send-campaign.ts
@@ -17,9 +17,11 @@
  * `{campaignId, userId}` is what enforces it; a batch that fails releases its
  * own claim so the next run retries exactly those people.
  *
- * The HTML and text files must both contain `{{unsubscribeUrl}}`. The script
- * refuses to send otherwise — a promotional email without a way out is the one
- * mistake here with a regulator attached.
+ * The HTML must contain `{{unsubscribeUrl}}`, and so must a `--text-file` if
+ * one is given. The script refuses to send otherwise — a promotional email
+ * with no way out is the one mistake here with a regulator attached. A text
+ * part derived from the HTML gets the link appended instead, because
+ * stripping tags takes away the `href` it was written in.
  *
  * Usage:
  *   pnpm --filter @langx/api exec tsx scripts/send-campaign.ts \
@@ -40,13 +42,15 @@ import { loadEnv, publicApiUrl, unsubscribeSecret } from '../src/env'
 import {
   campaignRecipients,
   claimCampaignRecipients,
+  deriveTextBody,
   releaseCampaignRecipients,
+  UNSUBSCRIBE_PLACEHOLDER,
 } from '../src/modules/notifications/campaign'
 
 /** Resend's default is two requests a second; this stays comfortably under. */
 const BATCH_DELAY_MS = 700
 
-const PLACEHOLDER = '{{unsubscribeUrl}}'
+const PLACEHOLDER = UNSUBSCRIBE_PLACEHOLDER
 
 function flag(name: string): string | undefined {
   const index = process.argv.indexOf(`--${name}`)
@@ -72,23 +76,30 @@ async function main(): Promise<void> {
   }
 
   const html = readFileSync(htmlFile, 'utf8')
-  // Stripping tags rather than demanding a second file: a text part is
-  // required by every deliverability guide, and one that is missing is a
-  // worse default than one that is plain.
-  const text = textFile
-    ? readFileSync(textFile, 'utf8')
-    : html
-        .replace(/<[^>]+>/g, ' ')
-        .replace(/\s+/g, ' ')
-        .trim()
+  if (!html.includes(PLACEHOLDER)) {
+    throw new Error(`the html body must contain ${PLACEHOLDER} — refusing to send without one`)
+  }
 
-  for (const [name, body] of [
-    ['html', html],
-    ['text', text],
-  ] as const) {
-    if (!body.includes(PLACEHOLDER)) {
-      throw new Error(`the ${name} body must contain ${PLACEHOLDER} — refusing to send without one`)
+  /**
+   * A plain-text part, because every deliverability guide asks for one and a
+   * missing part is a worse default than a plain one.
+   *
+   * Deriving it by stripping tags loses the placeholder every time it is
+   * written the way anybody actually writes it — inside
+   * `<a href="{{unsubscribeUrl}}">` — so the strip takes the attribute with
+   * it, and the check then refuses a campaign that was perfectly correct.
+   * Appending it to a derived body fixes that. A hand-written `--text-file` is
+   * still held to the same standard as the html, because there the omission is
+   * a real one.
+   */
+  let text: string
+  if (textFile) {
+    text = readFileSync(textFile, 'utf8')
+    if (!text.includes(PLACEHOLDER)) {
+      throw new Error(`the text body must contain ${PLACEHOLDER} — refusing to send without one`)
     }
+  } else {
+    text = deriveTextBody(html)
   }
 
   const env = loadEnv()

--- a/apps/api/src/modules/notifications/campaign.test.ts
+++ b/apps/api/src/modules/notifications/campaign.test.ts
@@ -6,7 +6,13 @@ import { COLLECTIONS } from '../../db/collections'
 import { ensureIndexes } from '../../db/indexes'
 import { authId } from '../../lib/authId'
 import type { Device } from '../push/devices'
-import { campaignRecipients, claimCampaignRecipients, releaseCampaignRecipients } from './campaign'
+import {
+  campaignRecipients,
+  claimCampaignRecipients,
+  deriveTextBody,
+  releaseCampaignRecipients,
+  UNSUBSCRIBE_PLACEHOLDER,
+} from './campaign'
 
 const CAMPAIGN = '2026-09-launch'
 
@@ -195,5 +201,27 @@ describe('claiming a batch', () => {
     await releaseCampaignRecipients(handle.db, CAMPAIGN, claimed)
 
     expect(await claimCampaignRecipients(handle.db, CAMPAIGN, ['a', 'b'])).toEqual(['a', 'b'])
+  })
+})
+
+describe('the plain-text part of a campaign', () => {
+  /**
+   * The bug this exists for: the placeholder is written inside
+   * `<a href="{{unsubscribeUrl}}">`, so stripping tags takes it away — and the
+   * script then refused a campaign that was perfectly correct, every time.
+   */
+  it('keeps a way out even when the link was written as an anchor', () => {
+    const text = deriveTextBody('<p>Hello</p><p><a href="{{unsubscribeUrl}}">Unsubscribe</a></p>')
+    expect(text).toContain(UNSUBSCRIBE_PLACEHOLDER)
+    expect(text).toContain('Hello')
+  })
+
+  it('does not repeat one that survived the strip', () => {
+    const text = deriveTextBody('<p>Hello. Out: {{unsubscribeUrl}}</p>')
+    expect(text.match(/\{\{unsubscribeUrl\}\}/g)).toHaveLength(1)
+  })
+
+  it('reads as text, not as markup', () => {
+    expect(deriveTextBody('<p>One</p><p>Two {{unsubscribeUrl}}</p>')).not.toContain('<')
   })
 })

--- a/apps/api/src/modules/notifications/campaign.ts
+++ b/apps/api/src/modules/notifications/campaign.ts
@@ -5,6 +5,29 @@ import { emailFor } from '../profiles/emailFor'
 import { localeFor } from '../push/devices'
 import type { Profile } from '../profiles/profiles'
 
+/** The token both campaign bodies must carry, replaced per recipient. */
+export const UNSUBSCRIBE_PLACEHOLDER = '{{unsubscribeUrl}}'
+
+/**
+ * A plain-text part for a campaign that only supplied HTML.
+ *
+ * Every deliverability guide asks for one, and a missing part is a worse
+ * default than a plain one. The catch is the placeholder: it is written the
+ * way anybody writes it, inside `<a href="{{unsubscribeUrl}}">`, so stripping
+ * tags takes the attribute with it — and the caller's check would then refuse
+ * a campaign that was perfectly correct. Appending it is what makes the
+ * derived body satisfy the same rule the HTML does.
+ */
+export function deriveTextBody(html: string): string {
+  const stripped = html
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return stripped.includes(UNSUBSCRIBE_PLACEHOLDER)
+    ? stripped
+    : `${stripped}\n\n${UNSUBSCRIBE_PLACEHOLDER}`
+}
+
 export interface CampaignSend {
   campaignId: string
   userId: string


### PR DESCRIPTION
Found by running the dry run against production, which is what it is for.

The guard was right and the derivation defeated it. Both bodies had to carry
`{{unsubscribeUrl}}`, and a text body that was not supplied got made by
stripping tags out of the HTML. Nobody writes that placeholder as bare text —
they write `<a href="{{unsubscribeUrl}}">` — so the strip took the attribute
with it and the script refused every campaign that was correct. `--text-file`
was documented as optional and was in practice required.

A derived body now has the link appended. A hand-written `--text-file` is
still held to the same standard as the HTML, where the omission is real.

`deriveTextBody` lives in the module rather than the script so it can be
tested; the script stays argument parsing and I/O.

Verified against production: a dry run now reports `recipients: 0,
optedOut: 26`, and an HTML body with no placeholder is still refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)