### PR TITLE
Point links and builds at app.langx.io and api.langx.io

### DIFF
--- a/apps/api/src/email/notify.test.ts
+++ b/apps/api/src/email/notify.test.ts
@@ -35,7 +35,7 @@ describe('sendNotificationEmail', () => {
     }
     u1 = new ObjectId().toHexString()
     sender = new CapturingEmailSender()
-    ctx = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api2.langx.io' }
+    ctx = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api.langx.io' }
   })
 
   async function seed(

--- a/apps/api/src/email/unsubscribeToken.test.ts
+++ b/apps/api/src/email/unsubscribeToken.test.ts
@@ -53,8 +53,8 @@ describe('unsubscribe tokens', () => {
 
   it('builds a url that survives a token in a query string', () => {
     const token = signUnsubscribeToken(SECRET, 'user/1', 'messages')
-    const url = unsubscribeUrl('https://api2.langx.io/', token)
-    expect(url.startsWith('https://api2.langx.io/email/unsubscribe?token=')).toBe(true)
+    const url = unsubscribeUrl('https://api.langx.io/', token)
+    expect(url.startsWith('https://api.langx.io/email/unsubscribe?token=')).toBe(true)
     const parsed = new URL(url)
     expect(verifyUnsubscribeToken(SECRET, parsed.searchParams.get('token') ?? undefined)).toEqual({
       userId: 'user/1',

--- a/apps/api/src/modules/notifications/badges.test.ts
+++ b/apps/api/src/modules/notifications/badges.test.ts
@@ -55,7 +55,7 @@ describe('the badge round-up', () => {
     sender = new CapturingEmailSender()
     senders = {
       push,
-      email: { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api2.langx.io' },
+      email: { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api.langx.io' },
     }
   })
 

--- a/apps/api/src/modules/notifications/profileVisits.test.ts
+++ b/apps/api/src/modules/notifications/profileVisits.test.ts
@@ -53,7 +53,7 @@ describe('the profile-visit round-up', () => {
     }
     push = new LoggingPushSender()
     sender = new CapturingEmailSender()
-    email = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api2.langx.io' }
+    email = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api.langx.io' }
   })
 
   async function newProfile(

--- a/apps/api/src/modules/notifications/unreadDigest.test.ts
+++ b/apps/api/src/modules/notifications/unreadDigest.test.ts
@@ -48,7 +48,7 @@ describe('the unread-message digest', () => {
       await handle.db.collection(name).deleteMany({})
     }
     sender = new CapturingEmailSender()
-    ctx = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api2.langx.io' }
+    ctx = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api.langx.io' }
   })
 
   async function newProfile(

--- a/apps/api/src/modules/push/reminderScheduler.test.ts
+++ b/apps/api/src/modules/push/reminderScheduler.test.ts
@@ -55,7 +55,7 @@ describe('the streak reminder pass', () => {
     }
     push = new LoggingPushSender()
     sender = new CapturingEmailSender()
-    email = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api2.langx.io' }
+    email = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api.langx.io' }
   })
 
   async function seed(

--- a/apps/api/src/routes/qr.ts
+++ b/apps/api/src/routes/qr.ts
@@ -35,7 +35,7 @@ const CACHE_SECONDS = 86_400
  *
  * Helmet sets `Cross-Origin-Resource-Policy: same-origin` for everything,
  * which is right for an API and wrong for a picture: the web build lives on
- * `app2.langx.io` and the image on `api2.langx.io`, so the browser blocked it
+ * `app.langx.io` and the image on `api.langx.io`, so the browser blocked it
  * outright — `ERR_BLOCKED_BY_RESPONSE.NotSameOrigin`, with no request logged
  * server-side and nothing on screen.
  *

--- a/apps/mobile/app/[username].tsx
+++ b/apps/mobile/app/[username].tsx
@@ -45,7 +45,7 @@ export default function SharedProfileScreen() {
   const handle = (params.username ?? '').toLowerCase()
   /*
    * The web half of the invite flow, and today the only half that fires: the
-   * app claims `app.langx.io` while links point at `app2.langx.io`, so on a
+   * app claims `app.langx.io` while links point at `app.langx.io`, so on a
    * phone an invite link opens a browser rather than the app. This screen is
    * already what that browser lands on.
    *

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -15,7 +15,7 @@
       "distribution": "internal",
       "channel": "preview",
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://api2.langx.io"
+        "EXPO_PUBLIC_API_URL": "https://api.langx.io"
       },
       "android": {
         "buildType": "apk"
@@ -25,7 +25,7 @@
       "channel": "production",
       "autoIncrement": true,
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://api2.langx.io"
+        "EXPO_PUBLIC_API_URL": "https://api.langx.io"
       },
       "android": {
         "buildType": "app-bundle"

--- a/apps/mobile/src/hooks/usePendingInvite.ts
+++ b/apps/mobile/src/hooks/usePendingInvite.ts
@@ -20,7 +20,7 @@ import { FLAG_KEYS, writeFlag } from '../lib/localFlags'
  *
  * Today this is mostly dormant. `APP_LINK_HOST` is `app.langx.io` — what the
  * app claims in its association files — while shared links point at
- * `WEB_HOST`, `app2.langx.io`, so on a phone an invite link opens the browser
+ * `WEB_HOST`, `app.langx.io`, so on a phone an invite link opens the browser
  * rather than the app. The web build is where it actually fires, and
  * `app/[username].tsx` covers that case directly. This is written now so that
  * the day the hosts converge, the flow already works.

--- a/apps/mobile/src/lib/inviteLink.test.ts
+++ b/apps/mobile/src/lib/inviteLink.test.ts
@@ -23,22 +23,13 @@ describe('normalizeInviteCode', () => {
    * labelled "invite code" is not ambiguous about intent.
    */
   it('accepts a pasted link, marked or not', () => {
-    expect(normalizeInviteCode('https://app2.langx.io/deniz?invite=1')).toBe('deniz')
-    expect(normalizeInviteCode('https://app2.langx.io/deniz')).toBe('deniz')
-    expect(normalizeInviteCode('app2.langx.io/deniz')).toBe('deniz')
+    expect(normalizeInviteCode('https://app.langx.io/deniz?invite=1')).toBe('deniz')
+    expect(normalizeInviteCode('https://app.langx.io/deniz')).toBe('deniz')
+    expect(normalizeInviteCode('app.langx.io/deniz')).toBe('deniz')
   })
 
   it('answers null for anything that is not a handle', () => {
-    for (const input of [
-      null,
-      undefined,
-      '',
-      '   ',
-      'nope!',
-      'ab',
-      '@',
-      'https://app2.langx.io/',
-    ]) {
+    for (const input of [null, undefined, '', '   ', 'nope!', 'ab', '@', 'https://app.langx.io/']) {
       expect(normalizeInviteCode(input), String(input)).toBeNull()
     }
   })
@@ -52,8 +43,8 @@ describe('inviteHandleFromUrl, as the app calls it', () => {
   })
 
   it('reads only a marked link, so sharing a profile is not an attribution', () => {
-    expect(inviteHandleFromUrl('https://app2.langx.io/deniz?invite=1')).toBe('deniz')
-    expect(inviteHandleFromUrl('https://app2.langx.io/deniz')).toBeNull()
+    expect(inviteHandleFromUrl('https://app.langx.io/deniz?invite=1')).toBe('deniz')
+    expect(inviteHandleFromUrl('https://app.langx.io/deniz')).toBeNull()
   })
 })
 

--- a/apps/mobile/src/lib/shareText.test.ts
+++ b/apps/mobile/src/lib/shareText.test.ts
@@ -55,12 +55,12 @@ describe('the sentences', () => {
 
   it('links a profile to the profile, not to an invite', () => {
     const { url } = profileShareText(t, { name: 'Deniz', handle: 'deniz' })
-    expect(url).toBe('https://app2.langx.io/deniz')
+    expect(url).toBe('https://app.langx.io/deniz')
   })
 
   it('links a post to the post', () => {
     const { url, message } = postShareText(t, { id: 'abc', body: 'Hola', languageName: 'Spanish' })
-    expect(url).toBe('https://app2.langx.io/post/abc')
+    expect(url).toBe('https://app.langx.io/post/abc')
     expect(message).toContain('Hola')
     expect(message).toContain('Spanish')
   })
@@ -72,7 +72,7 @@ describe('the sentences', () => {
       leaderboardShareText(t, { rank: 3, period: 'all', handle: 'deniz' }),
       badgeShareText(t, { label: '30 days', handle: 'deniz' }),
     ]) {
-      expect(url).toBe('https://app2.langx.io/deniz?invite=1')
+      expect(url).toBe('https://app.langx.io/deniz?invite=1')
     }
   })
 

--- a/packages/shared/src/appIdentity.ts
+++ b/packages/shared/src/appIdentity.ts
@@ -44,19 +44,20 @@ export const APP_LINK_HOST = 'app.langx.io'
  * Where the web build is actually served, and therefore what a shared link
  * points at.
  *
- * **Not the same constant as `APP_LINK_HOST`, on purpose.** That one is the
- * host the *app* claims: it is written into `associatedDomains`, into
- * `assetlinks.json` and `apple-app-site-association`, and it is carried over
- * from v1's AndroidManifest. Collapsing the two would mean that pointing links
- * at a different host silently re-declares the universal-link association as
- * well, which is a store-submission change wearing the clothes of a URL edit.
+ * **Still not the same constant as `APP_LINK_HOST`, even though they now hold
+ * the same string.** That one is the host the *app* claims: it is written into
+ * `associatedDomains`, into `assetlinks.json` and
+ * `apple-app-site-association`, and changing it is a store-submission change.
+ * This one is where links point. They agree today because the cutover below
+ * happened; merging them would mean the next time links move hosts, the
+ * universal-link association moves with them silently.
  *
- * Today the deployment lives at `app2.langx.io` while `app.langx.io` is still
- * being pointed at it — see `release-runbook.md`, where serving
- * `/.well-known/*` from that domain is an open item. When it closes, this is
- * the one line that changes.
+ * The web build lived at `app2.langx.io` until 2026-09-03, while
+ * `app.langx.io` still served v1's Angular app. That was the temporary state
+ * this comment used to describe, and this line is the one it said would
+ * change.
  */
-export const WEB_HOST = 'app2.langx.io'
+export const WEB_HOST = 'app.langx.io'
 
 /**
  * Any screen of the web build, as a link a mail client can follow.

--- a/packages/shared/src/referral.test.ts
+++ b/packages/shared/src/referral.test.ts
@@ -5,7 +5,7 @@ import { INVITE_QUERY_PARAM, inviteHandleFromUrl, inviteQrUrl, inviteUrl } from 
 
 describe('the invite link', () => {
   it('is a profile link with a marker, so every link already shared still works', () => {
-    expect(inviteUrl('deniz')).toBe('https://app2.langx.io/deniz?invite=1')
+    expect(inviteUrl('deniz')).toBe('https://app.langx.io/deniz?invite=1')
   })
 
   it('drops a leading @, the way profileUrl does', () => {
@@ -13,8 +13,8 @@ describe('the invite link', () => {
   })
 
   it('points the QR at the same marker the server branches on', () => {
-    expect(inviteQrUrl('https://api2.langx.io', 'deniz')).toBe(
-      'https://api2.langx.io/public/qr/deniz?invite=1',
+    expect(inviteQrUrl('https://api.langx.io', 'deniz')).toBe(
+      'https://api.langx.io/public/qr/deniz?invite=1',
     )
   })
 
@@ -30,9 +30,9 @@ describe('inviteHandleFromUrl', () => {
    * would attribute people who were never invited.
    */
   it('refuses an unmarked profile link', () => {
-    expect(inviteHandleFromUrl('https://app2.langx.io/deniz')).toBeNull()
-    expect(inviteHandleFromUrl('https://app2.langx.io/deniz?invite=0')).toBeNull()
-    expect(inviteHandleFromUrl('https://app2.langx.io/deniz?other=1')).toBeNull()
+    expect(inviteHandleFromUrl('https://app.langx.io/deniz')).toBeNull()
+    expect(inviteHandleFromUrl('https://app.langx.io/deniz?invite=0')).toBeNull()
+    expect(inviteHandleFromUrl('https://app.langx.io/deniz?other=1')).toBeNull()
   })
 
   it('reads a custom-scheme deep link, where URL parsers disagree', () => {
@@ -41,12 +41,12 @@ describe('inviteHandleFromUrl', () => {
   })
 
   it('takes the marker among other parameters, and ignores a fragment', () => {
-    expect(inviteHandleFromUrl('https://app2.langx.io/deniz?utm=x&invite=1')).toBe('deniz')
-    expect(inviteHandleFromUrl('https://app2.langx.io/deniz?invite=1#top')).toBe('deniz')
+    expect(inviteHandleFromUrl('https://app.langx.io/deniz?utm=x&invite=1')).toBe('deniz')
+    expect(inviteHandleFromUrl('https://app.langx.io/deniz?invite=1#top')).toBe('deniz')
   })
 
   it('lower-cases, because a handle is lower-case and a link is typed by hand', () => {
-    expect(inviteHandleFromUrl('https://app2.langx.io/DENIZ?invite=1')).toBe('deniz')
+    expect(inviteHandleFromUrl('https://app.langx.io/DENIZ?invite=1')).toBe('deniz')
   })
 
   /**
@@ -59,9 +59,9 @@ describe('inviteHandleFromUrl', () => {
       undefined,
       '',
       'not a url',
-      'https://app2.langx.io/?invite=1',
-      'https://app2.langx.io/no!thandle?invite=1',
-      'https://app2.langx.io/ab?invite=1',
+      'https://app.langx.io/?invite=1',
+      'https://app.langx.io/no!thandle?invite=1',
+      'https://app.langx.io/ab?invite=1',
     ]) {
       expect(inviteHandleFromUrl(input), String(input)).toBeNull()
     }
@@ -72,7 +72,7 @@ describe('inviteHandleFromUrl', () => {
    * handle, so a link to it is not an invite from anybody.
    */
   it('does not read a route as a referrer', () => {
-    const handle = inviteHandleFromUrl(`https://app2.langx.io/discover?${INVITE_QUERY_PARAM}=1`)
+    const handle = inviteHandleFromUrl(`https://app.langx.io/discover?${INVITE_QUERY_PARAM}=1`)
     expect(handle === null || RESERVED_HANDLES.has(handle)).toBe(true)
   })
 })


### PR DESCRIPTION
**Hold until DNS has moved.** Today `api.langx.io` serves v1's Express API and
`app.langx.io` serves v1's Angular app. A web bundle built from this and
deployed while that is still true talks to the wrong API and fails every
request.

The one line `WEB_HOST`'s comment said would change, changing. It now holds
the same string as `APP_LINK_HOST`; they stay two constants on purpose — one
is where links point, the other is what the app claims in its universal-link
association, and merging them would move the second silently the next time
the first moves.

Every email deep link goes through `webUrl()` and every share link through
`profileUrl()` / `postUrl()`, so the senders need no change. `eas.json`
follows, since `EXPO_PUBLIC_API_URL` is compiled into the binary.

Repointing `api.langx.io` is the *last* item of the runbook's "Retiring the
v1 API" checklist, and three of the five are open: the newsletter form on
langx.io posts to `/api/mail` (v2 has no mail route), token-website's
leaderboard reads `/api/leaderboard/token`, and `/api/update` is the only
channel that can tell a v0.15 install to update — every store install loses
the app the moment the host flips.

Infra that has to move with it, none of it in this repo: `BETTER_AUTH_URL`
and `TRUSTED_ORIGINS` on Fly, `fly certs add api.langx.io`, the Cloudflare
Pages custom domain for `app.langx.io`, and the Cloudflare DNS records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)