### PR TITLE
Serve the two things v1's API still served to the outside

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,9 @@ EMAIL_FROM=LangX <onboarding@resend.dev>
 # Unset, it falls back to BETTER_AUTH_SECRET, which works and inherits that
 # problem.
 EMAIL_UNSUBSCRIBE_SECRET=
+# The Resend audience the langx.io newsletter form subscribes to. Took over
+# from v1's SendGrid list when api.langx.io moved to this API.
+RESEND_AUDIENCE_ID=
 
 # ─── API: storage (Faz 2 / 11) ───────────────────────────────────────────────
 # S3-compatible; the published app runs on Backblaze B2 (same account as v1,

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -33,6 +33,7 @@ import { messageRoutes } from './routes/messages'
 import { moderationRoutes } from './routes/moderation'
 import { profileRoutes } from './routes/profiles'
 import { qrRoutes } from './routes/qr'
+import { publicRoutes } from './routes/public'
 import { translationRoutes } from './routes/translate'
 import { leaderboardRoutes } from './routes/leaderboard'
 import { referralRoutes } from './routes/referrals'
@@ -235,6 +236,7 @@ export async function buildApp({
   await registerAuthRoutes(app, auth)
   await app.register(profileRoutes)
   await app.register(qrRoutes)
+  await app.register(publicRoutes)
   await app.register(followRoutes)
   await app.register(handleRoutes)
   await app.register(mediaRoutes)

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -63,6 +63,13 @@ const envSchema = z.object({
    * auth secret, which works and merely inherits that rotation problem.
    */
   EMAIL_UNSUBSCRIBE_SECRET: emptyToUndefined(z.string().min(32).optional()),
+  /**
+   * The Resend audience the langx.io newsletter form subscribes people to.
+   * Replaces v1's SendGrid list — this API takes over `api.langx.io` and the
+   * form on the site posts here. Optional: unset, the route answers that it
+   * is not configured rather than pretending to subscribe anybody.
+   */
+  RESEND_AUDIENCE_ID: emptyToUndefined(z.string().optional()),
 
   // OAuth. Each provider activates only once both of its variables are set —
   // see socialProviders() in auth.ts — so leaving these blank still boots a

--- a/apps/api/src/routes/public.test.ts
+++ b/apps/api/src/routes/public.test.ts
@@ -1,0 +1,146 @@
+import { aggregateId } from '@langx/shared'
+import type { FastifyInstance } from 'fastify'
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { buildApp } from '../app'
+import { createAuth } from '../auth'
+import { connectToDatabase, type DbHandle } from '../db/client'
+import { COLLECTIONS } from '../db/collections'
+import { ensureIndexes } from '../db/indexes'
+import { loadEnv } from '../env'
+import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
+import { createStorageProvider } from '../storage/createStorageProvider'
+import { createTranslationProvider } from '../translation/createTranslationProvider'
+import { CapturingEmailSender } from '../testSupport/authFlow'
+
+/**
+ * The two routes that let api.langx.io move off v1's Express without the
+ * newsletter form or token.langx.io going dark. Neither has a session, so the
+ * harness signs nobody in.
+ */
+describe('the public routes v1 used to serve', () => {
+  let replSet: MongoMemoryReplSet
+  let handle: DbHandle
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+    handle = await connectToDatabase(replSet.getUri(), 'langx_public_test')
+    const env = loadEnv({
+      NODE_ENV: 'test',
+      MONGODB_URI: replSet.getUri(),
+      MONGODB_DB: 'langx_public_test',
+      LOG_LEVEL: 'silent',
+      BETTER_AUTH_SECRET: 'a'.repeat(32),
+      BETTER_AUTH_URL: 'http://localhost:4000',
+      // Deliberately no RESEND_AUDIENCE_ID: the unconfigured path is the one
+      // a self-hosted instance hits, and it must refuse rather than lie.
+    })
+    await ensureIndexes(handle.db)
+    const emailSender = new CapturingEmailSender()
+    const auth = await createAuth({ env, db: handle.db, client: handle.client, emailSender })
+    app = await buildApp({
+      env,
+      client: handle.client,
+      db: handle.db,
+      auth,
+      storage: createStorageProvider(env),
+      translation: createTranslationProvider(env),
+      revenueCat: createRevenueCatClientFromEnv(env),
+      email: emailSender,
+    })
+    await app.ready()
+  }, 120_000)
+
+  afterAll(async () => {
+    await app.close()
+    await handle.close()
+    await replSet.stop()
+  })
+
+  beforeEach(async () => {
+    for (const name of [COLLECTIONS.profiles, COLLECTIONS.tokenAggregates]) {
+      await handle.db.collection(name).deleteMany({})
+    }
+  })
+
+  describe('POST /public/newsletter', () => {
+    it('refuses a bad address before touching any provider', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/public/newsletter',
+        payload: { email: 'not-an-address' },
+      })
+      expect(response.statusCode).toBe(400)
+    })
+
+    /** Never a silent "ok" that subscribed nobody. */
+    it('fails loudly when no audience is configured', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/public/newsletter',
+        payload: { email: 'reader@example.com' },
+      })
+      expect(response.statusCode).toBe(500)
+      expect(response.json<{ status?: string }>().status).toBeUndefined()
+    })
+
+    it('needs no session', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/public/newsletter',
+        payload: { email: 'reader@example.com' },
+      })
+      expect(response.statusCode).not.toBe(401)
+    })
+  })
+
+  describe('GET /public/leaderboard/token', () => {
+    it('answers an empty board without a session, and caches it', async () => {
+      const response = await app.inject({ method: 'GET', url: '/public/leaderboard/token' })
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['cache-control']).toContain('max-age')
+      expect(response.json()).toEqual({ period: 'all', entries: [] })
+    })
+
+    it('shows rank, handle and tokens — and nothing about a viewer', async () => {
+      const now = new Date()
+      const people = [
+        { id: 'a', handle: 'ada', tokens: 300 },
+        { id: 'b', handle: 'bo', tokens: 300 },
+        { id: 'c', handle: 'cy', tokens: 100 },
+      ]
+      for (const p of people) {
+        await handle.db.collection(COLLECTIONS.profiles).insertOne({
+          _id: p.id,
+          handle: p.handle,
+          displayName: p.handle.toUpperCase(),
+          entitlement: { tier: 'free' },
+          streak: { current: 1, longest: 1, lastQualifiedDay: '2026-09-01' },
+          settings: { discoverable: true, notifications: {} },
+        } as never)
+        await handle.db.collection(COLLECTIONS.tokenAggregates).insertOne({
+          _id: aggregateId(p.id, 'all', 'all'),
+          userId: p.id,
+          periodType: 'all',
+          periodKey: 'all',
+          tokens: p.tokens,
+          updatedAt: now,
+        } as never)
+      }
+
+      const response = await app.inject({ method: 'GET', url: '/public/leaderboard/token' })
+      const body = response.json<{ entries: Record<string, unknown>[] }>()
+      expect(body.entries.map((e) => [e.rank, e.handle, e.tokens])).toEqual([
+        [1, 'ada', 300],
+        [1, 'bo', 300],
+        [3, 'cy', 100],
+      ])
+      for (const entry of body.entries) {
+        expect(entry).not.toHaveProperty('isViewer')
+        expect(entry).not.toHaveProperty('userId')
+      }
+      expect(body).not.toHaveProperty('viewer')
+    })
+  })
+})

--- a/apps/api/src/routes/public.ts
+++ b/apps/api/src/routes/public.ts
@@ -1,0 +1,93 @@
+import { ERROR_CODES } from '@langx/shared'
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { Resend } from 'resend'
+import { z } from 'zod'
+import { ApiError } from '../lib/ApiError'
+import { getLeaderboard } from '../modules/tokens/leaderboard'
+
+/** token.langx.io shows ten rows and nothing else. */
+const PUBLIC_BOARD_SIZE = 10
+/** A public table that changes at most once a day; a minute of caching is plenty. */
+const BOARD_CACHE_SECONDS = 60
+
+/**
+ * The two things v1's Express API served to callers outside the app, moved
+ * here so `api.langx.io` can point at this process without either going dark.
+ *
+ * Both are unauthenticated by nature: a marketing site cannot hold a session,
+ * and a public leaderboard is public. Each is rate-limited on its own, because
+ * the global limiter is sized for a signed-in client, not for a form on a
+ * page anybody can load.
+ */
+// eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
+export const publicRoutes: FastifyPluginAsyncZod = async (app) => {
+  /**
+   * The newsletter form on langx.io. v1 put the address on a SendGrid list;
+   * this puts it on a Resend audience, which is the provider every other
+   * email here already goes through. The response shape is v1's — `status:
+   * 'ok'` — because the form that reads it is deployed separately and must
+   * keep working across the cutover.
+   *
+   * Consent is explicit: the person typed their address into a box labelled
+   * newsletter. This is not the promotions switch on a profile, which is a
+   * different consent recorded in a different place.
+   */
+  app.post(
+    '/public/newsletter',
+    {
+      schema: { body: z.object({ email: z.string().trim().email().max(254) }) },
+      config: { rateLimit: { max: 10, timeWindow: '1 minute' } },
+    },
+    async (request, reply) => {
+      const { RESEND_API_KEY, RESEND_AUDIENCE_ID } = app.env
+      // Degrades like storage and translation do: an instance without the
+      // audience answers with a clear failure, never with a silent "ok" that
+      // subscribed nobody. The form shows its generic error either way.
+      if (!RESEND_API_KEY || !RESEND_AUDIENCE_ID) {
+        request.log.warn('newsletter subscribe refused: RESEND_AUDIENCE_ID is not set')
+        throw new ApiError(ERROR_CODES.INTERNAL, 'Newsletter is not configured')
+      }
+      const resend = new Resend(RESEND_API_KEY)
+      const { error } = await resend.contacts.create({
+        audienceId: RESEND_AUDIENCE_ID,
+        email: request.body.email,
+        unsubscribed: false,
+      })
+      // An address that is already on the list is a success from the reader's
+      // side — they asked to be subscribed and they are. Anything else is not.
+      if (error && !/already exists/i.test(error.message)) {
+        request.log.warn({ err: error }, 'newsletter subscribe failed')
+        throw new ApiError(ERROR_CODES.INTERNAL, 'Could not subscribe')
+      }
+      return reply.send({ status: 'ok' })
+    },
+  )
+
+  /**
+   * The all-time token leaderboard, top ten, for token.langx.io.
+   *
+   * The signed-in board takes a viewer — for blocks, and for "your rank" —
+   * and this one has none. An empty viewer id reaches nothing in either
+   * lookup: no block row names it and no aggregate is keyed by it, so the
+   * viewer-shaped fields come back empty and are simply not sent.
+   */
+  app.get(
+    '/public/leaderboard/token',
+    { config: { rateLimit: { max: 60, timeWindow: '1 minute' } } },
+    async (_request, reply) => {
+      const board = await getLeaderboard(app.mongo.db, '', {
+        period: 'all',
+        limit: PUBLIC_BOARD_SIZE,
+      })
+      return reply.header('cache-control', `public, max-age=${BOARD_CACHE_SECONDS}`).send({
+        period: board.period,
+        entries: board.entries.map(({ rank, handle, displayName, tokens }) => ({
+          rank,
+          handle,
+          displayName,
+          tokens,
+        })),
+      })
+    },
+  )
+}


### PR DESCRIPTION
Two of the three items under the runbook's "Retiring the v1 API". Additive
and safe to deploy now — nothing here depends on DNS moving.

- **`POST /public/newsletter`** replaces v1's `/api/mail`. Resend audience
  instead of a SendGrid list; answers v1's `status: 'ok'` so the form on
  langx.io keeps working across the cutover. Without `RESEND_AUDIENCE_ID` it
  refuses rather than pretending — never a silent ok that subscribed nobody.
- **`GET /public/leaderboard/token`** replaces v1's `/api/leaderboard/token`.
  The same board the app draws, cut to ten rows: real competition ranks,
  public handles, token totals, nothing shaped like a viewer. Cached a
  minute.
- Both rate-limited on their own; the global limiter is sized for a signed-in
  client.

The site-side halves are held until the host flips: `langx/website#132` and
`langx/token-website#21`. `/api/update` stays on v1 — it is the only channel
that can tell a v0.15 install anything.

Five tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)