### PR TITLE
Unregister the service worker v1 left on app.langx.io

### DIFF
--- a/apps/mobile/public/combined-sw.js
+++ b/apps/mobile/public/combined-sw.js
@@ -1,3 +1,4 @@
+/* global self, caches */
 /**
  * Kill switch for the service worker v1 left behind on app.langx.io.
  *

--- a/apps/mobile/public/combined-sw.js
+++ b/apps/mobile/public/combined-sw.js
@@ -1,0 +1,31 @@
+/**
+ * Kill switch for the service worker v1 left behind on app.langx.io.
+ *
+ * v1 was an Angular PWA and registered a worker under this name on the same
+ * origin the v2 web build now lives on. A browser that visited v1 still has
+ * that worker installed, and a worker answers navigations from its own cache
+ * before the network is consulted — so the person sees the old app shell,
+ * and sees it again on every reload, however many times the server behind it
+ * has changed.
+ *
+ * A 404 for the script would eventually clear the registration on an update
+ * check, but the old shell keeps being served until that check succeeds and
+ * the page is opened once more. This file is what the update check fetches
+ * instead: it takes over immediately, drops every cache, unregisters itself,
+ * and reloads every open tab, which then hits the network and gets v2.
+ */
+self.addEventListener('install', () => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys()
+      await Promise.all(keys.map((key) => caches.delete(key)))
+      await self.registration.unregister()
+      const clients = await self.clients.matchAll({ type: 'window' })
+      for (const client of clients) client.navigate(client.url)
+    })(),
+  )
+})

--- a/apps/mobile/public/ngsw-worker.js
+++ b/apps/mobile/public/ngsw-worker.js
@@ -1,3 +1,4 @@
+/* global self, caches */
 /**
  * Kill switch for the service worker v1 left behind on app.langx.io.
  *

--- a/apps/mobile/public/ngsw-worker.js
+++ b/apps/mobile/public/ngsw-worker.js
@@ -1,0 +1,31 @@
+/**
+ * Kill switch for the service worker v1 left behind on app.langx.io.
+ *
+ * v1 was an Angular PWA and registered a worker under this name on the same
+ * origin the v2 web build now lives on. A browser that visited v1 still has
+ * that worker installed, and a worker answers navigations from its own cache
+ * before the network is consulted — so the person sees the old app shell,
+ * and sees it again on every reload, however many times the server behind it
+ * has changed.
+ *
+ * A 404 for the script would eventually clear the registration on an update
+ * check, but the old shell keeps being served until that check succeeds and
+ * the page is opened once more. This file is what the update check fetches
+ * instead: it takes over immediately, drops every cache, unregisters itself,
+ * and reloads every open tab, which then hits the network and gets v2.
+ */
+self.addEventListener('install', () => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys()
+      await Promise.all(keys.map((key) => caches.delete(key)))
+      await self.registration.unregister()
+      const clients = await self.clients.matchAll({ type: 'window' })
+      for (const client of clients) client.navigate(client.url)
+    })(),
+  )
+})


### PR DESCRIPTION
app.langx.io served v1's Angular PWA until today, and a PWA registers a
service worker on its origin. Anyone who opened v1 there still has that
worker, and it answers navigations from its own cache before asking the
network — so they see the v1 shell on every reload while the server has been
v2 for an hour. The edge is verified serving the v2 bundle; the browser is
serving itself.

A 404 for the script clears the registration eventually, but the old shell
keeps coming until an update check succeeds and the page is opened again.
This ships v1's two worker filenames (`combined-sw.js`, `ngsw-worker.js`) as
a kill switch: skip waiting, drop every cache, unregister, reload every open
tab. Same origin and path, so the update check picks it up on its own.

Needs a web rebuild and Pages deploy after merge — `public/` is copied into
the export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)