### PR TITLE
Let any origin read /public/*, or the two pages it exists for cannot

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,4 @@
-import cors from '@fastify/cors'
+import cors, { type FastifyCorsOptions } from '@fastify/cors'
 import helmet from '@fastify/helmet'
 import rateLimit from '@fastify/rate-limit'
 import { ERROR_CODES, ERROR_STATUS, type ApiErrorBody } from '@langx/shared'
@@ -103,6 +103,15 @@ export interface BuildAppOptions {
   version?: string
 }
 
+/**
+ * `/public/*` is the API's contract with pages it does not serve: no session,
+ * readable from any origin. The same prefix `routes/public.ts` and the shared
+ * profile card already use, so a route is public by its name and nothing else.
+ */
+function isPublicPath(url: string): boolean {
+  return (url.split('?')[0] ?? '').startsWith('/public/')
+}
+
 export async function buildApp({
   env,
   client,
@@ -148,7 +157,30 @@ export async function buildApp({
 
   await app.register(helmet, { contentSecurityPolicy: false })
 
-  await app.register(cors, {
+  /**
+   * Two CORS policies, and the path decides which one answers.
+   *
+   * Everything under `/public/` exists for pages on other origins — the
+   * newsletter form on langx.io, the high-score board on token.langx.io — and
+   * none of it carries a session. A browser discards a cross-origin response
+   * unread unless `Access-Control-Allow-Origin` names the page, and the first
+   * deploy of those routes sent no such header: curl saw a 200 while both
+   * pages saw a CORS error. Wildcarded here rather than adding the two sites
+   * to `TRUSTED_ORIGINS`, because that list also feeds Better Auth's
+   * `trustedOrigins`, and a marketing page has no business being trusted with
+   * a session. Everything else keeps the credentialed policy.
+   *
+   * A delegator rather than per-route `config.cors`, because the preflight
+   * never reaches the route: `@fastify/cors` answers `OPTIONS` from its own
+   * wildcard route, whose config is empty. The path is the one thing the
+   * preflight and the real request have in common.
+   */
+  const publicCors: FastifyCorsOptions = {
+    origin: '*',
+    credentials: false,
+    methods: ['GET', 'HEAD', 'POST', 'OPTIONS'],
+  }
+  const trustedCors: FastifyCorsOptions = {
     origin: env.TRUSTED_ORIGINS.length > 0 ? env.TRUSTED_ORIGINS : true,
     // Better Auth uses cookies on web; native sends the session as a header.
     credentials: true,
@@ -168,6 +200,11 @@ export async function buildApp({
      * here has to be added *here* too.
      */
     methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  }
+  await app.register(cors, {
+    delegator: (request, callback) => {
+      callback(null, isPublicPath(request.url) ? publicCors : trustedCors)
+    },
   })
 
   await app.register(rateLimit, {

--- a/apps/api/src/routes/public.test.ts
+++ b/apps/api/src/routes/public.test.ts
@@ -13,6 +13,9 @@ import { createStorageProvider } from '../storage/createStorageProvider'
 import { createTranslationProvider } from '../translation/createTranslationProvider'
 import { CapturingEmailSender } from '../testSupport/authFlow'
 
+/** Stands in for the web build's origin; the two sites below are not on it. */
+const TRUSTED_ORIGIN = 'https://app.example.test'
+
 /**
  * The two routes that let api.langx.io move off v1's Express without the
  * newsletter form or token.langx.io going dark. Neither has a session, so the
@@ -33,6 +36,7 @@ describe('the public routes v1 used to serve', () => {
       LOG_LEVEL: 'silent',
       BETTER_AUTH_SECRET: 'a'.repeat(32),
       BETTER_AUTH_URL: 'http://localhost:4000',
+      TRUSTED_ORIGINS: TRUSTED_ORIGIN,
       // Deliberately no RESEND_AUDIENCE_ID: the unconfigured path is the one
       // a self-hosted instance hits, and it must refuse rather than lie.
     })
@@ -141,6 +145,57 @@ describe('the public routes v1 used to serve', () => {
         expect(entry).not.toHaveProperty('userId')
       }
       expect(body).not.toHaveProperty('viewer')
+    })
+  })
+
+  /**
+   * Both pages live on other origins, so the browser only hands them a
+   * response that names their origin. The first deploy did not, and curl's
+   * 200 hid a CORS error on every page load.
+   */
+  describe('CORS on /public/*', () => {
+    it('lets any origin read a public route, without credentials', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/public/leaderboard/token',
+        headers: { origin: 'https://token.langx.io' },
+      })
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['access-control-allow-origin']).toBe('*')
+      expect(response.headers['access-control-allow-credentials']).toBeUndefined()
+    })
+
+    it('answers the JSON preflight the newsletter form sends', async () => {
+      const response = await app.inject({
+        method: 'OPTIONS',
+        url: '/public/newsletter',
+        headers: {
+          origin: 'https://langx.io',
+          'access-control-request-method': 'POST',
+          'access-control-request-headers': 'content-type',
+        },
+      })
+      expect(response.statusCode).toBe(204)
+      expect(response.headers['access-control-allow-origin']).toBe('*')
+      expect(response.headers['access-control-allow-methods']).toContain('POST')
+      expect(response.headers['access-control-allow-headers']).toContain('content-type')
+    })
+
+    it('keeps every other route on the trusted-origin list', async () => {
+      const stranger = await app.inject({
+        method: 'GET',
+        url: '/health',
+        headers: { origin: 'https://token.langx.io' },
+      })
+      expect(stranger.headers['access-control-allow-origin']).toBeUndefined()
+
+      const trusted = await app.inject({
+        method: 'GET',
+        url: '/health',
+        headers: { origin: TRUSTED_ORIGIN },
+      })
+      expect(trusted.headers['access-control-allow-origin']).toBe(TRUSTED_ORIGIN)
+      expect(trusted.headers['access-control-allow-credentials']).toBe('true')
     })
   })
 })

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -601,31 +601,62 @@ stands — as repair work, not as a schedule for the repoint.
 | `website/src/lib/components/molecules/NewsletterForm.svelte`               | `/api/mail` — the newsletter form on langx.io |
 | `token-website/js/leaderboard-token.js`                                    | `/api/leaderboard/token`                      |
 
-It also answers `/api/update`, driven by `ANDROID_VERSION`,
+It also answered `/api/update`, driven by `ANDROID_VERSION`,
 `ANDROID_MAINTENANCE`, `IOS_*` and `WEB_*` in its `.env` (env only — a version
-bump needs no commit). That endpoint is the **only channel that can tell a v1
-install to update or that the service is down**, and v1 installs are exactly
+bump needed no commit). That endpoint was the **only channel that could tell a
+v1 install to update or that the service is down**, and v1 installs are exactly
 the users this release exists to migrate. Its fourth flag,
-`COPILOT_MAINTENANCE`, has no caller left in `copilot/` and blocks nothing.
+`COPILOT_MAINTENANCE`, had no caller left in `copilot/` and blocked nothing.
 
 Archiving the GitHub repo does not stop the deploy — archiving is a read-only
 flag — but it does declare dead a service the shipped app still depends on and
 leaves nobody able to push a fix to it. Do these first, in order:
 
-- [ ] Move the newsletter form off `/api/mail`. v2 has **no mail route**, so
-      this is real work, not a URL swap: add one to `apps/api`, or post to
-      SendGrid from the site
-- [ ] Point `token-website`'s leaderboard at v2's
-      `apps/api/src/routes/leaderboard.ts`
+- [x] Move the newsletter form off `/api/mail`. Done 3 September 2026:
+      `POST /public/newsletter` in `apps/api/src/routes/public.ts`
+      (langx/langx#1080) puts the address on the Resend audience named by
+      `RESEND_AUDIENCE_ID` — already a Fly secret — and answers v1's
+      `{ status: 'ok' }` so the form did not have to change shape. The form
+      posts there on `website`'s `main` (langx/website#132, deployed) and on
+      `redesign/v3-mobile-language`, which had branched off before the fix.
+      v1's SendGrid list is not migrated; the addresses on it stay there
+- [x] Point `token-website`'s leaderboard at v2. Done the same day:
+      `GET /public/leaderboard/token` (langx/langx#1080) serves the all-time
+      top ten as `{ period, entries: [{ rank, handle, displayName, tokens }] }`
+      — no `userId`, `streak` or viewer fields, so the open internet sees
+      less than a guest in the app does — and `js/leaderboard-token.js`
+      reads that shape (langx/token-website#21, deployed). The board is empty
+      until the migration ETL loads all-time aggregates into production
+- [x] Ship the CORS change (`fix/public-cors`, merged 3 September 2026).
+      Until it deployed **both pages were broken in a browser**: the API
+      answered `/public/*` without `Access-Control-Allow-Origin` for
+      `langx.io` or `token.langx.io`, since `TRUSTED_ORIGINS` names only the
+      web build. curl saw a 200; the page saw "No 'Access-Control-Allow-Origin'
+      header is present" and an empty board (checked on token.langx.io the
+      same day). After any deploy that touches CORS, verify with the command
+      under this list — the header, not the status
 - [ ] Confirm every migrated client takes its version and maintenance flags
       from v2's `appConfig` route and `middleware/maintenance.ts`
-- [ ] Let the v0.15 install base drain far enough that losing `/api/update`
-      strands nobody — the same install-base numbers the `minSdk` decision
-      under **Release** turns on
-- [ ] Only then repoint `api.langx.io`, stop the deploy, and archive the repo
+- [x] ~~Let the v0.15 install base drain far enough that losing `/api/update`
+      strands nobody~~ — overtaken. The repoint on 3 September 2026 took
+      `/api/update` down with it, so a v0.15 install can no longer be told to
+      update or that the service is down; the store listings and a forced
+      minimum version in the stores are the only levers left. The
+      install-base numbers under **Release** still decide `minSdk`
+- [ ] ~~Only then repoint `api.langx.io`~~ (done 3 September 2026), then stop
+      the v1 deploy and archive the repo
 
-Keep `/api/update` answering while any v1 client remains, even after the other
-two callers are gone: the user who never updates is the one it exists for.
+The check that would have caught the CORS gap on deploy day — the status code
+says nothing, only the header does:
+
+```bash
+curl -sI -H 'Origin: https://token.langx.io' https://api.langx.io/public/leaderboard/token | grep -i access-control-allow-origin   # must print *
+```
+
+`/api/update` stopped answering with the repoint. Nothing in v2 replaces it
+for a v1 client — `/app-config` speaks to v2 installs only — which is why the
+migration campaign, not this endpoint, is now what reaches the user who never
+updates.
 
 One unknown to resolve before pulling it down — where it actually runs.
 `netlify.toml` says Netlify (with `npm run start` as the build command) while


### PR DESCRIPTION
The newsletter form on langx.io and the high-score board on token.langx.io were repointed at `/public/newsletter` and `/public/leaderboard/token` today (#1080, website#132, token-website#21), and both still fail in a browser: the API answers them without `Access-Control-Allow-Origin`, because `TRUSTED_ORIGINS` holds `app.langx.io` and nothing else. curl sees a 200; the page sees "No 'Access-Control-Allow-Origin' header is present" and an empty board — verified on token.langx.io.

**The path now picks the CORS policy.** Everything under `/public/` answers any origin without credentials (none of it carries a session); every other route keeps the credentialed, trusted-origin policy it had. Wildcarding beats adding the two sites to the `TRUSTED_ORIGINS` Fly secret, since that list also feeds Better Auth's `trustedOrigins`.

It is a `@fastify/cors` delegator rather than per-route `config.cors` because the preflight never reaches the route — the plugin answers `OPTIONS` from its own wildcard route, whose config is empty — and the JSON POST the form sends is exactly the request that preflights.

Three tests in `routes/public.test.ts`: a foreign origin reads a public route, the form's preflight is answered, and `/health` still refuses that origin while echoing a trusted one with credentials.

The second commit ticks the two caller items in the runbook's **Retiring the v1 API** list, records this change as the third, and rewrites the `/api/update` items as what happened rather than what was planned.

Verify after deploy — the header, not the status:

```bash
curl -sI -H 'Origin: https://token.langx.io' https://api.langx.io/public/leaderboard/token | grep -i access-control-allow-origin   # must print *
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
