### PR TITLE
Move builds, submissions and updates onto EAS workflows

### DIFF
--- a/apps/mobile/.eas/workflows/preview-build.yml
+++ b/apps/mobile/.eas/workflows/preview-build.yml
@@ -1,0 +1,21 @@
+# An internal-distribution build, started by hand only.
+#
+# Deliberately not on push: a cloud build spends one of the free plan's
+# fifteen per platform per month, and a code change that only touches JS
+# reaches preview installs through preview-update.yml for nothing.
+name: Preview build
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        type: choice
+        description: Which platform to build
+        default: android
+        options: [android, ios]
+
+jobs:
+  build_preview:
+    type: build
+    params:
+      platform: ${{ inputs.platform }}
+      profile: preview

--- a/apps/mobile/.eas/workflows/preview-update.yml
+++ b/apps/mobile/.eas/workflows/preview-update.yml
@@ -1,0 +1,24 @@
+# Every merge to main becomes an over-the-air update on the `preview` channel.
+#
+# JS and assets only, no store build and no build quota: whoever runs a
+# preview APK gets the new code on the next launch. Production stays manual
+# — see release.yml — because an update there reaches everyone at once.
+#
+# Needs the GitHub repo linked in the Expo project's settings (base directory
+# apps/mobile); until then it can only be started by hand with
+# `eas workflow:run preview-update.yml`.
+name: Preview update
+on:
+  push:
+    branches: [main]
+    paths:
+      - apps/mobile/**
+      - packages/shared/**
+      - '!**/*.md'
+
+jobs:
+  publish_preview:
+    type: update
+    params:
+      channel: preview
+      message: ${{ github.event.head_commit.message || 'main' }}

--- a/apps/mobile/.eas/workflows/release.yml
+++ b/apps/mobile/.eas/workflows/release.yml
@@ -1,0 +1,29 @@
+# A store release: production builds for both platforms, then submission.
+#
+# Started by hand, on purpose. `production` auto-increments the build number
+# and `eas.json`'s submit profile opens Android at a 10% staged rollout; iOS
+# goes to App Store Connect for review. The iOS half needs a distribution
+# certificate and an App Store Connect API key in EAS before it can run.
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        type: choice
+        description: Which platform to release
+        default: android
+        options: [android, ios]
+
+jobs:
+  build_production:
+    type: build
+    params:
+      platform: ${{ inputs.platform }}
+      profile: production
+
+  submit_production:
+    type: submit
+    needs: [build_production]
+    params:
+      build_id: ${{ needs.build_production.outputs.build_id }}
+      profile: production

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2376,3 +2376,27 @@ reach FCM (`400 INVALID_ARGUMENT` on a fake token), which still proves the
 key Expo is handed is a working one before any build exists; and the lesson
 that `expo-notifications` and the Firebase SDK both hook the same iOS delegate
 and should not share a build.
+
+## Shipping lives on expo.dev, and only tests live on GitHub
+
+Behic's call on 3 September 2026, after a day of weighing the alternative:
+builds, store submissions and over-the-air updates are EAS workflows in
+`apps/mobile/.eas/workflows/`, started from Expo's dashboard or by a push to
+`main`. GitHub Actions keeps `ci.yml` and nothing else. The API and the web
+build are unaffected — Fly and Cloudflare Pages are still deployed by hand,
+see the runbook.
+
+Two things decided the shape of the workflows.
+
+_Updates are automatic, builds are not._ A merge to `main` publishes an OTA
+update to the `preview` channel for nothing; a cloud build spends one of the
+free plan's fifteen a month. So the only workflow on a push trigger is the
+update, and both build workflows are `workflow_dispatch` with a platform
+input. Somebody spends a build on purpose, not because a README changed.
+
+_Production updates are manual too._ An update on the `production` channel
+reaches every store install at once, and `runtimeVersion` is the SDK version,
+so a JS change that assumes a native module which is not in the store build
+would land on phones that cannot run it. Publishing to production is a
+deliberate `eas update --channel production` after the matching build has
+shipped, not a side effect of merging.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -303,6 +303,48 @@ pnpm --filter @langx/api exec tsx scripts/send-campaign.ts \
 - One campaign is one language. For a bilingual send, run it twice with
   different ids and `--locale`.
 
+## Shipping runs on expo.dev
+
+Builds, store submissions and over-the-air updates are all EAS jobs, defined
+in `apps/mobile/.eas/workflows/`. GitHub Actions only tests. The three
+workflows, and what each costs:
+
+| Workflow             | Trigger                  | Cost                                  |
+| -------------------- | ------------------------ | ------------------------------------- |
+| `preview-update.yml` | every merge to `main`    | nothing — an OTA update, no build     |
+| `preview-build.yml`  | by hand, pick a platform | one build of the free plan's 15/month |
+| `release.yml`        | by hand, pick a platform | one build, then `eas submit`          |
+
+The free plan allows 15 Android and 15 iOS cloud builds a month and 1,000
+monthly active users on updates. JS-only changes never need a build: a
+preview install picks them up on the next launch from the `preview` channel,
+and a store build from the `production` channel once one exists. Only a
+native change — a new module, a permission, an SDK bump, an icon — needs a
+build, and those are started by hand so the quota is spent on purpose.
+
+- [ ] **Link the GitHub repo once**, or the push trigger never fires: expo.dev
+      → project `langx` → Project settings → GitHub → connect `langx/langx`,
+      base directory `apps/mobile`. Manual runs work without it:
+      `eas workflow:run preview-build.yml` from `apps/mobile`.
+- [ ] **iOS credentials.** EAS holds the APNs key but no distribution
+      certificate or provisioning profile, and no App Store Connect API key
+      for submission. One interactive `eas credentials -p ios` on a Mac with
+      the Apple ID signed in creates the first two; the API key is made in
+      App Store Connect → Users and Access → Integrations and uploaded on the
+      same screen. Until then `preview-build.yml` and `release.yml` only work
+      for Android.
+- [ ] **Play submit permissions.** The service account
+      `eas-submit@langx-48eb0.iam.gserviceaccount.com` is uploaded to EAS but
+      Play does not know it yet: Play Console → Users and permissions → invite
+      that address with release permissions, and enable the Google Play
+      Android Developer API on the `langx-48eb0` project. Until then
+      `release.yml` builds Android and fails at the submit step.
+
+What is already in EAS: the Android application identifier with the real
+upload keystore (alias `key0`, the v1 key Play trusts), the FCM V1 service
+account and the APNs key for push, and `GOOGLE_SERVICES_JSON` /
+`GOOGLE_SERVICES_PLIST` as file variables on every environment.
+
 ## Actions that succeed silently
 
 `src/lib/alert.ts` and `AlertHost` give the app a dialog that works in the


### PR DESCRIPTION
Shipping lives on expo.dev; GitHub Actions keeps only `ci.yml`.

Three workflows under `apps/mobile/.eas/workflows/`, each validated with
`eas workflow:validate`:

| Workflow | Trigger | Cost |
| --- | --- | --- |
| `preview-update.yml` | push to `main` | none — OTA update |
| `preview-build.yml` | manual, platform input | one of 15/month |
| `release.yml` | manual, platform input | one build + submit |

Updates are automatic and builds are not, because a build spends quota and a
JS-only change never needs one. Production updates stay manual: they reach
every store install at once and `runtimeVersion` is the SDK version.

Runbook gains the section and the three one-time steps still open: link the
GitHub repo in the Expo project (base directory `apps/mobile`) or the push
trigger never fires; iOS distribution credentials via an Apple login; Play
Console permissions for `eas-submit@langx-48eb0`.

No build was run for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)