### PR TITLE
Declare babel-preset-expo, or `eas update` cannot bundle

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@types/react": "catalog:",
+    "babel-preset-expo": "~57.0.8",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,6 +358,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
+      babel-preset-expo:
+        specifier: ~57.0.8
+        version: 57.0.8(@babel/core@7.29.7)(@babel/runtime@7.29.7)(expo@57.0.16)(react-refresh@0.14.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3


### PR DESCRIPTION
`apps/mobile/babel.config.js` names `babel-preset-expo` as its preset, but the
package was never declared as a dependency. Under pnpm an undeclared package is
not linked into `apps/mobile/node_modules`, so it resolved only by accident.

`expo export` transforms each file from inside `.pnpm`, where the copy `expo`
pulls in is reachable, so the plain bundle has always worked. `eas update`
bundles with `--experimental-bundle`, and the tree-shaking serializer loads the
Babel config from the project root instead — from there the preset is not
reachable and the export dies before the first module:

```
Failed to construct transformer:  Error: Cannot find module 'babel-preset-expo'
```

No over-the-air update could be published on any channel, while a green
`expo export` gave every reason to think the bundle was fine.

`~57.0.8` is the range `expo@57.0.16` itself asks for, so this links the copy
already in the store rather than adding a second one (`.pnpm` still holds one
`babel-preset-expo`).

**Verified.** Typecheck, lint, format and 1527 tests pass. Afterwards
`eas update --branch preview` bundled both platforms and published update group
`1fe6aa6b-b5ad-4fa9-b3c9-ecb8a7443f85` from this commit's parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)