### PR TITLE
Cap Metro's workers, or the release bundle fails on a many-core machine

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -16,4 +16,11 @@ config.watchFolders = [workspaceRoot]
 // under `.pnpm/<name>/node_modules`, so Metro must be allowed to walk up the
 // tree or transitive deps like `expo-modules-core` stop resolving.
 
+// Metro spawns one transformer worker per core, and on a many-core machine the
+// release bundle step (`:app:createBundleReleaseJsAndAssets`) dies with
+// `Cannot read properties of undefined (reading 'transformFile')` — the pool
+// hands back a worker that never finished starting. Capping it trades a little
+// bundling speed for a build that finishes.
+config.maxWorkers = 2
+
 module.exports = config


### PR DESCRIPTION
## Why

The first local Android preview build (`eas build --local --platform android --profile preview`) failed in `:app:createBundleReleaseJsAndAssets`:

```
TypeError: Cannot read properties of undefined (reading 'transformFile')
    at Bundler.transformFile (metro@0.84.5/src/Bundler.js:55:30)
```

Metro spawns one transformer worker per core, and the pool handed back a worker that had not finished starting. This is the failure the release runbook's handoff notes predicted for this step.

## What

`config.maxWorkers = 2` in `apps/mobile/metro.config.js`, with a comment saying why.

Worth knowing before merging: this caps workers **everywhere**, including EAS cloud builders and CI, not only on a local machine. The trade is a little bundling speed for a build that finishes. If that turns out to matter on the cloud builders, the cap can be made conditional later.

## Verification

Local Android preview build on the same machine, from this branch:

- bundle step now succeeds — `Android Bundled 18154ms expo-router/entry.js (1978 modules)`
- zero `transformFile` errors in the log
- `app-release.apk` produced (116 MB), build successful in ~13 min
- `prettier --check` and `eslint` clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)