### PR TITLE
Move version numbers to EAS, or no production build can start

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -26,7 +26,12 @@ import type { ExpoConfig } from 'expo/config'
  *     against a file on the domain, so these entries do nothing until
  *     `apps/mobile/public/.well-known/` is actually served from that host.
  *
- * versionCode/buildNumber must stay above the published 119.
+ * The build number and Android versionCode are deliberately absent: `eas.json`
+ * sets `appVersionSource: "remote"`, so EAS owns them and hands one out per
+ * build. They were declared here until 3 September 2026, which silently broke
+ * every `production` build — `autoIncrement` cannot write back into a dynamic
+ * config, so the build failed before it started. The remote counter has to
+ * stay above the published 119.
  */
 // Existing EAS project, carried over from the abandoned rewrite.
 const EAS_PROJECT_ID = 'c331c0a6-b2fc-4664-a9a3-c04d1fb2c115'
@@ -41,8 +46,12 @@ const config: ExpoConfig = {
 
   ios: {
     bundleIdentifier: IOS_BUNDLE_ID,
-    buildNumber: '120',
     supportsTablet: true,
+    // The app encrypts nothing of its own; it only speaks HTTPS through the
+    // system stack, which Apple's export rules exempt. Answering that here
+    // answers it once — without it every upload sits in App Store Connect as
+    // "Missing Compliance" and TestFlight will not hand the build to anyone.
+    infoPlist: { ITSAppUsesNonExemptEncryption: false },
     // Adds the Sign in with Apple entitlement. Without it the native sheet
     // opens and then fails with no identity token, which reads like a bug in
     // the app rather than a missing capability.
@@ -56,7 +65,6 @@ const config: ExpoConfig = {
 
   android: {
     package: ANDROID_PACKAGE,
-    versionCode: 120,
     /**
      * FCM's Android client config. Only set when the file is actually there:
      * naming a file that does not exist fails the prebuild, and this repo is

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 12.5.1",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -23,7 +23,6 @@
     },
     "production": {
       "channel": "production",
-      "autoIncrement": true,
       "env": {
         "EXPO_PUBLIC_API_URL": "https://api.langx.io"
       },


### PR DESCRIPTION
## Why

Trying to produce the first iOS build for TestFlight, `eas build --local --platform ios --profile production` failed before doing any work:

```
autoIncrement option is not supported when using app.config.js
```

`autoIncrement` has to write the next build number back into the app config, and it cannot write into a dynamic `app.config.ts`.

This is not only an iOS problem and not only a local-build problem. `autoIncrement` is platform-agnostic and sits on the `production` profile, so **`release.yml` — the entire store release path — could not have worked for either platform.** It went unnoticed because no production build had ever been run; the Android build that succeeded earlier today used the `preview` profile, which has no `autoIncrement`.

## What

- `eas.json`: `appVersionSource` `local` → `remote`, and `autoIncrement` removed (redundant once EAS owns the counter).
- `app.config.ts`: hard-coded `ios.buildNumber` and `android.versionCode` removed, so there is one source of truth instead of two that can disagree. The comment above them now says where versions live and what went wrong.
- `app.config.ts`: `ios.infoPlist.ITSAppUsesNonExemptEncryption: false`. The app encrypts nothing of its own and only speaks HTTPS through the system stack, which Apple's export rules exempt. Without the key every upload parks in App Store Connect as "Missing Compliance" and TestFlight will not hand the build to anyone.

## Verification

A local iOS production build now runs to completion and produces a signed `.ipa`. Reading its `Info.plist` back:

```
CFBundleShortVersionString  2.0.0
CFBundleIdentifier          tech.newchapter.languageXchange
ITSAppUsesNonExemptEncryption  false
```

So the compliance declaration lands in the binary, and the `autoIncrement` failure is gone.

`prettier --check` and `tsc --noEmit` are clean.

## The trap this opens, and how it was closed

Switching to `remote` means EAS starts its own counter, and it starts at 1 — not at the value that used to be in `app.config.ts`. The first `.ipa` off this branch came out as **build 6**, which App Store Connect would reject outright: the highest build already uploaded is 118 and the live version is 0.15.0.

The remote counter has been seeded to **120** for both platforms, so this is already handled. Anyone setting up a fresh EAS project from this config should know the counter needs seeding above the published build before the first upload — a build number is not something you get to correct after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)