### PR TITLE
Make deleting a post work in the browser

### DIFF
--- a/apps/mobile/app/(app)/feed.tsx
+++ b/apps/mobile/app/(app)/feed.tsx
@@ -1,15 +1,7 @@
 import Feather from '@expo/vector-icons/Feather'
 import { MAX_POST_LENGTH, POST_KINDS, type PostKind } from '@langx/shared'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import {
-  ActivityIndicator,
-  Alert,
-  FlatList,
-  Pressable,
-  RefreshControl,
-  Text,
-  View,
-} from 'react-native'
+import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from 'react-native'
 import { FormField } from '../../src/components/ui/FormField'
 import { Button } from '../../src/components/ui/Button'
 import { uploadPostMedia } from '../../src/api/queries'
@@ -41,6 +33,7 @@ import { isImageContentType } from '@langx/shared'
 import { ApiRequestError } from '../../src/api/client'
 import { shareLink } from '../../src/lib/share'
 import { postShareText } from '../../src/lib/shareText'
+import { confirmAlert } from '../../src/lib/alert'
 import { showToast } from '../../src/lib/toast'
 import { relativeTime } from '../../src/lib/format'
 
@@ -256,19 +249,18 @@ export default function FeedScreen() {
     )
   }
 
-  function confirmDelete(postId: string): void {
-    Alert.alert(t('feed.deleteConfirmTitle'), t('feed.deletePostConfirmBody'), [
-      { text: t('common.cancel'), style: 'cancel' },
-      {
-        text: t('feed.deletePost'),
-        style: 'destructive',
-        onPress: () =>
-          deletePost.mutate(postId, {
-            onSuccess: () => showToast(t('feed.deleted')),
-            onError: () => showToast(t('common.retry')),
-          }),
-      },
-    ])
+  async function confirmDelete(postId: string): Promise<void> {
+    const yes = await confirmAlert({
+      title: t('feed.deleteConfirmTitle'),
+      message: t('feed.deletePostConfirmBody'),
+      confirmLabel: t('feed.deletePost'),
+      destructive: true,
+    })
+    if (!yes) return
+    deletePost.mutate(postId, {
+      onSuccess: () => showToast(t('feed.deleted')),
+      onError: () => showToast(t('common.retry')),
+    })
   }
 
   async function submitAsk(): Promise<void> {
@@ -579,7 +571,7 @@ export default function FeedScreen() {
                       accessibilityRole="button"
                       hitSlop={8}
                       disabled={deletePost.isPending}
-                      onPress={() => confirmDelete(item._id)}
+                      onPress={() => void confirmDelete(item._id)}
                       style={({ pressed }) => (pressed ? styles.pressed : null)}
                     >
                       <Text style={styles.deleteAction}>{t('feed.deletePost')}</Text>

--- a/apps/mobile/app/(app)/post/[id].tsx
+++ b/apps/mobile/app/(app)/post/[id].tsx
@@ -1,15 +1,7 @@
 import Feather from '@expo/vector-icons/Feather'
 import { useLocalSearchParams } from 'expo-router'
 import { useMemo, useState } from 'react'
-import {
-  ActivityIndicator,
-  Alert,
-  FlatList,
-  Pressable,
-  RefreshControl,
-  Text,
-  View,
-} from 'react-native'
+import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from 'react-native'
 import { MAX_COMMENT_LENGTH, MAX_POST_LENGTH } from '@langx/shared'
 import {
   uploadPostMedia,
@@ -43,6 +35,7 @@ import { foldCorrection } from '../../../src/lib/feedCache'
 import { listState } from '../../../src/lib/listState'
 import { goBackTo, openProfile } from '../../../src/lib/navigation'
 import { relativeTime } from '../../../src/lib/format'
+import { confirmAlert } from '../../../src/lib/alert'
 import { showToast } from '../../../src/lib/toast'
 import { shareLink } from '../../../src/lib/share'
 import { postShareText } from '../../../src/lib/shareText'
@@ -248,23 +241,22 @@ export default function PostScreen() {
     )
   }
 
-  function confirmDeletePost(): void {
+  async function confirmDeletePost(): Promise<void> {
     if (!post) return
-    Alert.alert(t('feed.deleteConfirmTitle'), t('feed.deletePostConfirmBody'), [
-      { text: t('common.cancel'), style: 'cancel' },
-      {
-        text: t('feed.deletePost'),
-        style: 'destructive',
-        onPress: () =>
-          deletePost.mutate(post._id, {
-            onSuccess: () => {
-              showToast(t('feed.deleted'))
-              goBackTo('/(app)/feed', from)
-            },
-            onError: () => showToast(t('common.retry')),
-          }),
+    const yes = await confirmAlert({
+      title: t('feed.deleteConfirmTitle'),
+      message: t('feed.deletePostConfirmBody'),
+      confirmLabel: t('feed.deletePost'),
+      destructive: true,
+    })
+    if (!yes) return
+    deletePost.mutate(post._id, {
+      onSuccess: () => {
+        showToast(t('feed.deleted'))
+        goBackTo('/(app)/feed', from)
       },
-    ])
+      onError: () => showToast(t('common.retry')),
+    })
   }
 
   function removeReply(replyId: string): void {
@@ -392,7 +384,7 @@ export default function PostScreen() {
                       accessibilityRole="button"
                       hitSlop={8}
                       disabled={deletePost.isPending}
-                      onPress={confirmDeletePost}
+                      onPress={() => void confirmDeletePost()}
                       style={({ pressed }) => (pressed ? styles.pressed : null)}
                     >
                       <Text style={styles.deleteAction}>{t('feed.deletePost')}</Text>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,30 @@ export default tseslint.config(
     },
   },
   {
+    // `Alert` from react-native is an empty static on react-native-web, so a
+    // confirmation written with it is a no-op in the browser: the dialog never
+    // appears and the `onPress` behind it never runs. Deleting a post did
+    // nothing on the web build for exactly this reason. `src/lib/alert` draws
+    // the same dialogs with `Modal`, which web does implement. This rule is the
+    // regression test — mobile vitest cannot load react-native, so nothing else
+    // can catch the import coming back.
+    files: ['apps/mobile/**/*.ts', 'apps/mobile/**/*.tsx'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'react-native',
+              importNames: ['Alert'],
+              message: 'Alert is a no-op on react-native-web. Use src/lib/alert.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ['**/*.test.ts', '**/*.test.tsx', '**/vitest.config.ts'],
     rules: {
       '@typescript-eslint/no-non-null-assertion': 'off',


### PR DESCRIPTION
`Alert` from `react-native` is `class Alert { static alert() {} }` on react-native-web. The two delete-post confirmations were written with it, so in the browser no dialog appeared and the `onPress` holding the mutation never ran — the Delete button on a post did nothing at all. These were the last two importers of `Alert` in the app.

## What changed

- `app/(app)/feed.tsx` and `app/(app)/post/[id].tsx` now `await confirmAlert(...)` from `src/lib/alert`, which renders with `Modal` and works on every platform. The mutation, the cache patch and the success/error toasts already existed behind the dead callback; nothing else moved.
- `eslint.config.mjs` gains a `no-restricted-imports` rule banning `Alert` from `react-native` under `apps/mobile`.

## Why a lint rule instead of a test

Mobile vitest cannot load `react-native`, so no unit test can reach either screen or notice the import coming back. Verified the rule fires: re-adding the import fails `pnpm lint` with the message pointing at `src/lib/alert`.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and the mobile suite (523 tests) all pass. Browser behaviour is covered in the live pass at the end of this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)