### PR TITLE
Show what is attached, and put a new post at the top of the feed

### DIFF
--- a/apps/mobile/app/(app)/feed.tsx
+++ b/apps/mobile/app/(app)/feed.tsx
@@ -15,7 +15,11 @@ import { Button } from '../../src/components/ui/Button'
 import { uploadPostMedia } from '../../src/api/queries'
 import { useCorrectPost, useCreatePost, useDeletePost, useFeed, useMe } from '../../src/api/queries'
 import type { FeedPost } from '../../src/api/types'
-import { AttachmentBar, type PendingAttachment } from '../../src/components/AttachmentBar'
+import {
+  AttachmentBar,
+  AttachmentPreview,
+  type PendingAttachment,
+} from '../../src/components/AttachmentBar'
 import { AudioBubble, ImageBubble } from '../../src/components/MediaBubble'
 import { PhotoViewer } from '../../src/components/PhotoViewer'
 import { Avatar } from '../../src/components/ui/Avatar'
@@ -389,11 +393,11 @@ export default function FeedScreen() {
               autoCapitalize="sentences"
               maxLength={MAX_POST_LENGTH}
             />
+            <AttachmentPreview pending={askMedia} onClear={() => setAskMedia(null)} />
             <View style={styles.composeActions}>
               <AttachmentBar
                 pending={askMedia}
                 onPick={setAskMedia}
-                onClear={() => setAskMedia(null)}
                 disabled={createPost.isPending || uploading}
               />
               <Button
@@ -716,10 +720,13 @@ export default function FeedScreen() {
                       autoCapitalize="sentences"
                       maxLength={MAX_POST_LENGTH}
                     />
+                    <AttachmentPreview
+                      pending={correctionMedia}
+                      onClear={() => setCorrectionMedia(null)}
+                    />
                     <AttachmentBar
                       pending={correctionMedia}
                       onPick={setCorrectionMedia}
-                      onClear={() => setCorrectionMedia(null)}
                       disabled={correctPost.isPending || uploading}
                     />
                     <View style={styles.actions}>

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -63,6 +63,7 @@ import {
   applyLike,
   applyLikeToAnswers,
   applyLikeToThread,
+  prependPost,
   removePost,
 } from '../lib/feedCache'
 import type { MessagePageDto } from '../lib/messageCache'
@@ -863,11 +864,22 @@ export function useCreatePost() {
   const client = useQueryClient()
   return useMutation({
     mutationFn: (input: CreatePostInput) => api.post<FeedPost>('/posts', input),
-    // Both sections, and the badges: a post changes neither, but the
-    // correction below does, and invalidating one list and not the other is
-    // how a feed starts disagreeing with itself.
-    onSuccess: () => {
-      void client.invalidateQueries({ queryKey: ['feed'] })
+    /*
+     * A patch, not an invalidation — see `prependPost`. The refetch applied
+     * the server's order, which puts your own post behind everyone you
+     * follow, so the sentence you had just written landed far below the fold.
+     *
+     * `POST /posts` answers with the whole card, so nothing is missing.
+     * `myPosts` is a child of the `['feed']` prefix but not of the section
+     * key, so it is patched by name.
+     */
+    onSuccess: (post) => {
+      client.setQueriesData<InfiniteData<FeedPage>>({ queryKey: keys.feed(post.kind) }, (data) =>
+        prependPost(data, post),
+      )
+      client.setQueriesData<InfiniteData<FeedPage>>({ queryKey: keys.myPosts() }, (data) =>
+        prependPost(data, post),
+      )
     },
   })
 }

--- a/apps/mobile/src/components/AttachmentBar.tsx
+++ b/apps/mobile/src/components/AttachmentBar.tsx
@@ -1,4 +1,5 @@
 import Feather from '@expo/vector-icons/Feather'
+import { Image } from 'expo-image'
 import { Pressable, Text, View } from 'react-native'
 import { useT } from '../i18n'
 import { useVoiceRecorder } from '../hooks/useVoiceRecorder'
@@ -18,8 +19,69 @@ export interface PendingAttachment {
 interface AttachmentBarProps {
   pending: PendingAttachment | null
   onPick: (attachment: PendingAttachment) => void
-  onClear: () => void
   disabled?: boolean
+}
+
+interface AttachmentPreviewProps {
+  pending: PendingAttachment | null
+  onClear: () => void
+}
+
+/**
+ * What is attached, drawn above the composer's buttons rather than inside them.
+ *
+ * It used to be the words "Photo attached" on the same line as Post, which
+ * answered neither question somebody asks after picking: *which* photo, and
+ * how do I take it back. A thumbnail answers the first by being the picture,
+ * and the cross on its corner is the second — the same gesture every gallery
+ * uses.
+ *
+ * Its own component, and its own row, because the row it used to share is the
+ * one holding the submit button. Anything that grows in there is competing for
+ * width with the only control that sends the post.
+ */
+export function AttachmentPreview({ pending, onClear }: AttachmentPreviewProps) {
+  const styles = useStyles()
+  const { colors } = useTheme()
+  const t = useT()
+
+  if (!pending) return null
+
+  if (pending.kind === 'image') {
+    return (
+      <View style={styles.previewRow}>
+        <View>
+          <Image source={{ uri: pending.uri }} style={styles.thumb} contentFit="cover" />
+          <Pressable
+            onPress={onClear}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={t('feed.removeAttachment')}
+            style={styles.removeBadge}
+          >
+            <Feather name="x" size={12} color={colors.bg} />
+          </Pressable>
+        </View>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.previewRow}>
+      <Feather name="mic" size={16} color={colors.textMuted} />
+      <Text style={styles.attached} numberOfLines={1}>
+        {t('feed.voiceAttached')}
+      </Text>
+      <Pressable
+        onPress={onClear}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel={t('feed.removeAttachment')}
+      >
+        <Feather name="x" size={16} color={colors.textMuted} />
+      </Pressable>
+    </View>
+  )
 }
 
 /**
@@ -36,7 +98,7 @@ interface AttachmentBarProps {
  * while recording, which is chat's arrangement. A component with enough props
  * to serve both would not be a component.
  */
-export function AttachmentBar({ pending, onPick, onClear, disabled }: AttachmentBarProps) {
+export function AttachmentBar({ pending, onPick, disabled }: AttachmentBarProps) {
   const styles = useStyles()
   const { colors } = useTheme()
   const t = useT()
@@ -86,28 +148,12 @@ export function AttachmentBar({ pending, onPick, onClear, disabled }: Attachment
     )
   }
 
-  if (pending) {
-    return (
-      <View style={styles.row}>
-        <Feather
-          name={pending.kind === 'image' ? 'image' : 'mic'}
-          size={16}
-          color={colors.textMuted}
-        />
-        <Text style={styles.attached} numberOfLines={1}>
-          {pending.kind === 'image' ? t('feed.photoAttached') : t('feed.voiceAttached')}
-        </Text>
-        <Pressable
-          onPress={onClear}
-          hitSlop={8}
-          accessibilityRole="button"
-          accessibilityLabel={t('feed.removeAttachment')}
-        >
-          <Feather name="x" size={16} color={colors.textMuted} />
-        </Pressable>
-      </View>
-    )
-  }
+  /*
+   * Nothing while something is attached. A post carries one attachment, so a
+   * second camera is an offer the composer cannot keep, and the row it would
+   * sit in belongs to the submit button.
+   */
+  if (pending) return null
 
   return (
     <View style={styles.row}>
@@ -135,8 +181,24 @@ export function AttachmentBar({ pending, onPick, onClear, disabled }: Attachment
   )
 }
 
-const useStyles = makeStyles(({ colors, font }) => ({
-  row: { alignItems: 'center', flexDirection: 'row', gap: 10 },
+const useStyles = makeStyles(({ colors, font, radius, spacing }) => ({
+  // `flexShrink` so this can never starve the submit button beside it: a row
+  // whose child asks for `flex: 1` measures at the full width offered to it,
+  // and React Native does not shrink a flex item unless it is told to.
+  row: { alignItems: 'center', flexDirection: 'row', flexShrink: 1, gap: 10 },
+  previewRow: { alignItems: 'center', flexDirection: 'row', gap: 10, marginBottom: spacing.sm },
+  thumb: { borderRadius: radius.md, height: 64, width: 64 },
+  removeBadge: {
+    alignItems: 'center',
+    backgroundColor: colors.text,
+    borderRadius: radius.pill,
+    height: 20,
+    justifyContent: 'center',
+    position: 'absolute',
+    right: -6,
+    top: -6,
+    width: 20,
+  },
   // v3 draws attachment controls as bare muted glyphs; the 36 box keeps the
   // touch target the outlined circle used to give them.
   button: {

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -777,7 +777,6 @@ export const ar: Localized<EnMessages> = {
     attachPhoto: 'إرفاق صورة',
     recordVoice: 'تسجيل مقطع صوتي',
     removeAttachment: 'إزالة المرفق',
-    photoAttached: 'أُرفقت صورة',
     voiceAttached: 'أُرفق مقطع صوتي',
     photosPermission: 'يحتاج LangX إلى الوصول إلى صورك لإرفاق واحدة.',
     attachmentFailed: 'لم يُرفع المرفق. حاول مرة أخرى.',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -675,7 +675,6 @@ export const de: Localized<EnMessages> = {
     attachPhoto: 'Foto anhängen',
     recordVoice: 'Sprachnotiz aufnehmen',
     removeAttachment: 'Anhang entfernen',
-    photoAttached: 'Foto angehängt',
     voiceAttached: 'Sprachnotiz angehängt',
     photosPermission: 'LangX braucht Zugriff auf deine Fotos, um eines anzuhängen.',
     attachmentFailed: 'Der Anhang wurde nicht hochgeladen. Versuch es noch einmal.',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -691,7 +691,6 @@ export const en = {
     attachPhoto: 'Attach a photo',
     recordVoice: 'Record a voice note',
     removeAttachment: 'Remove attachment',
-    photoAttached: 'Photo attached',
     voiceAttached: 'Voice note attached',
     photosPermission: 'LangX needs access to your photos to attach one.',
     attachmentFailed: 'The attachment did not upload. Try again.',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -654,7 +654,6 @@ export const es: Localized<EnMessages> = {
     attachPhoto: 'Adjuntar una foto',
     recordVoice: 'Grabar una nota de voz',
     removeAttachment: 'Quitar el archivo adjunto',
-    photoAttached: 'Foto adjunta',
     voiceAttached: 'Nota de voz adjunta',
     photosPermission: 'LangX necesita acceso a tus fotos para adjuntar una.',
     attachmentFailed: 'El archivo adjunto no se subió. Inténtalo de nuevo.',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -658,7 +658,6 @@ export const fr: Localized<EnMessages> = {
     attachPhoto: 'Joindre une photo',
     recordVoice: 'Enregistrer une note vocale',
     removeAttachment: 'Retirer la pièce jointe',
-    photoAttached: 'Photo jointe',
     voiceAttached: 'Note vocale jointe',
     photosPermission: 'LangX a besoin d’accéder à vos photos pour en joindre une.',
     attachmentFailed: 'La pièce jointe n’a pas été envoyée. Réessayez.',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -647,7 +647,6 @@ export const ptBR: Localized<EnMessages> = {
     attachPhoto: 'Anexar uma foto',
     recordVoice: 'Gravar um áudio',
     removeAttachment: 'Remover anexo',
-    photoAttached: 'Foto anexada',
     voiceAttached: 'Áudio anexado',
     photosPermission: 'O LangX precisa acessar suas fotos para anexar uma.',
     attachmentFailed: 'O anexo não foi enviado. Tente de novo.',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -748,7 +748,6 @@ export const ru: Localized<EnMessages> = {
     attachPhoto: 'Прикрепить фото',
     recordVoice: 'Записать голосовую заметку',
     removeAttachment: 'Убрать вложение',
-    photoAttached: 'Фото прикреплено',
     voiceAttached: 'Голосовая заметка прикреплена',
     photosPermission: 'LangX нужен доступ к вашим фото, чтобы прикрепить одно.',
     attachmentFailed: 'Вложение не загрузилось. Попробуйте ещё раз.',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -660,7 +660,6 @@ export const tr: Localized<EnMessages> = {
     attachPhoto: 'Fotoğraf ekle',
     recordVoice: 'Ses kaydı al',
     removeAttachment: 'Eki kaldır',
-    photoAttached: 'Fotoğraf eklendi',
     voiceAttached: 'Ses kaydı eklendi',
     photosPermission: 'Fotoğraf eklemek için LangX’in fotoğraflarına erişmesi gerekiyor.',
     attachmentFailed: 'Ek yüklenemedi. Tekrar dene.',

--- a/apps/mobile/src/lib/feedCache.test.ts
+++ b/apps/mobile/src/lib/feedCache.test.ts
@@ -14,6 +14,7 @@ import {
   applyLike,
   applyLikeToThread,
   markCorrected,
+  prependPost,
   removePost,
 } from './feedCache'
 
@@ -195,6 +196,34 @@ describe('applyCommentCount', () => {
     // Two devices deleting the same comment would otherwise leave -1 on screen.
     const data = pages([post({ commentCount: 0 })])
     expect(applyCommentCount(data, 'p1', -1)!.pages[0]!.items[0]!.commentCount).toBe(0)
+  })
+})
+
+describe('prependPost', () => {
+  it('puts the new post at the top of the first page', () => {
+    const data = pages([post({ _id: 'p1' }), post({ _id: 'p2' })])
+    const patched = prependPost(data, post({ _id: 'new' }))
+    expect(patched!.pages[0]!.items.map((item) => item._id)).toEqual(['new', 'p1', 'p2'])
+  })
+
+  it('does not draw the post twice when it is already loaded', () => {
+    // The server can hand back a post the pages already hold — a refetch that
+    // landed between the write and this patch. Two identical cards is the
+    // visible failure, so the old copy goes.
+    const data = pages([post({ _id: 'p1' })], [post({ _id: 'new' }), post({ _id: 'p2' })])
+    const patched = prependPost(data, post({ _id: 'new', body: 'edited' }))
+    expect(patched!.pages[0]!.items.map((item) => item._id)).toEqual(['new', 'p1'])
+    expect(patched!.pages[1]!.items.map((item) => item._id)).toEqual(['p2'])
+  })
+
+  it('leaves later pages alone when nothing has to be dropped from them', () => {
+    const data = pages([post({ _id: 'p1' })], [post({ _id: 'p2' })])
+    const patched = prependPost(data, post({ _id: 'new' }))
+    expect(patched!.pages[1]).toBe(data.pages[1])
+  })
+
+  it('does nothing when the feed has not been loaded', () => {
+    expect(prependPost(undefined, post({ _id: 'new' }))).toBeUndefined()
   })
 })
 

--- a/apps/mobile/src/lib/feedCache.ts
+++ b/apps/mobile/src/lib/feedCache.ts
@@ -114,6 +114,35 @@ export function markCorrected(data: Pages, postId: string): Pages {
  * Returns the identical object when nothing matched, so React Query sees an
  * unchanged cache and does not re-render every card in the list.
  */
+/**
+ * A post you just wrote, put at the top of the loaded pages instead of
+ * refetching for it.
+ *
+ * The feed is stitched from two queries — the people you follow or have talked
+ * to, then everybody else — and the viewer is not in their own audience, so a
+ * post of yours always lands in the second half, behind every post by somebody
+ * you know. Invalidating on success meant the refetch applied that order and
+ * the sentence you had just written appeared far below the fold, which reads
+ * as "it did not post".
+ *
+ * Same treatment as `applyCorrection`, for the same reason: patch now, and let
+ * the next natural refetch put it where the server says it belongs. The server
+ * order is not wrong — a queue that drains has to sort by how few answers a
+ * post has, not by who wrote it — it just should not decide where your own
+ * post goes in the frame where you wrote it.
+ */
+export function prependPost(data: Pages, post: FeedPost): Pages {
+  if (!data) return data
+  const pages = data.pages.map((page, index) => {
+    const items = page.items.filter((existing) => existing._id !== post._id)
+    // Only the first page gains it; dropping a duplicate elsewhere keeps a
+    // post that was already loaded from being drawn twice.
+    if (index === 0) return { ...page, items: [post, ...items] }
+    return items.length === page.items.length ? page : { ...page, items }
+  })
+  return { ...data, pages }
+}
+
 function patchPost(data: Pages, postId: string, patch: (post: FeedPost) => FeedPost): Pages {
   if (!data) return data
   let found = false


### PR DESCRIPTION
Three complaints about the feed composer, verified in a browser against an isolated stack.

## Attachment preview and detach

Picking a photo used to produce the words "Photo attached" on the same line as the Post button. It answered neither question somebody asks after picking: which photo, and how do I take it back. There is now a 64 px thumbnail with a cross badge on its corner, in `AttachmentPreview`, drawn in its own row above the composer's buttons. Both composers on the feed get it. The camera and microphone hide while something is attached, since a post carries one attachment.

## The vanishing Post button did not reproduce

The button was reported as disappearing after attaching. I could not reproduce it on react-native-web: it stays fully drawn at 900, 390 and 360 px viewport widths, in English and in Turkish (whose labels are longer), and while a voice note is recording. Checked with Playwright screenshots at each width; they are on the droplet, not in the repo.

The restructure removes the risk anyway, because the preview no longer shares a row with the button, and `AttachmentBar` gains `flexShrink: 1` so a future child cannot starve it. If it is still happening on a real phone it is native Yoga behaviour that web does not share, and it needs a device to see.

## A new post lands at the top

`listFeed` stitches the audience you follow or have talked to, then everybody else, and the viewer is excluded from their own audience — so your post always fell into the second half, behind every post by somebody you know. `useCreatePost` invalidated `['feed']`, the refetch applied that order, and the sentence you had just written appeared below the fold.

Fixed the way `applyCorrection` already does it: `prependPost` patches the loaded pages, and the next natural refetch sorts it away for real. Pinning your own posts server-side would change the product rule that makes the queue drain, so that is deliberately not done here.

## Verification

Browser, isolated stack on :4100/:8082, phone-width viewport:

- thumbnail renders from the `blob:` URL at 64x64, the cross removes it, the camera returns, Post stays visible in every state
- posting shows the "Posted. Somebody will correct it." toast at the top, and the new card is the first row of the feed

Posting *with* an attachment could not be exercised: the isolated stack has no object storage, so `/media/upload-url` answers 500 by design. That path is unchanged by this PR.

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and the mobile suite (527 tests, four new for `prependPost`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)