### PR TITLE
Open a v2 user for every v1 account, so forgot-password and Google/Apple work

### DIFF
--- a/apps/api/scripts/precreate-v1-users.ts
+++ b/apps/api/scripts/precreate-v1-users.ts
@@ -19,6 +19,12 @@
  * staged had no profile in v1; the row is opened all the same, and they go
  * through onboarding as a new user would, under the account they remember.
  *
+ * Accounts their owners **deleted** in v1 (Appwrite `status: false`, which is
+ * what v1's "delete account" did — it never hard-deleted) get no row: a
+ * deleted account must not come back as a live one. Their address is kept in
+ * `v1DeletedContacts` instead, for one announcement and nothing else, and
+ * that collection is meant to be dropped once it has gone out.
+ *
  * Idempotent and re-runnable: an address that already has a `user` — from an
  * earlier run, or from a real sign-up that got there first — is left exactly
  * as it is. Needs the live v1 Appwrite (`APPWRITE_*`) for the plaintext
@@ -37,6 +43,15 @@ import { insertPrecreatedUser, normalizeEmail } from '../src/modules/handles/leg
 import type { LegacyProfile } from '../src/modules/handles/legacyProfiles'
 
 const PAGE_SIZE = 100
+
+interface DeletedContact {
+  /** The Appwrite user id. */
+  _id: string
+  email: string
+  name: string
+  legacyUserId: string
+  recordedAt: Date
+}
 
 interface V1User {
   id: string
@@ -77,6 +92,7 @@ interface Summary {
   seen: number
   noEmail: number
   blockedInV1: number
+  deletedContactsKept: number
   /** Informational: opened all the same, restore has nothing to find. */
   notStaged: number
   /** Informational: opened all the same, see the module doc. */
@@ -129,6 +145,7 @@ async function main(): Promise<void> {
     seen: 0,
     noEmail: 0,
     blockedInV1: 0,
+    deletedContactsKept: 0,
     notStaged: 0,
     unverifiedInV1: 0,
     hashMismatch: 0,
@@ -150,6 +167,16 @@ async function main(): Promise<void> {
     }
     if (!user.status) {
       summary.blockedInV1++
+      if (apply) {
+        const kept = await db.collection<DeletedContact>(COLLECTIONS.v1DeletedContacts).updateOne(
+          { _id: user.id },
+          {
+            $setOnInsert: { email, name: user.name, legacyUserId: user.id, recordedAt: new Date() },
+          },
+          { upsert: true },
+        )
+        if (kept.upsertedCount > 0) summary.deletedContactsKept++
+      }
       continue
     }
 
@@ -185,7 +212,8 @@ async function main(): Promise<void> {
   console.log('\n=== Summary ===')
   console.log(`v1 Auth users seen:               ${summary.seen}`)
   console.log(`No email on the Auth user:        ${summary.noEmail}`)
-  console.log(`Blocked in v1:                    ${summary.blockedInV1}`)
+  console.log(`Deleted in v1 (no row opened):    ${summary.blockedInV1}`)
+  if (apply) console.log(`  …of which newly kept as contacts: ${summary.deletedContactsKept}`)
   console.log(`Nothing staged (opened anyway):   ${summary.notStaged}`)
   console.log(`Unverified in v1 (opened anyway): ${summary.unverifiedInV1}`)
   console.log(`Email hash does not match ETL:    ${summary.hashMismatch}`)

--- a/apps/api/scripts/precreate-v1-users.ts
+++ b/apps/api/scripts/precreate-v1-users.ts
@@ -1,0 +1,205 @@
+/**
+ * Opens a v2 `user` row for every v1 account, so its owner can come back
+ * through "forgot password" or Google/Apple instead of having to guess that
+ * signing up again is the way in.
+ *
+ * Why this exists, and why every row is created verified, is in
+ * `src/modules/handles/legacyPrecreate.ts`. What this file decides is *who*
+ * gets a row: **every v1 Auth user with an email that is not blocked**, so
+ * that nobody who once had an account is asked to make a new one. Whether v1
+ * had verified the address does not matter — the row has no password, so a
+ * reset link or a provider has to prove the address before it can be used —
+ * and it is only reported.
+ *
+ * Accounts with something **staged** (a `legacyProfiles` document or a
+ * `handleReservations` row keyed on the Appwrite id) get one extra check: the
+ * hash of the live email has to equal what the ETL stored. A mismatch means
+ * the row would be opened under an address the restore can never match, so
+ * it is counted and skipped rather than written. An Auth user with nothing
+ * staged had no profile in v1; the row is opened all the same, and they go
+ * through onboarding as a new user would, under the account they remember.
+ *
+ * Idempotent and re-runnable: an address that already has a `user` — from an
+ * earlier run, or from a real sign-up that got there first — is left exactly
+ * as it is. Needs the live v1 Appwrite (`APPWRITE_*`) for the plaintext
+ * emails, which the staging tables deliberately do not carry.
+ *
+ * Usage (dry run prints a summary and writes nothing):
+ *   pnpm --filter @langx/api exec tsx --env-file=../../.env --env-file=../../.env.prod scripts/precreate-v1-users.ts
+ *   pnpm --filter @langx/api exec tsx --env-file=../../.env --env-file=../../.env.prod scripts/precreate-v1-users.ts --apply
+ */
+import { Client, Query, Users } from 'node-appwrite'
+import { connectToDatabase } from '../src/db/client'
+import { COLLECTIONS } from '../src/db/collections'
+import { loadEnv } from '../src/env'
+import { hashLegacyEmail } from '../src/modules/handles/legacyEmailHash'
+import { insertPrecreatedUser, normalizeEmail } from '../src/modules/handles/legacyPrecreate'
+import type { LegacyProfile } from '../src/modules/handles/legacyProfiles'
+
+const PAGE_SIZE = 100
+
+interface V1User {
+  id: string
+  email: string
+  name: string
+  emailVerification: boolean
+  /** Appwrite's "blocked" switch, inverted: `false` means the account was disabled. */
+  status: boolean
+}
+
+async function* fetchAllUsers(users: Users): AsyncGenerator<V1User> {
+  let cursor: string | undefined
+  for (;;) {
+    const queries = [Query.limit(PAGE_SIZE)]
+    if (cursor) queries.push(Query.cursorAfter(cursor))
+    const page = await users.list({ queries })
+    for (const user of page.users) {
+      yield {
+        id: user.$id,
+        email: user.email,
+        name: user.name,
+        emailVerification: user.emailVerification,
+        status: user.status,
+      }
+    }
+    if (page.users.length < PAGE_SIZE) break
+    cursor = page.users.at(-1)?.$id
+  }
+}
+
+interface Reservation {
+  handle: string
+  legacyEmailHash: string
+  legacyUserId?: string
+}
+
+interface Summary {
+  seen: number
+  noEmail: number
+  blockedInV1: number
+  /** Informational: opened all the same, restore has nothing to find. */
+  notStaged: number
+  /** Informational: opened all the same, see the module doc. */
+  unverifiedInV1: number
+  hashMismatch: number
+  alreadyInV2: number
+  wouldCreate: number
+  created: number
+}
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes('--apply')
+  const env = loadEnv()
+
+  if (!env.APPWRITE_ENDPOINT || !env.APPWRITE_PROJECT_ID || !env.APPWRITE_API_KEY) {
+    throw new Error('APPWRITE_ENDPOINT, APPWRITE_PROJECT_ID and APPWRITE_API_KEY are required')
+  }
+  if (!env.LEGACY_EMAIL_HASH_SALT) {
+    throw new Error('LEGACY_EMAIL_HASH_SALT is required — must match what the ETL hashed with')
+  }
+  const salt = env.LEGACY_EMAIL_HASH_SALT
+
+  const client = new Client()
+    .setEndpoint(env.APPWRITE_ENDPOINT)
+    .setProject(env.APPWRITE_PROJECT_ID)
+    .setKey(env.APPWRITE_API_KEY)
+  const users = new Users(client)
+
+  const { db, close } = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
+  console.log(`Database: ${env.MONGODB_DB}`)
+
+  // Both staging tables, keyed on the Appwrite id. The profile carries the
+  // display name, which is the nicest thing to call the account until its
+  // owner is back to say otherwise.
+  const profilesById = new Map<string, LegacyProfile>()
+  for await (const profile of db.collection<LegacyProfile>(COLLECTIONS.legacyProfiles).find()) {
+    profilesById.set(profile._id, profile)
+  }
+  const reservationsById = new Map<string, Reservation>()
+  for await (const reservation of db
+    .collection<Reservation>(COLLECTIONS.handleReservations)
+    .find({ legacyUserId: { $exists: true } })) {
+    if (reservation.legacyUserId) reservationsById.set(reservation.legacyUserId, reservation)
+  }
+  console.log(
+    `Staged: ${profilesById.size} legacy profiles, ${reservationsById.size} handle reservations`,
+  )
+
+  const summary: Summary = {
+    seen: 0,
+    noEmail: 0,
+    blockedInV1: 0,
+    notStaged: 0,
+    unverifiedInV1: 0,
+    hashMismatch: 0,
+    alreadyInV2: 0,
+    wouldCreate: 0,
+    created: 0,
+  }
+
+  console.log(apply ? 'Applying to `user`…' : 'Dry run — no writes will happen…')
+  console.log('Fetching all v1 Auth users…')
+
+  for await (const user of fetchAllUsers(users)) {
+    summary.seen++
+
+    const email = normalizeEmail(user.email ?? '')
+    if (!email) {
+      summary.noEmail++
+      continue
+    }
+    if (!user.status) {
+      summary.blockedInV1++
+      continue
+    }
+
+    const profile = profilesById.get(user.id)
+    const reservation = reservationsById.get(user.id)
+    if (!profile && !reservation) summary.notStaged++
+    if (!user.emailVerification) summary.unverifiedInV1++
+
+    const staged = profile?.legacyEmailHash ?? reservation?.legacyEmailHash
+    if (staged && staged !== hashLegacyEmail(email, salt)) {
+      summary.hashMismatch++
+      console.warn(`  hash mismatch for v1 user ${user.id} — skipped`)
+      continue
+    }
+
+    const name = profile?.displayName || profile?.handle || reservation?.handle || user.name
+    const input = { email, name: name || email.split('@')[0] || 'LangX', legacyUserId: user.id }
+
+    if (!apply) {
+      const exists = await db
+        .collection(COLLECTIONS.user)
+        .findOne({ email }, { projection: { _id: 1 } })
+      if (exists) summary.alreadyInV2++
+      else summary.wouldCreate++
+      continue
+    }
+
+    const { outcome } = await insertPrecreatedUser(db, input)
+    if (outcome === 'exists') summary.alreadyInV2++
+    else summary.created++
+  }
+
+  console.log('\n=== Summary ===')
+  console.log(`v1 Auth users seen:               ${summary.seen}`)
+  console.log(`No email on the Auth user:        ${summary.noEmail}`)
+  console.log(`Blocked in v1:                    ${summary.blockedInV1}`)
+  console.log(`Nothing staged (opened anyway):   ${summary.notStaged}`)
+  console.log(`Unverified in v1 (opened anyway): ${summary.unverifiedInV1}`)
+  console.log(`Email hash does not match ETL:    ${summary.hashMismatch}`)
+  console.log(`Already have a v2 user:           ${summary.alreadyInV2}`)
+  if (apply) console.log(`Created:                          ${summary.created}`)
+  else {
+    console.log(`Would create:                     ${summary.wouldCreate}`)
+    console.log('\n(dry run — re-run with --apply to write)')
+  }
+
+  await close()
+}
+
+main().catch((error: unknown) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,4 +1,4 @@
-import { APP_SCHEMES, IOS_BUNDLE_ID, PASSWORD_MIN_LENGTH, WEB_HOST } from '@langx/shared'
+import { APP_SCHEMES, IOS_BUNDLE_ID, PASSWORD_MIN_LENGTH, WEB_HOST, webUrl } from '@langx/shared'
 import { betterAuth } from 'better-auth'
 import { mongodbAdapter } from 'better-auth/adapters/mongodb'
 import { expo } from '@better-auth/expo'
@@ -6,10 +6,11 @@ import { anonymous } from 'better-auth/plugins/anonymous'
 import { deviceAuthorization } from 'better-auth/plugins/device-authorization'
 import type { Db, MongoClient } from 'mongodb'
 import { generateAppleClientSecret } from './auth/appleClientSecret'
+import { settlePrecreatedUser } from './modules/handles/legacyPrecreate'
 import { restoreLegacyProfile } from './modules/handles/legacyRestore'
 import { recordTermsAcceptance } from './modules/account/terms'
 import type { EmailSender } from './email/sender'
-import { resetPasswordEmail, verificationEmail } from './email/templates'
+import { existingAccountEmail, resetPasswordEmail, verificationEmail } from './email/templates'
 import { localeFromHeader } from './i18n'
 import { publicApiUrl, type Env } from './env'
 import type { RevenueCatClient } from './modules/billing/revenueCatClient'
@@ -106,6 +107,23 @@ export async function createAuth({ env, db, client, emailSender, revenueCat }: C
         )
         await emailSender.send({ to: user.email, ...email })
       },
+      /**
+       * A sign-up for an address that already has an account is answered with
+       * the same "check your email" as a fresh one — Better Auth's
+       * anti-enumeration answer, in force here because email verification is
+       * required — and then nothing arrives. This is the hook meant for that
+       * gap: tell them, over the one channel that leaks nothing, that the
+       * account exists and how to get into it. Written for the v1 rows
+       * `legacyPrecreate.ts` opens, whose owners will mostly try signing up
+       * first; right for anyone else who forgot they had an account, too.
+       */
+      onExistingUserSignUp: async ({ user }, request) => {
+        const email = existingAccountEmail(
+          webUrl('/forgot-password'),
+          localeFromHeader(request?.headers.get('accept-language') ?? undefined),
+        )
+        await emailSender.send({ to: user.email, ...email })
+      },
     },
 
     emailVerification: {
@@ -155,6 +173,25 @@ export async function createAuth({ env, db, client, emailSender, revenueCat }: C
 
             if (!user.emailVerified) return
             await tryRestore(user.id, user.email)
+          },
+        },
+      },
+      session: {
+        create: {
+          /**
+           * The one route the hook above cannot see: a `user` row the
+           * pre-creation script wrote for a v1 account, which its owner then
+           * claims with a password reset or a Google/Apple link — neither of
+           * which creates a user. The first session is where that account
+           * gets the terms stamp and the restore every other route already
+           * had. See `legacyPrecreate.ts`; a no-op for everyone else.
+           */
+          after: async (session) => {
+            try {
+              await settlePrecreatedUser(db, session.userId, tryRestore)
+            } catch (error) {
+              console.error('[legacy-precreate] settle failed', { userId: session.userId, error })
+            }
           },
         },
       },

--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -130,6 +130,16 @@ export const COLLECTIONS = {
    * half-finished campaign safe.
    */
   emailCampaigns: 'emailCampaigns',
+  /**
+   * The v1 accounts whose owners deleted them, kept as plaintext addresses for
+   * **one** announcement and nothing else. Written by
+   * `scripts/precreate-v1-users.ts`, which opens no `user` row for them —
+   * a deleted account must not come back as a live one. This is the only
+   * place a v1 email is stored in the clear; drop the collection once that
+   * one mail has gone out. See `docs/decisions.md` → _Every v1 account has a
+   * v2 `user` row_.
+   */
+  v1DeletedContacts: 'v1DeletedContacts',
 } as const
 
 export type CollectionName = (typeof COLLECTIONS)[keyof typeof COLLECTIONS]

--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -144,6 +144,12 @@ export const INDEXES: Partial<IndexSpec> = {
     { key: { restoredBy: 1 }, name: 'restored_by', sparse: true },
   ],
 
+  [COLLECTIONS.v1DeletedContacts]: [
+    // One address once, however many times the script is re-run; the send
+    // that reads this must not be able to mail anybody twice.
+    { key: { email: 1 }, name: 'v1_deleted_email_uidx', unique: true },
+  ],
+
   [COLLECTIONS.legacyRooms]: [
     // "Which of this returning user's threads exist?" — the multikey lookup
     // the import runs once per restore.

--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -123,6 +123,30 @@ export function resetPasswordEmail(url: string, locale: Locale): Email {
 }
 
 /**
+ * What a sign-up for an address that already has an account gets instead of
+ * an error. Better Auth answers such a sign-up exactly as it answers a new one
+ * — so the form cannot be used to learn which addresses are registered — and
+ * this mail is the only channel left that can say "you already have an
+ * account" to the one person entitled to hear it. The link is the app's own
+ * forgot-password screen, not a token: nothing here was asked for by proof
+ * of ownership, so nothing here may grant any.
+ */
+export function existingAccountEmail(url: string, locale: Locale): Email {
+  const t = translator(locale)
+  return {
+    subject: t('email.existingSubject'),
+    html: wrap(
+      locale,
+      t('email.existingPreheader'),
+      `<p>${t('email.existingBody')}</p>
+       <p>${button(url, t('email.existingButton'))}</p>
+       <p style="font-size: 12px; color: #888;">${t('email.orPaste', { url })}</p>`,
+    ),
+    text: t('email.existingText', { url }),
+  }
+}
+
+/**
  * The streak nudge, for somebody with no phone signed in.
  *
  * Deliberately the same two sentences as the push — `push.streakTitle` and

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -162,10 +162,12 @@ const envSchema = z.object({
   // emails into handleReservations.legacyEmailHash, or nothing ever matches.
   LEGACY_EMAIL_HASH_SALT: emptyToUndefined(z.string().optional()),
 
-  // Faz 2 (one-off): scripts/migrate-appwrite.ts only. Never read by the
-  // running server — Appwrite BaaS itself is already shut down (30 Sep
-  // 2025); this is solely for pointing the ETL at the old project's REST API
-  // to pull profile/handle data out.
+  // Read by the one-off ETLs (scripts/migrate-*.ts, precreate-v1-users.ts)
+  // and, only if set on the server, by the legacy password bridge in
+  // routes/login.ts. Not set on Fly, so the bridge is off in production and
+  // the running server never talks to Appwrite. The v1 instance is still up
+  // and is the only place the plaintext v1 emails live — the staging tables
+  // carry a hash on purpose.
   APPWRITE_ENDPOINT: emptyToUndefined(z.url().optional()),
   APPWRITE_PROJECT_ID: emptyToUndefined(z.string().optional()),
   APPWRITE_API_KEY: emptyToUndefined(z.string().optional()),

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -36,6 +36,13 @@ export const ar: Localized<ServerMessages> = {
     resetButton: 'إعادة تعيين كلمة المرور',
     resetText: 'إعادة تعيين كلمة مرور LangX: {url}',
 
+    existingSubject: 'لديك حساب LangX بالفعل',
+    existingPreheader: 'لديك حساب LangX بالفعل',
+    existingBody:
+      'حاول أحدهم التسجيل بهذا البريد، لكن يوجد حساب لهذا العنوان بالفعل. للدخول، أعد تعيين كلمة المرور أو سجّل الدخول عبر Google أو Apple بهذا العنوان.',
+    existingButton: 'إعادة تعيين كلمة المرور',
+    existingText: 'لديك حساب LangX بالفعل. أعد تعيين كلمة المرور من هنا: {url}',
+
     whyThisMail: 'تصلك هذه الرسالة بسبب إعدادات الإشعارات في LangX.',
     unsubscribeLink: 'أوقف هذه الرسائل',
     unsubscribeText: 'أوقف هذه الرسائل: {url}',

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -35,6 +35,13 @@ export const de: Localized<ServerMessages> = {
     resetButton: 'Passwort zurücksetzen',
     resetText: 'Setze dein LangX-Passwort zurück: {url}',
 
+    existingSubject: 'Du hast bereits ein LangX-Konto',
+    existingPreheader: 'Du hast bereits ein LangX-Konto',
+    existingBody:
+      'Jemand hat versucht, sich mit dieser E-Mail zu registrieren, aber dafür gibt es bereits ein Konto. Setze dein Passwort zurück oder melde dich mit Google oder Apple über diese Adresse an.',
+    existingButton: 'Passwort zurücksetzen',
+    existingText: 'Du hast bereits ein LangX-Konto. Setze dein Passwort hier zurück: {url}',
+
     whyThisMail: 'Du bekommst das wegen deiner LangX-Benachrichtigungseinstellungen.',
     unsubscribeLink: 'Diese E-Mails abstellen',
     unsubscribeText: 'Diese E-Mails abstellen: {url}',

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -38,6 +38,13 @@ export const en = {
     resetButton: 'Reset password',
     resetText: 'Reset your LangX password: {url}',
 
+    existingSubject: 'You already have a LangX account',
+    existingPreheader: 'You already have a LangX account',
+    existingBody:
+      'Someone tried to sign up with this email, but an account already exists for it. To get in, reset your password, or sign in with Google or Apple using this address.',
+    existingButton: 'Reset password',
+    existingText: 'You already have a LangX account. Reset your password here: {url}',
+
     /*
      * The footer every notification email carries, and the page its link
      * leads to. Not the same as `ignore` above: this mail was asked for, so it

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -34,6 +34,13 @@ export const es: Localized<ServerMessages> = {
     resetButton: 'Restablecer contraseña',
     resetText: 'Restablece tu contraseña de LangX: {url}',
 
+    existingSubject: 'Ya tienes una cuenta de LangX',
+    existingPreheader: 'Ya tienes una cuenta de LangX',
+    existingBody:
+      'Alguien ha intentado registrarse con este correo, pero ya existe una cuenta para esta dirección. Para entrar, restablece tu contraseña o inicia sesión con Google o Apple usando este correo.',
+    existingButton: 'Restablecer contraseña',
+    existingText: 'Ya tienes una cuenta de LangX. Restablece tu contraseña aquí: {url}',
+
     whyThisMail: 'Recibes esto por tus ajustes de notificaciones de LangX.',
     unsubscribeLink: 'Desactivar estos correos',
     unsubscribeText: 'Desactivar estos correos: {url}',

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -36,6 +36,13 @@ export const fr: Localized<ServerMessages> = {
     resetButton: 'Réinitialiser le mot de passe',
     resetText: 'Réinitialisez votre mot de passe LangX : {url}',
 
+    existingSubject: 'Vous avez déjà un compte LangX',
+    existingPreheader: 'Vous avez déjà un compte LangX',
+    existingBody:
+      'Quelqu’un a tenté de s’inscrire avec cet e-mail, mais un compte existe déjà pour cette adresse. Pour vous connecter, réinitialisez votre mot de passe ou connectez-vous avec Google ou Apple avec cette adresse.',
+    existingButton: 'Réinitialiser le mot de passe',
+    existingText: 'Vous avez déjà un compte LangX. Réinitialisez votre mot de passe ici : {url}',
+
     whyThisMail: 'Vous recevez ceci en raison de vos réglages de notifications LangX.',
     unsubscribeLink: 'Désactiver ces e-mails',
     unsubscribeText: 'Désactiver ces e-mails : {url}',

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -34,6 +34,13 @@ export const ptBR: Localized<ServerMessages> = {
     resetButton: 'Redefinir senha',
     resetText: 'Redefina sua senha do LangX: {url}',
 
+    existingSubject: 'Você já tem uma conta no LangX',
+    existingPreheader: 'Você já tem uma conta no LangX',
+    existingBody:
+      'Alguém tentou se cadastrar com este e-mail, mas já existe uma conta para ele. Para entrar, redefina sua senha ou entre com Google ou Apple usando este endereço.',
+    existingButton: 'Redefinir senha',
+    existingText: 'Você já tem uma conta no LangX. Redefina sua senha aqui: {url}',
+
     whyThisMail: 'Você recebe isto por causa das suas configurações de notificações do LangX.',
     unsubscribeLink: 'Desativar estes e-mails',
     unsubscribeText: 'Desativar estes e-mails: {url}',

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -44,6 +44,13 @@ export const ru: Localized<ServerMessages> = {
     resetButton: 'Сбросить пароль',
     resetText: 'Сброс пароля LangX: {url}',
 
+    existingSubject: 'У вас уже есть аккаунт LangX',
+    existingPreheader: 'У вас уже есть аккаунт LangX',
+    existingBody:
+      'Кто-то попытался зарегистрироваться с этой почтой, но аккаунт для неё уже существует. Чтобы войти, сбросьте пароль или войдите через Google или Apple с этим адресом.',
+    existingButton: 'Сбросить пароль',
+    existingText: 'У вас уже есть аккаунт LangX. Сбросьте пароль здесь: {url}',
+
     whyThisMail: 'Вы получаете это из-за настроек уведомлений в LangX.',
     unsubscribeLink: 'Отключить эти письма',
     unsubscribeText: 'Отключить эти письма: {url}',

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -28,6 +28,13 @@ export const tr: Localized<ServerMessages> = {
     resetButton: 'Parolayı sıfırla',
     resetText: 'LangX parolanı sıfırla: {url}',
 
+    existingSubject: 'Zaten bir LangX hesabın var',
+    existingPreheader: 'Zaten bir LangX hesabın var',
+    existingBody:
+      'Biri bu e-posta ile kayıt olmayı denedi ama bu adrese ait bir hesap zaten var. Giriş yapmak için parolanı sıfırla ya da bu adresle Google veya Apple üzerinden giriş yap.',
+    existingButton: 'Parolayı sıfırla',
+    existingText: 'Zaten bir LangX hesabın var. Parolanı buradan sıfırla: {url}',
+
     whyThisMail: 'Bunu LangX bildirim ayarların yüzünden alıyorsun.',
     unsubscribeLink: 'Bu e-postaları kapat',
     unsubscribeText: 'Bu e-postaları kapat: {url}',

--- a/apps/api/src/modules/handles/legacyPrecreate.test.ts
+++ b/apps/api/src/modules/handles/legacyPrecreate.test.ts
@@ -1,0 +1,229 @@
+import { TOKEN_RULES } from '@langx/shared'
+import type { FastifyInstance } from 'fastify'
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { buildApp } from '../../app'
+import { createAuth } from '../../auth'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import { ensureIndexes } from '../../db/indexes'
+import { loadEnv } from '../../env'
+import { authId } from '../../lib/authId'
+import { createRevenueCatClientFromEnv } from '../billing/createRevenueCatClient'
+import { createStorageProvider } from '../../storage/createStorageProvider'
+import { CapturingEmailSender, setCookieValue } from '../../testSupport/authFlow'
+import { createTranslationProvider } from '../../translation/createTranslationProvider'
+import { hashLegacyEmail } from './legacyEmailHash'
+import { insertPrecreatedUser } from './legacyPrecreate'
+import type { LegacyProfile } from './legacyProfiles'
+
+const SALT = 'test-legacy-salt'
+const NEW_PASSWORD = 'a brand new horse staple'
+
+describe('pre-created v1 users: reset password → sign in → restored', () => {
+  let replSet: MongoMemoryReplSet
+  let handle: DbHandle
+  let app: FastifyInstance
+  let emailSender: CapturingEmailSender
+
+  function stageLegacy(email: string, overrides: Partial<LegacyProfile> = {}) {
+    const record: LegacyProfile = {
+      _id: `appwrite-${email}`,
+      handle: 'oldtimer',
+      legacyEmailHash: hashLegacyEmail(email, SALT),
+      displayName: 'Old Timer',
+      birthDate: '1990-06-15',
+      gender: 'other',
+      nativeLanguages: [{ code: 'tr' }],
+      learning: [{ code: 'en', level: 'intermediate', priority: 1 }],
+      photos: [],
+      migratedAt: new Date(),
+      legacyTokenBalance: 5000,
+      ...overrides,
+    }
+    return handle.db.collection<LegacyProfile>(COLLECTIONS.legacyProfiles).insertOne(record)
+  }
+
+  const signIn = (email: string, password: string) =>
+    app.inject({ method: 'POST', url: '/api/auth/sign-in/email', payload: { email, password } })
+
+  async function resetPassword(email: string, newPassword: string): Promise<void> {
+    const forgot = await app.inject({
+      method: 'POST',
+      url: '/api/auth/request-password-reset',
+      payload: { email, redirectTo: 'http://localhost:4000/reset' },
+    })
+    expect(forgot.statusCode, forgot.body).toBe(200)
+    const tokenMatch = /\/reset-password\/([^/?]+)/.exec(emailSender.latestUrl())
+    if (!tokenMatch?.[1]) throw new Error('no token in reset URL')
+    const reset = await app.inject({
+      method: 'POST',
+      url: '/api/auth/reset-password',
+      payload: { newPassword, token: decodeURIComponent(tokenMatch[1]) },
+    })
+    expect(reset.statusCode, reset.body).toBe(200)
+  }
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+    handle = await connectToDatabase(replSet.getUri(), 'langx_precreate_test')
+    const env = loadEnv({
+      NODE_ENV: 'test',
+      MONGODB_URI: replSet.getUri(),
+      MONGODB_DB: 'langx_precreate_test',
+      LOG_LEVEL: 'silent',
+      BETTER_AUTH_SECRET: 'a'.repeat(32),
+      BETTER_AUTH_URL: 'http://localhost:4000',
+      LEGACY_EMAIL_HASH_SALT: SALT,
+    })
+    await ensureIndexes(handle.db)
+    emailSender = new CapturingEmailSender()
+    const auth = await createAuth({ env, db: handle.db, client: handle.client, emailSender })
+    app = await buildApp({
+      env,
+      client: handle.client,
+      db: handle.db,
+      auth,
+      storage: createStorageProvider(env),
+      translation: createTranslationProvider(env),
+      revenueCat: createRevenueCatClientFromEnv(env),
+    })
+    await app.ready()
+
+    // See auth.test.ts: a fresh single-node replica set's first transaction
+    // through the adapter is flaky, so the first real request is a warm-up.
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      const warmUp = await app.inject({
+        method: 'POST',
+        url: '/api/auth/sign-up/email',
+        payload: { email: `warmup-${attempt}@example.com`, password: NEW_PASSWORD, name: 'Warm' },
+      })
+      if (warmUp.statusCode === 200) break
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+    emailSender.messages.length = 0
+  }, 120_000)
+
+  afterAll(async () => {
+    await app?.close()
+    await handle?.close()
+    await replSet?.stop()
+  })
+
+  it('opens a verified, passwordless row once; a second run leaves it alone', async () => {
+    const email = 'Twice@Example.com'
+    const first = await insertPrecreatedUser(handle.db, {
+      email,
+      name: 'Twice',
+      legacyUserId: 'appwrite-twice',
+    })
+    const second = await insertPrecreatedUser(handle.db, {
+      email,
+      name: 'Twice again',
+      legacyUserId: 'appwrite-twice',
+    })
+    expect(first.outcome).toBe('inserted')
+    expect(second).toEqual({ outcome: 'exists', userId: first.userId })
+
+    const stored = await handle.db
+      .collection(COLLECTIONS.user)
+      .findOne({ _id: authId(first.userId) })
+    expect(stored).toMatchObject({ email: 'twice@example.com', emailVerified: true, name: 'Twice' })
+    expect(stored?.terms).toBeUndefined()
+    const accounts = await handle.db
+      .collection(COLLECTIONS.account)
+      .countDocuments({ userId: { $in: [authId(first.userId), first.userId] } })
+    expect(accounts).toBe(0)
+  })
+
+  it('cannot be signed into before the reset; signing up over it sends the "already have an account" mail', async () => {
+    const email = 'locked@example.com'
+    await insertPrecreatedUser(handle.db, {
+      email,
+      name: 'Locked',
+      legacyUserId: 'appwrite-locked',
+    })
+
+    const guess = await signIn(email, 'whatever they used in v1')
+    expect(guess.statusCode).toBe(401)
+
+    const again = await app.inject({
+      method: 'POST',
+      url: '/api/auth/sign-up/email',
+      payload: { email, password: NEW_PASSWORD, name: 'Impostor' },
+    })
+    // Better Auth answers exactly as it would a fresh sign-up so the form
+    // cannot enumerate addresses — but it must create nothing, and the mail
+    // that goes out must be the one that says what to do instead.
+    expect(again.statusCode).toBe(200)
+    expect(emailSender.messages.at(-1)).toMatchObject({
+      to: email,
+      subject: expect.stringMatching(/already/i) as string,
+    })
+    expect(emailSender.latestUrl()).toContain('/forgot-password')
+    const impostor = await signIn(email, NEW_PASSWORD)
+    expect(impostor.statusCode).toBe(401)
+    const user = await handle.db.collection(COLLECTIONS.user).findOne({ email })
+    expect(user).toMatchObject({ name: 'Locked', emailVerified: true })
+    const accounts = await handle.db
+      .collection(COLLECTIONS.account)
+      .countDocuments({ userId: { $in: [authId(String(user?._id)), String(user?._id)] } })
+    expect(accounts).toBe(0)
+  })
+
+  it('reset → sign-in restores the v1 profile and stamps the terms, exactly once', async () => {
+    const email = 'returning@example.com'
+    await stageLegacy(email)
+    const { userId } = await insertPrecreatedUser(handle.db, {
+      email,
+      name: 'Old Timer',
+      legacyUserId: `appwrite-${email}`,
+    })
+
+    // The row is the whole point: with it, the reset finds someone to mail.
+    await resetPassword(email, NEW_PASSWORD)
+
+    const session = await signIn(email, NEW_PASSWORD)
+    expect(session.statusCode, session.body).toBe(200)
+    const cookie = setCookieValue(session)
+
+    const me = await app.inject({ method: 'GET', url: '/profiles/me', headers: { cookie } })
+    expect(me.statusCode, me.body).toBe(200)
+    const profile = me.json<{ handle: string; displayName: string; restoredFromV1?: unknown }>()
+    expect(profile).toMatchObject({ handle: 'oldtimer', displayName: 'Old Timer' })
+    expect(profile.restoredFromV1).toMatchObject({ tokensCredited: expect.any(Number) as number })
+
+    const user = await handle.db.collection(COLLECTIONS.user).findOne({ _id: authId(userId) })
+    expect(user?.terms).toMatchObject({ version: expect.any(String) as string })
+    const firstAcceptedAt = (user?.terms as { acceptedAt: Date }).acceptedAt
+
+    // A second session must not pay the welcome-back bonus twice or move the
+    // consent date — sessions are created on every sign-in.
+    const secondSession = await signIn(email, NEW_PASSWORD)
+    expect(secondSession.statusCode).toBe(200)
+    const welcomeBacks = await handle.db
+      .collection(COLLECTIONS.tokenLedger)
+      .countDocuments({ userId, kind: 'welcomeBack' })
+    expect(welcomeBacks).toBe(1)
+    expect(TOKEN_RULES.welcomeBackBonus).toBeGreaterThan(0)
+    const userAgain = await handle.db.collection(COLLECTIONS.user).findOne({ _id: authId(userId) })
+    expect((userAgain?.terms as { acceptedAt: Date }).acceptedAt).toEqual(firstAcceptedAt)
+  })
+
+  it('an ordinary sign-up is untouched by the session hook', async () => {
+    const email = 'fresh@example.com'
+    await app.inject({
+      method: 'POST',
+      url: '/api/auth/sign-up/email',
+      payload: { email, password: NEW_PASSWORD, name: 'Fresh' },
+    })
+    await resetPassword(email, NEW_PASSWORD)
+    // Still unverified — the reset does not verify, and the hook must not
+    // pretend otherwise for a row the script never wrote.
+    const blocked = await signIn(email, NEW_PASSWORD)
+    expect(blocked.statusCode).toBe(403)
+    const user = await handle.db.collection(COLLECTIONS.user).findOne({ email })
+    expect(user?.precreatedFromV1).toBeUndefined()
+    expect(user?.emailVerified).toBe(false)
+  })
+})

--- a/apps/api/src/modules/handles/legacyPrecreate.ts
+++ b/apps/api/src/modules/handles/legacyPrecreate.ts
@@ -1,0 +1,151 @@
+import { ObjectId, type Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { authId } from '../../lib/authId'
+import { recordTermsAcceptance } from '../account/terms'
+
+/**
+ * A v2 `user` opened on behalf of a v1 account, before its owner has come back.
+ *
+ * The staged v1 data (`legacyProfiles`, `handleReservations`) is keyed on a
+ * *hash* of the email and there was, until this, no `user` row at all — so a
+ * returning person who reached for "forgot password" got a "check your email"
+ * screen and no email, because Better Auth had nobody to send it to. The only
+ * working route back was to sign up again, which nobody guesses.
+ *
+ * Opening the row up front turns the two routes people actually try into the
+ * two that work: a password reset finds the account and mails the link, and
+ * Google or Apple links onto it. Signing up fresh with that address is now
+ * refused as "already exists", which is what we want — the old profile is on
+ * this row, and a second account would strand it.
+ *
+ * **`emailVerified` is `true` from the start, for every row.** Better Auth
+ * refuses to link a social sign-in onto a local user whose address is
+ * unverified (`accountLinking.requireLocalEmailVerified`, on by default and
+ * rightly so — it is the takeover defence against a *password* account
+ * squatting on someone else's address), so an unverified row would send every
+ * returning Google user to an error. The defence is not needed here because
+ * the row has no password: there is no credential to squat with, and nothing
+ * can turn it into a session without proving the address once more — a reset
+ * link delivered to it, or a provider that has already done the proving.
+ * That holds whether or not v1 ever saw the address verified, which is why the
+ * script does not filter on it.
+ */
+export interface PrecreatedFromV1 {
+  at: Date
+  /** The Appwrite user id, which is also `legacyProfiles._id`. */
+  legacyUserId: string
+}
+
+export interface PrecreatedUserDoc {
+  _id: ObjectId
+  email: string
+  name: string
+  emailVerified: true
+  createdAt: Date
+  updatedAt: Date
+  precreatedFromV1: PrecreatedFromV1
+}
+
+export interface PrecreateInput {
+  email: string
+  name: string
+  legacyUserId: string
+  at?: Date
+}
+
+/** Better Auth lowercases on lookup; storing anything else would never match. */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+export function buildPrecreatedUser(input: PrecreateInput): PrecreatedUserDoc {
+  const at = input.at ?? new Date()
+  return {
+    _id: new ObjectId(),
+    email: normalizeEmail(input.email),
+    name: input.name,
+    emailVerified: true,
+    createdAt: at,
+    updatedAt: at,
+    precreatedFromV1: { at, legacyUserId: input.legacyUserId },
+  }
+}
+
+export type PrecreateOutcome = 'inserted' | 'exists'
+
+/**
+ * Writes the row, or leaves alone whatever is already there — a real sign-up
+ * that beat the script to the address, or an earlier run. The unique index on
+ * `user.email` is the real guard; the read before it just keeps the summary
+ * honest without relying on a duplicate-key error for control flow.
+ *
+ * Writes to a Better Auth collection directly, which the codebase otherwise
+ * avoids. There is no server-side "create a user with no credentials" in
+ * Better Auth, and going through `signUpEmail` would mint a password nobody
+ * knows and send a verification mail nobody asked for.
+ */
+export async function insertPrecreatedUser(
+  db: Db,
+  input: PrecreateInput,
+): Promise<{ outcome: PrecreateOutcome; userId: string }> {
+  const users = db.collection<PrecreatedUserDoc>(COLLECTIONS.user)
+  const email = normalizeEmail(input.email)
+  const existing = await users.findOne({ email }, { projection: { _id: 1 } })
+  if (existing) return { outcome: 'exists', userId: String(existing._id) }
+
+  const doc = buildPrecreatedUser({ ...input, email })
+  try {
+    await users.insertOne(doc)
+  } catch (error) {
+    if (isDuplicateKey(error)) {
+      const raced = await users.findOne({ email }, { projection: { _id: 1 } })
+      if (raced) return { outcome: 'exists', userId: String(raced._id) }
+    }
+    throw error
+  }
+  return { outcome: 'inserted', userId: String(doc._id) }
+}
+
+/**
+ * What a pre-created account has never had done to it, done on its first
+ * session.
+ *
+ * Every other route into an account passes through `user.create.after`, which
+ * stamps the terms and restores a v1 profile. A pre-created row was written by
+ * a script, so that hook never fired for it, and the reset or the social link
+ * that brings its owner back creates no user either. The session is the one
+ * event those routes share.
+ *
+ * Idempotent, because sessions are created on every sign-in: the terms stamp
+ * is skipped once present, and the restore is a no-op once the staged profile
+ * is marked taken. Returns whether this was a pre-created row at all, so the
+ * common case — every ordinary sign-in — costs one indexed read and nothing
+ * else.
+ */
+export async function settlePrecreatedUser(
+  db: Db,
+  userId: string,
+  restore: (userId: string, email: string) => Promise<void>,
+): Promise<boolean> {
+  const user = await db
+    .collection<{ _id: ObjectId; email: string; precreatedFromV1?: unknown; terms?: unknown }>(
+      COLLECTIONS.user,
+    )
+    .findOne({ _id: authId(userId) }, { projection: { email: 1, precreatedFromV1: 1, terms: 1 } })
+  if (!user?.precreatedFromV1) return false
+
+  /*
+   * The consent record, stamped on the first sign-in rather than by the script:
+   * the script ran without them in the room, and a consent dated to a moment
+   * nobody was present for is not one. This is the same standard the social
+   * providers already meet — continuing past the sign-in screen is the act,
+   * and the server stamps it at the moment the account becomes usable.
+   */
+  if (!user.terms) await recordTermsAcceptance(db, userId)
+  await restore(userId, user.email)
+  return true
+}
+
+function isDuplicateKey(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 11000
+}

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -236,10 +236,12 @@ export const ar: Localized<EnMessages> = {
     googleSignInFailed: 'تعذّر تسجيل الدخول بحساب Google',
     appleSignInFailed: 'تعذّر تسجيل الدخول بحساب Apple',
     resetFailed: 'تعذّرت إعادة تعيين كلمة المرور',
-    invalidCredentials: 'هذا البريد وكلمة المرور لا يطابقان أي حساب.',
+    invalidCredentials:
+      'هذا البريد وكلمة المرور لا يطابقان أي حساب. هل كان لديك حساب في التطبيق السابق؟ أعد تعيين كلمة المرور أو تابع عبر Google أو Apple.',
     attachmentUnsupported: 'صيغة هذه الصورة غير مدعومة. استخدم صورة بصيغة JPEG أو PNG أو WebP.',
     attachmentTooLarge: 'هذا الملف أكبر من أن يُرسل.',
-    userExists: 'يوجد حساب بهذا البريد بالفعل.',
+    userExists:
+      'يوجد حساب بهذا البريد بالفعل. سجّل الدخول أو أعد تعيين كلمة المرور أو تابع عبر Google أو Apple.',
     emailNotVerified: 'أكّد بريدك أولًا — تحقق من صندوق الوارد.',
     passwordTooShort: 'كلمة المرور قصيرة جدًا.',
     invalidEmail: 'هذا لا يبدو عنوان بريد.',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -186,11 +186,13 @@ export const de: Localized<EnMessages> = {
     googleSignInFailed: 'Google-Anmeldung fehlgeschlagen',
     appleSignInFailed: 'Apple-Anmeldung fehlgeschlagen',
     resetFailed: 'Passwort konnte nicht zurückgesetzt werden',
-    invalidCredentials: 'Diese E-Mail und dieses Passwort passen zu keinem Konto.',
+    invalidCredentials:
+      'Diese E-Mail und dieses Passwort passen zu keinem Konto. Hattest du ein Konto in der alten App? Setze dein Passwort zurück oder fahre mit Google oder Apple fort.',
     attachmentUnsupported:
       'Dieses Fotoformat wird nicht unterstützt. Verwende ein JPEG-, PNG- oder WebP-Bild.',
     attachmentTooLarge: 'Diese Datei ist zu groß zum Senden.',
-    userExists: 'Mit dieser E-Mail gibt es bereits ein Konto.',
+    userExists:
+      'Mit dieser E-Mail gibt es bereits ein Konto. Melde dich an, setze dein Passwort zurück oder fahre mit Google oder Apple fort.',
     emailNotVerified: 'Bestätige zuerst deine E-Mail-Adresse — schau in dein Postfach.',
     passwordTooShort: 'Dieses Passwort ist zu kurz.',
     invalidEmail: 'Das sieht nicht nach einer E-Mail-Adresse aus.',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -217,10 +217,12 @@ export const en = {
     googleSignInFailed: 'Google sign-in failed',
     appleSignInFailed: 'Apple sign-in failed',
     resetFailed: 'Could not reset password',
-    invalidCredentials: 'That email and password do not match an account.',
+    invalidCredentials:
+      'That email and password do not match an account. If you had an account in the previous app, reset your password or continue with Google or Apple.',
     attachmentUnsupported: 'That photo format isn’t supported. Use a JPEG, PNG or WebP image.',
     attachmentTooLarge: 'That file is too large to send.',
-    userExists: 'An account already exists for that email.',
+    userExists:
+      'An account already exists for that email. Sign in, reset your password, or continue with Google or Apple.',
     emailNotVerified: 'Verify your email address first — check your inbox.',
     passwordTooShort: 'That password is too short.',
     invalidEmail: 'That does not look like an email address.',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -185,10 +185,12 @@ export const es: Localized<EnMessages> = {
     googleSignInFailed: 'No se pudo iniciar sesión con Google',
     appleSignInFailed: 'No se pudo iniciar sesión con Apple',
     resetFailed: 'No se pudo restablecer la contraseña',
-    invalidCredentials: 'Ese correo y esa contraseña no coinciden con ninguna cuenta.',
+    invalidCredentials:
+      'Ese correo y esa contraseña no coinciden con ninguna cuenta. ¿Tenías una cuenta en la app anterior? Restablece tu contraseña o continúa con Google o Apple.',
     attachmentUnsupported: 'Ese formato de foto no es compatible. Usa una imagen JPEG, PNG o WebP.',
     attachmentTooLarge: 'Ese archivo es demasiado grande para enviarlo.',
-    userExists: 'Ya existe una cuenta con ese correo.',
+    userExists:
+      'Ya existe una cuenta con ese correo. Inicia sesión, restablece tu contraseña o continúa con Google o Apple.',
     emailNotVerified: 'Verifica primero tu correo: mira tu bandeja de entrada.',
     passwordTooShort: 'Esa contraseña es demasiado corta.',
     invalidEmail: 'Eso no parece una dirección de correo.',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -187,11 +187,13 @@ export const fr: Localized<EnMessages> = {
     googleSignInFailed: 'Connexion Google impossible',
     appleSignInFailed: 'Connexion Apple impossible',
     resetFailed: 'Réinitialisation impossible',
-    invalidCredentials: 'Cet e-mail et ce mot de passe ne correspondent à aucun compte.',
+    invalidCredentials:
+      'Cet e-mail et ce mot de passe ne correspondent à aucun compte. Vous aviez un compte dans l’ancienne appli ? Réinitialisez votre mot de passe ou continuez avec Google ou Apple.',
     attachmentUnsupported:
       'Ce format de photo n’est pas pris en charge. Utilise une image JPEG, PNG ou WebP.',
     attachmentTooLarge: 'Ce fichier est trop volumineux pour être envoyé.',
-    userExists: 'Un compte existe déjà avec cet e-mail.',
+    userExists:
+      'Un compte existe déjà avec cet e-mail. Connectez-vous, réinitialisez votre mot de passe ou continuez avec Google ou Apple.',
     emailNotVerified: 'Vérifie d’abord ton adresse e-mail — regarde ta boîte de réception.',
     passwordTooShort: 'Ce mot de passe est trop court.',
     invalidEmail: 'Cela ne ressemble pas à une adresse e-mail.',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -181,11 +181,13 @@ export const ptBR: Localized<EnMessages> = {
     googleSignInFailed: 'Não foi possível entrar com o Google',
     appleSignInFailed: 'Não foi possível entrar com a Apple',
     resetFailed: 'Não foi possível redefinir a senha',
-    invalidCredentials: 'Esse e-mail e essa senha não correspondem a nenhuma conta.',
+    invalidCredentials:
+      'Esse e-mail e essa senha não correspondem a nenhuma conta. Tinha uma conta no app anterior? Redefina sua senha ou continue com Google ou Apple.',
     attachmentUnsupported:
       'Esse formato de foto não é compatível. Use uma imagem JPEG, PNG ou WebP.',
     attachmentTooLarge: 'Esse arquivo é grande demais para enviar.',
-    userExists: 'Já existe uma conta com esse e-mail.',
+    userExists:
+      'Já existe uma conta com esse e-mail. Entre, redefina sua senha ou continue com Google ou Apple.',
     emailNotVerified: 'Confirme seu e-mail primeiro — olhe sua caixa de entrada.',
     passwordTooShort: 'Essa senha é curta demais.',
     invalidEmail: 'Isso não parece um endereço de e-mail.',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -223,11 +223,13 @@ export const ru: Localized<EnMessages> = {
     googleSignInFailed: 'Не удалось войти через Google',
     appleSignInFailed: 'Не удалось войти через Apple',
     resetFailed: 'Не удалось сбросить пароль',
-    invalidCredentials: 'Эта почта и пароль не подходят ни к одному аккаунту.',
+    invalidCredentials:
+      'Эта почта и пароль не подходят ни к одному аккаунту. Был аккаунт в старом приложении? Сбросьте пароль или войдите через Google или Apple.',
     attachmentUnsupported:
       'Этот формат фото не поддерживается. Используй изображение JPEG, PNG или WebP.',
     attachmentTooLarge: 'Этот файл слишком большой для отправки.',
-    userExists: 'Аккаунт с такой почтой уже есть.',
+    userExists:
+      'Аккаунт с такой почтой уже есть. Войдите, сбросьте пароль или продолжите через Google или Apple.',
     emailNotVerified: 'Сначала подтверди почту — посмотри входящие.',
     passwordTooShort: 'Этот пароль слишком короткий.',
     invalidEmail: 'Это не похоже на адрес почты.',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -196,11 +196,13 @@ export const tr: Localized<EnMessages> = {
     googleSignInFailed: 'Google ile giriş yapılamadı',
     appleSignInFailed: 'Apple ile giriş yapılamadı',
     resetFailed: 'Parola sıfırlanamadı',
-    invalidCredentials: 'Bu e-posta ve parola bir hesapla eşleşmiyor.',
+    invalidCredentials:
+      'Bu e-posta ve parola bir hesapla eşleşmiyor. Önceki uygulamada hesabın vardıysa parolanı sıfırla ya da Google veya Apple ile devam et.',
     attachmentUnsupported:
       'Bu fotoğraf biçimi desteklenmiyor. JPEG, PNG veya WebP bir görsel kullan.',
     attachmentTooLarge: 'Bu dosya gönderilemeyecek kadar büyük.',
-    userExists: 'Bu e-posta ile bir hesap zaten var.',
+    userExists:
+      'Bu e-posta ile bir hesap zaten var. Giriş yap, parolanı sıfırla ya da Google veya Apple ile devam et.',
     emailNotVerified: 'Önce e-posta adresini doğrula — gelen kutuna bak.',
     passwordTooShort: 'Bu parola çok kısa.',
     invalidEmail: 'Bu bir e-posta adresine benzemiyor.',

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2400,3 +2400,54 @@ so a JS change that assumes a native module which is not in the store build
 would land on phones that cannot run it. Publishing to production is a
 deliberate `eas update --channel production` after the matching build has
 shipped, not a side effect of merging.
+
+## Every v1 account has a v2 `user` row before its owner comes back
+
+Behic's call on 3 September 2026, after the question "can an old user get in
+through forgot-password?" turned out to have the answer "no, and nothing tells
+them so".
+
+The staged v1 data — `legacyProfiles`, `handleReservations` — was keyed on a
+hash of the email, and no `user` row existed until the person signed up again.
+That was a sound way to avoid carrying plaintext addresses, and it made the
+one route people actually try a dead end: Better Auth's reset endpoint looks
+the address up in `user`, finds nobody, and by design answers "check your
+email" either way. The password bridge in `routes/login.ts` would have caught
+the same person had it been on, but it needs Appwrite credentials the server
+does not have, and it was only ever a stopgap. The real way in was to sign up
+again with the old address and click the verification link, which nobody
+guesses from a sign-in screen.
+
+So `scripts/precreate-v1-users.ts` opens a `user` row for **every** v1 Auth
+account, and the row is **verified** from the start with **no credential**
+behind it. Three consequences, all intended:
+
+- "Forgot password" now works: the reset finds the row, mails the link, and
+  the new password is the first credential the account ever has.
+- Google and Apple link onto the row. This is why it has to be verified —
+  Better Auth refuses to link a social sign-in onto an unverified local user,
+  and rightly so, since that rule is the defence against a password account
+  squatting on someone else's address. There is no password here to squat
+  with, so the defence is not needed and the address is proven by the very
+  act that first uses the row.
+- Signing up fresh with the address is refused as "already exists", which is
+  what we want — the old profile belongs to this row and a second account
+  would strand it. The sign-up and sign-in errors now say what to do instead.
+
+Whether v1 had verified the address is reported, not filtered on: an
+unverified v1 address still cannot do anything with the row until a reset
+link arrives at it.
+
+The row is written by a script, so the `user.create.after` hook that stamps
+the terms and restores a profile never fires for it, and neither a reset nor a
+social link creates a user. The first _session_ is the event those routes
+share, so `session.create.after` does both for rows carrying
+`precreatedFromV1` — idempotently, since sessions are made on every sign-in —
+and is a single indexed read for everyone else. The consent is stamped then,
+not by the script: a consent dated to a moment nobody was present for is not
+one, and continuing past the sign-in screen is the same act the social
+providers already count.
+
+Appwrite is still running and is the only place the plaintext v1 emails live;
+the script needs it. If it goes away before the script has run, the rows
+cannot be opened and this whole path is lost — see the runbook.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2448,6 +2448,15 @@ not by the script: a consent dated to a moment nobody was present for is not
 one, and continuing past the sign-in screen is the same act the social
 providers already count.
 
+Accounts their owners deleted in v1 — Appwrite `status: false`, which is what
+v1's "delete account" set, since it never hard-deleted — get no row: a deleted
+account must not come back as a live one. Behic wants those 837 addresses
+kept for **one** announcement, so the script writes them to
+`v1DeletedContacts`, the only place a v1 email is stored in the clear. That
+mail is to people who ended their relationship with the product, so it is
+one mail, with an unsubscribe, and the collection is dropped afterwards —
+keeping it would turn a courtesy into a list.
+
 Appwrite is still running and is the only place the plaintext v1 emails live;
 the script needs it. If it goes away before the script has run, the rows
 cannot be opened and this whole path is lost — see the runbook.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -577,8 +577,16 @@ before either runs.
    it, while the discovery `minLevel` filter matches none of them — silently,
    in both cases. **Order matters:** run it _after_ the profile ETL, or the ETL
    writes fresh CEFR values behind it.
-6. Verify a returning user's handle claim end to end before opening the gates.
-7. Verify chat history too: restore two accounts that talked to each other in
+6. Open the v2 accounts:
+   `tsx --env-file=../../.env --env-file=../../.env.prod scripts/precreate-v1-users.ts --apply`
+   (dry run first). Writes a verified, passwordless `user` row for every v1
+   Auth account, so "forgot password" and Google/Apple work for returning
+   users and nobody has to sign up again — see `docs/decisions.md` → _Every
+   v1 account has a v2 `user` row_. **Also needs the live Appwrite**: it is
+   the only source of the plaintext emails. Idempotent; an address that
+   already has a v2 user is left alone.
+7. Verify a returning user's handle claim end to end before opening the gates.
+8. Verify chat history too: restore two accounts that talked to each other in
    v1 and confirm the thread arrives with its photos and voice notes. A
    conversation is only imported once **both** sides are back, so testing with
    one account proves nothing.


### PR DESCRIPTION
## Why

A returning v1 user had no `user` row until they signed up again — the staged v1 data is keyed on an email hash. So "forgot password" showed "check your email" and sent nothing (Better Auth had nobody to mail), the password bridge in `routes/login.ts` is off in production (no `APPWRITE_*` on Fly), and the only way in was to re-register, which nobody guesses from a sign-in screen.

## What

- **`scripts/precreate-v1-users.ts`** opens a verified, passwordless `user` row for every v1 Auth account (blocked and email-less accounts excluded; idempotent). Verified from the start because Better Auth refuses to link a social sign-in onto an unverified local user; the row has no credential, so nothing can use it before a reset link or a provider proves the address. Needs the live Appwrite for the plaintext emails.
- **`session.create.after` hook** (`legacyPrecreate.ts`): on the first sign-in of such a row, stamps the terms and restores the v1 profile (handle, tokens, streak, conversations, lifetime grant). `user.create.after` never fires for a script-written user, and neither a reset nor a social link creates one. One indexed read for everyone else.
- **`onExistingUserSignUp`** mails "you already have an account" with a link to the forgot-password screen. Better Auth answers a sign-up for an existing address exactly like a fresh one (anti-enumeration), so without this the person waits for a verification mail that never comes.
- Sign-in / sign-up error copy points at reset, Google or Apple, in all eight languages.
- `docs/decisions.md` entry, runbook step, and a corrected comment in `env.ts` (Appwrite is still up and is the only source of plaintext v1 emails).

## Dry run against production (3 Sept 2026)

```
v1 Auth users seen:               4809
No email on the Auth user:        71
Blocked in v1:                    837
Nothing staged (opened anyway):   427
Unverified in v1 (opened anyway): 1976
Email hash does not match ETL:    0
Already have a v2 user:           0
Would create:                     3901
```

## Tests

New `legacyPrecreate.test.ts`: idempotent insert; sign-in refused before reset; sign-up over the row returns the generic 200, creates no credential, and sends the "already have an account" mail; reset → sign-in restores the profile and stamps the terms exactly once across two sessions; an ordinary sign-up is untouched by the hook. Full suite green (api 776, mobile 523), typecheck, lint, format:check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
