### PR TITLE
Make approving a sign-in from the phone actually work

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,5 +1,7 @@
 import { APP_SCHEMES, IOS_BUNDLE_ID, PASSWORD_MIN_LENGTH, WEB_HOST } from '@langx/shared'
 import { betterAuth } from 'better-auth'
+import { createAuthMiddleware } from 'better-auth/api'
+import { setSessionCookie } from 'better-auth/cookies'
 import { mongodbAdapter } from 'better-auth/adapters/mongodb'
 import { expo } from '@better-auth/expo'
 import { anonymous } from 'better-auth/plugins/anonymous'
@@ -126,6 +128,45 @@ export async function createAuth({ env, db, client, emailSender, revenueCat }: C
       },
     },
 
+    session: {
+      /*
+       * `/list-sessions` sits behind Better Auth's freshness check, whose
+       * default is 24 hours. A phone that signed in last week is exactly the
+       * device somebody wants to see their sessions on, and it was answered
+       * with 403 SESSION_NOT_FRESH — the list could not even be read, let
+       * alone acted on.
+       *
+       * Zero turns the check off for that endpoint. It does not weaken
+       * revocation: `/revoke-session` and `/revoke-other-sessions` use the
+       * authoritative-session check, not the freshness one, and they are
+       * unchanged. The only other fresh-gated endpoint is `/unlink-account`,
+       * which this app never calls.
+       */
+      freshAge: 0,
+    },
+
+    hooks: {
+      /**
+       * Give the browser a session cookie when the device grant hands out a
+       * session.
+       *
+       * `/device/token` is an OAuth endpoint, so it answers with a bearer
+       * token and nothing else — correct for the RFC, useless here. Nothing in
+       * this app sends an `Authorization` header; every client is cookie-based,
+       * so the browser polling for approval was handed a token it had no way
+       * to use and stayed signed out with a 200 in its hand.
+       *
+       * The plugin has already created the real session and put it on the
+       * context, so this only writes the cookie for it. Anything else that
+       * creates a session sets its own.
+       */
+      after: createAuthMiddleware(async (ctx) => {
+        if (ctx.path !== '/device/token') return
+        const created = ctx.context.newSession
+        if (created) await setSessionCookie(ctx, created)
+      }),
+    },
+
     databaseHooks: {
       user: {
         create: {
@@ -185,24 +226,28 @@ export async function createAuth({ env, db, client, emailSender, revenueCat }: C
       /*
        * QR sign-in on the web, which is RFC 8628's device flow with a picture
        * in front of it: the browser asks for a code, shows it as a QR *and* as
-       * six characters, and polls `/device/token` until a signed-in phone
+       * eight characters, and polls `/device/token` until a signed-in phone
        * approves it.
        *
        * The plugin rather than something hand-rolled — this is a protocol with
        * known failure modes (`slow_down`, `authorization_pending`, single-use
        * codes, expiry) and it already implements them.
        *
-       * Scanning is **not** what makes it work. The six-character user code is
-       * the primary path and the QR is a shortcut, which is deliberate:
+       * Scanning is **not** what makes it work. The eight-character user code
+       * is the primary path and the QR is a shortcut, which is deliberate:
        * `expo-camera` is not in this app, and adding it means a new native
        * build with a new camera permission — so a scanner cannot ship over the
        * air. Typing the code works today on every platform.
+       *
+       * The QR encodes a `langx://` link rather than a web address: it is
+       * scanned by the phone's own camera, and the phone is where the session
+       * is — an https link opened a browser signed in as nobody.
        */
       deviceAuthorization({
         /*
-         * Two minutes. Long enough to pick up a phone and read six characters,
-         * short enough that a code photographed off somebody's screen is
-         * worthless by the time they have walked away.
+         * Two minutes. Long enough to pick up a phone and read eight
+         * characters, short enough that a code photographed off somebody's
+         * screen is worthless by the time they have walked away.
          */
         expiresIn: '2m',
         /** What the poller is told to wait between attempts. */

--- a/apps/api/src/routes/deviceFlow.test.ts
+++ b/apps/api/src/routes/deviceFlow.test.ts
@@ -1,0 +1,307 @@
+import type { FastifyInstance } from 'fastify'
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { buildApp } from '../app'
+import { createAuth } from '../auth'
+import { connectToDatabase, type DbHandle } from '../db/client'
+import { ensureIndexes } from '../db/indexes'
+import { loadEnv } from '../env'
+import { createStorageProvider } from '../storage/createStorageProvider'
+import { createTranslationProvider } from '../translation/createTranslationProvider'
+import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
+import {
+  CapturingEmailSender,
+  setCookieValue,
+  signUpAndSignIn,
+  type SignedUpUser,
+} from '../testSupport/authFlow'
+
+const PASSWORD = 'correct horse battery staple'
+const USER_CODE_CHARSET = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]+$/
+
+/**
+ * RFC 8628 from both ends: a browser with no session asks for a code, and a
+ * phone that has one approves it.
+ *
+ * The case this file exists for is `approve` **without the claim first**.
+ * Better Auth will not let a code be approved until a signed-in `GET /device`
+ * has attached it to that user, and the app called approve straight away — so
+ * approving from the phone answered "that code is no longer valid" every
+ * single time, for everyone, and nothing in the suite noticed.
+ */
+describe('device sign-in flow', () => {
+  let replSet: MongoMemoryReplSet
+  let handle: DbHandle
+  let app: FastifyInstance
+  let emailSender: CapturingEmailSender
+  let phone: SignedUpUser
+  let other: SignedUpUser
+
+  /** The browser asking to be signed in: no session, only a client id. */
+  async function requestCode(): Promise<{ userCode: string; deviceCode: string }> {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/auth/device/code',
+      payload: { client_id: 'langx-web', scope: 'openid' },
+    })
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{ user_code: string; device_code: string }>()
+    return { userCode: body.user_code, deviceCode: body.device_code }
+  }
+
+  /** What the phone does before it can approve: `GET /device?user_code=`. */
+  function claim(userCode: string, cookie: string) {
+    return app.inject({
+      method: 'GET',
+      url: `/api/auth/device?user_code=${encodeURIComponent(userCode)}`,
+      headers: { cookie },
+    })
+  }
+
+  function approve(userCode: string, cookie: string) {
+    return app.inject({
+      method: 'POST',
+      url: '/api/auth/device/approve',
+      headers: { cookie },
+      payload: { userCode },
+    })
+  }
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+    handle = await connectToDatabase(replSet.getUri(), 'langx_device_test')
+    await ensureIndexes(handle.db)
+
+    const env = loadEnv({
+      NODE_ENV: 'test',
+      MONGODB_URI: replSet.getUri(),
+      MONGODB_DB: 'langx_device_test',
+      LOG_LEVEL: 'silent',
+      BETTER_AUTH_SECRET: 'a'.repeat(32),
+      BETTER_AUTH_URL: 'http://localhost:4000',
+      LEGACY_EMAIL_HASH_SALT: 'test-legacy-salt',
+    })
+
+    emailSender = new CapturingEmailSender()
+    const auth = await createAuth({ env, db: handle.db, client: handle.client, emailSender })
+    app = await buildApp({
+      env,
+      client: handle.client,
+      db: handle.db,
+      auth,
+      storage: createStorageProvider(env),
+      translation: createTranslationProvider(env),
+      revenueCat: createRevenueCatClientFromEnv(env),
+    })
+    await app.ready()
+
+    // Same first-transaction warm-up as the other suites — see auth.test.ts.
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      const warmUp = await app.inject({
+        method: 'POST',
+        url: '/api/auth/sign-up/email',
+        payload: { email: `warmup-${attempt}@example.com`, password: PASSWORD, name: 'Warm Up' },
+      })
+      if (warmUp.statusCode === 200) break
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+    emailSender.messages.length = 0
+
+    phone = await signUpAndSignIn(app, emailSender, {
+      email: 'phone@example.com',
+      password: PASSWORD,
+      name: 'Phone Owner',
+    })
+    other = await signUpAndSignIn(app, emailSender, {
+      email: 'other@example.com',
+      password: PASSWORD,
+      name: 'Somebody Else',
+    })
+  }, 120_000)
+
+  afterAll(async () => {
+    await app?.close()
+    await handle?.close()
+    await replSet?.stop()
+  })
+
+  it('hands the browser an eight-character code from the unambiguous charset', async () => {
+    const { userCode, deviceCode } = await requestCode()
+    // Eight, not six: the app's copy said six and the plugin's default is
+    // eight, so a placeholder shaped like ABCDEF was wrong on every screen.
+    expect(userCode.replace(/-/g, '')).toHaveLength(8)
+    expect(userCode.replace(/-/g, '')).toMatch(USER_CODE_CHARSET)
+    expect(deviceCode).toBeTruthy()
+  })
+
+  it('refuses to approve a code that has not been claimed', async () => {
+    const { userCode } = await requestCode()
+    const response = await approve(userCode, phone.cookie)
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toContain('claimed')
+  })
+
+  it('claims the code for the signed-in phone, and says what is asking', async () => {
+    const { userCode } = await requestCode()
+    const claimed = await claim(userCode, phone.cookie)
+    expect(claimed.statusCode).toBe(200)
+    expect(claimed.json()).toMatchObject({ status: 'pending', client_id: 'langx-web' })
+  })
+
+  it('signs the browser in once the phone approves', async () => {
+    const { userCode, deviceCode } = await requestCode()
+    expect((await claim(userCode, phone.cookie)).statusCode).toBe(200)
+    expect((await approve(userCode, phone.cookie)).statusCode).toBe(200)
+
+    const token = await app.inject({
+      method: 'POST',
+      url: '/api/auth/device/token',
+      payload: {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: deviceCode,
+        client_id: 'langx-web',
+      },
+    })
+    expect(token.statusCode).toBe(200)
+
+    /*
+     * The cookie is the point. This endpoint is an OAuth one and answers with
+     * a bearer token, which nothing in this app knows how to send — the hook
+     * in `auth.ts` writes the session cookie for the session the plugin has
+     * already created. Without it the browser polls, gets a 200, and stays
+     * signed out.
+     */
+    const browserCookie = setCookieValue(token)
+    const me = await app.inject({
+      method: 'GET',
+      url: '/profiles/me',
+      headers: { cookie: browserCookie },
+    })
+    // No profile yet in this suite, so 404 is the signed-in answer; 401 is not.
+    expect(me.statusCode).not.toBe(401)
+  })
+
+  it('accepts the code as it was typed, lowercase and hyphenated', async () => {
+    const { userCode } = await requestCode()
+    const typed = `${userCode.slice(0, 4).toLowerCase()}-${userCode.slice(4).toLowerCase()}`
+    expect((await claim(typed, phone.cookie)).statusCode).toBe(200)
+    expect((await approve(typed, phone.cookie)).statusCode).toBe(200)
+  })
+
+  it('will not let a second account approve a code the first has claimed', async () => {
+    const { userCode } = await requestCode()
+    expect((await claim(userCode, phone.cookie)).statusCode).toBe(200)
+    const response = await approve(userCode, other.cookie)
+    expect(response.statusCode).toBe(403)
+  })
+
+  it('tells the polling browser it was denied', async () => {
+    const { userCode, deviceCode } = await requestCode()
+    expect((await claim(userCode, phone.cookie)).statusCode).toBe(200)
+    const denied = await app.inject({
+      method: 'POST',
+      url: '/api/auth/device/deny',
+      headers: { cookie: phone.cookie },
+      payload: { userCode },
+    })
+    expect(denied.statusCode).toBe(200)
+
+    const token = await app.inject({
+      method: 'POST',
+      url: '/api/auth/device/token',
+      payload: {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: deviceCode,
+        client_id: 'langx-web',
+      },
+    })
+    expect(token.statusCode).toBeGreaterThanOrEqual(400)
+    expect(token.body).toContain('access_denied')
+  })
+
+  it('lists both devices, and can sign one of them out', async () => {
+    const { userCode, deviceCode } = await requestCode()
+    expect((await claim(userCode, phone.cookie)).statusCode).toBe(200)
+    expect((await approve(userCode, phone.cookie)).statusCode).toBe(200)
+    const token = await app.inject({
+      method: 'POST',
+      url: '/api/auth/device/token',
+      payload: {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: deviceCode,
+        client_id: 'langx-web',
+      },
+    })
+    const browserCookie = setCookieValue(token)
+
+    const listed = await app.inject({
+      method: 'GET',
+      url: '/api/auth/list-sessions',
+      headers: { cookie: phone.cookie },
+    })
+    expect(listed.statusCode).toBe(200)
+    const sessions = listed.json<{ token: string }[]>()
+    expect(sessions.length).toBeGreaterThanOrEqual(2)
+
+    // The browser's row, found by the token its cookie carries.
+    const browserToken = decodeURIComponent(browserCookie.split('=')[1] ?? '').split('.')[0]
+    const browserRow = sessions.find((session) => session.token === browserToken)
+    expect(browserRow).toBeTruthy()
+
+    const revoked = await app.inject({
+      method: 'POST',
+      url: '/api/auth/revoke-session',
+      headers: { cookie: phone.cookie },
+      payload: { token: browserToken },
+    })
+    expect(revoked.statusCode).toBe(200)
+
+    const afterWeb = await app.inject({
+      method: 'GET',
+      url: '/profiles/me',
+      headers: { cookie: browserCookie },
+    })
+    expect(afterWeb.statusCode).toBe(401)
+
+    const afterPhone = await app.inject({
+      method: 'GET',
+      url: '/api/auth/list-sessions',
+      headers: { cookie: phone.cookie },
+    })
+    expect(afterPhone.statusCode).toBe(200)
+  })
+
+  it('lists sessions from a phone that signed in days ago', async () => {
+    /*
+     * The freshness default would have answered 403 here. Written as a test
+     * because `freshAge: 0` is one line in a config that reads like a
+     * preference and is in fact the difference between a screen that works
+     * and one nobody can open.
+     */
+    const token = decodeURIComponent(phone.cookie.split('=')[1] ?? '').split('.')[0]
+    await handle.db
+      .collection('session')
+      .updateOne({ token }, { $set: { createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000) } })
+    const listed = await app.inject({
+      method: 'GET',
+      url: '/api/auth/list-sessions',
+      headers: { cookie: phone.cookie },
+    })
+    expect(listed.statusCode).toBe(200)
+  })
+
+  it('refuses an expired code', async () => {
+    const { userCode } = await requestCode()
+    /*
+     * By `userCode`, never by `_id`: Better Auth stores its ids as ObjectId
+     * and ours are strings, so a lookup by id here matches nothing and the
+     * test would pass for the wrong reason.
+     */
+    await handle.db
+      .collection('deviceCode')
+      .updateOne({ userCode }, { $set: { expiresAt: new Date(Date.now() - 60_000) } })
+    const response = await claim(userCode, phone.cookie)
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toContain('expired_token')
+  })
+})

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -1,4 +1,5 @@
-import { CURRENT_TERMS_VERSION, PLAN_LIMITS } from '@langx/shared'
+import { CURRENT_TERMS_VERSION, deviceLinkTarget, PLAN_LIMITS, WEB_HOST } from '@langx/shared'
+import QRCode from 'qrcode'
 import { ObjectId } from 'mongodb'
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
 import type { FastifyInstance } from 'fastify'
@@ -578,9 +579,29 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
     it('lets the device link code be embedded too', async () => {
       const response = await app.inject({ method: 'GET', url: '/public/qr/link/ABCD1234' })
       expect(response.statusCode, response.body).toBe(200)
+      expect(response.headers['content-type']).toBe('image/svg+xml')
       expect(response.headers['cross-origin-resource-policy']).toBe('cross-origin')
       // Two minutes of life; caching the picture past that serves the dead.
       expect(response.headers['cache-control']).toBe('no-store')
+    })
+
+    /*
+     * The scan happens on the phone that already holds the session, so the
+     * link inside has to open the app. Encoded as an https address it opened a
+     * browser on that same phone, signed in as nobody.
+     */
+    it('encodes a link that opens the app, not the website', async () => {
+      const response = await app.inject({ method: 'GET', url: '/public/qr/link/ABCD2345' })
+      // Compared against the same encoder rather than decoded: the picture is
+      // a pure function of the string, so an identical SVG is an identical
+      // payload, and it costs the suite no new dependency.
+      const expected = await QRCode.toString(deviceLinkTarget('ABCD2345'), {
+        type: 'svg',
+        errorCorrectionLevel: 'M',
+        margin: 2,
+      })
+      expect(response.body).toBe(expected)
+      expect(response.body).not.toContain(WEB_HOST)
     })
   })
 

--- a/apps/api/src/routes/qr.ts
+++ b/apps/api/src/routes/qr.ts
@@ -1,4 +1,10 @@
-import { handleSchema, INVITE_QUERY_PARAM, inviteUrl, profileUrl, WEB_HOST } from '@langx/shared'
+import {
+  deviceLinkTarget,
+  handleSchema,
+  INVITE_QUERY_PARAM,
+  inviteUrl,
+  profileUrl,
+} from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import QRCode from 'qrcode'
 import { z } from 'zod'
@@ -101,12 +107,17 @@ export const qrRoutes: FastifyPluginAsyncZod = async (app) => {
       config: { rateLimit: { max: 60, timeWindow: '1 minute' } },
     },
     async (request, reply) => {
-      // `user_code`, because that is the name Better Auth puts in its own
-      // `verification_uri_complete` — a QR that used a different one would
-      // send people to the same page with the field left empty.
-      const target = `https://${WEB_HOST}/link-device?user_code=${encodeURIComponent(
-        request.params.code,
-      )}`
+      /*
+       * A link into the app, not the website. This picture is scanned with the
+       * phone's own camera, and the phone is where the session already is —
+       * an https address opened a browser on that same phone, signed in as
+       * nobody, which is the one place the approval cannot be given.
+       *
+       * `user_code` is the parameter name because that is what Better Auth
+       * puts in its own `verification_uri_complete`, and what the screen
+       * reads.
+       */
+      const target = deviceLinkTarget(request.params.code)
       const svg = await QRCode.toString(target, {
         type: 'svg',
         errorCorrectionLevel: 'M',

--- a/apps/mobile/app/(app)/link-device.tsx
+++ b/apps/mobile/app/(app)/link-device.tsx
@@ -1,14 +1,18 @@
 import { router, useLocalSearchParams } from 'expo-router'
 import { useState } from 'react'
-import { Text, TextInput, View } from 'react-native'
+import { ActivityIndicator, Pressable, Text, TextInput, View } from 'react-native'
+import { useRevokeOtherSessions, useRevokeSession, useSessions } from '../../src/api/queries'
 import { Button } from '../../src/components/ui/Button'
 import { Screen } from '../../src/components/ui/Screen'
 import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
-import { showAlert } from '../../src/lib/alert'
+import { confirmAlert, showAlert } from '../../src/lib/alert'
 import { authClient } from '../../src/lib/auth-client'
+import { relativeTime } from '../../src/lib/format'
 import { goBackTo } from '../../src/lib/navigation'
+import { sessionLabel } from '../../src/lib/sessionLabel'
 import { makeStyles, useTheme } from '../../src/lib/theme'
-import { useT } from '../../src/i18n'
+import { showToast } from '../../src/lib/toast'
+import { useLocale, useT } from '../../src/i18n'
 
 /**
  * Approve a sign-in somewhere else.
@@ -38,11 +42,64 @@ export default function LinkDeviceScreen() {
 
   const [entered, setEntered] = useState(code ?? '')
   const [busy, setBusy] = useState(false)
+  const { locale } = useLocale()
+
+  /*
+   * Which row is the phone in your hand. Better Auth's session hook holds the
+   * same token the list returns, so the comparison needs no extra request.
+   */
+  const currentToken = authClient.useSession().data?.session.token
+  const sessions = useSessions()
+  const revokeOne = useRevokeSession()
+  const revokeOthers = useRevokeOtherSessions()
+
+  async function signOutOne(token: string, label: string): Promise<void> {
+    const yes = await confirmAlert({
+      title: t('linkDevice.signOutDevice'),
+      message: label,
+      confirmLabel: t('linkDevice.signOutDevice'),
+      destructive: true,
+    })
+    if (!yes) return
+    revokeOne.mutate(token, {
+      onSuccess: () => showToast(t('linkDevice.signedOutDevice')),
+      onError: () => showToast(t('common.retry')),
+    })
+  }
+
+  async function signOutOthers(): Promise<void> {
+    const yes = await confirmAlert({
+      title: t('linkDevice.signOutOthers'),
+      confirmLabel: t('linkDevice.signOutOthers'),
+      destructive: true,
+    })
+    if (!yes) return
+    revokeOthers.mutate(undefined, {
+      onSuccess: () => showToast(t('linkDevice.signedOutDevice')),
+      onError: () => showToast(t('common.retry')),
+    })
+  }
 
   async function decide(approve: boolean): Promise<void> {
     const userCode = entered.trim().toUpperCase()
     if (!userCode) return
     setBusy(true)
+
+    /*
+     * Claim the code first. Better Auth will not approve a code that no
+     * account has taken ownership of, and taking ownership is what this GET
+     * does — approving straight away answered DEVICE_CODE_NOT_CLAIMED, which
+     * this screen showed as "that code is no longer valid". Every approval
+     * from a phone failed this way, and the message made it look like the code
+     * had expired rather than like a step being missing.
+     */
+    const claimed = await authClient.device({ query: { user_code: userCode } })
+    if (claimed.error || claimed.data?.status !== 'pending') {
+      setBusy(false)
+      await showAlert(t('linkDevice.failed'))
+      return
+    }
+
     const { error } = approve
       ? await authClient.device.approve({ userCode })
       : await authClient.device.deny({ userCode })
@@ -55,7 +112,10 @@ export default function LinkDeviceScreen() {
       return
     }
     await showAlert(t(approve ? 'linkDevice.approved' : 'linkDevice.denied'))
-    goBackTo('/(app)/settings')
+    // Not back to settings on an approval: the device list below is where the
+    // laptop now appears, which is the only proof the approval landed.
+    if (!approve) goBackTo('/(app)/settings')
+    else void sessions.refetch()
   }
 
   return (
@@ -100,6 +160,60 @@ export default function LinkDeviceScreen() {
       <Text style={styles.hint} onPress={() => router.back()}>
         {t('linkDevice.hint')}
       </Text>
+
+      {/*
+        The other half of the same question. Approving a sign-in and seeing
+        where you are already signed in are one concern — "who is in this
+        account" — and the list is also the only feedback that an approval
+        worked, since the device it signed in is somewhere else.
+      */}
+      <Text style={styles.sectionTitle}>{t('linkDevice.devices')}</Text>
+      {sessions.isPending ? (
+        <ActivityIndicator style={styles.spinner} />
+      ) : (
+        <View>
+          {(sessions.data ?? []).map((session) => {
+            const label = sessionLabel(session.userAgent) ?? t('linkDevice.unknownDevice')
+            const isThis = session.token === currentToken
+            return (
+              <View key={session.token} style={styles.deviceRow}>
+                <View style={styles.deviceText}>
+                  <Text style={styles.deviceName}>
+                    {label}
+                    {isThis ? ` · ${t('linkDevice.thisDevice')}` : ''}
+                  </Text>
+                  <Text style={styles.deviceMeta}>
+                    {[
+                      relativeTime(new Date(session.createdAt).toISOString(), { t, locale }),
+                      session.ipAddress,
+                    ]
+                      .filter(Boolean)
+                      .join(' · ')}
+                  </Text>
+                </View>
+                {isThis ? null : (
+                  <Pressable
+                    onPress={() => void signOutOne(session.token, label)}
+                    hitSlop={8}
+                    accessibilityRole="button"
+                  >
+                    <Text style={styles.signOut}>{t('linkDevice.signOutDevice')}</Text>
+                  </Pressable>
+                )}
+              </View>
+            )
+          })}
+          {(sessions.data ?? []).length > 1 ? (
+            <Button
+              label={t('linkDevice.signOutOthers')}
+              variant="secondary"
+              loading={revokeOthers.isPending}
+              onPress={() => void signOutOthers()}
+              style={styles.signOutAll}
+            />
+          ) : null}
+        </View>
+      )}
     </Screen>
   )
 }
@@ -121,4 +235,19 @@ const useStyles = makeStyles(({ colors, font, radius, spacing }) => ({
   warning: { ...font.caption, color: colors.warning, lineHeight: 19, marginTop: spacing.md },
   actions: { gap: spacing.sm, marginTop: spacing.xl },
   hint: { ...font.caption, color: colors.textFaint, marginTop: spacing.lg, textAlign: 'center' },
+  sectionTitle: { ...font.label, color: colors.text, marginTop: spacing.xl },
+  spinner: { marginTop: spacing.lg },
+  deviceRow: {
+    alignItems: 'center',
+    borderBottomColor: colors.border,
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    gap: spacing.sm,
+    paddingVertical: spacing.md,
+  },
+  deviceText: { flex: 1, gap: 2, minWidth: 0 },
+  deviceName: { ...font.body, color: colors.text },
+  deviceMeta: { ...font.caption, color: colors.textMuted },
+  signOut: { ...font.caption, color: colors.danger },
+  signOutAll: { marginTop: spacing.lg },
 }))

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -54,6 +54,7 @@ import {
 } from '@tanstack/react-query'
 import type { InfiniteData } from '@tanstack/react-query'
 import { api } from './client'
+import { authClient } from '../lib/auth-client'
 import type { ConversationPageDto } from '../lib/conversationCache'
 import { putWithProgress } from '../lib/putWithProgress'
 import {
@@ -117,6 +118,7 @@ export const keys = {
   likers: (targetType: string, targetId: string) => ['likers', targetType, targetId] as const,
   follows: (userId: string, which: string) => ['follows', userId, which] as const,
   quota: ['quota'] as const,
+  sessions: ['sessions'] as const,
   viewers: ['viewers'] as const,
   leaderboard: (period: PeriodType) => ['leaderboard', period] as const,
   blocks: ['blocks'] as const,
@@ -1436,6 +1438,51 @@ export function useDiscloseGender() {
       // The filter row reads `me.gender` to decide whether `onlyMyGender` does
       // anything, and discovery results change the moment it does.
       void queryClient.invalidateQueries({ queryKey: ['discovery'] })
+    },
+  })
+}
+
+/**
+ * Where this account is signed in.
+ *
+ * Better Auth owns these three endpoints, so they go through `authClient`
+ * rather than our own `api` client — same cookie, different base path, and no
+ * DTO of ours in between.
+ */
+export function useSessions(enabled = true) {
+  return useQuery({
+    queryKey: keys.sessions,
+    queryFn: async () => {
+      const { data, error } = await authClient.listSessions()
+      if (error) throw new Error(error.message ?? 'could not list sessions')
+      return data ?? []
+    },
+    enabled,
+  })
+}
+
+export function useRevokeSession() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: async (token: string) => {
+      const { error } = await authClient.revokeSession({ token })
+      if (error) throw new Error(error.message ?? 'could not sign that device out')
+    },
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: keys.sessions })
+    },
+  })
+}
+
+export function useRevokeOtherSessions() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: async () => {
+      const { error } = await authClient.revokeOtherSessions()
+      if (error) throw new Error(error.message ?? 'could not sign the other devices out')
+    },
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: keys.sessions })
     },
   })
 }

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -1021,7 +1021,7 @@ export const ar: Localized<EnMessages> = {
     showStatsBody: 'السلسلة والتصحيحات والتوكنات ورسم هذا الأسبوع على ملفك.',
     legalSection: 'القانونية',
     communitySection: 'المجتمع',
-    linkDeviceBody: 'وافق على تسجيل دخول على حاسوب.',
+    linkDeviceBody: 'وافق على تسجيل دخول وشاهد أين سجّلت الدخول.',
     showInDiscover: 'أظهرني في الاستكشاف',
     showInDiscoverBody: 'أطفئه ولن يعثر عليك أحد — لا في الاستكشاف ولا بالبحث عن اسم المستخدم.',
     incognito: 'تصفّح خفي',
@@ -1350,7 +1350,7 @@ export const ar: Localized<EnMessages> = {
   linkDevice: {
     title: 'تسجيل الدخول على جهاز آخر',
     body: 'أدخل الرمز الظاهر على الشاشة الأخرى، أو امسحه هناك.',
-    placeholder: 'ABCDEF',
+    placeholder: 'ABCD2345',
     warning: 'وافق فقط على رمز تراه بنفسك. من يُدخله يحصل على وصول كامل إلى حسابك.',
     approve: 'موافقة',
     deny: 'رفض',
@@ -1358,6 +1358,12 @@ export const ar: Localized<EnMessages> = {
     denied: 'تم الرفض',
     failed: 'لم يعد هذا الرمز صالحًا.',
     hint: 'ليس الآن',
+    devices: 'الأجهزة المسجّلة الدخول',
+    thisDevice: 'هذا الجهاز',
+    signOutDevice: 'تسجيل الخروج',
+    signOutOthers: 'تسجيل الخروج من كل مكان آخر',
+    signedOutDevice: 'تم تسجيل الخروج.',
+    unknownDevice: 'جهاز غير معروف',
   },
 
   qrSignIn: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -881,7 +881,7 @@ export const de: Localized<EnMessages> = {
     showStatsBody: 'Streak, Korrekturen, Tokens und das Wochendiagramm auf deinem Profil.',
     legalSection: 'Rechtliches',
     communitySection: 'Community',
-    linkDeviceBody: 'Eine Anmeldung am Computer bestätigen.',
+    linkDeviceBody: 'Eine Anmeldung bestätigen und sehen, wo du angemeldet bist.',
     showInDiscover: 'In Entdecken zeigen',
     showInDiscoverBody:
       'Schalte das aus und niemand findet dich — weder in Entdecken noch über deinen Benutzernamen.',
@@ -1151,7 +1151,7 @@ export const de: Localized<EnMessages> = {
   linkDevice: {
     title: 'Auf einem anderen Gerät anmelden',
     body: 'Gib den Code vom anderen Bildschirm ein, oder scanne ihn dort.',
-    placeholder: 'ABCDEF',
+    placeholder: 'ABCD2345',
     warning:
       'Bestätige nur einen Code, den du selbst siehst. Wer ihn eingibt, bekommt vollen Zugriff auf dein Konto.',
     approve: 'Bestätigen',
@@ -1160,6 +1160,12 @@ export const de: Localized<EnMessages> = {
     denied: 'Abgelehnt',
     failed: 'Dieser Code gilt nicht mehr.',
     hint: 'Jetzt nicht',
+    devices: 'Angemeldete Geräte',
+    thisDevice: 'dieses Gerät',
+    signOutDevice: 'Abmelden',
+    signOutOthers: 'Überall sonst abmelden',
+    signedOutDevice: 'Abgemeldet.',
+    unknownDevice: 'Unbekanntes Gerät',
   },
 
   qrSignIn: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -896,7 +896,7 @@ export const en = {
     showStatsBody: 'Streak, corrections, tokens and this week’s chart on your profile.',
     legalSection: 'Legal',
     communitySection: 'Community',
-    linkDeviceBody: 'Approve a sign-in on a computer.',
+    linkDeviceBody: 'Approve a sign-in, and see where you are signed in.',
     showInDiscover: 'Show me in Discover',
     showInDiscoverBody:
       'Turn this off and nobody will find you — not in Discover, and not by searching your username.',
@@ -1164,7 +1164,7 @@ export const en = {
   linkDevice: {
     title: 'Sign in on another device',
     body: 'Enter the code shown on the other screen, or scan it there.',
-    placeholder: 'ABCDEF',
+    placeholder: 'ABCD2345',
     warning:
       'Only approve a code you are looking at yourself. Anyone who gets it in gains full access to your account.',
     approve: 'Approve',
@@ -1173,6 +1173,12 @@ export const en = {
     denied: 'Denied',
     failed: 'That code is no longer valid.',
     hint: 'Not now',
+    devices: 'Signed-in devices',
+    thisDevice: 'this device',
+    signOutDevice: 'Sign out',
+    signOutOthers: 'Sign out everywhere else',
+    signedOutDevice: 'Signed out.',
+    unknownDevice: 'Unknown device',
   },
 
   qrSignIn: {

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -858,7 +858,7 @@ export const es: Localized<EnMessages> = {
     showStatsBody: 'Racha, correcciones, tokens y el gráfico de la semana en tu perfil.',
     legalSection: 'Legal',
     communitySection: 'Comunidad',
-    linkDeviceBody: 'Aprueba un inicio de sesión en un ordenador.',
+    linkDeviceBody: 'Aprueba un inicio de sesión y mira dónde tienes la sesión abierta.',
     showInDiscover: 'Mostrarme en Descubrir',
     showInDiscoverBody:
       'Desactívalo y nadie te encontrará: ni en Descubrir ni buscando tu nombre de usuario.',
@@ -1125,7 +1125,7 @@ export const es: Localized<EnMessages> = {
   linkDevice: {
     title: 'Iniciar sesión en otro dispositivo',
     body: 'Escribe el código de la otra pantalla, o escanéalo allí.',
-    placeholder: 'ABCDEF',
+    placeholder: 'ABCD2345',
     warning:
       'Aprueba solo un código que estés viendo tú. Quien lo introduzca obtiene acceso total a tu cuenta.',
     approve: 'Aprobar',
@@ -1134,6 +1134,12 @@ export const es: Localized<EnMessages> = {
     denied: 'Rechazado',
     failed: 'Ese código ya no es válido.',
     hint: 'Ahora no',
+    devices: 'Dispositivos con sesión',
+    thisDevice: 'este dispositivo',
+    signOutDevice: 'Cerrar sesión',
+    signOutOthers: 'Cerrar sesión en todos los demás',
+    signedOutDevice: 'Sesión cerrada.',
+    unknownDevice: 'Dispositivo desconocido',
   },
 
   qrSignIn: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -865,7 +865,7 @@ export const fr: Localized<EnMessages> = {
     showStatsBody: 'Série, corrections, jetons et le graphique de la semaine sur votre profil.',
     legalSection: 'Mentions légales',
     communitySection: 'Communauté',
-    linkDeviceBody: 'Approuver une connexion sur un ordinateur.',
+    linkDeviceBody: 'Approuver une connexion et voir où vous êtes connecté.',
     showInDiscover: 'M’afficher dans Découvrir',
     showInDiscoverBody:
       'Désactive-le et personne ne te trouvera — ni dans Découvrir, ni en cherchant ton nom d’utilisateur.',
@@ -1135,7 +1135,7 @@ export const fr: Localized<EnMessages> = {
   linkDevice: {
     title: 'Se connecter sur un autre appareil',
     body: 'Saisis le code affiché sur l’autre écran, ou scanne-le là-bas.',
-    placeholder: 'ABCDEF',
+    placeholder: 'ABCD2345',
     warning:
       'N’approuve qu’un code que tu vois toi-même. Quiconque le saisit obtient un accès complet à ton compte.',
     approve: 'Approuver',
@@ -1144,6 +1144,12 @@ export const fr: Localized<EnMessages> = {
     denied: 'Refusé',
     failed: 'Ce code n’est plus valide.',
     hint: 'Pas maintenant',
+    devices: 'Appareils connectés',
+    thisDevice: 'cet appareil',
+    signOutDevice: 'Se déconnecter',
+    signOutOthers: 'Se déconnecter partout ailleurs',
+    signedOutDevice: 'Déconnecté.',
+    unknownDevice: 'Appareil inconnu',
   },
 
   qrSignIn: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -852,7 +852,7 @@ export const ptBR: Localized<EnMessages> = {
     showStatsBody: 'Sequência, correções, tokens e o gráfico da semana no seu perfil.',
     legalSection: 'Jurídico',
     communitySection: 'Comunidade',
-    linkDeviceBody: 'Aprove um login em um computador.',
+    linkDeviceBody: 'Aprove um login e veja onde você está conectado.',
     showInDiscover: 'Mostrar em Descobrir',
     showInDiscoverBody:
       'Desligue e ninguém te encontra — nem no Descobrir, nem buscando seu nome de usuário.',
@@ -1122,7 +1122,7 @@ export const ptBR: Localized<EnMessages> = {
   linkDevice: {
     title: 'Entrar em outro dispositivo',
     body: 'Digite o código da outra tela, ou escaneie por lá.',
-    placeholder: 'ABCDEF',
+    placeholder: 'ABCD2345',
     warning:
       'Aprove apenas um código que você mesmo esteja vendo. Quem o inserir ganha acesso total à sua conta.',
     approve: 'Aprovar',
@@ -1131,6 +1131,12 @@ export const ptBR: Localized<EnMessages> = {
     denied: 'Recusado',
     failed: 'Esse código não é mais válido.',
     hint: 'Agora não',
+    devices: 'Dispositivos conectados',
+    thisDevice: 'este dispositivo',
+    signOutDevice: 'Sair',
+    signOutOthers: 'Sair de todos os outros',
+    signedOutDevice: 'Sessão encerrada.',
+    unknownDevice: 'Dispositivo desconhecido',
   },
 
   qrSignIn: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -978,7 +978,7 @@ export const ru: Localized<EnMessages> = {
     showStatsBody: 'Стрик, исправления, токены и график недели в профиле.',
     legalSection: 'Правовые документы',
     communitySection: 'Сообщество',
-    linkDeviceBody: 'Подтвердить вход на компьютере.',
+    linkDeviceBody: 'Подтвердить вход и посмотреть, где вы вошли.',
     showInDiscover: 'Показывать меня в Поиске',
     showInDiscoverBody: 'Выключи — и тебя не найдут: ни в «Обзоре», ни по имени пользователя.',
     incognito: 'Невидимый просмотр',
@@ -1288,7 +1288,7 @@ export const ru: Localized<EnMessages> = {
   linkDevice: {
     title: 'Вход на другом устройстве',
     body: 'Введите код с другого экрана или отсканируйте его там.',
-    placeholder: 'ABCDEF',
+    placeholder: 'ABCD2345',
     warning:
       'Подтверждайте только код, который видите сами. Тот, кто его введёт, получит полный доступ к аккаунту.',
     approve: 'Подтвердить',
@@ -1297,6 +1297,12 @@ export const ru: Localized<EnMessages> = {
     denied: 'Отклонено',
     failed: 'Этот код больше не действителен.',
     hint: 'Не сейчас',
+    devices: 'Устройства с активным входом',
+    thisDevice: 'это устройство',
+    signOutDevice: 'Выйти',
+    signOutOthers: 'Выйти на всех остальных',
+    signedOutDevice: 'Выход выполнен.',
+    unknownDevice: 'Неизвестное устройство',
   },
 
   qrSignIn: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -865,7 +865,7 @@ export const tr: Localized<EnMessages> = {
     showStatsBody: 'Profilinde streak, düzeltme, token ve bu haftanın grafiği.',
     legalSection: 'Hukuki',
     communitySection: 'Topluluk',
-    linkDeviceBody: 'Bilgisayardaki bir girişi onayla.',
+    linkDeviceBody: 'Bir girişi onayla, nerelerde açık olduğunu gör.',
     showInDiscover: 'Keşfet’te görün',
     showInDiscoverBody:
       'Bunu kapatırsan kimse seni bulamaz — ne Keşfet’te, ne de kullanıcı adınla arayarak.',
@@ -1131,7 +1131,7 @@ export const tr: Localized<EnMessages> = {
   linkDevice: {
     title: 'Başka cihazda oturum aç',
     body: 'Diğer ekranda görünen kodu gir, ya da oradan okut.',
-    placeholder: 'ABCDEF',
+    placeholder: 'ABCD2345',
     warning:
       'Sadece kendi gördüğün bir kodu onayla. Bu kodu geçiren herkes hesabına tam erişim kazanır.',
     approve: 'Onayla',
@@ -1140,6 +1140,12 @@ export const tr: Localized<EnMessages> = {
     denied: 'Reddedildi',
     failed: 'Bu kod artık geçerli değil.',
     hint: 'Şimdi değil',
+    devices: 'Giriş yapılmış cihazlar',
+    thisDevice: 'bu cihaz',
+    signOutDevice: 'Çıkış yap',
+    signOutOthers: 'Diğer her yerden çıkış yap',
+    signedOutDevice: 'Çıkış yapıldı.',
+    unknownDevice: 'Bilinmeyen cihaz',
   },
 
   qrSignIn: {

--- a/apps/mobile/src/lib/sessionLabel.test.ts
+++ b/apps/mobile/src/lib/sessionLabel.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { sessionLabel } from './sessionLabel'
+
+describe('sessionLabel', () => {
+  it('names the app on iOS from its networking stack', () => {
+    expect(sessionLabel('LangX/1.0 CFNetwork/1494 Darwin/23.4.0')).toBe('LangX · iPhone')
+  })
+
+  it('names the app on Android from OkHttp', () => {
+    expect(sessionLabel('okhttp/4.12.0')).toBe('LangX · Android')
+  })
+
+  it('reads Chrome on a Mac', () => {
+    expect(
+      sessionLabel(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0 Safari/537.36',
+      ),
+    ).toBe('Chrome · Mac')
+  })
+
+  it('does not call Chrome Safari, though Chrome says it is', () => {
+    // Every Chrome agent ends in "Safari/537.36", so the order of these checks
+    // is the whole correctness of this function.
+    expect(sessionLabel('… Chrome/140.0 Safari/537.36')).toContain('Chrome')
+  })
+
+  it('reads Safari on an iPhone', () => {
+    expect(
+      sessionLabel(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1',
+      ),
+    ).toBe('Safari · iOS')
+  })
+
+  it('reads Firefox on Windows', () => {
+    expect(
+      sessionLabel('Mozilla/5.0 (Windows NT 10.0; Win64; x64) Gecko/20100101 Firefox/130.0'),
+    ).toBe('Firefox · Windows')
+  })
+
+  it('gives back nothing it cannot name, so the screen can say so in words', () => {
+    expect(sessionLabel('curl/8.5.0')).toBeNull()
+    expect(sessionLabel(null)).toBeNull()
+    expect(sessionLabel('')).toBeNull()
+  })
+})

--- a/apps/mobile/src/lib/sessionLabel.ts
+++ b/apps/mobile/src/lib/sessionLabel.ts
@@ -1,0 +1,46 @@
+/**
+ * A user agent turned into something a person can recognise their own device in.
+ *
+ * Not a parser. The question this answers is "is one of these rows the laptop
+ * I am worried about", and for that a phone needs to say phone and a browser
+ * needs to say which browser — everything past that is noise on a row that is
+ * two lines tall.
+ *
+ * Order matters: the app's own networking layers name themselves before they
+ * name a browser engine, and Chrome's agent claims Safari, so the specific
+ * cases have to be tested before the general ones.
+ */
+export function sessionLabel(userAgent: string | null | undefined): string | null {
+  if (!userAgent) return null
+  const ua = userAgent.toLowerCase()
+
+  // The app itself: iOS networking is CFNetwork/Darwin, Android's OkHttp.
+  if (ua.includes('cfnetwork') || ua.includes('darwin')) return 'LangX · iPhone'
+  if (ua.includes('okhttp')) return 'LangX · Android'
+
+  const browser = ua.includes('firefox')
+    ? 'Firefox'
+    : ua.includes('edg/')
+      ? 'Edge'
+      : ua.includes('chrome') || ua.includes('crios')
+        ? 'Chrome'
+        : ua.includes('safari')
+          ? 'Safari'
+          : null
+  if (!browser) return null
+
+  const platform =
+    ua.includes('iphone') || ua.includes('ipad')
+      ? 'iOS'
+      : ua.includes('android')
+        ? 'Android'
+        : ua.includes('mac os')
+          ? 'Mac'
+          : ua.includes('windows')
+            ? 'Windows'
+            : ua.includes('linux')
+              ? 'Linux'
+              : null
+
+  return platform ? `${browser} · ${platform}` : browser
+}

--- a/packages/shared/src/appIdentity.test.ts
+++ b/packages/shared/src/appIdentity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { postUrl, profileUrl, WEB_HOST } from './appIdentity'
+import { deviceLinkQrUrl, deviceLinkTarget, postUrl, profileUrl, WEB_HOST } from './appIdentity'
 import { RESERVED_HANDLES } from './reservedHandles'
 
 describe('postUrl', () => {
@@ -23,5 +23,30 @@ describe('postUrl', () => {
 
   it('escapes an id that is not a plain ObjectId', () => {
     expect(postUrl('a b/c')).toBe(`https://${WEB_HOST}/post/a%20b%2Fc`)
+  })
+})
+
+describe('deviceLinkTarget', () => {
+  it('opens the app rather than a browser', () => {
+    // The scan happens on the phone that already holds the session. An https
+    // link took it to a browser where nobody is signed in, which is the one
+    // place the approval cannot be given.
+    expect(deviceLinkTarget('ABCD2345')).toBe('langx://link-device?user_code=ABCD2345')
+  })
+
+  it('carries the parameter name the screen already reads', () => {
+    expect(deviceLinkTarget('X').includes('user_code=')).toBe(true)
+  })
+
+  it('escapes a code that is not plain characters', () => {
+    expect(deviceLinkTarget('A B&C')).toBe('langx://link-device?user_code=A%20B%26C')
+  })
+})
+
+describe('deviceLinkQrUrl', () => {
+  it('asks the API for the picture, by code and nothing else', () => {
+    expect(deviceLinkQrUrl('https://api.langx.io/', 'ABCD2345')).toBe(
+      'https://api.langx.io/public/qr/link/ABCD2345',
+    )
   })
 })

--- a/packages/shared/src/appIdentity.ts
+++ b/packages/shared/src/appIdentity.ts
@@ -1,3 +1,5 @@
+import { APP_SCHEME } from './appScheme'
+
 /**
  * Who this app *is*, to Apple, Google and the web — the values that have to be
  * byte-identical across five places or something breaks silently.
@@ -165,4 +167,21 @@ export function profileQrUrl(apiBaseUrl: string, handle: string): string {
  */
 export function deviceLinkQrUrl(apiBaseUrl: string, userCode: string): string {
   return `${apiBaseUrl.replace(/\/$/, '')}/public/qr/link/${encodeURIComponent(userCode)}`
+}
+
+/**
+ * What that QR actually encodes: a link that opens the app, not the website.
+ *
+ * The picture is scanned with the phone's own camera, and the phone is where
+ * the session already is. Encoding an `https://` address sent it to a browser
+ * on that same phone, where nobody is signed in — the one place the approval
+ * cannot happen. A scheme URL hands it to the installed app instead, which is
+ * both a shorter path and the only one that works.
+ *
+ * Not a universal link on the web host: those need `.well-known` files served
+ * from a host that currently answers with v1, which is an infrastructure move
+ * rather than a change to a QR code.
+ */
+export function deviceLinkTarget(userCode: string): string {
+  return `${APP_SCHEME}://link-device?user_code=${encodeURIComponent(userCode)}`
 }


### PR DESCRIPTION
QR sign-in on the web has never worked end to end. Three separate faults, all on the path between the browser showing a code and the phone approving it. Each one is covered by a new test in `apps/api/src/routes/deviceFlow.test.ts`.

## 1. The code was never claimed

Better Auth refuses to approve a device code until a signed-in `GET /device?user_code=` has attached it to an account. The screen called `approve` directly, so every attempt returned `DEVICE_CODE_NOT_CLAIMED`, which it displayed as "That code is no longer valid" — an expiry message for a missing step. The claim now runs first.

The single failure message stays deliberately vague for expired, used and unknown codes, so that guessing a code learns nothing.

## 2. The browser never got a session

`/device/token` is an OAuth endpoint. It answers with a bearer token and nothing else, and nothing in this app sends an `Authorization` header — so even after a correct approval the browser held a 200 and stayed signed out. The web screen's own comment claimed the response set a cookie; it did not.

An `after` hook in `auth.ts` writes the session cookie for the session the plugin has already created. The test asserts the cookie reaches `/profiles/me`.

## 3. The QR pointed at a browser

It encoded `https://<web host>/link-device?user_code=…`. That picture is scanned with the phone's own camera, and the phone is where the session already is — the https link opened a browser on that same phone, signed in as nobody. It now encodes `langx://link-device?user_code=…`, built by `deviceLinkTarget` in `packages/shared` so it is unit tested and the API and the app cannot disagree. No native code, ships over the air.

Not a universal link on the web host: that host still serves v1 and the `.well-known` files are not checked in, which is an infrastructure migration rather than a QR change. Some Android cameras ignore custom schemes, so the eight-character code stays the primary path.

## Copy

The user code is eight characters, not six. The placeholder said `ABCDEF` and three comments said six.

## Signed-in devices

The same screen now lists where the account is signed in, with per-row sign out and sign out everywhere else. It is the other half of the same question, and it is also the only feedback that an approval worked, since the device it signed in is somewhere else.

`session: { freshAge: 0 }` is what makes the list readable. Better Auth puts `/list-sessions` behind a 24-hour freshness check by default, so a phone that signed in last week got 403 and could never open the screen. Revocation uses the authoritative-session check, not the freshness one, so it is unaffected. A test asserts a two-day-old session can still list, and it fails without the setting.

`sessionLabel` turns a user agent into something a person recognises. It is pure and in `src/lib`, so vitest reaches it: seven cases, including the one that matters, that every Chrome agent also claims to be Safari.

## Verification

The full API suite (56 files, 783 tests) and the mobile suite (530) pass, along with typecheck, lint and format. The device flow is covered end to end in tests rather than in a browser: the scheme link needs a real phone with the app installed, which is an Android build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)