### PR TITLE
Show unread messages on the Chats tab

### DIFF
--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -509,6 +509,37 @@ export async function markPendingDelivered(db: Db, userId: string): Promise<Deli
   return swept
 }
 
+/**
+ * How many unread messages this account has, everywhere.
+ *
+ * Summed on the server because the app cannot do it: the list is paged, so a
+ * client only ever holds the threads it has scrolled to, and the archive is
+ * excluded from every other tab — a total added up in the cache would be a
+ * total of whatever happened to be loaded.
+ *
+ * Blocked counterparts are left out for the same reason their threads are left
+ * out of the list: a badge that counts a conversation nobody can open is a
+ * number with nowhere to go.
+ */
+export async function countUnread(db: Db, userId: string): Promise<number> {
+  const hidden = await blockedUserIds(db, userId)
+  const unreadPath = `unread.${userId}`
+  const rows = await db
+    .collection<Conversation>(COLLECTIONS.conversations)
+    .aggregate<{ total: number }>([
+      {
+        $match: {
+          participants: hidden.length > 0 ? { $eq: userId, $nin: hidden } : userId,
+          [`archivedBy.${userId}`]: { $ne: true },
+          [unreadPath]: { $gt: 0 },
+        },
+      },
+      { $group: { _id: null, total: { $sum: `$${unreadPath}` } } },
+    ])
+    .toArray()
+  return rows[0]?.total ?? 0
+}
+
 export async function markConversationRead(
   db: Db,
   userId: string,

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -250,6 +250,86 @@ describe('Faz 5 — conversation/message history REST', () => {
     expect(body.items[0]?.participants).toContain(newer.userId) // most recent activity first
   })
 
+  describe('the unread total behind the tab badge', () => {
+    async function unreadTotal(viewer: SignedUpUser) {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/me/unread',
+        headers: { cookie: viewer.cookie },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+      return response.json<{ total: number }>().total
+    }
+
+    it('adds up every thread, and drops to nothing when they are read', async () => {
+      const viewer = await newUser('unread-viewer@example.com')
+      const first = await newUser('unread-first@example.com')
+      const second = await newUser('unread-second@example.com')
+      const { sendTextMessage } = await import('../modules/chat/messages')
+
+      expect(await unreadTotal(viewer)).toBe(0)
+
+      const one = (await startConversation(first, viewer.userId, 'hello'))._id
+      const two = (await startConversation(second, viewer.userId, 'hi there'))._id
+      await sendTextMessage(handle.db, first.userId, {
+        conversationId: one,
+        body: 'and another',
+        clientId: 'unread-1',
+      })
+      // Two threads, three messages — the badge is a sum, not a thread count.
+      expect(await unreadTotal(viewer)).toBe(3)
+
+      // The sender sees none of their own.
+      expect(await unreadTotal(first)).toBe(0)
+
+      await app.inject({
+        method: 'POST',
+        url: `/conversations/${one}/read`,
+        headers: { cookie: viewer.cookie },
+      })
+      expect(await unreadTotal(viewer)).toBe(1)
+
+      await app.inject({
+        method: 'POST',
+        url: `/conversations/${two}/read`,
+        headers: { cookie: viewer.cookie },
+      })
+      expect(await unreadTotal(viewer)).toBe(0)
+    })
+
+    it('leaves out threads the badge cannot lead anywhere', async () => {
+      const viewer = await newUser('unread-hidden-viewer@example.com')
+      const archived = await newUser('unread-archived@example.com')
+      const blocked = await newUser('unread-blocked@example.com')
+
+      const quiet = (await startConversation(archived, viewer.userId, 'archive me'))._id
+      await app.inject({
+        method: 'PATCH',
+        url: `/conversations/${quiet}/flags`,
+        headers: { cookie: viewer.cookie },
+        payload: { archived: true },
+      })
+      // Archived: still unread, deliberately not counted — the archive tab is
+      // where it lives and the badge does not point there.
+      expect(await unreadTotal(viewer)).toBe(0)
+
+      await startConversation(blocked, viewer.userId, 'you cannot open this')
+      // One before the block, so the zero below is the block doing the work
+      // rather than the thread never having counted.
+      expect(await unreadTotal(viewer)).toBe(1)
+      await handle.db
+        .collection(COLLECTIONS.blocks)
+        .insertOne({ blockerId: viewer.userId, blockedId: blocked.userId })
+      // A blocked counterpart's thread is gone from the list, so counting it
+      // would be a number with nowhere to go.
+      expect(await unreadTotal(viewer)).toBe(0)
+    })
+
+    it('needs a session', async () => {
+      expect((await app.inject({ method: 'GET', url: '/me/unread' })).statusCode).toBe(401)
+    })
+  })
+
   describe('tabs, pins and the view layer', () => {
     async function list(viewer: SignedUpUser, filter?: string) {
       const response = await app.inject({

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -11,6 +11,7 @@ import { z } from 'zod'
 import { ApiError } from '../lib/ApiError'
 import { requireAuth, requireMember } from '../middleware/requireAuth'
 import {
+  countUnread,
   listConversations,
   listMessages,
   listMessagesAround,
@@ -92,6 +93,16 @@ export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
       return reply.send(page)
     },
   )
+
+  /*
+   * One number for the tab badge. Its own route rather than a field on the
+   * conversations page: the badge has to be right on a screen that never
+   * opened the chats list, and the list is paged besides.
+   */
+  app.get('/me/unread', { preHandler: requireAuth }, async (request, reply) => {
+    const total = await countUnread(app.mongo.db, request.userId)
+    return reply.send({ total })
+  })
 
   app.get(
     '/conversations/:id/messages',

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,6 +1,7 @@
 import Feather from '@expo/vector-icons/Feather'
 import { Tabs } from 'expo-router'
 import type { ColorValue } from 'react-native'
+import { useUnreadTotal } from '../../src/api/queries'
 import { DeletionBanner } from '../../src/components/DeletionBanner'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useTheme } from '../../src/lib/theme'
@@ -12,6 +13,7 @@ import { useDailyCheckIn } from '../../src/hooks/useDailyCheckIn'
 import { authClient } from '../../src/lib/auth-client'
 import { shouldGateGuest } from '../../src/lib/guestGate'
 import { useSocket } from '../../src/hooks/useSocket'
+import { unreadBadge } from '../../src/lib/unreadBadge'
 
 /** Not a tab, and no tab bar under it either. */
 const FULL_SCREEN = { href: null, tabBarStyle: { display: 'none' } } as const
@@ -49,6 +51,12 @@ export default function AppLayout() {
    */
   const isGuest = shouldGateGuest(session?.user)
   useSocket({ enabled: !isGuest })
+  // A guest has no conversations, so asking for a total would be a request
+  // that can only ever answer zero.
+  const unread = useUnreadTotal(!isGuest)
+  // Spread rather than passed as `undefined`: the option is typed as present
+  // or absent, and an explicit `undefined` is neither.
+  const badge = unreadBadge(unread.data)
   useLocationRefresh({ enabled: !isGuest })
   useDailyCheckIn({ enabled: !isGuest })
   usePushRegistration({ enabled: !isGuest })
@@ -90,6 +98,21 @@ export default function AppLayout() {
           options={{
             title: t('tabs.chats'),
             tabBarIcon: ({ color }) => <TabIcon name="message-square" color={color} />,
+            /*
+             * A message that arrives while somebody is on another tab was
+             * invisible until they went looking for it. The count comes from
+             * the server rather than from the loaded chat list, which is paged
+             * and would only ever total what had been scrolled to.
+             */
+            ...(badge
+              ? {
+                  tabBarBadge: badge,
+                  tabBarBadgeStyle: {
+                    backgroundColor: colors.danger,
+                    color: colors.textInverse,
+                  },
+                }
+              : {}),
           }}
         />
         <Tabs.Screen

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -120,6 +120,13 @@ export const keys = {
   follows: (userId: string, which: string) => ['follows', userId, which] as const,
   quota: ['quota'] as const,
   sessions: ['sessions'] as const,
+  /*
+   * Deliberately not under `['conversations']`, tempting as that is: the
+   * socket patches that prefix with `setQueriesData`, and the patcher walks
+   * `data.pages`. A single number sitting in that prefix would be handed to it
+   * and would throw. `invalidateUnread` is what keeps the two in step instead.
+   */
+  unread: ['unread'] as const,
   viewers: ['viewers'] as const,
   leaderboard: (period: PeriodType) => ['leaderboard', period] as const,
   blocks: ['blocks'] as const,
@@ -138,6 +145,32 @@ export const keys = {
  * would be two chances for one of them to forget the invalidation and leave a
  * stale unread count on the list behind.
  */
+/**
+ * The number on the Chats tab.
+ *
+ * Server-side rather than summed from the loaded list: the list is paged and
+ * excludes the archive, so a total added up in the cache is a total of
+ * whatever the user happened to have scrolled to.
+ */
+export function useUnreadTotal(enabled = true) {
+  return useQuery({
+    queryKey: keys.unread,
+    queryFn: async () => (await api.get<{ total: number }>('/me/unread')).total,
+    enabled,
+  })
+}
+
+/**
+ * Called wherever the conversations cache is written or invalidated.
+ *
+ * The badge is on screen on every tab, including the ones that never load the
+ * chat list, so it cannot ride along on that list's own refetch — every event
+ * that changes an unread count has to say so here too.
+ */
+export function invalidateUnread(client: QueryClient): void {
+  void client.invalidateQueries({ queryKey: keys.unread })
+}
+
 export async function markConversationRead(
   conversationId: string,
   queryClient: QueryClient,
@@ -146,6 +179,7 @@ export async function markConversationRead(
   try {
     await api.post(`/conversations/${conversationId}/read`)
     await queryClient.invalidateQueries({ queryKey: ['conversations'] })
+    invalidateUnread(queryClient)
   } catch {
     // Best-effort: failing to clear an unread badge must never surface as an
     // error over a conversation the user is reading perfectly happily.
@@ -699,6 +733,8 @@ export function useDeleteConversation() {
     mutationFn: (conversationId: string) => api.delete<void>(`/conversations/${conversationId}`),
     onSuccess: () => {
       void client.invalidateQueries({ queryKey: ['conversations'] })
+      // A deleted thread takes its unread messages with it.
+      invalidateUnread(client)
     },
   })
 }
@@ -716,6 +752,8 @@ export function useConversationFlags() {
     }) => api.patch<ConversationDto>(`/conversations/${conversationId}/flags`, flags),
     onSuccess: () => {
       void client.invalidateQueries({ queryKey: ['conversations'] })
+      // Archiving hides a thread from the badge as well as from the list.
+      invalidateUnread(client)
     },
   })
 }

--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import { AppState } from 'react-native'
 import type { MeProfile, MessageDto } from '../api/queries'
-import { keys, markConversationRead } from '../api/queries'
+import { invalidateUnread, keys, markConversationRead } from '../api/queries'
 import { getActiveConversation } from '../lib/activeConversation'
 import { previewOf, shouldShowIncomingBanner, showMessageBanner } from '../lib/inAppNotifications'
 import { applyIncomingMessage, type ConversationPageDto } from '../lib/conversationCache'
@@ -99,6 +99,9 @@ export function useSocket({ enabled = true }: { enabled?: boolean } = {}): void 
           },
         )
         if (!patched) void queryClient.invalidateQueries({ queryKey: ['conversations'] })
+        // The tab badge is on screen on every tab, including the ones that
+        // never load this list, so the patch above does not reach it.
+        invalidateUnread(queryClient)
         void queryClient.invalidateQueries({ queryKey: keys.tokens })
 
         /**
@@ -153,6 +156,7 @@ export function useSocket({ enabled = true }: { enabled?: boolean } = {}): void 
         // one thing this cannot patch from here.
         if (message.deleted) {
           void queryClient.invalidateQueries({ queryKey: ['conversations'] })
+          invalidateUnread(queryClient)
         }
       })
 

--- a/apps/mobile/src/lib/unreadBadge.test.ts
+++ b/apps/mobile/src/lib/unreadBadge.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { unreadBadge, UNREAD_BADGE_MAX } from './unreadBadge'
+
+describe('unreadBadge', () => {
+  it('draws nothing when there is nothing unread', () => {
+    // Not '0': the tab bar draws a badge for any string, and a zero on a tab
+    // says "something is waiting" as loudly as a one does.
+    expect(unreadBadge(0)).toBeUndefined()
+  })
+
+  it('draws nothing before the count has loaded', () => {
+    expect(unreadBadge(undefined)).toBeUndefined()
+  })
+
+  it('draws the count itself while it fits', () => {
+    expect(unreadBadge(1)).toBe('1')
+    expect(unreadBadge(UNREAD_BADGE_MAX)).toBe('99')
+  })
+
+  it('caps rather than widening the tab', () => {
+    expect(unreadBadge(UNREAD_BADGE_MAX + 1)).toBe('99+')
+    expect(unreadBadge(1482)).toBe('99+')
+  })
+
+  it('treats a negative count as nothing, rather than drawing a minus sign', () => {
+    expect(unreadBadge(-3)).toBeUndefined()
+  })
+})

--- a/apps/mobile/src/lib/unreadBadge.ts
+++ b/apps/mobile/src/lib/unreadBadge.ts
@@ -1,0 +1,17 @@
+/**
+ * The number drawn on the Chats tab, as text.
+ *
+ * A cap rather than the true count past a point: the badge sits on a tab that
+ * is a quarter of the screen wide, and "1482" widens it until the label
+ * underneath no longer fits. Anybody with more than ninety-nine unread
+ * messages is not counting them.
+ *
+ * `undefined` at zero, because that is what the tab bar wants in order to draw
+ * nothing at all — a badge showing "0" is a badge saying you have something.
+ */
+export const UNREAD_BADGE_MAX = 99
+
+export function unreadBadge(total: number | undefined): string | undefined {
+  if (!total || total <= 0) return undefined
+  return total > UNREAD_BADGE_MAX ? `${UNREAD_BADGE_MAX}+` : String(total)
+}


### PR DESCRIPTION
Asked for directly: put the unread count on the Chats tab. A message arriving while you are on another tab was invisible until you went looking.

## Where the number comes from

`GET /me/unread`, backed by `countUnread` in the chat module. Not summed from the loaded conversations cache, which would have been free and wrong: the list is paged, so the app holds only what has been scrolled to, and the archive is excluded from every other tab.

Two exclusions, both deliberate and both tested:

- **Archived threads** do not count. The archive tab is where they live and the badge does not point there.
- **Blocked counterparts' threads** do not count. They are already gone from the list, so counting them is a number with nowhere to go.

## Keeping it live

`invalidateUnread` is called wherever the conversations cache is written or invalidated: an arriving socket message, a deleted message, marking a thread read, archiving, deleting a thread. The badge is drawn on tabs that never load the chat list, so it cannot ride along on that list's own refetch.

The query key is deliberately **not** under the `['conversations']` prefix. The socket patches that prefix with `setQueriesData`, and the patcher walks `data.pages` — a single number placed there would be handed to it and would throw.

## The badge itself

`unreadBadge` in `src/lib` so vitest can reach it, since no mobile test can render a component. Nothing at zero or before the count loads, the number itself up to ninety-nine, `99+` above that. A four-digit badge widens the tab until the label under it no longer fits.

## Verification

Two browsers against the isolated stack, phone-width viewport. The reader sits on Discover, a tab that never loads the chat list; the other account sends two messages through the app over the socket; the badge appears reading `2` without any navigation; opening the thread and going back leaves it empty.

Three API tests cover the total: it sums across threads and drops to zero as each is read, the sender sees none of their own, archived and blocked are excluded (asserted at one immediately before the block, so the zero is the block doing the work), and the route needs a session.

Typecheck, lint, format and both suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)