### PR TITLE
Send the one announcement to v1-deleted accounts, then drop their addresses

### DIFF
--- a/apps/api/scripts/send-v1-deleted-announcement.ts
+++ b/apps/api/scripts/send-v1-deleted-announcement.ts
@@ -1,0 +1,169 @@
+/**
+ * The one email to the v1 accounts their owners deleted — the addresses
+ * `scripts/precreate-v1-users.ts` set aside in `v1DeletedContacts` — and the
+ * end of that collection.
+ *
+ * These people ended their relationship with the product once, so this is
+ * held to a stricter standard than a campaign: it goes out **once**, it
+ * carries an unsubscribe that forgets the address on the spot, and `--drop`
+ * removes the collection when everyone has been sent to. Nothing else reads
+ * or writes those rows. See `docs/decisions.md` → _Every v1 account has a v2
+ * `user` row_.
+ *
+ * Every row is claimed (`sentAt`) before its batch goes out, so a re-run
+ * after a crash retries exactly the people who were not sent to and nobody
+ * else. A batch that fails releases its own claim.
+ *
+ * The HTML must contain `{{unsubscribeUrl}}`, and so must a `--text-file` if
+ * one is given — the same rule as `send-campaign.ts`, for the same reason.
+ *
+ * Usage:
+ *   pnpm --filter @langx/api exec tsx --env-file=../../.env --env-file=../../.env.prod \
+ *     scripts/send-v1-deleted-announcement.ts \
+ *     --subject "LangX is back" --html-file ./announcement.html \
+ *     [--text-file ./announcement.txt] [--limit 50] [--confirm] [--drop]
+ *
+ * Without `--confirm` it counts, prints and sends nothing. Without
+ * RESEND_API_KEY it prints each message instead of sending it. `--drop` is
+ * refused while anybody is still unsent, and can be run alone later.
+ */
+import { readFileSync } from 'node:fs'
+import { connectToDatabase } from '../src/db/client'
+import { unsubscribeHeaders } from '../src/email/notify'
+import { createEmailSender, EMAIL_BATCH_SIZE, type EmailMessage } from '../src/email/sender'
+import { signUnsubscribeToken, unsubscribeUrl } from '../src/email/unsubscribeToken'
+import { loadEnv, publicApiUrl, unsubscribeSecret } from '../src/env'
+import { deriveTextBody, UNSUBSCRIBE_PLACEHOLDER } from '../src/modules/notifications/campaign'
+import {
+  claimDeletedContacts,
+  dropDeletedContacts,
+  pendingDeletedContacts,
+  releaseDeletedContacts,
+} from '../src/modules/notifications/v1DeletedContacts'
+
+/** Resend's default is two requests a second; this stays comfortably under. */
+const BATCH_DELAY_MS = 700
+
+function flag(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`)
+  return index === -1 ? undefined : process.argv[index + 1]
+}
+
+function mask(email: string): string {
+  const [user = '', domain = ''] = email.split('@')
+  return `${user.slice(0, 2)}***@${domain}`
+}
+
+async function main(): Promise<void> {
+  const subject = flag('subject')
+  const htmlFile = flag('html-file')
+  const textFile = flag('text-file')
+  const limit = flag('limit') ? Number(flag('limit')) : undefined
+  const confirm = process.argv.includes('--confirm')
+  const drop = process.argv.includes('--drop')
+
+  const env = loadEnv()
+  const { db, close } = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
+
+  try {
+    // `--drop` on its own: the send already happened, this is the tidy-up.
+    if (drop && !subject && !htmlFile) {
+      await finish(db)
+      return
+    }
+
+    if (!subject || !htmlFile) throw new Error('--subject and --html-file are both required')
+
+    const html = readFileSync(htmlFile, 'utf8')
+    if (!html.includes(UNSUBSCRIBE_PLACEHOLDER)) {
+      throw new Error(
+        `the html body must contain ${UNSUBSCRIBE_PLACEHOLDER} — refusing to send without one`,
+      )
+    }
+    let text: string
+    if (textFile) {
+      text = readFileSync(textFile, 'utf8')
+      if (!text.includes(UNSUBSCRIBE_PLACEHOLDER)) {
+        throw new Error(
+          `the text body must contain ${UNSUBSCRIBE_PLACEHOLDER} — refusing to send without one`,
+        )
+      }
+    } else {
+      text = deriveTextBody(html)
+    }
+
+    const sender = createEmailSender(env, console)
+    const secret = unsubscribeSecret(env)
+    const apiBaseUrl = publicApiUrl(env)
+
+    const recipients = await pendingDeletedContacts(db, limit)
+    console.log(`v1 deleted-account announcement on ${env.MONGODB_DB}`)
+    console.log(`  unsent recipients: ${recipients.length}${limit ? ` (limit ${limit})` : ''}`)
+    for (const recipient of recipients.slice(0, 5)) console.log(`    ${mask(recipient.email)}`)
+    if (recipients.length > 5) console.log(`    …and ${recipients.length - 5} more`)
+
+    if (!confirm) {
+      console.log('\n(dry run — re-run with --confirm to send)')
+      return
+    }
+    if (!env.RESEND_API_KEY) {
+      console.log('\nRESEND_API_KEY is not set — every message will be printed, not sent')
+    }
+
+    let sent = 0
+    for (let index = 0; index < recipients.length; index += EMAIL_BATCH_SIZE) {
+      const batch = recipients.slice(index, index + EMAIL_BATCH_SIZE)
+      const claimed = new Set(
+        await claimDeletedContacts(
+          db,
+          batch.map((recipient) => recipient._id),
+        ),
+      )
+      const messages: EmailMessage[] = batch
+        .filter((recipient) => claimed.has(recipient._id))
+        .map((recipient) => {
+          const url = unsubscribeUrl(
+            apiBaseUrl,
+            signUnsubscribeToken(secret, recipient._id, 'v1contact'),
+          )
+          return {
+            to: recipient.email,
+            subject,
+            html: html.replaceAll(UNSUBSCRIBE_PLACEHOLDER, url),
+            text: text.replaceAll(UNSUBSCRIBE_PLACEHOLDER, url),
+            headers: unsubscribeHeaders(url),
+          }
+        })
+      if (messages.length === 0) continue
+
+      try {
+        if (sender.sendBatch) await sender.sendBatch(messages)
+        else for (const message of messages) await sender.send(message)
+        sent += messages.length
+      } catch (error) {
+        await releaseDeletedContacts(db, [...claimed])
+        throw error
+      }
+
+      if (index + EMAIL_BATCH_SIZE < recipients.length) {
+        await new Promise((resolve) => setTimeout(resolve, BATCH_DELAY_MS))
+      }
+    }
+
+    console.log(`\nsent ${sent}`)
+    if (drop) await finish(db)
+  } finally {
+    await close()
+  }
+}
+
+async function finish(db: Parameters<typeof dropDeletedContacts>[0]): Promise<void> {
+  const outcome = await dropDeletedContacts(db)
+  if (outcome.dropped) console.log('v1DeletedContacts dropped — nothing of these addresses remains')
+  else console.log(`not dropped: ${outcome.unsent} still unsent — send to them first`)
+}
+
+main().catch((error: unknown) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/api/src/email/unsubscribeToken.test.ts
+++ b/apps/api/src/email/unsubscribeToken.test.ts
@@ -14,6 +14,14 @@ describe('unsubscribe tokens', () => {
     expect(verifyUnsubscribeToken(SECRET, token)?.scope).toBe('all')
   })
 
+  it('round-trips the v1-contact scope, which names a contact row rather than a user', () => {
+    const token = signUnsubscribeToken(SECRET, 'appwrite-id', 'v1contact')
+    expect(verifyUnsubscribeToken(SECRET, token)).toEqual({
+      userId: 'appwrite-id',
+      scope: 'v1contact',
+    })
+  })
+
   it('refuses a tampered signature', () => {
     const token = signUnsubscribeToken(SECRET, 'user-1', 'messages')
     expect(verifyUnsubscribeToken(SECRET, `${token}x`)).toBeNull()

--- a/apps/api/src/email/unsubscribeToken.ts
+++ b/apps/api/src/email/unsubscribeToken.ts
@@ -1,8 +1,13 @@
 import { NOTIFICATION_TYPES, type NotificationType } from '@langx/shared'
 import { createHmac, timingSafeEqual } from 'node:crypto'
 
-/** Every kind, plus the "stop all of it" the confirmation page also offers. */
-export type UnsubscribeScope = NotificationType | 'all'
+/**
+ * Every kind, plus the "stop all of it" the confirmation page also offers,
+ * plus the one scope that names no preference: `v1contact` is the link in the
+ * single announcement sent to v1 accounts their owners deleted, where the
+ * "user id" is the contact row and stopping means forgetting the address.
+ */
+export type UnsubscribeScope = NotificationType | 'all' | 'v1contact'
 
 const VERSION = 'v1'
 
@@ -41,7 +46,12 @@ export function verifyUnsubscribeToken(
   if (parts.length !== 4) return null
   const [version, userId, scope, provided] = parts as [string, string, string, string]
   if (version !== VERSION || !userId) return null
-  if (scope !== 'all' && !NOTIFICATION_TYPES.includes(scope as NotificationType)) return null
+  if (
+    scope !== 'all' &&
+    scope !== 'v1contact' &&
+    !NOTIFICATION_TYPES.includes(scope as NotificationType)
+  )
+    return null
 
   const expected = signature(secret, userId, scope as UnsubscribeScope)
   // `timingSafeEqual` throws on a length mismatch rather than returning false,

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -94,6 +94,7 @@ export const ar: Localized<ServerMessages> = {
       profileVisits: 'ملخّصات زيارات الملف',
       promotions: 'الأخبار والعروض',
       all: 'رسائل LangX',
+      v1contact: 'الرسالة الوحيدة عن LangX الجديد',
     },
   },
 }

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -99,6 +99,7 @@ export const de: Localized<ServerMessages> = {
       profileVisits: 'Übersichten zu Profilbesuchen',
       promotions: 'Neues und Angebote',
       all: 'E-Mails von LangX',
+      v1contact: 'die eine Nachricht über das neue LangX',
     },
   },
 }

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -101,6 +101,7 @@ export const en = {
       profileVisits: 'profile-visit summaries',
       promotions: 'news and offers',
       all: 'email from LangX',
+      v1contact: 'the one message about the new LangX',
     },
   },
 } as const

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -98,6 +98,7 @@ export const es: Localized<ServerMessages> = {
       profileVisits: 'los resúmenes de visitas a tu perfil',
       promotions: 'las novedades y ofertas',
       all: 'el correo de LangX',
+      v1contact: 'el único mensaje sobre el nuevo LangX',
     },
   },
 }

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -100,6 +100,7 @@ export const fr: Localized<ServerMessages> = {
       profileVisits: 'les résumés de visites de profil',
       promotions: 'les actualités et offres',
       all: 'les e-mails de LangX',
+      v1contact: 'le message unique sur le nouveau LangX',
     },
   },
 }

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -97,6 +97,7 @@ export const ptBR: Localized<ServerMessages> = {
       profileVisits: 'os resumos de visitas ao perfil',
       promotions: 'as novidades e ofertas',
       all: 'os e-mails do LangX',
+      v1contact: 'a única mensagem sobre o novo LangX',
     },
   },
 }

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -107,6 +107,7 @@ export const ru: Localized<ServerMessages> = {
       profileVisits: 'сводки визитов в профиль',
       promotions: 'новости и предложения',
       all: 'письма от LangX',
+      v1contact: 'единственное сообщение о новом LangX',
     },
   },
 }

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -84,6 +84,7 @@ export const tr: Localized<ServerMessages> = {
       profileVisits: 'profil ziyareti özetleri',
       promotions: 'haberler ve kampanyalar',
       all: 'LangX’ten gelen e-postalar',
+      v1contact: 'yeni LangX hakkındaki tek mesaj',
     },
   },
 }

--- a/apps/api/src/modules/notifications/v1DeletedContacts.test.ts
+++ b/apps/api/src/modules/notifications/v1DeletedContacts.test.ts
@@ -1,0 +1,76 @@
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import { ensureIndexes } from '../../db/indexes'
+import {
+  claimDeletedContacts,
+  dropDeletedContacts,
+  pendingDeletedContacts,
+  releaseDeletedContacts,
+  removeDeletedContact,
+  type DeletedContact,
+} from './v1DeletedContacts'
+
+describe('the one announcement to v1-deleted accounts', () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+
+  const contact = (id: string): DeletedContact => ({
+    _id: id,
+    email: `${id}@example.com`,
+    name: id,
+    legacyUserId: id,
+    recordedAt: new Date(),
+  })
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'v1_contacts_test')
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    await handle.db.collection(COLLECTIONS.v1DeletedContacts).deleteMany({})
+    await ensureIndexes(handle.db)
+    await handle.db
+      .collection<DeletedContact>(COLLECTIONS.v1DeletedContacts)
+      .insertMany([contact('a'), contact('b'), contact('c')])
+  })
+
+  it('claims each row once, so a re-run cannot send twice', async () => {
+    expect((await pendingDeletedContacts(handle.db)).map((c) => c._id)).toEqual(['a', 'b', 'c'])
+
+    expect(await claimDeletedContacts(handle.db, ['a', 'b'])).toEqual(['a', 'b'])
+    expect(await claimDeletedContacts(handle.db, ['a', 'b', 'c'])).toEqual(['c'])
+    expect(await pendingDeletedContacts(handle.db)).toEqual([])
+  })
+
+  it('a released claim is sent to again; a removed address is not', async () => {
+    await claimDeletedContacts(handle.db, ['a', 'b'])
+    await releaseDeletedContacts(handle.db, ['b'])
+    await removeDeletedContact(handle.db, 'c')
+    await removeDeletedContact(handle.db, 'c')
+    expect((await pendingDeletedContacts(handle.db)).map((c) => c._id)).toEqual(['b'])
+  })
+
+  it('refuses to drop while anyone is unsent, then drops', async () => {
+    await claimDeletedContacts(handle.db, ['a', 'b'])
+    expect(await dropDeletedContacts(handle.db)).toEqual({ dropped: false, unsent: 1 })
+    expect(await handle.db.listCollections({ name: COLLECTIONS.v1DeletedContacts }).hasNext()).toBe(
+      true,
+    )
+
+    await claimDeletedContacts(handle.db, ['c'])
+    expect(await dropDeletedContacts(handle.db)).toEqual({ dropped: true, unsent: 0 })
+    expect(await handle.db.listCollections({ name: COLLECTIONS.v1DeletedContacts }).hasNext()).toBe(
+      false,
+    )
+    // Dropping what is already gone is not an error either.
+    expect(await dropDeletedContacts(handle.db)).toEqual({ dropped: true, unsent: 0 })
+  })
+})

--- a/apps/api/src/modules/notifications/v1DeletedContacts.ts
+++ b/apps/api/src/modules/notifications/v1DeletedContacts.ts
@@ -1,0 +1,87 @@
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+
+/**
+ * One row per v1 account its owner deleted, written by
+ * `scripts/precreate-v1-users.ts`. See `COLLECTIONS.v1DeletedContacts` for
+ * why they exist at all: one announcement, then the collection goes.
+ */
+export interface DeletedContact {
+  /** The Appwrite user id. */
+  _id: string
+  email: string
+  name: string
+  legacyUserId: string
+  recordedAt: Date
+  /** Claimed by the send, before the batch goes out. */
+  sentAt?: Date
+}
+
+function contacts(db: Db) {
+  return db.collection<DeletedContact>(COLLECTIONS.v1DeletedContacts)
+}
+
+/** Everyone the announcement has not yet gone to. */
+export async function pendingDeletedContacts(db: Db, limit?: number): Promise<DeletedContact[]> {
+  const cursor = contacts(db)
+    .find({ sentAt: { $exists: false } })
+    .sort({ _id: 1 })
+  return limit ? cursor.limit(limit).toArray() : cursor.toArray()
+}
+
+/**
+ * Claims a batch before it is sent, the same way `claimCampaignRecipients`
+ * does: the conditional update is what makes a re-run unable to mail anybody
+ * twice. Returns the ids actually claimed — a row claimed by a concurrent run,
+ * or removed by its owner between the read and now, is simply not in the list.
+ */
+export async function claimDeletedContacts(
+  db: Db,
+  ids: string[],
+  at: Date = new Date(),
+): Promise<string[]> {
+  const claimed: string[] = []
+  for (const id of ids) {
+    const result = await contacts(db).updateOne(
+      { _id: id, sentAt: { $exists: false } },
+      { $set: { sentAt: at } },
+    )
+    if (result.modifiedCount > 0) claimed.push(id)
+  }
+  return claimed
+}
+
+/** Undoes a claim whose send then failed, so a re-run retries exactly those. */
+export async function releaseDeletedContacts(db: Db, ids: string[]): Promise<void> {
+  if (ids.length === 0) return
+  await contacts(db).updateMany({ _id: { $in: ids } }, { $unset: { sentAt: '' } })
+}
+
+/**
+ * What the unsubscribe link in that one mail does. There is no preference to
+ * switch off — these people have no account — so the only honest "stop" is
+ * to forget the address. Idempotent: a second click finds nothing and that is
+ * the right answer.
+ */
+export async function removeDeletedContact(db: Db, id: string): Promise<void> {
+  await contacts(db).deleteOne({ _id: id })
+}
+
+export interface DropOutcome {
+  dropped: boolean
+  /** Why not, when not. */
+  unsent: number
+}
+
+/**
+ * The end of the collection's life, refused while anyone is still unsent —
+ * dropping then would lose people the announcement was meant for, and the
+ * script that calls this is the only thing that knows whether it finished.
+ */
+export async function dropDeletedContacts(db: Db): Promise<DropOutcome> {
+  const unsent = await contacts(db).countDocuments({ sentAt: { $exists: false } })
+  if (unsent > 0) return { dropped: false, unsent }
+  const exists = await db.listCollections({ name: COLLECTIONS.v1DeletedContacts }).hasNext()
+  if (exists) await db.dropCollection(COLLECTIONS.v1DeletedContacts)
+  return { dropped: true, unsent: 0 }
+}

--- a/apps/api/src/routes/email.test.ts
+++ b/apps/api/src/routes/email.test.ts
@@ -194,4 +194,44 @@ describe('unsubscribing from a link in an email', () => {
     expect((await app.inject({ method: 'GET', url: '/email/unsubscribe' })).statusCode).toBe(400)
     expect((await app.inject({ method: 'POST', url: '/email/unsubscribe' })).statusCode).toBe(400)
   })
+
+  /**
+   * The link in the one mail to v1 accounts their owners deleted. No account
+   * behind it, so the only thing "stop" can mean is forgetting the address.
+   */
+  it('the v1-contact scope forgets the address, and only on the POST', async () => {
+    const contacts = handle.db.collection(COLLECTIONS.v1DeletedContacts)
+    await contacts.insertOne({
+      _id: 'appwrite-gone' as never,
+      email: 'gone@example.com',
+      name: 'Gone',
+      legacyUserId: 'appwrite-gone',
+      recordedAt: new Date(),
+    })
+    const token = signUnsubscribeToken(SECRET, 'appwrite-gone', 'v1contact')
+
+    const asked = await app.inject({
+      method: 'GET',
+      url: `/email/unsubscribe?token=${encodeURIComponent(token)}`,
+    })
+    expect(asked.statusCode).toBe(200)
+    expect(asked.body).toContain('the one message about the new LangX')
+    expect(await contacts.countDocuments({ _id: 'appwrite-gone' as never })).toBe(1)
+
+    const done = await app.inject({
+      method: 'POST',
+      url: `/email/unsubscribe?token=${encodeURIComponent(token)}`,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: 'List-Unsubscribe=One-Click',
+    })
+    expect(done.statusCode).toBe(200)
+    expect(await contacts.countDocuments({ _id: 'appwrite-gone' as never })).toBe(0)
+
+    // A second press is not an error page.
+    const again = await app.inject({
+      method: 'POST',
+      url: `/email/unsubscribe?token=${encodeURIComponent(token)}`,
+    })
+    expect(again.statusCode).toBe(200)
+  })
 })

--- a/apps/api/src/routes/email.ts
+++ b/apps/api/src/routes/email.ts
@@ -2,6 +2,7 @@ import { webUrl } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { publicApiUrl, unsubscribeSecret } from '../env'
 import { localeFromHeader, translator } from '../i18n'
+import { removeDeletedContact } from '../modules/notifications/v1DeletedContacts'
 import { setEmailNotifications } from '../modules/profiles/profiles'
 import {
   signUnsubscribeToken,
@@ -119,7 +120,13 @@ export const emailRoutes: FastifyPluginAsyncZod = async (app) => {
 
       // Idempotent on purpose: a mail client may retry, and a second press of
       // the button must not be an error page for something already done.
-      await setEmailNotifications(app.mongo.db, claim.userId, claim.scope, false)
+      if (claim.scope === 'v1contact') {
+        // No account, so no preference to switch off: the address itself is
+        // what goes. See `v1DeletedContacts.ts`.
+        await removeDeletedContact(app.mongo.db, claim.userId)
+      } else {
+        await setEmailNotifications(app.mongo.db, claim.userId, claim.scope, false)
+      }
       request.log.info({ scope: claim.scope }, 'unsubscribed from notification email')
 
       return reply.type('text/html; charset=utf-8').send(

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2455,7 +2455,12 @@ kept for **one** announcement, so the script writes them to
 `v1DeletedContacts`, the only place a v1 email is stored in the clear. That
 mail is to people who ended their relationship with the product, so it is
 one mail, with an unsubscribe, and the collection is dropped afterwards —
-keeping it would turn a courtesy into a list.
+keeping it would turn a courtesy into a list. That send is
+`scripts/send-v1-deleted-announcement.ts`: it claims each row before the
+batch goes out, so a re-run cannot mail anybody twice; its unsubscribe link
+carries the `v1contact` scope, which has no preference to switch off and
+simply forgets the address; and `--drop` removes the collection only once
+nobody is left unsent.
 
 Appwrite is still running and is the only place the plaintext v1 emails live;
 the script needs it. If it goes away before the script has run, the rows


### PR DESCRIPTION
Follow-up to #1093. The 837 addresses set aside in `v1DeletedContacts` (v1 accounts their owners deleted) get exactly one email, and then the collection goes.

- **`scripts/send-v1-deleted-announcement.ts`** — same shape as `send-campaign.ts`: `--subject`, `--html-file` (must contain `{{unsubscribeUrl}}`), optional `--text-file`, `--limit`, `--confirm`. Each row is claimed (`sentAt`) before its batch is sent, so a re-run cannot mail anybody twice; a failed batch releases its claim. `--drop` removes the collection and is refused while anyone is still unsent; it can be run on its own afterwards.
- **`v1contact` unsubscribe scope** — no account behind these addresses, so "stop" means forgetting the row. The GET still only asks; the POST (one-click included) deletes the contact. Idempotent.
- `email.kind.v1contact` in all eight server locales for the confirmation page.
- Tests: module (claim once / release / remove / refuse-then-drop), token round-trip, route GET-then-POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
