### PR TITLE
Sell the missed day in the store, and make the store speak

### DIFF
--- a/apps/api/src/modules/tokens/streakDays.test.ts
+++ b/apps/api/src/modules/tokens/streakDays.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isRepairable, streakDayId, streakFromDays } from './streakDays'
+import { streakDayId, streakFromDays } from './streakDays'
 
 describe('streakFromDays', () => {
   const today = '2026-08-29'
@@ -38,28 +38,6 @@ describe('streakFromDays', () => {
   it('ignores days after today', () => {
     const days = new Set(['2026-08-30', '2026-08-29'])
     expect(streakFromDays(days, today)).toBe(1)
-  })
-})
-
-describe('isRepairable', () => {
-  const now = new Date('2026-08-29T12:00:00.000Z')
-  const today = '2026-08-29'
-
-  it('refuses today, which is earned rather than bought', () => {
-    expect(isRepairable(today, today, 'UTC', now)).toBe(false)
-  })
-
-  it('refuses a day that has not happened', () => {
-    expect(isRepairable('2026-08-30', today, 'UTC', now)).toBe(false)
-  })
-
-  it('allows yesterday and the edge of the window', () => {
-    expect(isRepairable('2026-08-28', today, 'UTC', now)).toBe(true)
-    expect(isRepairable('2026-08-15', today, 'UTC', now)).toBe(true)
-  })
-
-  it('refuses one day past the window', () => {
-    expect(isRepairable('2026-08-14', today, 'UTC', now)).toBe(false)
   })
 })
 

--- a/apps/api/src/modules/tokens/streakDays.ts
+++ b/apps/api/src/modules/tokens/streakDays.ts
@@ -1,5 +1,3 @@
-import { localDayKey, shiftDayKey, TOKEN_RULES } from '@langx/shared'
-
 // Re-exported so callers here keep one import; the walk itself lives in shared,
 // because the client has to predict the same number before a repair is bought.
 // `streakHeadDay` travels with it: they share the rule about where an
@@ -141,10 +139,11 @@ export async function repairsInMonth(db: Db, userId: string, day: string): Promi
   })
 }
 
-/** Whether a day is inside the window a repair may still reach. */
-export function isRepairable(day: string, today: string, timeZone: string, now: Date): boolean {
-  // Today is earned, not bought, and tomorrow has not happened.
-  if (day >= today) return false
-  const oldest = shiftDayKey(localDayKey(now, timeZone), -TOKEN_RULES.sinks.dayRepairMaxAgeDays)
-  return day >= oldest
-}
+/*
+ * Moved to `@langx/shared` so the app can ask the same question the server
+ * answers — the store row for a repair has to know which day is still
+ * reachable, and a second copy of that rule in the client is how the two
+ * would come to disagree. Re-exported here because this is where every
+ * server-side caller already looks for it.
+ */
+export { isRepairable } from '@langx/shared'

--- a/apps/api/src/modules/tokens/wallet.ts
+++ b/apps/api/src/modules/tokens/wallet.ts
@@ -260,7 +260,7 @@ export async function repairDay(db: Db, userId: string, day: string): Promise<Re
   const timeZone = profile.timezone ?? 'UTC'
   const today = localDayKey(now, timeZone)
 
-  if (!isRepairable(day, today, timeZone, now)) {
+  if (!isRepairable(day, today)) {
     throw new ApiError(
       ERROR_CODES.VALIDATION_FAILED,
       `Only the last ${TOKEN_RULES.sinks.dayRepairMaxAgeDays} days, and not today — today is earned`,

--- a/apps/mobile/app/(app)/wallet.tsx
+++ b/apps/mobile/app/(app)/wallet.tsx
@@ -1,13 +1,15 @@
-import { COSMETICS, type PeriodType } from '@langx/shared'
+import { COSMETICS, shiftDayKey, TOKEN_RULES, type PeriodType } from '@langx/shared'
 import { useState } from 'react'
 import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { router } from 'expo-router'
 import Feather from '@expo/vector-icons/Feather'
 import { LoadFailed } from '../../src/components/LoadFailed'
 import {
+  useActivity,
   useLeaderboard,
   useMe,
   usePurchase,
+  useRepairDay,
   useTokens,
   useUpdateProfile,
   useWallet,
@@ -15,13 +17,17 @@ import {
 import { EquipPicker } from '../../src/components/store/EquipPicker'
 import { StoreRow } from '../../src/components/store/StoreRow'
 import { LeaderboardSection } from '../../src/components/LeaderboardSection'
+import type { StoreOffer } from '../../src/lib/storeOffers'
 import { Screen } from '../../src/components/ui/Screen'
 import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
 import { StatTile } from '../../src/components/ui/StatTile'
+import { showAlert } from '../../src/lib/alert'
 import { goBackTo } from '../../src/lib/navigation'
+import { confirmAndRepair } from '../../src/lib/repairFlow'
+import { showToast } from '../../src/lib/toast'
 import { buildStoreOffers } from '../../src/lib/storeOffers'
 import { makeStyles, useTheme } from '../../src/lib/theme'
-import { periodLabel, useT } from '../../src/i18n'
+import { periodLabel, useLocale, useT } from '../../src/i18n'
 import { leaderboardShareText } from '../../src/lib/shareText'
 
 /**
@@ -44,11 +50,20 @@ export default function WalletScreen() {
   const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()
+  const { locale } = useLocale()
 
   const me = useMe()
   const wallet = useWallet()
   const [period, setPeriod] = useState<PeriodType>('week')
   const board = useLeaderboard(period)
+  /*
+   * The window a repair can still reach, so the store can offer the newest day
+   * inside it. Same query the heatmap on `/me` already runs, so it is usually
+   * in cache by the time somebody walks over here.
+   */
+  const today = new Date().toISOString().slice(0, 10)
+  const activity = useActivity(shiftDayKey(today, -TOKEN_RULES.sinks.dayRepairMaxAgeDays), today)
+  const repairDay = useRepairDay()
   const purchase = usePurchase()
   const update = useUpdateProfile()
   // The shop needs both to draw a gate's progress; the wallet itself does not.
@@ -83,10 +98,54 @@ export default function WalletScreen() {
     lifetimeCorrections: xp.data?.lifetime.corrections ?? 0,
     owned,
     streakFreezes: wallet.data?.streakFreezes ?? 0,
+    ...(activity.data
+      ? {
+          repair: {
+            today: activity.data.today,
+            filled: new Set(activity.data.days.map((day) => day.day)),
+            price: activity.data.repair.price,
+            usedThisMonth: activity.data.repair.usedThisMonth,
+          },
+        }
+      : {}),
   })
 
+  /**
+   * Buying, and saying so.
+   *
+   * Both halves were missing. The purchase was `purchase.mutate(id)` with no
+   * success and no error handler, so a freeze bought at a full bank failed in
+   * silence — the button dimmed, nothing else moved, and there was no way to
+   * tell a refusal from a slow network.
+   *
+   * A repair is a different endpoint and a different confirmation, which is
+   * why the row carries the day rather than the screen parsing it back out of
+   * an id.
+   */
+  function buy(offer: StoreOffer): void {
+    if (offer.repairDay && activity.data) {
+      void confirmAndRepair({
+        day: offer.repairDay,
+        today: activity.data.today,
+        filled: new Set(activity.data.days.map((day) => day.day)),
+        price: activity.data.repair.price,
+        balance,
+        left: Math.max(0, activity.data.repair.perMonth - activity.data.repair.usedThisMonth),
+        perMonth: activity.data.repair.perMonth,
+        t,
+        locale,
+        repair: (day, handlers) => repairDay.mutate(day, handlers),
+      })
+      return
+    }
+    purchase.mutate(offer.id, {
+      onSuccess: () => showToast(t('store.bought', { title: offer.title })),
+      onError: () => void showAlert(t('store.buyFailed'), t('common.retry')),
+    })
+  }
+
   function refresh(): void {
-    void Promise.all([me.refetch(), wallet.refetch(), xp.refetch()])
+    void Promise.all([me.refetch(), wallet.refetch(), xp.refetch(), activity.refetch()])
   }
 
   /*
@@ -182,7 +241,7 @@ export default function WalletScreen() {
             offer={offer}
             pending={purchase.isPending}
             last={index === offers.length - 1}
-            onBuy={(id) => purchase.mutate(id)}
+            onBuy={buy}
             viewer={viewer}
           />
         ))}

--- a/apps/mobile/src/components/ActivityMap.tsx
+++ b/apps/mobile/src/components/ActivityMap.tsx
@@ -6,14 +6,11 @@ import {
   ACTIVITY_CELL_GAP,
   activityCellSize,
   activityGrid,
-  repairEffect,
   type ActivityCell,
 } from '../lib/activityMap'
-import { confirmAlert, showAlert } from '../lib/alert'
-import { dayLabel } from '../lib/messageGroups'
+import { confirmAndRepair } from '../lib/repairFlow'
 import { makeStyles, useTheme } from '../lib/theme'
 import { useLocale, useT } from '../i18n'
-import { showToast } from '../lib/toast'
 
 /** Half a year, which is as much as fits without the squares becoming dots. */
 const WEEKS = 26
@@ -104,56 +101,17 @@ export function ActivityMap({ handle }: ActivityMapProps = {}) {
 
   async function onPressDay(cell: ActivityCell): Promise<void> {
     if (handle || cell.state !== 'repairable') return
-    if (left === 0) {
-      await showAlert(
-        t('activity.noRepairsTitle'),
-        t('activity.perMonth', { count: rules.perMonth }),
-      )
-      return
-    }
-
-    const effect = repairEffect({
+    await confirmAndRepair({
       day: cell.day,
       today,
       filled,
       price: rules.price,
       balance: wallet.data?.balance ?? 0,
-    })
-    if (!effect.affordable) {
-      await showAlert(
-        t('activity.notEnoughTokensTitle'),
-        t('activity.notEnoughTokensBody', {
-          price: rules.price,
-          balance: wallet.data?.balance ?? 0,
-        }),
-      )
-      return
-    }
-
-    /**
-     * The whole point of the confirmation: it says what the purchase does
-     * *before* it happens, including when the answer is "nothing much". A
-     * square in the middle of a fortnight nobody was active in fills and joins
-     * no streak, and saying so is worth more than the sale.
-     */
-    const label = dayLabel(cell.day, { t, locale, now: new Date(`${today}T12:00:00`) })
-    const streakLine = effect.changesStreak
-      ? t('activity.streakChange', { before: effect.streakBefore, count: effect.streakAfter })
-      : t('activity.noStreakChange')
-    const confirmed = await confirmAlert({
-      title: t('activity.fillInTitle', { day: label }),
-      message: t('activity.balanceChange', {
-        streakLine,
-        before: wallet.data?.balance ?? 0,
-        after: effect.balanceAfter,
-      }),
-      confirmLabel: t('activity.fillIt'),
-    })
-    if (!confirmed) return
-
-    repair.mutate(cell.day, {
-      onSuccess: () => showToast(t('activity.filled')),
-      onError: () => void showAlert(t('activity.fillFailed'), t('common.retry')),
+      left,
+      perMonth: rules.perMonth,
+      t,
+      locale,
+      repair: (day, handlers) => repair.mutate(day, handlers),
     })
   }
 

--- a/apps/mobile/src/components/store/StoreRow.tsx
+++ b/apps/mobile/src/components/store/StoreRow.tsx
@@ -22,7 +22,7 @@ export function StoreRow({
   offer: StoreOffer
   pending: boolean
   last?: boolean
-  onBuy: (id: string) => void
+  onBuy: (offer: StoreOffer) => void
   viewer?: { name: string; avatarUrl?: string | undefined }
 }) {
   const t = useT()
@@ -74,7 +74,7 @@ export function StoreRow({
         }
         accessibilityState={{ disabled: !buyable }}
         disabled={!buyable}
-        onPress={() => onBuy(offer.id)}
+        onPress={() => onBuy(offer)}
         style={({ pressed }) => [
           styles.price,
           // Yellow only when the tap does something. An affordable, unowned

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -1089,7 +1089,7 @@ export const ar: Localized<EnMessages> = {
 
   store: {
     streakFreeze: 'تجميد السلسلة',
-    streakFreezeBody: 'ينقذ يومًا فائتًا · {banked}/{max} مُدّخر',
+    streakFreezeBody: 'يغطّي أول يوم تفوته · {banked}/{max} في الرصيد',
     ownedAccessibility: '{title}، مملوك',
     buy: 'شراء {title} مقابل {price} رمزًا',
     yourFrames: 'إطاراتك',
@@ -1104,6 +1104,10 @@ export const ar: Localized<EnMessages> = {
     frameKind: 'إطار الملف',
     titleKind: 'لقب',
     todayCounts: '{messages} · {corrections}',
+    repairDay: 'استرجع يومًا',
+    repairDayBody: 'يملأ يومًا فاتك · بقي لك {left} هذا الشهر',
+    bought: '{title} أصبح لك',
+    buyFailed: 'تعذّر الشراء',
   },
 
   wallet: {
@@ -1114,7 +1118,7 @@ export const ar: Localized<EnMessages> = {
     itemsOwned: 'العناصر المملوكة',
     storeTitle: 'المتجر',
     disclaimer:
-      'الرموز نقاط داخل التطبيق. لا يمكن شراؤها أو تداولها أو سحبها أو استخدامها لفتح خطة مدفوعة — فقط تجميدات السلسلة والعناصر التجميلية. لا سلسلة ولا عقد ولا سوق.',
+      'الرموز نقاط داخل التطبيق. لا يمكن شراؤها أو تداولها أو سحبها أو استخدامها لفتح خطة مدفوعة — فقط تجميدات السلسلة والأيام الفائتة والعناصر التجميلية. لا سلسلة ولا عقد ولا سوق.',
   },
 
   tokens: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -948,7 +948,7 @@ export const de: Localized<EnMessages> = {
 
   store: {
     streakFreeze: 'Serienschutz',
-    streakFreezeBody: 'Rettet einen verpassten Tag · {banked}/{max} auf Vorrat',
+    streakFreezeBody: 'Deckt den nächsten verpassten Tag · {banked}/{max} auf Lager',
     ownedAccessibility: '{title}, bereits vorhanden',
     buy: '{title} für {price} Token kaufen',
     yourFrames: 'Deine Rahmen',
@@ -963,6 +963,10 @@ export const de: Localized<EnMessages> = {
     frameKind: 'Profilrahmen',
     titleKind: 'Titel',
     todayCounts: '{messages} · {corrections}',
+    repairDay: 'Einen Tag zurückkaufen',
+    repairDayBody: 'Füllt einen verpassten Tag · diesen Monat noch {left}',
+    bought: '{title} gehört dir',
+    buyFailed: 'Kauf nicht möglich',
   },
 
   wallet: {
@@ -973,7 +977,7 @@ export const de: Localized<EnMessages> = {
     itemsOwned: 'Besitz',
     storeTitle: 'Shop',
     disclaimer:
-      'Token sind In-App-Punkte. Sie lassen sich nicht kaufen, handeln, auszahlen oder gegen einen bezahlten Tarif eintauschen — nur Serien-Freezes und Kosmetik. Es gibt keine Chain, keinen Vertrag und keinen Markt.',
+      'Token sind In-App-Punkte. Sie lassen sich nicht kaufen, handeln, auszahlen oder gegen einen bezahlten Tarif eintauschen — nur Serien-Freezes, verpasste Tage und Kosmetik. Es gibt keine Chain, keinen Vertrag und keinen Markt.',
   },
 
   tokens: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -961,7 +961,7 @@ export const en = {
 
   store: {
     streakFreeze: 'Streak freeze',
-    streakFreezeBody: 'Saves one missed day · {banked}/{max} banked',
+    streakFreezeBody: 'Covers the next day you miss · {banked}/{max} banked',
     ownedAccessibility: '{title}, owned',
     buy: 'Buy {title} for {price} tokens',
     yourFrames: 'Your frames',
@@ -976,6 +976,10 @@ export const en = {
     frameKind: 'Profile frame',
     titleKind: 'Title',
     todayCounts: '{messages} · {corrections}',
+    repairDay: 'Buy a day back',
+    repairDayBody: 'Fills in a day you missed · {left} left this month',
+    bought: '{title} is yours',
+    buyFailed: 'Could not buy that',
   },
 
   wallet: {
@@ -986,7 +990,7 @@ export const en = {
     itemsOwned: 'Items owned',
     storeTitle: 'Store',
     disclaimer:
-      'Tokens are in-app points. They cannot be bought, traded, withdrawn or used to unlock a paid plan — only streak freezes and cosmetics. There is no chain, no contract and no market.',
+      'Tokens are in-app points. They cannot be bought, traded, withdrawn or used to unlock a paid plan — only streak freezes, missed days and cosmetics. There is no chain, no contract and no market.',
   },
 
   tokens: {

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -924,7 +924,7 @@ export const es: Localized<EnMessages> = {
 
   store: {
     streakFreeze: 'Congelar racha',
-    streakFreezeBody: 'Salva un día perdido · {banked}/{max} guardadas',
+    streakFreezeBody: 'Cubre el próximo día que falles · {banked}/{max} guardados',
     ownedAccessibility: '{title}, ya lo tienes',
     buy: 'Comprar {title} por {price} fichas',
     yourFrames: 'Tus marcos',
@@ -939,6 +939,10 @@ export const es: Localized<EnMessages> = {
     frameKind: 'Marco de perfil',
     titleKind: 'Título',
     todayCounts: '{messages} · {corrections}',
+    repairDay: 'Recupera un día',
+    repairDayBody: 'Rellena un día que perdiste · te quedan {left} este mes',
+    bought: '{title} es tuyo',
+    buyFailed: 'No se pudo comprar',
   },
 
   wallet: {
@@ -949,7 +953,7 @@ export const es: Localized<EnMessages> = {
     itemsOwned: 'Objetos',
     storeTitle: 'Tienda',
     disclaimer:
-      'Las fichas son puntos dentro de la app. No se pueden comprar, intercambiar, retirar ni usar para desbloquear un plan de pago: solo congelaciones de racha y cosméticos. No hay cadena, ni contrato, ni mercado.',
+      'Las fichas son puntos dentro de la app. No se pueden comprar, intercambiar, retirar ni usar para desbloquear un plan de pago: solo congelaciones de racha, días perdidos y cosméticos. No hay cadena, ni contrato, ni mercado.',
   },
 
   tokens: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -930,7 +930,7 @@ export const fr: Localized<EnMessages> = {
 
   store: {
     streakFreeze: 'Gel de série',
-    streakFreezeBody: 'Sauve un jour manqué · {banked}/{max} en réserve',
+    streakFreezeBody: 'Couvre le prochain jour manqué · {banked}/{max} en réserve',
     ownedAccessibility: '{title}, déjà acquis',
     buy: 'Acheter {title} pour {price} jetons',
     yourFrames: 'Tes cadres',
@@ -945,6 +945,10 @@ export const fr: Localized<EnMessages> = {
     frameKind: 'Cadre de profil',
     titleKind: 'Titre',
     todayCounts: '{messages} · {corrections}',
+    repairDay: 'Racheter un jour',
+    repairDayBody: 'Comble un jour manqué · il t’en reste {left} ce mois-ci',
+    bought: '{title} est à toi',
+    buyFailed: 'Achat impossible',
   },
 
   wallet: {
@@ -955,7 +959,7 @@ export const fr: Localized<EnMessages> = {
     itemsOwned: 'Objets possédés',
     storeTitle: 'Boutique',
     disclaimer:
-      'Les jetons sont des points internes à l’app. Ils ne peuvent être achetés, échangés, retirés ni servir à débloquer une formule payante — seulement des gels de série et des cosmétiques. Pas de chaîne, pas de contrat, pas de marché.',
+      'Les jetons sont des points internes à l’app. Ils ne peuvent être achetés, échangés, retirés ni servir à débloquer une formule payante — seulement des gels de série, des jours manqués et des cosmétiques. Pas de chaîne, pas de contrat, pas de marché.',
   },
 
   tokens: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -919,7 +919,7 @@ export const ptBR: Localized<EnMessages> = {
 
   store: {
     streakFreeze: 'Congelar sequência',
-    streakFreezeBody: 'Salva um dia perdido · {banked}/{max} guardados',
+    streakFreezeBody: 'Cobre o próximo dia que você perder · {banked}/{max} guardados',
     ownedAccessibility: '{title}, você já tem',
     buy: 'Comprar {title} por {price} fichas',
     yourFrames: 'Suas molduras',
@@ -934,6 +934,10 @@ export const ptBR: Localized<EnMessages> = {
     frameKind: 'Moldura de perfil',
     titleKind: 'Título',
     todayCounts: '{messages} · {corrections}',
+    repairDay: 'Recupere um dia',
+    repairDayBody: 'Preenche um dia perdido · restam {left} neste mês',
+    bought: '{title} é seu',
+    buyFailed: 'Não foi possível comprar',
   },
 
   wallet: {
@@ -944,7 +948,7 @@ export const ptBR: Localized<EnMessages> = {
     itemsOwned: 'Itens',
     storeTitle: 'Loja',
     disclaimer:
-      'As fichas são pontos dentro do app. Não podem ser compradas, trocadas, sacadas nem usadas para desbloquear um plano pago — apenas congelamentos de sequência e cosméticos. Não há cadeia, contrato nem mercado.',
+      'As fichas são pontos dentro do app. Não podem ser compradas, trocadas, sacadas nem usadas para desbloquear um plano pago — apenas congelamentos de sequência, dias perdidos e cosméticos. Não há cadeia, contrato nem mercado.',
   },
 
   tokens: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -1045,7 +1045,7 @@ export const ru: Localized<EnMessages> = {
 
   store: {
     streakFreeze: 'Заморозка серии',
-    streakFreezeBody: 'Спасает один пропущенный день · накоплено {banked}/{max}',
+    streakFreezeBody: 'Покроет следующий пропущенный день · {banked}/{max} в запасе',
     ownedAccessibility: '{title}, уже есть',
     buy: 'Купить {title} за {price} жетонов',
     yourFrames: 'Ваши рамки',
@@ -1060,6 +1060,10 @@ export const ru: Localized<EnMessages> = {
     frameKind: 'Рамка профиля',
     titleKind: 'Титул',
     todayCounts: '{messages} · {corrections}',
+    repairDay: 'Вернуть день',
+    repairDayBody: 'Закрывает пропущенный день · осталось {left} в этом месяце',
+    bought: '{title} — твой',
+    buyFailed: 'Не удалось купить',
   },
 
   wallet: {
@@ -1070,7 +1074,7 @@ export const ru: Localized<EnMessages> = {
     itemsOwned: 'Предметы',
     storeTitle: 'Магазин',
     disclaimer:
-      'Жетоны — это внутренние баллы. Их нельзя купить, обменять, вывести или разблокировать ими платный тариф — только заморозки серии и косметика. Нет ни цепочки, ни контракта, ни рынка.',
+      'Жетоны — это внутренние баллы. Их нельзя купить, обменять, вывести или разблокировать ими платный тариф — только заморозки серии, пропущенные дни и косметика. Нет ни цепочки, ни контракта, ни рынка.',
   },
 
   tokens: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -931,7 +931,7 @@ export const tr: Localized<EnMessages> = {
 
   store: {
     streakFreeze: 'Seri dondurma',
-    streakFreezeBody: 'Kaçırılan bir günü kurtarır · {banked}/{max} birikti',
+    streakFreezeBody: 'Kaçıracağın ilk günü karşılar · {banked}/{max} bankada',
     ownedAccessibility: '{title}, sende var',
     buy: '{title} için {price} jeton öde',
     yourFrames: 'Çerçevelerin',
@@ -946,6 +946,10 @@ export const tr: Localized<EnMessages> = {
     frameKind: 'Profil çerçevesi',
     titleKind: 'Unvan',
     todayCounts: '{messages} · {corrections}',
+    repairDay: 'Bir günü geri al',
+    repairDayBody: 'Kaçırdığın bir günü doldurur · bu ay {left} hakkın var',
+    bought: '{title} senin',
+    buyFailed: 'Satın alınamadı',
   },
 
   wallet: {
@@ -956,7 +960,7 @@ export const tr: Localized<EnMessages> = {
     itemsOwned: 'Sahip olunan',
     storeTitle: 'Mağaza',
     disclaimer:
-      'Jetonlar uygulama içi puandır. Satın alınamaz, takas edilemez, çekilemez ve ücretli bir planı açamaz — yalnızca seri dondurma ve kozmetikler. Zincir yok, sözleşme yok, piyasa yok.',
+      'Jetonlar uygulama içi puandır. Satın alınamaz, takas edilemez, çekilemez ve ücretli bir planı açamaz — yalnızca seri dondurma, kaçırılan günler ve kozmetikler. Zincir yok, sözleşme yok, piyasa yok.',
   },
 
   tokens: {

--- a/apps/mobile/src/lib/repairFlow.ts
+++ b/apps/mobile/src/lib/repairFlow.ts
@@ -1,0 +1,77 @@
+import type { TranslateFn } from '../i18n/runtime'
+import type { Locale } from '@langx/shared'
+import { repairEffect } from './activityMap'
+import { confirmAlert, showAlert } from './alert'
+import { dayLabel } from './messageGroups'
+import { showToast } from './toast'
+
+interface ConfirmAndRepairInput {
+  day: string
+  today: string
+  filled: ReadonlySet<string>
+  price: number
+  balance: number
+  left: number
+  perMonth: number
+  t: TranslateFn
+  locale: Locale
+  /** The mutation itself, so this file needs no React and the tests can reach it. */
+  repair: (day: string, handlers: { onSuccess: () => void; onError: () => void }) => void
+}
+
+/**
+ * Buy a missed day back, with the sentence that says what it will do.
+ *
+ * Lifted out of `ActivityMap` when the store gained a repair row: two entry
+ * points to the same purchase, and the *confirmation* is the part that must
+ * not diverge. It says what the purchase does before it happens — including
+ * when the honest answer is "nothing much", because a square in the middle of
+ * a fortnight nobody was active in fills and joins no streak, and saying so is
+ * worth more than the sale.
+ */
+export async function confirmAndRepair({
+  day,
+  today,
+  filled,
+  price,
+  balance,
+  left,
+  perMonth,
+  t,
+  locale,
+  repair,
+}: ConfirmAndRepairInput): Promise<void> {
+  if (left === 0) {
+    await showAlert(t('activity.noRepairsTitle'), t('activity.perMonth', { count: perMonth }))
+    return
+  }
+
+  const effect = repairEffect({ day, today, filled: new Set(filled), price, balance })
+  if (!effect.affordable) {
+    await showAlert(
+      t('activity.notEnoughTokensTitle'),
+      t('activity.notEnoughTokensBody', { price, balance }),
+    )
+    return
+  }
+
+  const label = dayLabel(day, { t, locale, now: new Date(`${today}T12:00:00`) })
+  const streakLine = effect.changesStreak
+    ? t('activity.streakChange', { before: effect.streakBefore, count: effect.streakAfter })
+    : t('activity.noStreakChange')
+  const confirmed = await confirmAlert({
+    title: t('activity.fillInTitle', { day: label }),
+    message: t('activity.balanceChange', {
+      streakLine,
+      before: balance,
+      after: effect.balanceAfter,
+    }),
+    confirmLabel: t('activity.fillIt'),
+  })
+  if (!confirmed) return
+
+  repair(day, {
+    onSuccess: () => showToast(t('activity.filled')),
+    onError: () => void showAlert(t('activity.fillFailed'), t('common.retry')),
+  })
+}

--- a/apps/mobile/src/lib/storeOffers.test.ts
+++ b/apps/mobile/src/lib/storeOffers.test.ts
@@ -1,4 +1,4 @@
-import { COSMETICS, STREAK_FREEZE_SKU, TOKEN_RULES } from '@langx/shared'
+import { COSMETICS, shiftDayKey, STREAK_FREEZE_SKU, TOKEN_RULES } from '@langx/shared'
 import { describe, expect, it } from 'vitest'
 import { createTranslate } from '../i18n/runtime'
 import { buildStoreOffers, type StoreInput } from './storeOffers'
@@ -18,6 +18,72 @@ describe('buildStoreOffers', () => {
   it('always lists the freeze and every cosmetic', () => {
     const ids = buildStoreOffers(base).map((offer) => offer.id)
     expect(ids).toEqual([STREAK_FREEZE_SKU, ...COSMETICS.map((c) => c.id)])
+  })
+
+  describe('the day repair', () => {
+    const today = '2026-09-03'
+    const repairs = (over: Partial<NonNullable<StoreInput['repair']>> = {}) => ({
+      today,
+      filled: new Set<string>(),
+      price: TOKEN_RULES.sinks.dayRepair,
+      usedThisMonth: 0,
+      ...over,
+    })
+    const repairOffer = (input: Partial<StoreInput>) =>
+      buildStoreOffers({ ...base, ...input }).find((offer) => offer.repairDay !== undefined)
+
+    it('offers the newest missed day, not the oldest', () => {
+      /*
+       * The oldest is the one about to fall out of the window, but the newest
+       * is the one next to a live streak — which is the one that repairing
+       * actually rescues.
+       */
+      const filled = new Set([shiftDayKey(today, -1)])
+      const offer = repairOffer({ balance: 5_000, repair: repairs({ filled }) })
+      expect(offer?.repairDay).toBe(shiftDayKey(today, -2))
+      expect(offer?.id).toBe(`dayRepair:${shiftDayKey(today, -2)}`)
+    })
+
+    it('offers nothing when every day in the window is already filled', () => {
+      const filled = new Set(
+        Array.from({ length: TOKEN_RULES.sinks.dayRepairMaxAgeDays + 1 }, (_, i) =>
+          shiftDayKey(today, -i),
+        ),
+      )
+      expect(repairOffer({ balance: 5_000, repair: repairs({ filled }) })).toBeUndefined()
+    })
+
+    it('offers nothing at the monthly cap', () => {
+      expect(
+        repairOffer({
+          balance: 5_000,
+          repair: repairs({ usedThisMonth: TOKEN_RULES.sinks.dayRepairPerMonth }),
+        }),
+      ).toBeUndefined()
+    })
+
+    it('offers nothing without the activity window', () => {
+      // A screen that cannot say which days are filled must not be handed a
+      // row it would price wrongly.
+      expect(repairOffer({ balance: 5_000 })).toBeUndefined()
+    })
+
+    it('is unaffordable below the price, and never locked', () => {
+      const offer = repairOffer({
+        balance: TOKEN_RULES.sinks.dayRepair - 1,
+        repair: repairs(),
+      })
+      expect(offer).toMatchObject({ affordable: false, owned: false })
+      // `locked` means "you cannot have this yet", which is a different
+      // sentence from "come back richer" — a repair is never the former.
+      expect(offer?.locked).toBeUndefined()
+    })
+
+    it('sits below the freeze, where the streak things belong', () => {
+      const ids = buildStoreOffers({ ...base, balance: 5_000, repair: repairs() }).map((o) => o.id)
+      expect(ids[0]).toBe(STREAK_FREEZE_SKU)
+      expect(ids[1]).toBe(`dayRepair:${shiftDayKey(today, -1)}`)
+    })
   })
 
   describe('streak freeze', () => {

--- a/apps/mobile/src/lib/storeOffers.ts
+++ b/apps/mobile/src/lib/storeOffers.ts
@@ -5,6 +5,8 @@ import {
   type CosmeticTone,
   STREAK_FREEZE_SKU,
   TOKEN_RULES,
+  isRepairable,
+  shiftDayKey,
 } from '@langx/shared'
 import type { MessageKey, TranslateFn } from '../i18n/runtime'
 
@@ -39,6 +41,15 @@ export interface StoreOffer {
   /** Whether the balance covers the price. Separate from `owned`: an owned
    *  item is never buyable however much the balance is. */
   affordable: boolean
+  /**
+   * The day this offer would fill in, when it is a repair.
+   *
+   * Carried explicitly rather than parsed back out of `id`. The id is
+   * `dayRepair:<day>` because the row needs a stable key and the day is what
+   * makes it unique — but a screen reading the day by slicing the id is a
+   * screen that breaks the moment the id gains a second part.
+   */
+  repairDay?: string
 }
 
 export interface StoreInput {
@@ -49,6 +60,19 @@ export interface StoreInput {
   /** Cosmetic ids already bought, from `GET /me/wallet`. */
   owned: readonly string[]
   streakFreezes: number
+  /**
+   * The missed days a repair could still reach, or nothing when the screen has
+   * no activity loaded. Optional so the store is buildable without it — a
+   * caller that cannot say which days are filled must not be given a repair
+   * row it cannot price honestly.
+   */
+  repair?: {
+    today: string
+    /** Days already active or already bought back. */
+    filled: ReadonlySet<string>
+    price: number
+    usedThisMonth: number
+  }
   /**
    * Passed in rather than reached for, so this stays a pure function the tests
    * can call without a React tree — and so the wording of an offer is decided
@@ -110,6 +134,44 @@ export function buildStoreOffers(input: StoreInput): StoreOffer[] {
     ...freezeOffer,
     affordable: freezeOffer.affordable && input.streakFreezes < maxFreezes,
   })
+
+  /*
+   * The day repair, sold where the freeze is sold.
+   *
+   * The freeze is prospective — it covers the *next* day you miss — and that
+   * is deliberate, but it left nothing in the store for the day you have
+   * already missed. The repair existed and could only be reached by finding
+   * the right grey square on the heatmap.
+   *
+   * The newest missed day, not the oldest. The oldest is the one about to fall
+   * out of the window, but the newest is the one adjacent to a live streak,
+   * which is the one repairing it actually rescues.
+   */
+  const repair = input.repair
+  if (repair && repair.usedThisMonth < TOKEN_RULES.sinks.dayRepairPerMonth) {
+    let day: string | null = null
+    for (let back = 1; back <= TOKEN_RULES.sinks.dayRepairMaxAgeDays; back++) {
+      const candidate = shiftDayKey(repair.today, -back)
+      if (!isRepairable(candidate, repair.today)) break
+      if (!repair.filled.has(candidate)) {
+        day = candidate
+        break
+      }
+    }
+    if (day) {
+      offers.push({
+        ...priced(
+          `dayRepair:${day}`,
+          t('store.repairDay'),
+          t('store.repairDayBody', {
+            left: TOKEN_RULES.sinks.dayRepairPerMonth - repair.usedThisMonth,
+          }),
+          repair.price,
+        ),
+        repairDay: day,
+      })
+    }
+  }
 
   const progress = {
     longestStreak: input.longestStreak,

--- a/packages/shared/src/token.test.ts
+++ b/packages/shared/src/token.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { streakFromDays, streakHeadDay } from './token'
+import { isRepairable, streakFromDays, streakHeadDay } from './token'
 
 const days = (...list: string[]) => new Set(list)
 
@@ -46,5 +46,26 @@ describe('streakHeadDay', () => {
     const set = days('2026-08-27', '2026-08-28', '2026-08-29', '2026-08-30')
     expect(streakHeadDay(set, '2026-08-31')).toBe('2026-08-30')
     expect(streakFromDays(set, '2026-08-31')).toBe(4)
+  })
+})
+
+describe('isRepairable', () => {
+  const today = '2026-08-29'
+
+  it('refuses today, which is earned rather than bought', () => {
+    expect(isRepairable(today, today)).toBe(false)
+  })
+
+  it('refuses a day that has not happened', () => {
+    expect(isRepairable('2026-08-30', today)).toBe(false)
+  })
+
+  it('allows yesterday and the edge of the window', () => {
+    expect(isRepairable('2026-08-28', today)).toBe(true)
+    expect(isRepairable('2026-08-15', today)).toBe(true)
+  })
+
+  it('refuses one day past the window', () => {
+    expect(isRepairable('2026-08-14', today)).toBe(false)
   })
 })

--- a/packages/shared/src/token.ts
+++ b/packages/shared/src/token.ts
@@ -579,6 +579,21 @@ export const repairDaySchema = z.object({
  * Yesterday is where an unfinished today starts from — a user who has not sent
  * anything yet today still has the run that ended yesterday.
  */
+/**
+ * Whether a missed day is still inside the window a repair can reach.
+ *
+ * Two dates and nothing else. It used to take a timezone and a clock as well,
+ * and derive today from them — but every caller already knows what today is,
+ * because everything else about a streak is keyed on that same day string. The
+ * extra arguments were a second way to compute the same answer, which is a
+ * second way to get it wrong.
+ */
+export function isRepairable(day: string, today: string): boolean {
+  // Today is earned rather than bought, and tomorrow has not happened.
+  if (day >= today) return false
+  return day >= shiftDayKey(today, -TOKEN_RULES.sinks.dayRepairMaxAgeDays)
+}
+
 export function streakFromDays(days: Set<string>, today: string): number {
   let cursor = streakHeadDay(days, today)
   if (cursor === null) return 0


### PR DESCRIPTION
The streak freeze reads as though it undoes a day you already missed — "Saves one missed day" — and it does not. It is banked and spent on the *next* gap, which is deliberate and priced that way. Somebody who has just broken a streak buys one, watches nothing happen, and is right to be confused.

The thing they wanted already existed. `repairDay` is well tested and reachable only by finding the right grey square on the heatmap on your own profile, which nobody does on the day they are looking for it.

## What changed

- **The repair is a store row**, for the newest missed day still inside the window. The newest rather than the oldest: the oldest is about to fall out of the window, but the newest is the one adjacent to a live streak, so it is the one repairing actually rescues. It disappears at the monthly cap and when the window is full.
- **The freeze copy** says what it does: "Covers the next day you miss."
- **The store speaks.** Every purchase was a bare `mutate` with no handlers, so a freeze bought against a full bank failed in silence — the button dimmed and nothing else moved, which is indistinguishable from a slow network. Toast on success, alert on failure.
- **`wallet.disclaimer`** now lists missed days among what tokens buy, in all eight locales.

## Shared rules, not copied ones

`isRepairable` moves to `packages/shared` so the app can ask the question the server answers, and loses its `timeZone` and `now` parameters on the way: every caller already knows what today is, and deriving it a second time is a second way to get it wrong. Its tests move with it.

The confirmation is extracted to `src/lib/repairFlow.ts` and shared with the heatmap, because that is the part that must not diverge — it states the streak and balance effect before the purchase, including when the honest answer is "nothing much".

`StoreRow.onBuy` now takes the offer rather than an id, and the repair carries its day explicitly. Parsing the day back out of `dayRepair:<day>` would break the moment the id gains a second part.

## Verification

Live, on the isolated stack: the row reads "Buy a day back · Fills in a day you missed · 2 left this month · 600"; below the price it renders inert, as designed. With the balance topped up, pressing it opens "Fill in Yesterday? Your streak goes from 1 to 2 days. Your balance goes 3256 → 2656", and confirming leaves the balance at 2656, spent at 600 and the row saying "1 left this month".

Six new tests on the pure builder: newest missed day wins, nothing when the window is full, nothing at the cap, nothing without the activity window, unaffordable below the price and never `locked`, and the row sits directly below the freeze. The API side was already covered.

Full suites pass: 768 API, 529 mobile, 229 shared, plus typecheck, lint and format.

Note: #1099 also edits the wallet screen (it adds the token board under the balance). The regions differ, but whichever merges second will want a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)