### PR TITLE
Write down what the 3 September series changed

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -225,6 +225,17 @@ files.
   `authClient.getCookie()` and attached by hand with `credentials: "omit"`, all
   of it hidden behind one `apiFetch` wrapper.
 - The Socket.io handshake validates the same session → `socket.data.userId`.
+- **Sessions are visible and revocable.** Settings → _Sign in on another
+  device_ lists every session (`GET /list-sessions`) with a per-row sign-out
+  (`POST /revoke-session`) and _sign out everywhere else_. `freshAge: 0` in
+  `auth.ts` is what makes the list readable: the default gates it behind a
+  24-hour freshness check, and a phone that signed in last week got a 403.
+- **QR sign-in on the web** is RFC 8628's device flow. The browser polls
+  `/device/token`; the phone claims the code (`GET /device?user_code=`) and
+  then approves. The QR encodes a `langx://link-device` link so the phone's own
+  camera lands in the app, and an `after` hook writes the session cookie for
+  the browser — the token endpoint is OAuth and answers with a bearer token
+  nothing in this app sends. See `decisions.md` → _Device sign-in_.
 - **Age gate:** `birthDate` (`YYYY-MM-DD`) is required at onboarding and
   under-18s cannot complete it. The check is server-side, before `profiles` is
   written — the client's date picker is not trusted. The rule still counts

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2516,3 +2516,49 @@ than `immutable`, because the picture is no longer a pure function of its URL �
 gender is writable exactly once, from `undisclosed` to a value, and a
 cache-busting parameter would have to carry the very field this keeps off the
 wire.
+
+## Device sign-in: claim first, a scheme link in the QR, and a cookie the plugin does not set
+
+Fixed on 3 September 2026, after "that code is no longer valid" turned out to
+be the answer to every approval ever attempted from the phone. Three separate
+faults sat on the path between the browser showing a code and the phone
+approving it, and none of them was the expiry the message described.
+
+**The claim.** Better Auth's device plugin will not approve a code until a
+signed-in `GET /device?user_code=` has attached it to an account. The screen
+called `approve` straight away, so every attempt came back
+`DEVICE_CODE_NOT_CLAIMED`. The claim runs first now, and its response — which
+names the client asking — is only returned to the account that claimed, so the
+confirmation can say what is being approved. The single failure message stays
+deliberately vague across expired, used and unknown codes, so guessing a code
+learns nothing.
+
+**The session.** `/device/token` is an OAuth endpoint: it answers with a bearer
+token and nothing else. Nothing in this app sends an `Authorization` header —
+every client is cookie-based — so even a correct approval left the browser with
+a 200 and no session. A `hooks.after` middleware in `auth.ts` writes the
+session cookie for the session the plugin has already created. It is scoped to
+that one path; everything else that creates a session sets its own.
+
+**The QR.** It encoded an `https://` link to the web app. The picture is scanned
+with the phone's own camera, and the phone is where the session already is —
+so the link opened a browser on that same phone, signed in as nobody, which is
+the one place the approval cannot be given. It encodes `langx://link-device`
+now (`deviceLinkTarget` in `packages/shared`), which the installed app resolves
+to the approval screen. No native code, ships over the air. Not a universal
+link on the web host: that needs `.well-known` served from a host that still
+answers with v1, which is an infrastructure move rather than a QR change. Some
+Android cameras ignore custom schemes, so the eight-character code stays the
+primary path — eight, not the six three comments and a placeholder claimed.
+
+**`freshAge: 0`.** The same screen lists where the account is signed in, which
+is also the only feedback that an approval landed, since the device it signed
+in is somewhere else. Better Auth puts `/list-sessions` behind a 24-hour
+freshness check by default, so a phone that signed in last week could not open
+the list at all. Zero turns the check off. Revocation uses the
+authoritative-session check, not the freshness one, and is unaffected; the only
+other fresh-gated endpoint is `/unlink-account`, which the app never calls.
+
+All of it is covered end to end in `routes/deviceFlow.test.ts`, including the
+case as it was lived — approve without claim — and a test that fails without
+the `freshAge` line.

--- a/docs/learn-module.md
+++ b/docs/learn-module.md
@@ -218,8 +218,10 @@ should be made on purpose. If it is taken, the unit should be a completed
 session of `SRS_RULES.sessionSize` cards, never a single card, or the condition
 becomes "open the app and tap once" under another name.
 
-No new leaderboard. There are four already, and a fifth would split attention
-rather than add any.
+No leaderboard of its own. The token board has four period tabs and the streak
+page carries a streak table (added 3 September 2026 — current run and longest,
+see `modules/tokens/streakLeaderboard.ts`); a review count ranked beside them
+would split attention rather than add any.
 
 ## Plan limits
 


### PR DESCRIPTION
Docs only. Three places the code moved past the docs during the eight-PR series merged today (#1090–#1101).

- **`docs/learn-module.md`** said there would be no new leaderboard because four was already plenty. #1099 added a streak table; the paragraph now says what the sentence still means, which is that the learn module gets no board of its own.
- **`docs/decisions.md`** had no entry for device sign-in. Added: the claim step, the session cookie the OAuth token endpoint does not set, why the QR is a `langx://` link, and `freshAge: 0` — all from #1094.
- **`docs/architecture.md`** gains the session-management surface and the device flow, one bullet each, pointing at the decision.

Also checked while here: the plan this series came from claimed the `.well-known` files were not checked in. They are, so the release runbook's statement stands and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)