### PR TITLE
Keep app.config.ts's two modules free of imports

### DIFF
--- a/apps/api/src/lib/appConfigImports.test.ts
+++ b/apps/api/src/lib/appConfigImports.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `apps/mobile/app.config.ts` loads two modules of `@langx/shared` under plain
+ * Node ESM resolution, which cannot follow an extensionless relative import.
+ * The first one added to `appIdentity.ts` broke `expo export` on every
+ * platform while typecheck, lint and every other test stayed green — nothing
+ * in CI runs the config loader.
+ *
+ * This lives in the API package only because it is the one with Node's types
+ * and a filesystem in its test setup; `packages/shared` is browser-neutral and
+ * the mobile suite cannot reach outside `src/lib`. It guards a mobile
+ * invariant by reading the shared source.
+ */
+describe('the modules app.config.ts loads directly', () => {
+  for (const file of ['appIdentity.ts', 'appScheme.ts']) {
+    it(`${file} imports nothing`, () => {
+      const path = fileURLToPath(
+        new URL(`../../../../packages/shared/src/${file}`, import.meta.url),
+      )
+      const imports = readFileSync(path, 'utf8')
+        .split('\n')
+        .filter((line) => /^import\s/.test(line))
+      expect(imports, `${file} must stay import-free for app.config.ts`).toEqual([])
+    })
+  }
+})

--- a/packages/shared/src/appIdentity.test.ts
+++ b/packages/shared/src/appIdentity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { deviceLinkQrUrl, deviceLinkTarget, postUrl, profileUrl, WEB_HOST } from './appIdentity'
+import { deviceLinkQrUrl, postUrl, profileUrl, WEB_HOST } from './appIdentity'
+import { deviceLinkTarget } from './appScheme'
 import { RESERVED_HANDLES } from './reservedHandles'
 
 describe('postUrl', () => {

--- a/packages/shared/src/appIdentity.ts
+++ b/packages/shared/src/appIdentity.ts
@@ -1,5 +1,10 @@
-import { APP_SCHEME } from './appScheme'
-
+/*
+ * No imports in this file, on purpose. `apps/mobile/app.config.ts` loads it
+ * under plain Node ESM resolution, which cannot follow an extensionless
+ * relative import — the first one added here broke `expo export` on every
+ * platform while typecheck, lint and tests all stayed green. `appScheme.ts`
+ * is under the same rule. `apps/api/src/lib/appConfigImports.test.ts` fails if either gains one.
+ */
 /**
  * Who this app *is*, to Apple, Google and the web — the values that have to be
  * byte-identical across five places or something breaks silently.
@@ -167,21 +172,4 @@ export function profileQrUrl(apiBaseUrl: string, handle: string): string {
  */
 export function deviceLinkQrUrl(apiBaseUrl: string, userCode: string): string {
   return `${apiBaseUrl.replace(/\/$/, '')}/public/qr/link/${encodeURIComponent(userCode)}`
-}
-
-/**
- * What that QR actually encodes: a link that opens the app, not the website.
- *
- * The picture is scanned with the phone's own camera, and the phone is where
- * the session already is. Encoding an `https://` address sent it to a browser
- * on that same phone, where nobody is signed in — the one place the approval
- * cannot happen. A scheme URL hands it to the installed app instead, which is
- * both a shorter path and the only one that works.
- *
- * Not a universal link on the web host: those need `.well-known` files served
- * from a host that currently answers with v1, which is an infrastructure move
- * rather than a change to a QR code.
- */
-export function deviceLinkTarget(userCode: string): string {
-  return `${APP_SCHEME}://link-device?user_code=${encodeURIComponent(userCode)}`
 }

--- a/packages/shared/src/appScheme.ts
+++ b/packages/shared/src/appScheme.ts
@@ -15,3 +15,24 @@
 export const APP_SCHEME = 'langx'
 export const V1_URL_SCHEME = 'tech.newchapter.languagexchange'
 export const APP_SCHEMES = [APP_SCHEME, V1_URL_SCHEME] as const
+
+/**
+ * What that QR actually encodes: a link that opens the app, not the website.
+ *
+ * The picture is scanned with the phone's own camera, and the phone is where
+ * the session already is. Encoding an `https://` address sent it to a browser
+ * on that same phone, where nobody is signed in — the one place the approval
+ * cannot happen. A scheme URL hands it to the installed app instead, which is
+ * both a shorter path and the only one that works.
+ *
+ * Not a universal link on the web host: those need `.well-known` files served
+ * from a host that currently answers with v1, which is an infrastructure move
+ * rather than a change to a QR code.
+ *
+ * Lives here rather than in `appIdentity.ts` because it needs `APP_SCHEME`,
+ * and neither file may import the other — see the note at the top of that
+ * file.
+ */
+export function deviceLinkTarget(userCode: string): string {
+  return `${APP_SCHEME}://link-device?user_code=${encodeURIComponent(userCode)}`
+}


### PR DESCRIPTION
Found while deploying the web build after today's series: `expo export` failed on `main`.

`apps/mobile/app.config.ts` loads `@langx/shared/appIdentity` and `@langx/shared/appScheme` under plain Node ESM resolution, which cannot follow an extensionless relative import. The comment above those imports says exactly this and says to keep both files import-free. #1094 added `import { APP_SCHEME } from './appScheme'` to `appIdentity.ts`, and the config loader has been unable to read the app config since — on every platform, so EAS builds would have failed the same way. Typecheck, lint and every test stayed green: nothing in CI runs the config loader.

## Fix

`deviceLinkTarget` moves into `appScheme.ts`, where `APP_SCHEME` already lives, and the import goes. Callers import from the package root and are unchanged; the shared test moves with it.

## Guard

`apps/api/src/lib/appConfigImports.test.ts` reads the two source files and fails if either has an `import` line. It sits in the API package only because that is the one with Node's types and a filesystem in its test setup — `packages/shared` is browser-neutral and the mobile suite cannot reach outside `src/lib`. Both files now carry a note pointing at it.

## Verification

`expo export --platform web` completes on this branch and fails on `main`. Typecheck, lint, format, the shared suite (240) and the new test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)