### PR TITLE
Draw the message banner at full opacity, and let only its position animate

### DIFF
--- a/apps/mobile/src/components/MessageBannerHost.tsx
+++ b/apps/mobile/src/components/MessageBannerHost.tsx
@@ -40,6 +40,22 @@ export function MessageBannerHost() {
   const profiles = useProfileCache(banner ? [banner.senderId] : [])
   const sender = banner ? profiles[banner.senderId] : undefined
 
+  /**
+   * The slide is decoration; being visible is not. The card is drawn at full
+   * opacity from its first frame and only its position animates, so a banner
+   * whose animation never runs is a banner sitting 16pt too high, not a banner
+   * nobody saw.
+   *
+   * That is what the first iOS device test produced: the socket handler ran,
+   * `showMessageBanner` was called, the host mounted — and nothing was on
+   * screen. The first banner of a launch is the one case where the view mounts
+   * with its `Animated.Value` still JS-side and the native driver connects to
+   * an already-mounted view from a passive effect; every later banner mounts
+   * against a value that is native already. A fade from 0 gates the whole
+   * card on that first connect succeeding, and it did not. `ToastHost` still
+   * fades in the same way on purpose: it is left as the control until the
+   * same test has been run on it.
+   */
   useEffect(() => {
     if (!banner) return
     slide.setValue(0)
@@ -63,7 +79,6 @@ export function MessageBannerHost() {
         styles.layer,
         {
           paddingTop: insets.top + spacing.sm,
-          opacity: slide,
           transform: [
             { translateY: slide.interpolate({ inputRange: [0, 1], outputRange: [-16, 0] }) },
           ],

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2277,6 +2277,28 @@ keeps the JS thread alive in the background — the chat screen can be the
 focused route with nobody looking at it, and marking a message read there
 clears a badge for something never seen.
 
+## An entry animation never gates visibility
+
+The first iOS device test sent a message while the app sat on another tab, and
+no banner appeared — though the socket handler ran, the decision was `banner`,
+and the host mounted, which the sender-profile fetch in the API log shows. A
+banner drawn later in the same session was fine.
+
+The first banner of a launch is structurally different from every later one.
+Its `Animated.Value` is still JS-side when the view mounts with `opacity: 0`,
+and a passive effect then starts a native-driver timing that has to connect
+the node to an already-mounted view. Every later banner mounts against a
+value that is native already and connects during commit. A fade from zero
+gates the whole card on that first connect succeeding, and on this device it
+did not.
+
+So the card is drawn at full opacity from its first frame and only its
+position animates. An animation that never runs now costs sixteen points of
+placement rather than the notification. `ToastHost` keeps its fade for the
+moment, deliberately: it is the control. If the first toast of an iOS launch
+turns out to be invisible too, it gets the same treatment; if it is not, the
+cause is narrower than this entry claims and worth chasing.
+
 ## Scheduled notifications claim before they send
 
 Every pass writes a row into `notificationLedger` — `_id` is


### PR DESCRIPTION
## What

The in-app message banner no longer fades in from `opacity: 0`; it is drawn at full opacity from its first frame and only its position animates (`translateY` −16 → 0, native driver as before).

## Why

First iOS device test (TestFlight build 120, 3 Sept 2026): a message arrived over the socket while the app was on Discover and no banner appeared. The API log shows the handler ran and the host mounted (the sender-profile fetch is the host's `useProfileCache`), and a banner drawn later in the session was fine.

The first banner of a launch is structurally different from every later one: its `Animated.Value` is still JS-side when the view mounts with a static `opacity: 0`, and a passive effect then starts a native-driver timing that has to connect the node to an already-mounted view. Later banners mount against a native value and connect during commit. A fade from zero gates the whole card on that first connect succeeding.

`ToastHost` keeps the identical fade deliberately, as the control: the device check is whether the first "Copied" toast of an iOS launch is visible. If it is not, it gets the same edit in a follow-up.

## Checks

`pnpm test`, `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` all green locally. Decision logic (`inAppNotifications.ts`) and its tests are untouched.

Entry added to `docs/decisions.md`: *An entry animation never gates visibility*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
