### PR TITLE
Refetch what the socket missed, on resume and on reconnect

### DIFF
--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -3,10 +3,12 @@ import type { InfiniteData } from '@tanstack/react-query'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import { AppState } from 'react-native'
+import type { Socket } from 'socket.io-client'
 import type { MeProfile, MessageDto } from '../api/queries'
 import { invalidateUnread, keys, markConversationRead } from '../api/queries'
 import { getActiveConversation } from '../lib/activeConversation'
 import { previewOf, shouldShowIncomingBanner, showMessageBanner } from '../lib/inAppNotifications'
+import { invalidateMissedEvents, resumedFromBackground } from '../lib/missedEvents'
 import { applyIncomingMessage, type ConversationPageDto } from '../lib/conversationCache'
 import {
   appendIncomingMessage,
@@ -32,10 +34,50 @@ export function useSocket({ enabled = true }: { enabled?: boolean } = {}): void 
     if (!enabled) return
     let cancelled = false
     let heartbeat: ReturnType<typeof setInterval> | null = null
+    let opened: Socket | null = null
+
+    /**
+     * What the socket missed while it was away.
+     *
+     * Events are not replayed. A phone in the background has no connection,
+     * so a message sent then became a push and never a `message:new` — and
+     * tapping that push opened a thread already mounted as the hidden tab,
+     * with its cached pages and without the message. The two signals that a
+     * gap happened are the app coming back from the background and the
+     * socket reconnecting after a drop while the app was open; both end in
+     * the same invalidation. They can fire within a second of each other
+     * after a resume, and the second merely restarts the fetch the first
+     * began.
+     *
+     * Here rather than in `useNotificationRouting` (the tap is one way back,
+     * not the only one), the chat screen's focus effect (which would refetch
+     * every loaded page on every navigation) or a `focusManager` wiring
+     * (every mounted screen on every foreground): the gap is the socket's,
+     * so the socket owns it. `resumedFromBackground` says which transitions
+     * count.
+     */
+    const resync = (): void => {
+      void invalidateMissedEvents(queryClient)
+    }
+    let lastAppState = AppState.currentState
+    const appStateSubscription = AppState.addEventListener('change', (next) => {
+      if (resumedFromBackground(lastAppState, next)) resync()
+      lastAppState = next
+    })
 
     void (async () => {
       const socket = await getSocket()
       if (cancelled) return
+      opened = socket
+
+      /*
+       * On the Manager, not the socket: `reconnect` is the Manager's event,
+       * and it fires only for an automatic reconnection — the one case where
+       * something may have happened in between. socket.io-client keeps one
+       * Manager per URL across `closeSocket()`, so the cleanup below has to
+       * take this handler off again or every re-run of this effect stacks one.
+       */
+      socket.io.on('reconnect', resync)
 
       /**
        * Says "still here" while the app is open. Without it `lastActiveAt`
@@ -210,6 +252,8 @@ export function useSocket({ enabled = true }: { enabled?: boolean } = {}): void 
     return () => {
       cancelled = true
       if (heartbeat) clearInterval(heartbeat)
+      appStateSubscription.remove()
+      opened?.io.off('reconnect', resync)
       closeSocket()
     }
   }, [enabled, queryClient])

--- a/apps/mobile/src/lib/missedEvents.test.ts
+++ b/apps/mobile/src/lib/missedEvents.test.ts
@@ -1,0 +1,46 @@
+import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, it } from 'vitest'
+import { invalidateMissedEvents, resumedFromBackground } from './missedEvents'
+
+describe('resumedFromBackground', () => {
+  it('is the phone coming back from the background', () => {
+    expect(resumedFromBackground('background', 'active')).toBe(true)
+  })
+
+  /** The notification shade or Face ID going away; the socket never dropped. */
+  it('is not the shade going away', () => {
+    expect(resumedFromBackground('inactive', 'active')).toBe(false)
+  })
+
+  it('is not leaving, and not the first state of a launch', () => {
+    expect(resumedFromBackground('active', 'background')).toBe(false)
+    expect(resumedFromBackground('active', 'inactive')).toBe(false)
+    expect(resumedFromBackground('unknown', 'active')).toBe(false)
+    expect(resumedFromBackground('active', 'active')).toBe(false)
+  })
+})
+
+describe('invalidateMissedEvents', () => {
+  /**
+   * Every list tab and every cache under a thread, including a jump window —
+   * and nothing else. `me` is the control: a resume is not a reason to ask
+   * who the user is again.
+   */
+  it('marks every chat list and thread cache stale, and nothing else', async () => {
+    const client = new QueryClient()
+    const stale = [
+      ['conversations', 'all'],
+      ['conversations', 'unread'],
+      ['messages', 'c1'],
+      ['messages', 'c1', 'around', 'm9'],
+    ]
+    for (const key of [...stale, ['me']]) client.setQueryData(key, {})
+
+    await invalidateMissedEvents(client)
+
+    for (const key of stale) {
+      expect(client.getQueryState(key)?.isInvalidated, key.join('/')).toBe(true)
+    }
+    expect(client.getQueryState(['me'])?.isInvalidated).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/missedEvents.ts
+++ b/apps/mobile/src/lib/missedEvents.ts
@@ -1,0 +1,46 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+/**
+ * What to do about the events the socket was not there to receive.
+ *
+ * The socket is the only realtime channel, and it has a blind spot. A phone in
+ * the background has no JS running and no connection, so a message sent then
+ * reaches the server, becomes a push, and never becomes a `message:new` —
+ * nothing replays it. On the first iOS device test, tapping that push opened
+ * the right thread with the message missing: `chat/[id]` was already mounted
+ * as the hidden tab and kept its cached pages.
+ *
+ * Two signals say "there was a gap": the app coming back from the background,
+ * and the socket reconnecting after a drop while the app was open. Both end
+ * in `invalidateMissedEvents`. Pure and free of `react-native` so the mobile
+ * test setup can load it; the hook passes the states in.
+ */
+
+/** RN's `AppStateStatus`, spelled out so this file imports nothing native. */
+export type AppStateName = 'active' | 'background' | 'inactive' | 'unknown' | 'extension'
+
+/**
+ * Only `background → active`. `inactive → active` is the notification shade
+ * or Face ID going away a second later — the socket never dropped, nothing
+ * was missed, and on iOS that transition happens far more often.
+ */
+export function resumedFromBackground(previous: AppStateName, next: AppStateName): boolean {
+  return previous === 'background' && next === 'active'
+}
+
+/**
+ * Prefixes, not keys: the chat list is tabbed, and `messagesAround` sits under
+ * `['messages', id]`. `invalidateQueries` refetches only the *active* ones —
+ * the mounted chat list and the one thread the hidden tab holds — and marks
+ * the rest stale for their next mount. The infinite-query "every loaded page"
+ * cost that `useSocket` refuses to pay per message is paid once per gap here.
+ *
+ * The literals rather than `keys` from `api/queries`: that module reaches the
+ * API client, which the test setup cannot load.
+ */
+export async function invalidateMissedEvents(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ['conversations'] }),
+    queryClient.invalidateQueries({ queryKey: ['messages'] }),
+  ])
+}

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2377,6 +2377,39 @@ key Expo is handed is a working one before any build exists; and the lesson
 that `expo-notifications` and the Firebase SDK both hook the same iOS delegate
 and should not share a build.
 
+## A resume refetches what the socket missed
+
+The socket is the only realtime channel and nothing replays it. A phone in the
+background has no JS running and no connection; a message sent then reaches
+the server, becomes a push, and never becomes a `message:new`. On the first
+iOS device test, tapping that push opened the right thread with the message
+missing — `chat/[id]` was already mounted as the hidden tab and kept its
+cached pages, and nothing anywhere invalidated them. `useNotificationRouting`
+only navigates, `markConversationRead` only touches the list, and TanStack's
+`focusManager` is not wired to `AppState` on native, so `refetchOnWindowFocus`
+had never once fired.
+
+Two signals say a gap happened, and `useSocket` listens for both: the app
+coming back from the background, and the socket's Manager reporting a
+reconnection after a drop while the app was open. Both invalidate the
+`['conversations']` and `['messages']` prefixes and nothing else. Only active
+queries refetch — the mounted chat list and the one thread the hidden tab
+holds — so the "every loaded page" cost the `message:new` handler refuses to
+pay per message is paid once per gap.
+
+Three other places were considered and passed over. The routing hook covers
+the tap and nothing else; the chat screen's focus effect would refetch every
+loaded page on every navigation; a `focusManager` wiring would refetch every
+mounted screen on every foreground. Only `background → active` counts as a
+resume: `inactive → active` is the notification shade or Face ID going away a
+second later, the socket never dropped, and on iOS that happens far more
+often.
+
+Left as it was: the ~45 s after a resume during which the server may still
+see the old socket in the user's room, so a message sent in that window gets
+neither a push nor a delivery stamp until the ping timeout. That is fan-out
+semantics, not this bug.
+
 ## Shipping lives on expo.dev, and only tests live on GitHub
 
 Behic's call on 3 September 2026, after a day of weighing the alternative:


### PR DESCRIPTION
## What

`useSocket` now invalidates the `['conversations']` and `['messages']` prefixes on two signals: the app returning from the background (`background → active`), and the socket Manager reporting an automatic reconnection.

New pure module `apps/mobile/src/lib/missedEvents.ts` holds both decisions, so vitest can exercise them.

## Why

First iOS device test (TestFlight build 120, 3 Sept 2026): tapping the OS notification for a message received while backgrounded opened the correct thread, without that message.

Events are not replayed. A backgrounded phone has no connection, so the message became a push and never a `message:new`, and `chat/[id]` was already mounted as the hidden tab holding its cached pages. Nothing invalidated them — `useNotificationRouting` only navigates, `markConversationRead` only touches the list, and TanStack's `focusManager` is not wired to `AppState` on native, so `refetchOnWindowFocus` had never once fired.

## Where the refetch lives, and why not elsewhere

The gap is the socket's, so the socket owns it. The routing hook would cover the tap and nothing else; the chat screen's focus effect would refetch every loaded page on every navigation; a `focusManager` wiring would refetch every mounted screen on every foreground.

Only active queries refetch, so the cost is the mounted chat list plus the one thread the hidden tab holds — once per gap, not once per message. `inactive → active` is excluded on purpose: the notification shade or Face ID going away is not a dropped socket, and on iOS it happens far more often.

## Verification

- New unit tests: the four `AppState` transitions, and that invalidation hits every list tab and every thread cache including a jump window (`['messages', id, 'around', anchor]`) while leaving `['me']` alone.
- The socket.io API was checked against a real server on this branch's client version: the Manager's `reconnect` does not fire on the first connect, fires exactly once per automatic reconnection, and `off` removes it (the effect's teardown does this, since one Manager per URL outlives `closeSocket()`).
- `pnpm test`, `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` green.

## Not changed

The ~45 s after a resume during which the server may still see the old socket in the user's room, so a message sent in that window gets neither a push nor a delivery stamp until the ping timeout. That is fan-out semantics, not this bug; noted in `docs/decisions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
