### PR TITLE
Give the toast and the message banner a paint order over the navigator

### DIFF
--- a/apps/mobile/src/components/AppSplash.tsx
+++ b/apps/mobile/src/components/AppSplash.tsx
@@ -9,6 +9,7 @@ import { useAppReady } from '../hooks/useAppReady'
 import { useReduceMotion } from '../hooks/useReduceMotion'
 import { markAppReady } from '../lib/appReady'
 import { SPLASH_TIMING, msUntilExitAllowed } from '../lib/splashTiming'
+import { OVERLAY_LAYER } from '../lib/overlayLayers'
 import { makeStyles, useTheme } from '../lib/theme'
 
 /**
@@ -227,7 +228,15 @@ export function SplashFill({ children }: { children?: ReactNode }) {
 
 const useStyles = makeStyles(({ colors }) => ({
   // Over `react-native-screens`, which a plain later-sibling is not enough for.
-  layer: { alignItems: 'center', elevation: 100, justifyContent: 'center', zIndex: 100 },
+  // Over `react-native-screens`, which a plain later-sibling is not enough
+  // for. The number moved to `overlayLayers.ts` when the toast and the banner
+  // turned out to need the same thing.
+  layer: {
+    alignItems: 'center',
+    elevation: OVERLAY_LAYER.splash,
+    justifyContent: 'center',
+    zIndex: OVERLAY_LAYER.splash,
+  },
   fill: {
     alignItems: 'center',
     backgroundColor: colors.bg,

--- a/apps/mobile/src/components/MessageBannerHost.tsx
+++ b/apps/mobile/src/components/MessageBannerHost.tsx
@@ -10,6 +10,7 @@ import {
   subscribeToMessageBanner,
   type MessageBanner,
 } from '../lib/inAppNotifications'
+import { OVERLAY_LAYER } from '../lib/overlayLayers'
 import { makeStyles, useTheme } from '../lib/theme'
 import { Avatar } from './ui/Avatar'
 
@@ -113,11 +114,16 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   // signed-in screen is where the tab bar is, and this one is tappable.
   layer: {
     alignItems: 'center',
+    // Not decoration: without it this layer paints *behind* the navigator's
+    // screens on native, whatever order the tree puts it in. See
+    // `overlayLayers.ts` — this is the bug the first iOS device test hit.
+    elevation: OVERLAY_LAYER.messageBanner,
     left: 0,
     paddingHorizontal: spacing.lg,
     position: 'absolute',
     right: 0,
     top: 0,
+    zIndex: OVERLAY_LAYER.messageBanner,
   },
   // A surface card rather than the toast's solid yellow: this is somebody
   // else's message, not the app reporting on itself, and it carries a face.

--- a/apps/mobile/src/components/ToastHost.tsx
+++ b/apps/mobile/src/components/ToastHost.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Animated, Pressable, Text } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { dismissToast, subscribeToToasts, type Toast } from '../lib/toast'
+import { OVERLAY_LAYER } from '../lib/overlayLayers'
 import { makeStyles, useTheme } from '../lib/theme'
 
 /**
@@ -64,11 +65,16 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   // heading, which nobody was going to press.
   layer: {
     alignItems: 'center',
+    // The same reason the message banner carries one; see `overlayLayers.ts`.
+    // Nobody had reported a missing toast, but it is the same absolute layer
+    // over the same navigator, so it was the same latent bug.
+    elevation: OVERLAY_LAYER.toast,
     left: 0,
     paddingHorizontal: spacing.lg,
     position: 'absolute',
     right: 0,
     top: 0,
+    zIndex: OVERLAY_LAYER.toast,
   },
   // Neutral dark rather than `colors.success`: these sentences report what
   // happened, and green would dress "Signed out" up as a celebration.

--- a/apps/mobile/src/lib/overlayLayers.test.ts
+++ b/apps/mobile/src/lib/overlayLayers.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { OVERLAY_LAYER } from './overlayLayers'
+
+describe('the root overlays', () => {
+  /**
+   * The order `app/_layout.tsx` renders them in, held to as numbers — the
+   * tree order alone does not decide this on native, which is the whole
+   * reason these exist.
+   */
+  it('stack splash over banner over toast', () => {
+    expect(OVERLAY_LAYER.splash).toBeGreaterThan(OVERLAY_LAYER.messageBanner)
+    expect(OVERLAY_LAYER.messageBanner).toBeGreaterThan(OVERLAY_LAYER.toast)
+  })
+
+  /** Above anything a screen sets for itself; those are single digits. */
+  it('sit far above the in-screen z-indexes', () => {
+    for (const layer of Object.values(OVERLAY_LAYER)) expect(layer).toBeGreaterThan(10)
+  })
+})

--- a/apps/mobile/src/lib/overlayLayers.ts
+++ b/apps/mobile/src/lib/overlayLayers.ts
@@ -1,0 +1,25 @@
+/**
+ * How the root overlays stack over the navigator, and over each other.
+ *
+ * On native, being a later sibling of `<Stack>` is *not* enough:
+ * `react-native-screens` gives each screen its own native container, and a
+ * plain absolutely-positioned sibling paints behind them in an order nothing
+ * guarantees. `AppSplash` has carried a `zIndex`/`elevation` for that reason
+ * since it was written; the toast and the message banner did not, which is
+ * why the first iOS device test saw no banner when a message arrived, and
+ * then saw one after navigating around — the paint order had changed, not the
+ * code path. The dialogs escape it by being `Modal`s, which are their own
+ * native window.
+ *
+ * `elevation` as well as `zIndex`, because Android orders by the first and
+ * iOS by the second.
+ *
+ * The order between them is the same one `app/_layout.tsx` renders them in:
+ * the splash covers everything while it is up, and a message arriving is more
+ * urgent than the app reporting on itself.
+ */
+export const OVERLAY_LAYER = {
+  toast: 80,
+  messageBanner: 90,
+  splash: 100,
+} as const

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2288,27 +2288,33 @@ keeps the JS thread alive in the background — the chat screen can be the
 focused route with nobody looking at it, and marking a message read there
 clears a badge for something never seen.
 
-## An entry animation never gates visibility
+## The root overlays carry a paint order, not just a place in the tree
 
-The first iOS device test sent a message while the app sat on another tab, and
-no banner appeared — though the socket handler ran, the decision was `banner`,
-and the host mounted, which the sender-profile fetch in the API log shows. A
-banner drawn later in the same session was fine.
+The first iOS device test sent a message while the app sat on another tab and
+no banner appeared, though the socket handler ran, the decision was `banner`
+and the host mounted. A banner drawn later in the same session, after moving
+around the app, was fine.
 
-The first banner of a launch is structurally different from every later one.
-Its `Animated.Value` is still JS-side when the view mounts with `opacity: 0`,
-and a passive effect then starts a native-driver timing that has to connect
-the node to an already-mounted view. Every later banner mounts against a
-value that is native already and connects during commit. A fade from zero
-gates the whole card on that first connect succeeding, and on this device it
-did not.
+`AppSplash` had the answer written on it already: its layer carries
+`zIndex`/`elevation` with the comment _"over `react-native-screens`, which a
+plain later-sibling is not enough for"_. `ToastHost` and `MessageBannerHost`
+are the same kind of absolutely-positioned sibling of `<Stack>` and carried
+neither, so on native they painted behind the navigator's screen containers in
+an order nothing guarantees — which is exactly a banner that is missing, then
+present once the stack has changed under it. The dialogs escaped it by being
+`Modal`s, which are their own native window. On the web, DOM order alone puts
+them on top, so nothing about this was ever visible there.
 
-So the card is drawn at full opacity from its first frame and only its
-position animates. An animation that never runs now costs sixteen points of
-placement rather than the notification. `ToastHost` keeps its fade for the
-moment, deliberately: it is the control. If the first toast of an iOS launch
-turns out to be invisible too, it gets the same treatment; if it is not, the
-cause is narrower than this entry claims and worth chasing.
+The three numbers now live together in `src/lib/overlayLayers.ts`: splash over
+banner over toast, the order `app/_layout.tsx` renders them in. `elevation` as
+well as `zIndex`, because Android orders by the first and iOS by the second.
+
+The banner was hardened at the same time, and that part is belt-and-braces
+rather than a diagnosis: it is drawn at full opacity and only its position
+animates, so it no longer depends on the first native-driver animation of a
+launch having connected. `ToastHost` still fades, which is fine — a fade that
+never runs on a layer that paints where it should is a toast that appears
+without sliding, not a toast nobody sees.
 
 ## Scheduled notifications claim before they send
 


### PR DESCRIPTION
## What

`ToastHost` and `MessageBannerHost` layers now carry `zIndex` and `elevation`, from a new shared `src/lib/overlayLayers.ts` that also holds the number `AppSplash` already had. Splash over banner over toast, the order `app/_layout.tsx` renders them in.

## Why

This is the actual cause of the missing banner from the first iOS device test, and it was written down in this repo already. `AppSplash`'s layer has carried a `zIndex`/`elevation` since it was written, with the comment *"over `react-native-screens`, which a plain later-sibling is not enough for"*.

The toast and the banner are the same kind of absolutely-positioned sibling of `<Stack>` and carried neither. On native they paint behind the navigator's screen containers in an order nothing guarantees — which is exactly what was reported: no banner when the message arrived, then a banner after moving around the app, because navigating changed the paint order rather than the code path. The dialogs escaped it by being `Modal`s. The web never showed it because DOM order alone puts these on top, which is why the browser pass was green both before and after.

This supersedes the animation explanation in #1106. That change (banner visible at rest, only its position animates) stays as hardening, and `docs/decisions.md` has been corrected to lead with the paint order. `ToastHost` keeps its fade: a fade that fails on a layer that paints where it should is a toast that appears without sliding, not a toast nobody sees.

## Verification

- Browser pass on the isolated stack (throwaway API on :4100, real Expo web build on :8082, Playwright): a message sent by another user over socket.io while the app sits on Discover draws the banner at effective opacity 1, at the top of the screen, and `elementFromPoint` at its centre hits the banner itself. Screenshot confirms the avatar, name and preview.
- Same harness, the other bug from that test: with the browser context offline, a message sent over the socket does not appear; back online, the reconnect invalidation brings it into the open thread. That is #1107 verified end to end in the real app.
- New unit test holds the three layers in order.
- `pnpm test`, `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` green.

## Still needs a device

The iOS half cannot be proven here — web never reproduced the bug. The device test after the OTA is what confirms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
