### PR TITLE
Lower the minimum age from 18 to 16

### DIFF
--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -9,6 +9,7 @@ import {
   effectivePlanTier,
   isOnlineAt,
   findCosmetic,
+  MINIMUM_AGE,
   meetsMinimumAge,
   NOTIFICATION_TYPES,
   newHandleSchema,
@@ -259,7 +260,7 @@ export async function createProfile(
   }
 
   if (!meetsMinimumAge(input.birthDate)) {
-    throw new ApiError(ERROR_CODES.UNDERAGE, 'You must be 18 or older to use LangX')
+    throw new ApiError(ERROR_CODES.UNDERAGE, `You must be ${MINIMUM_AGE} or older to use LangX`)
   }
 
   /**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ learning. Discovery _ranks_ by mutual fit, but listing is not a gate — there i
 conversations per rolling 24 hours and reply to everything they receive without
 limit. HelloTalk/Tandem, not Tinder. Users correct each other's sentences, and
 the whole thing is wrapped in a game: streaks, token, leaderboards. Mobile
-(iOS/Android) and web come out of **one Expo codebase**. Minimum age **18**.
+(iOS/Android) and web come out of **one Expo codebase**. Minimum age **16**.
 
 **v2 stays open source** — BSD 3-Clause, public repo. That is an architectural
 constraint, not a footnote: no secrets in the repo, entitlement enforced
@@ -102,14 +102,15 @@ This is communication work, and it is part of the delivery:
 - `langx.io/terms-conditions`: dated 7 June 2024. Add subscription terms,
   cancellation, renewal, and the token's non-transferability. **Clean up §11** — today
   it contains both "under-18s may not use this" and "our users may be children,
-  we follow the Families policy / COPPA". 18+ wins.
+  we follow the Families policy / COPPA". 18+ wins. (Lowered to 16+ in
+  September 2026 — see `decisions.md`.)
 - Privacy policy: new backend, Sentry, location, gender, activity/token data.
 - The `docs.langx.io` litepaper: state plainly that the on-chain design in it
   is not being built, and that tokens are not transferable.
 - Store listing copy and the **App Privacy / Data Safety** forms.
 - **Check Play Console's "target audience" declaration** — a Families
   declaration changes Data Safety, ad SDK rules and content policy entirely,
-  and contradicts an 18+ policy.
+  and contradicts an adults-and-teens-only policy.
 
 > **Flag — community reaction.** Making this change without explaining it to
 > the community on Discord, Reddit and GitHub damages the brand's strongest
@@ -142,7 +143,7 @@ This is communication work, and it is part of the delivery:
 | Username            | Old usernames are reserved; **claimed once, proven by a verified email match**                                                                                                                                                                                                                                                                                                                          |
 | Storage             | S3-compatible abstraction; **Backblaze B2** today (v1's account, new bucket), R2 reachable by config                                                                                                                                                                                                                                                                                                    |
 | Migration           | Profile data + avatars + username reservations out of Appwrite, idempotent ETL                                                                                                                                                                                                                                                                                                                          |
-| **Minimum age**     | **18+** (already in the Terms); age gate at sign-up, verified via `birthDate`                                                                                                                                                                                                                                                                                                                           |
+| **Minimum age**     | **16+** (was 18+ until September 2026; the Terms moved with it); age gate at sign-up, verified via `birthDate`                                                                                                                                                                                                                                                                                          |
 | **Licence**         | **BSD 3-Clause, public repo** — same as v1                                                                                                                                                                                                                                                                                                                                                              |
 | **Codebase**        | Written from scratch in langx2; the abandoned Expo rewrite used only as a screen/route reference                                                                                                                                                                                                                                                                                                        |
 | Release model       | Brownfield update — same bundle ID and package name, staged rollout                                                                                                                                                                                                                                                                                                                                     |
@@ -237,9 +238,9 @@ files.
   the browser — the token endpoint is OAuth and answers with a bearer token
   nothing in this app sends. See `decisions.md` → _Device sign-in_.
 - **Age gate:** `birthDate` (`YYYY-MM-DD`) is required at onboarding and
-  under-18s cannot complete it. The check is server-side, before `profiles` is
+  under-16s cannot complete it. The check is server-side, before `profiles` is
   written — the client's date picker is not trusted. The rule still counts
-  whole years from the birth _year_, so somebody who turns 18 in December is
+  whole years from the birth _year_, so somebody who turns 16 in December is
   admitted in January; collecting the day made the strict version possible and
   did not adopt it. Only the age is ever public — the date itself never leaves
   `GET /profiles/me`.
@@ -978,7 +979,7 @@ only thing that matters is preserving store identity.
 | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Play App Signing status**           | If enabled, a lost keystore is recoverable via an upload key reset. If disabled and the original keystore is lost, that listing **cannot** be updated |
 | Apple Developer + Play Console access | Certificates, provisioning, listing management                                                                                                        |
-| Play "target audience" declaration    | A Families declaration contradicts the 18+ policy and changes Data Safety and SDK rules                                                               |
+| Play "target audience" declaration    | A Families declaration contradicts the 16+ policy and changes Data Safety and SDK rules                                                               |
 | Install base OS distribution          | minSdk is rising; devices below the threshold stop receiving updates                                                                                  |
 | iOS associated domains                | If `app.langx.io` is declared on iOS too, it must move into entitlements                                                                              |
 
@@ -1001,7 +1002,7 @@ only thing that matters is preserving store identity.
 ## MVP (P0)
 
 1. Sign-up/sign-in (email + Google + Apple), verification, password reset,
-   **18+ age gate**
+   **16+ age gate** (18+ at launch)
 2. Onboarding: languages + levels → gender/bio/avatar/interests → **username
    claim**
 3. Profile view/edit, presigned avatar upload + **multi-photo gallery**

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2634,3 +2634,34 @@ other fresh-gated endpoint is `/unlink-account`, which the app never calls.
 All of it is covered end to end in `routes/deviceFlow.test.ts`, including the
 case as it was lived — approve without claim — and a test that fails without
 the `freshAge` line.
+
+## The age gate went from 18 to 16
+
+LangX launched v2 as 18+. The number came from v1's published Terms and from
+the reasoning in `age.ts`: at 18 neither COPPA nor GDPR's Article 8 can apply,
+so nothing about parental consent ever had to be built. The store docs went a
+step further and predicted that unrestricted chat plus user photos would rate
+17+/18+ on both stores, "which matches the age gate".
+
+The questionnaires came back 13+ on Apple and Teen on Google. That is a rating
+of the content and says nothing about who may hold an account, but it made the
+question unavoidable: 18 was a choice, not a constraint. Behic lowered it to 16
+on 3 September 2026.
+
+Why 16 and not the 13 the stores suggest: Article 8 lets each EU state set its
+digital-consent age between 13 and 16, and several chose 16. At 16 no country
+in the EU or UK needs a parental-consent flow; COPPA covers under-13s and stays
+irrelevant. 13 would have needed consent flows in half of Europe and the extra
+duties that come with minors on a stranger-to-stranger chat. 16 needed a
+constant, a handful of sentences and a Play Console declaration.
+
+Two things did not change. The arithmetic is still whole years from the birth
+year, so somebody who turns 16 in December is admitted in January; the strict
+version was possible and is still not adopted. And nobody already inside was
+affected — lowering a floor only admits people. The one visible side effect is
+in `legacyRestore.ts`, which treats an under-age v1 birth date as a missing
+field: v1 holders aged 16 and 17, bounced back to onboarding until now, can
+finish the restore.
+
+The lesson is about the docs, not the number: a prediction about what a form
+will say should not be written as if the form had been filled in.

--- a/docs/legal/promise-change.md
+++ b/docs/legal/promise-change.md
@@ -96,7 +96,7 @@ And for the token section:
 | Token            | Redefine it: an in-app point with no cash value. Non-transferable, cannot be purchased, sold, traded, staked or withdrawn. State that v1 balances carry over at 1:100 and that nothing is redeemable for money |
 | Virtual items    | Cover the streak freeze, filled-in activity days and cosmetics; forfeited on account deletion                                                                                                                  |
 | Account deletion | 30-day grace period, then permanent. Messages you sent stay in the other person's conversation with their content removed                                                                                      |
-| Minimum age      | 18+, enforced at profile creation                                                                                                                                                                              |
+| Minimum age      | 16+ (was 18+), enforced at profile creation                                                                                                                                                                    |
 
 ### Store listings
 
@@ -116,9 +116,12 @@ the store forms and the GitBook copy still need them.
 
 - **A date of birth, not a year.** v1 stored a full birthdate and only ever
   used the year; v2 now keeps and uses the whole day, so that birthdays can
-  exist. The age gate is unchanged — whole years, so somebody who turns 18 in
-  December is admitted in January. Only the age is ever shown to another user;
-  the date is visible to nobody but its owner.
+  exist. The arithmetic is unchanged — whole years, so somebody who reaches
+  the minimum age in December is admitted in January — but the floor itself
+  moved from 18 to **16** in September 2026, once the store questionnaires
+  rated the content 13+/Teen. A v1 account whose holder is 16 or 17 can now
+  finish the restore; under 16 still cannot. Only the age is ever shown to
+  another user; the date is visible to nobody but its owner.
 - **The country is derived from the connection's IP** at profile creation,
   rather than typed. A country filter anybody can set by hand is not a filter.
   The address is not stored — only the two-letter code it resolved to — and the

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -625,6 +625,10 @@ next to the Console rather than working from this section:
 - [ ] The privacy policy has to describe it: what is stored, that it is
       optional, that it is rounded, and that other users see only a bucketed
       distance. `docs/store/privacy-data-safety.md` is the source text
+- [ ] Play → **Target audience and content**: tick **16–17** and **18 and
+      over**, nothing younger. The minimum age went from 18 to 16 in September
+      2026 and the declaration still says 18+ until somebody changes it. The
+      content rating (Teen / Apple 13+) does not need resubmitting
 
 The permission itself is **when-in-use only** and declared in
 `app.config.ts`. Nothing here needs a background-location declaration, and

--- a/docs/store/privacy-data-safety.md
+++ b/docs/store/privacy-data-safety.md
@@ -13,7 +13,7 @@ Both stores treat a wrong answer here as a policy violation, and both accept
 | Email address of a v1 account its owner deleted | `v1DeletedContacts`                     | One announcement that the new app exists, then the collection is dropped; the mail's unsubscribe link deletes the address on the spot (`docs/decisions.md` → _Every v1 account has a v2 `user` row_)              | Temporary — gone after that one send  |
 | Name / display name                             | `profiles.displayName`                  | Shown on your profile                                                                                                                                                                                             | Required                              |
 | Username                                        | `profiles.handle`                       | Your public identity                                                                                                                                                                                              | Required                              |
-| Date of birth                                   | `profiles.birthDate`                    | 18+ age gate, and birthdays; only the **age** is ever shown to others (`toPublicProfile`)                                                                                                                         | Required                              |
+| Date of birth                                   | `profiles.birthDate`                    | 16+ age gate, and birthdays; only the **age** is ever shown to others (`toPublicProfile`)                                                                                                                         | Required                              |
 | Gender                                          | `profiles.gender`                       | Shown on profile; used by the Pro gender filter                                                                                                                                                                   | `undisclosed` is a valid answer       |
 | Country                                         | `profiles.country`                      | Shown on profile; Pro country filter. Derived from the connection's IP at sign-up (Cloudflare's `CF-IPCountry`); the address itself is never stored                                                               | Required, not editable by hand        |
 | City                                            | `profiles.cityName`                     | Shown on profile, and the Pro city filter. **Derived**, not entered: read off the shared location against a fixed list of places. Nothing to fill in, and removable from the profile with Settings → Hide my city | Only exists if location sharing is on |
@@ -200,13 +200,18 @@ party to.
 
 ## Play "target audience and content"
 
-LangX is **18+** and the age gate is enforced server-side at profile creation
+LangX is **16+** and the age gate is enforced server-side at profile creation
 (`meetsMinimumAge`, `packages/shared/src/age.ts`) for all three sign-up paths.
-Do not declare a Families audience: it contradicts the 18+ policy and changes
-which SDKs and data practices are permitted.
+Declare the **16–17** and **18 and over** age groups and nothing younger. Do not
+declare a Families audience: it applies as soon as an under-13 group is ticked,
+contradicts the 16+ policy and changes which SDKs and data practices are
+permitted.
 
 ## Age rating inputs
 
 Unrestricted user-to-user text communication and user-generated photos, with
-in-app blocking and reporting. That combination normally lands at 17+/18+ on
-both stores, which matches the age gate.
+in-app blocking and reporting. The questionnaires rated that **13+ on Apple**
+and **Teen on Google** (September 2026). A rating describes the content; the
+16+ floor is a term of use enforced at profile creation. The two are allowed to
+differ, and they do: a 14-year-old can install the app and is refused at
+onboarding.

--- a/docs/store/privacy-forms-checklist.md
+++ b/docs/store/privacy-forms-checklist.md
@@ -118,7 +118,7 @@ document. Every row is "collected, not shared".
 | --------------------------------------------- | ------------------------------------------------------------------ |
 | Personal info → Name, Email address           | display name, handle, sign-in email — required                     |
 | Personal info → User IDs                      | account id                                                         |
-| Personal info → Other info                    | date of birth (18+ gate; only the age is shown), gender, bio, city |
+| Personal info → Other info                    | date of birth (16+ gate; only the age is shown), gender, bio, city |
 | Location → Approximate location               | optional, see above                                                |
 | Photos and videos → Photos                    | avatar and gallery — optional                                      |
 | Messages → Other in-app messages              | chat bodies                                                        |
@@ -128,9 +128,10 @@ document. Every row is "collected, not shared".
 | Financial info                                | nothing — purchase state only, never a card number                 |
 | Contacts, Calendar, Health, Microphone, Ad ID | nothing                                                            |
 
-Target audience: **18+**, enforced server-side at profile creation. Do not
-declare a Families audience — it contradicts the age gate and changes which
-SDKs are permitted.
+Target audience: **16+**, enforced server-side at profile creation. Declare the
+**16–17** and **18 and over** groups and nothing younger. Do not declare a
+Families audience — it applies once any under-13 group is ticked, contradicts
+the age gate and changes which SDKs are permitted.
 
 > **City is collected, and that is all the form asks.** `privacy-data-safety.md`
 > describes it as "shown on profile", which is not true today — nothing renders

--- a/packages/shared/src/age.ts
+++ b/packages/shared/src/age.ts
@@ -1,15 +1,22 @@
 import { z } from 'zod'
 
 /**
- * LangX is 18+. This is already the published policy in the v1 Terms
- * ("You must be at least 18 years old to create an account and use the LangX
- * app") and it keeps the app clear of COPPA / GDPR-K, which matters because
- * discovery collects location and gender.
+ * LangX is 16+.
+ *
+ * It was 18+ until September 2026, inherited from v1's published Terms and
+ * chosen so that COPPA / GDPR-K could not apply — discovery collects location
+ * and gender. Then the store questionnaires rated the content 13+ (Apple) and
+ * Teen (Google): a rating of the content, not a floor on who may sign up, but
+ * it showed 18 was a policy choice rather than a constraint. 16 is the highest
+ * digital-consent age any EU state picked under GDPR Article 8, so at 16 no
+ * country in the EU or UK needs a parental-consent flow, and COPPA (under-13s)
+ * stays irrelevant. 13 would have needed both, which is why the floor stopped
+ * here. See docs/decisions.md.
  *
  * Enforced server-side before a profile is written — the client date picker is
  * a convenience, not a gate.
  */
-export const MINIMUM_AGE = 18
+export const MINIMUM_AGE = 16
 
 /** Oldest birth year we accept, to reject obvious garbage. */
 export const EARLIEST_BIRTH_YEAR = 1900
@@ -63,10 +70,10 @@ export function ageFromBirthDate(birthDate: string, now: Date = new Date()): num
 /**
  * True when the user is at least {@link MINIMUM_AGE}.
  *
- * Someone born in `now.year - 18` turns 18 at some point this year but may not
- * have yet. We accept them: requiring the birthday to have passed would lock
- * out every genuine 18-year-old for up to a year, and that was the call when
- * only the year was collected. Collecting the full date makes the strict
+ * Someone born in `now.year - MINIMUM_AGE` reaches the age at some point this
+ * year but may not have yet. We accept them: requiring the birthday to have
+ * passed would lock out every genuine sixteen-year-old for up to a year, and
+ * that was the call when only the year was collected. Collecting the full date makes the strict
  * version *possible*; it does not make it decided.
  */
 export function meetsMinimumAge(birthDate: string, now: Date = new Date()): boolean {

--- a/packages/shared/src/discovery.ts
+++ b/packages/shared/src/discovery.ts
@@ -1,3 +1,4 @@
+import { MINIMUM_AGE } from './age'
 import { languageLevelSchema, levelRank } from './level'
 import { NEARBY_MAX_KM } from './location'
 import { countryCodeSchema } from './countries'
@@ -109,8 +110,8 @@ export const discoveryQuerySchema = z
     minLevel: languageLevelSchema.optional(),
     maxLevel: languageLevelSchema.optional(),
     /** Free filters. */
-    ageMin: z.coerce.number().int().min(18).optional(),
-    ageMax: z.coerce.number().int().min(18).optional(),
+    ageMin: z.coerce.number().int().min(MINIMUM_AGE).optional(),
+    ageMax: z.coerce.number().int().min(MINIMUM_AGE).optional(),
     country: countryCodeSchema.optional(),
     /**
      * How far `sort=nearby` looks. Ignored by every other sort.

--- a/packages/shared/src/rules.test.ts
+++ b/packages/shared/src/rules.test.ts
@@ -27,19 +27,19 @@ import {
 const NOW = new Date('2026-08-26T00:00:00Z')
 
 describe('age gate', () => {
-  it('is 18+', () => {
-    expect(MINIMUM_AGE).toBe(18)
+  it('is 16+', () => {
+    expect(MINIMUM_AGE).toBe(16)
   })
 
   /**
    * Still counted by year, now that the whole date is known: somebody who
-   * turns 18 in December is let in in January. Making that strict is a product
+   * turns 16 in December is let in in January. Making that strict is a product
    * decision — the point of this test is that collecting the day did not
    * quietly change who gets in.
    */
-  it('accepts someone turning 18 this year and rejects 17', () => {
-    expect(meetsMinimumAge('2008-12-31', NOW)).toBe(true) // turns 18 in 2026
-    expect(meetsMinimumAge('2009-01-01', NOW)).toBe(false)
+  it('accepts someone turning 16 this year and rejects 15', () => {
+    expect(meetsMinimumAge('2010-12-31', NOW)).toBe(true) // turns 16 in 2026
+    expect(meetsMinimumAge('2011-01-01', NOW)).toBe(false)
   })
 
   it('rejects an underage birth date through the schema', () => {


### PR DESCRIPTION
## Why

The store questionnaires rated LangX **13+ (Apple) / Teen (Google)**. That is a content rating, not a sign-up floor, but it showed that the 18 in `age.ts` was a policy choice rather than a constraint. Behic chose **16**: the highest digital-consent age any EU state set under GDPR Article 8, so no parental-consent flow is needed anywhere in the EU/UK, and COPPA (under-13s) stays irrelevant. 13 would have needed both.

## What changes

- `MINIMUM_AGE = 16` in `packages/shared/src/age.ts`, with the reasoning rewritten.
- `discovery.ts` `ageMin`/`ageMax` and the `UNDERAGE` error text read `MINIMUM_AGE` instead of a literal 18.
- Boundary test moved to 2010/2011.
- Docs: architecture, a new `decisions.md` entry, both store-form docs (the 17+/18+ rating prediction was wrong and is replaced by the actual result), `promise-change.md`, and a Play "target audience" item in the release runbook.

## What does not change

- The arithmetic: still whole years from the birth year.
- Mobile: screens and all eight locales already interpolate `MINIMUM_AGE`.
- Nobody currently inside. v1 holders aged 16–17 that `legacyRestore.ts` bounced can now finish onboarding.

## After merge

- The website Terms/Privacy PR (langx/website) lands the same day.
- Play Console → Target audience and content: tick 16–17 and 18+, nothing younger. Content rating needs no resubmission.
- No EAS build: the OTA update carries the constant and the server enforces it regardless of client version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
