### PR TITLE
Make the runtime version a fingerprint, so merging may release

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -127,10 +127,24 @@ const config: ExpoConfig = {
   /**
    * An update is only offered to a build with the same runtime version, which
    * is what stops a JS bundle expecting a native module the installed binary
-   * does not have. Tied to the SDK, so it changes exactly when the native
-   * layer does.
+   * does not have.
+   *
+   * `fingerprint` hashes the native layer itself — the native dependencies,
+   * the config plugins, everything `expo prebuild` would produce — so the
+   * version changes exactly when the binary would have had to change. The
+   * `sdkVersion` policy this replaces was one number for a whole SDK release:
+   * adding a native module inside SDK 57 left the runtime at
+   * `exposdk:57.0.0`, so the update was still offered to a store build that
+   * could not run it. That is the guard that lets every merge to `main`
+   * publish straight to `production` (`decisions.md`); with one number per SDK
+   * it was not a guard at all. A mismatched phone now simply sees no update
+   * and keeps the bundle it shipped with.
+   *
+   * The cost is that a build made under the old policy — 2.0.0 (121), the
+   * first store release — has runtime `exposdk:57.0.0` and will never match a
+   * fingerprint. It cannot be reached over the air; the next build can.
    */
-  runtimeVersion: { policy: 'sdkVersion' },
+  runtimeVersion: { policy: 'fingerprint' },
 
   /**
    * The brand mark, from `branding/app-resources`. There was no `icon` at all

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -843,22 +843,29 @@ which half it stopped in; see `decisions.md`.
 Three layers ship independently, and the difference between them decides how
 fast a fix reaches anyone.
 
-| Layer                  | How it updates                                    | How long                 |
-| ---------------------- | ------------------------------------------------- | ------------------------ |
-| Web                    | redeploy the static export                        | next page load           |
-| API                    | redeploy the container                            | immediate                |
-| Mobile — JS and assets | **EAS Update** (`eas update --branch production`) | minutes, next app launch |
-| Mobile — native        | EAS Build + store submission                      | days, store review       |
+| Layer                  | How it updates                           | How long                 |
+| ---------------------- | ---------------------------------------- | ------------------------ |
+| Web                    | redeploy the static export               | next page load           |
+| API                    | redeploy the container                   | immediate                |
+| Mobile — JS and assets | **EAS Update**, on every merge to `main` | minutes, next app launch |
+| Mobile — native        | EAS Build + store submission             | days, store review       |
 
 ### Over-the-air updates
 
-`expo-updates` points at EAS Update on the `production` and `preview` channels
-already declared in `eas.json`. Screens, logic, copy and most bug fixes go out
-this way without a store review; a new native module, a new permission or an
-SDK bump still needs a build.
+`expo-updates` points at EAS Update on the one channel this project has,
+`production`; both build profiles in `eas.json` use it, so an internal APK and
+a store install read the same stream. Screens, logic, copy and most bug fixes
+go out this way without a store review; a new native module, a new permission
+or an SDK bump still needs a build.
 
-`runtimeVersion` follows the SDK version, which is what stops a JS bundle
-being offered to a binary whose native layer cannot run it.
+Publishing is automatic: `update.yml` runs on every merge to `main`. There is
+no second channel to hold a change back on — see `decisions.md` for why, and
+for the guard that makes it safe.
+
+`runtimeVersion` is `{ policy: 'fingerprint' }`, a hash of the native layer
+itself, so a bundle is only ever offered to a binary that can run it. A commit
+that changes the native side changes the fingerprint, and the update reaches
+nobody until the matching build ships.
 
 Launch never blocks on the network (`fallbackToCacheTimeout: 0`): the app
 starts on the bundle it has and picks up a new one in the background, applied

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2461,17 +2461,44 @@ see the runbook.
 Two things decided the shape of the workflows.
 
 _Updates are automatic, builds are not._ A merge to `main` publishes an OTA
-update to the `preview` channel for nothing; a cloud build spends one of the
-free plan's fifteen a month. So the only workflow on a push trigger is the
-update, and both build workflows are `workflow_dispatch` with a platform
-input. Somebody spends a build on purpose, not because a README changed.
+update for nothing; a cloud build is the metered thing. So the only workflow
+on a push trigger is the update, and `release.yml` is `workflow_dispatch` with
+a platform input. Somebody spends a build on purpose, not because a README
+changed.
 
-_Production updates are manual too._ An update on the `production` channel
-reaches every store install at once, and `runtimeVersion` is the SDK version,
-so a JS change that assumes a native module which is not in the store build
-would land on phones that cannot run it. Publishing to production is a
-deliberate `eas update --channel production` after the matching build has
-shipped, not a side effect of merging.
+_Production updates were manual too, at first._ An update reaches every store
+install at once, so publishing was a deliberate `eas update --channel
+production` after the matching build had shipped. That step is gone — see
+_One update channel, and merging is releasing_ — and what replaced it is
+below, because removing the human without replacing the guard would have been
+the worst of both.
+
+## The runtime version is a fingerprint, so merging can release
+
+The manual production publish was a person standing in for a check the tooling
+was not making. `runtimeVersion` was `{ policy: 'sdkVersion' }` — one number
+for the whole of SDK 57 — so a commit that added a native module left the
+runtime at `exposdk:57.0.0` and its JS would still have been offered to a
+store binary without the module. The manual step was what stopped that, and it
+stopped it by being slow rather than by knowing anything.
+
+`{ policy: 'fingerprint' }` hashes the native layer itself: the native
+dependencies, the config plugins, everything `expo prebuild` would produce. A
+commit that changes the binary changes the version, and the update is then
+offered to nobody — a mismatched phone sees no update and keeps the bundle it
+shipped with. The check the human was performing is now a property of the
+version, which is the only reason every merge may publish straight to
+`production`.
+
+This landed a day after the channel merge rather than with it, and for that
+day `main` published automatically with `sdkVersion` still in place — the
+guard removed and its replacement not yet written. Nothing shipped through the
+gap.
+
+It is paid for once. 2.0.0 (121) was built under the old policy, carries
+runtime `exposdk:57.0.0`, and can never match a fingerprint: the first store
+release is unreachable over the air. The next build is not. A bad JS-only
+update is still undone with `eas update:rollback`.
 
 ## Every v1 account has a v2 `user` row before its owner comes back
 


### PR DESCRIPTION
Reopens the one part of #1112 that never landed. `e1cb4b11` made every merge to `main` publish an OTA update to `production` — but the check the removed manual step had been performing was never replaced.

`runtimeVersion` was `{ policy: 'sdkVersion' }`: one number for the whole of SDK 57. A commit that added a native module left the runtime at `exposdk:57.0.0`, so its JS would still have been offered to a store binary without the module. The manual publish stopped that by being slow, not by knowing anything — and since yesterday there was neither.

`{ policy: 'fingerprint' }` hashes the native layer itself — native dependencies, config plugins, everything `expo prebuild` would produce. A commit that changes the binary changes the version, and the update reaches nobody: a mismatched phone sees no update and keeps the bundle it shipped with. The guard is a property of the version now, which is the only thing that makes an automatic publish defensible.

**Paid for once:** 2.0.0 (121) was built under the old policy, carries runtime `exposdk:57.0.0`, and can never match a fingerprint. The first store release is unreachable over the air; the next build is not. A bad JS-only update is still undone with `eas update:rollback`.

## Docs

Three places still described the world before `e1cb4b11` and are now true:

- `architecture.md` — the ship table said `eas update --branch production` by hand; the OTA section said two channels and "runtimeVersion follows the SDK version".
- `decisions.md` — "_Production updates are manual too_" stood next to the new section saying the opposite. It now points there, and a new section records this call, including the day the guard was missing.

## Checks

`pnpm test` — api 815, mobile 566, all passing; prettier clean. Repo-wide `typecheck`/`lint` fail locally only on two untracked scratch files in the working tree (`apps/api/scripts/tmp-*.ts`) that are not part of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)