### PR TITLE
Add a build that does not submit

### DIFF
--- a/apps/mobile/.eas/workflows/build.yml
+++ b/apps/mobile/.eas/workflows/build.yml
@@ -1,0 +1,30 @@
+# A production build, and nothing after it.
+#
+# `release.yml` is the same build with a submission chained onto it; this is
+# the half you want when the artefact is for testing, or when a build is
+# needed before a JS-only release can reach anybody.
+#
+# Started on EAS rather than from a laptop, and that is the point rather than
+# a convenience. Under the `fingerprint` runtime policy the CLI computes a
+# runtime version locally and the builder computes its own, and the build is
+# refused if they disagree. They always disagree for Android: `app.config.ts`
+# reads `GOOGLE_SERVICES_JSON`, which is a **secret** file variable, so it is
+# materialised on the builder and cannot be read anywhere else — the file
+# joins one fingerprint and not the other, whatever environment the CLI is
+# told to use. Run from here there is no second machine to disagree with.
+name: Build
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        type: choice
+        description: Which platform to build
+        default: android
+        options: [android, ios, all]
+
+jobs:
+  build_production:
+    type: build
+    params:
+      platform: ${{ inputs.platform }}
+      profile: production


### PR DESCRIPTION
`release.yml` was the only way to get a production build, and it chains a submission onto it: Play at a 10% staged rollout, iOS into App Store Connect. There was no way to ask for the artefact alone — for a device test, or for the build that has to exist before a JS-only release can reach anybody.

Being an EAS workflow rather than a local `eas build` is the substance of it, not the packaging. Under the fingerprint policy the CLI computes a runtime version on the machine starting the build and the builder computes its own, and a disagreement fails the build in `CONFIGURE_EXPO_UPDATES` before anything compiles. For Android they always disagree: `app.config.ts` reads `GOOGLE_SERVICES_JSON`, a **secret** file variable, which by definition exists only on the builder — so the file joins that fingerprint and no other. Naming the environment in the build profile does not fix it, because a secret cannot be read back at all; both hashes simply change.

```
Runtime version calculated on local machine: cd1990db…
Runtime version calculated on EAS:           8b26fba0…
```

Started from EAS there is no second machine to disagree with.

Found by running into it twice while building #1115 for both platforms. iOS was never affected — nothing in the config reads `GOOGLE_SERVICES_PLIST`.

This was written as part of #1115 and missed its push; it is unrelated to video and stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)