### PR TITLE
Release to everyone on Play, not to a tenth of them

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -27,8 +27,7 @@
     "production": {
       "android": {
         "track": "production",
-        "releaseStatus": "inProgress",
-        "rollout": 0.1
+        "releaseStatus": "completed"
       },
       "ios": {
         "ascAppId": "6474187141",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1003,7 +1003,10 @@ only thing that matters is preserving store identity.
 
 ### Releasing
 
-- **Staged:** 5–10% staged rollout on Play, phased release on iOS.
+- **Play releases to everyone at once**, phased release on iOS. It was a 5–10%
+  staged rollout on Play until 4 September 2026 — see the release runbook for
+  what the stage was buying and what now has to be checked before the
+  submission instead of after it.
 - The existing keystore is imported into EAS; `versionCode`/`buildNumber` start
   **above 119**.
 - **App Privacy / Data Safety forms updated** — see

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -602,18 +602,23 @@ before either runs.
 
 ## Release
 
-- **Play:** staged rollout starting at 10% (`eas.json` sets `rollout: 0.1`).
+- **Play:** full release (`eas.json` sets `releaseStatus: completed`). It was a
+  10% staged rollout until 4 September 2026; Behic's call to release to
+  everyone at once. What the stage was buying is written below, and is now
+  bought by watching after the fact instead of before.
 - **iOS:** phased release.
-- Watch crash-free sessions before widening. The `minSdk` bump means some v1
-  devices will stop receiving updates — check the install base's OS
-  distribution first so that is a decision, not a surprise.
+- Watch crash-free sessions. The `minSdk` bump means some v1 devices will stop
+  receiving updates — check the install base's OS distribution first so that is
+  a decision, not a surprise.
 
 ## The 16 KB page size requirement
 
 Android's deadline was **31 May 2026 — already passed**. Expo SDK 57 / RN 0.86
 handle this, but any third-party native library that has not been rebuilt for
 16 KB pages will fail on newer devices. Verify with a real device or emulator
-image configured for 16 KB before the rollout widens past 10%.
+image configured for 16 KB. This used to be gated behind the 10% stage; with a
+full release there is no stage to catch it, so it has to be checked on a device
+before the submission rather than after.
 
 ## Location changes both privacy forms
 


### PR DESCRIPTION
Behic's call, asked for and confirmed: the Play submit profile becomes `releaseStatus: completed` instead of `inProgress` at `rollout: 0.1`.

The stage was buying two things, both written into the release runbook, and neither disappears with it:

- **Crash-free sessions** were meant to be watched while only a tenth of the install base was exposed. Still worth watching, now after the fact.
- **Android's 16 KB page size**, in force since 31 May 2026 and carried by any third-party native library not rebuilt for it, was explicitly gated behind "before the rollout widens past 10%". This release adds `expo-video`, which is exactly that kind of library and has not run on a real device yet. With no stage, that check has to happen on a device *before* the submission rather than after it.

Both docs now describe the release that exists rather than a stage that is not there.

The Android submission already in flight went out at 10% and is unaffected; this applies from the next one onwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)