### PR TITLE
An attachment costs nothing, and a message is a message

### DIFF
--- a/apps/api/src/routes/feed.test.ts
+++ b/apps/api/src/routes/feed.test.ts
@@ -712,23 +712,19 @@ describe('community feed', () => {
       expect(response.json()).toMatchObject({ code: 'UNSUPPORTED_MEDIA_TYPE' })
     })
 
-    it('spends the media quota only when there is an attachment', async () => {
-      // The same bucket chat uses: it is the same abuse surface, and a second
-      // one would be a free tier that is really twice the limit through two
-      // doors.
+    it('charges nothing for an attachment on a post either', async () => {
+      // The same bucket chat uses, and it is empty on every tier now — see
+      // `PLAN_LIMITS.mediaPer24h`. Kept rather than deleted so a limit coming
+      // back has to come back through a failing test.
       const author = await newUser('media-quota@example.com')
 
       await post(author, 'A sentence with nothing attached.')
-      const afterPlain = await handle.db
-        .collection<Profile>(COLLECTIONS.profiles)
-        .findOne({ _id: author.userId })
-      expect(afterPlain?.quota.media ?? []).toHaveLength(0)
-
       await postWithMedia(author, 'A sentence with a photo.', image)
-      const afterMedia = await handle.db
+
+      const profile = await handle.db
         .collection<Profile>(COLLECTIONS.profiles)
         .findOne({ _id: author.userId })
-      expect(afterMedia?.quota.media ?? []).toHaveLength(1)
+      expect(profile?.quota.media ?? []).toHaveLength(0)
     })
 
     it('carries a gallery back on the feed', async () => {
@@ -796,19 +792,19 @@ describe('community feed', () => {
       expect(response.statusCode).toBe(400)
     })
 
-    it('spends one media unit for a gallery, not one per file', async () => {
-      // The byte ceiling is per file and is the control that bounds storage;
-      // the daily count is a ceiling on abuse, and six photos are one post.
+    it('takes a gallery without charging for it', async () => {
+      // The per-file byte ceiling is the only thing bounding storage now.
       const author = await newUser('media-gallery-quota@example.com')
-      await postWithAttachments(author, 'Three of them.', [
+      const response = await postWithAttachments(author, 'Three of them.', [
         image,
         { ...image, url: 'https://cdn.example.com/posts/u/2.jpg' },
         { ...image, url: 'https://cdn.example.com/posts/u/3.jpg' },
       ])
+      expect(response.statusCode).toBe(201)
       const profile = await handle.db
         .collection<Profile>(COLLECTIONS.profiles)
         .findOne({ _id: author.userId })
-      expect(profile?.quota.media ?? []).toHaveLength(1)
+      expect(profile?.quota.media ?? []).toHaveLength(0)
     })
 
     it('signs an upload URL only for a type we serve', async () => {
@@ -1039,25 +1035,31 @@ describe('community feed', () => {
       expect(asImage.statusCode).toBe(415)
     })
 
-    it('spends one media unit for a two-take answer', async () => {
-      // The ruling the half-speed decision left open. Two files, one unit —
-      // charging twice would make the optional slow take feel expensive and be
-      // skipped, which is the behaviour it exists to encourage.
+    it('takes a two-take answer without charging for it', async () => {
+      // The ruling the half-speed decision left open was two files, one unit.
+      // It is now two files and nothing, because attachments are unlimited on
+      // every tier — but the shape it protected still holds: an answer must
+      // never be more expensive for having recorded the slow take.
       const asker = await newUser('pron-quota-asker@example.com')
       const helper = await newUser('pron-quota-helper@example.com')
       const askId = (await ask(asker, 'anemone')).json<{ _id: string }>()._id
 
-      await answer(helper, askId, { media: take('fast'), slowMedia: take('slow') })
+      const response = await answer(helper, askId, {
+        media: take('fast'),
+        slowMedia: take('slow'),
+      })
+      expect(response.statusCode).toBe(201)
 
       const profile = await handle.db
         .collection<Profile>(COLLECTIONS.profiles)
         .findOne({ _id: helper.userId })
-      expect(profile?.quota?.media).toHaveLength(1)
+      expect(profile?.quota?.media ?? []).toHaveLength(0)
     })
 
-    it('spends nothing when the second take is rejected', async () => {
-      // Assert-all-then-consume, pinned: a bad slow take must not burn a unit
-      // for an answer that never got written.
+    it('refuses the whole answer when the second take is rejected', async () => {
+      // Assert-all-then-write, pinned: a bad slow take must not leave half an
+      // answer behind. It used to be phrased as "must not burn a unit"; there
+      // is no unit any more, and the write is the thing that matters.
       const asker = await newUser('pron-quota2-asker@example.com')
       const helper = await newUser('pron-quota2-helper@example.com')
       const askId = (await ask(asker, 'quinoa')).json<{ _id: string }>()._id
@@ -1068,10 +1070,10 @@ describe('community feed', () => {
       })
       expect(response.statusCode).toBe(400)
 
-      const profile = await handle.db
-        .collection<Profile>(COLLECTIONS.profiles)
-        .findOne({ _id: helper.userId })
-      expect(profile?.quota?.media ?? []).toHaveLength(0)
+      const answers = await handle.db
+        .collection(COLLECTIONS.pronunciationAnswers)
+        .countDocuments({ authorId: helper.userId })
+      expect(answers).toBe(0)
     })
 
     it('refuses answering your own request, and answering twice', async () => {

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -1123,21 +1123,23 @@ describe('Faz 5 — conversation/message history REST', () => {
       expect(reply.message.replyTo?.preview).toBe('🎬 Video')
     })
 
-    it('charges the media quota, which text and corrections do not', async () => {
+    it('charges nothing for an attachment, on any tier', async () => {
+      // Unlimited everywhere since 4 September 2026. `consumeQuota` returns
+      // early on a `null` limit and never touches the bucket, so this asserts
+      // the absence rather than a number — a limit reappearing would fail it.
       const { a, conversationId } = await pair('media-quota')
       const { sendMediaMessage, sendTextMessage } = await import('../modules/chat/messages')
       const { consumeQuota } = await import('../lib/quota')
 
       await sendTextMessage(handle.db, a.userId, { conversationId, body: 'free of charge' })
       await sendMediaMessage(handle.db, a.userId, { conversationId, attachments: [image] }, BUCKET)
-      // The send path itself does not spend it — the socket handler does, so
-      // spend one here and check the bucket is the media one.
-      await consumeQuota(handle.db, a.userId, 'free', 'media')
+      const spent = await consumeQuota(handle.db, a.userId, 'free', 'media')
+      expect(spent.consumed).toBe(true)
 
       const profile = await handle.db
         .collection<Profile>(COLLECTIONS.profiles)
         .findOne({ _id: a.userId })
-      expect(profile?.quota.media).toHaveLength(1)
+      expect(profile?.quota.media ?? []).toHaveLength(0)
       expect(profile?.quota.initiations).toHaveLength(1) // just the conversation they opened
     })
   })

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,8 +204,7 @@ Keys are prefixed `avatars/{userId}/`, `photos/{userId}/`,
 `messages/{conversationId}/` and `posts/{userId}/`. The feed's prefix is keyed
 by user rather than by post because the post does not exist when the URL is
 signed; every prefix is one the account purge can sweep. Attachments on posts
-and corrections share `mediaSchema` and `PLAN_LIMITS.mediaPer24h` with chat —
-one shape, one ceiling table, one abuse budget. The ceilings are per kind, in
+and corrections share `mediaSchema` with chat — one shape, one ceiling table. The ceilings are per kind, in
 `MEDIA_LIMITS`: 8MB for an image, 16MB and two minutes for a voice note, 64MB
 and sixty seconds for a video. A message or a post carries up to
 `MAX_ATTACHMENTS` of them and spends one unit of the budget however many that
@@ -659,10 +658,10 @@ rather than an empty bubble, and everything reads through `attachmentsOf`.
 Nothing is migrated — dropping `media` is a change of its own. Video is stored
 exactly as uploaded: no transcoding, and no thumbnail file, because the player
 already holds the first frame. Size is capped when the upload
-URL is _signed_ rather than after the bytes have been paid for, and
-`PLAN_LIMITS.mediaPer24h` caps the count on the free tier — a ceiling on abuse
-rather than a paywall, since v1 offered both free. Corrections stay uncapped
-because they cost nothing to store.
+URL is _signed_ rather than after the bytes have been paid for, and that
+per-file ceiling is now the only thing bounding storage:
+`PLAN_LIMITS.mediaPer24h` is `null` on every tier since 4 September 2026, so a
+message costs the same whether it carries something or not.
 
 Index `{ conversationId: 1, createdAt: -1 }` → cursor pagination, with `_id` as
 the tiebreak for a true keyset.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1743,21 +1743,17 @@ when the cap bites.
 The conversation query is sorted now, which it was not. Truncating an unsorted
 find would have kept whichever rows Mongo happened to return.
 
-## Feed attachments share chat's media quota, and its ceilings
+## Feed attachments share chat's ceilings
 
-A post and a correction can carry a photo or a voice note. They are the same
-shape as a chat attachment — one `mediaSchema`, one set of size limits — and
-they spend the same `mediaPer24h` bucket.
+A post and a correction can carry a photo, a video or a voice note. They are
+the same shape as a chat attachment — one `mediaSchema`, one set of size
+limits.
 
-The same bucket, not a second one, because it is the same abuse surface: bytes
-stored and served forever. `PLAN_LIMITS.mediaPer24h` is documented as a ceiling
-on abuse rather than a paywall, and a second bucket would mean a second limit
-key, a second quota kind, and a free tier that is really a hundred a day
-through two doors. The consequence is user-visible and belongs in the release
-note: **a heavy day in chat leaves fewer attachments for the feed.**
-
-The quota is spent only when there is an attachment, so a plain sentence still
-costs nothing.
+They shared a daily count as well, `mediaPer24h`, on the argument that it was
+one abuse surface and a second bucket would be a free tier that is really twice
+the limit through two doors. That count is `null` on every tier now — see _An
+attachment costs nothing, and a message is a message_ — so what they share is
+the per-file byte ceiling, which is the whole of the cost control.
 
 ## The attachment uploads on submit, not on pick
 
@@ -2810,3 +2806,28 @@ have crashed on an import. Now those phones are offered no update at all and
 keep what they shipped with, until a build carrying `expo-video` replaces it.
 That belongs in the release note either way — nobody sees video until they
 install a new binary.
+
+## An attachment costs nothing, and a message is a message
+
+`PLAN_LIMITS.mediaPer24h` was 50 on the free tier. It is `null` everywhere as
+of 4 September 2026, Behic's call, asked for in those words: a message is a
+message and whether it has something attached is not the user's problem.
+
+It never counted files. Six photos in one message spent one unit, the way a
+pronunciation answer's two takes always did, so the number people met was a
+number of _messages_ — which is exactly why the pricing page's line was wrong
+before it was rewritten: "50 photo, video or voice messages a day" reads as a
+cap on messages, and there has never been one. Replies and corrections are
+unlimited two lines above it on the same page.
+
+**What this gives up, written down because it is not free.** The count was the
+ceiling on abuse; the per-file byte ceiling is now the only thing bounding
+storage, and video raised that ceiling to sixty-four megabytes. One account can
+upload as many sixty-four megabyte videos as it has hours in the day. Nothing
+in the code stops it, and storage is billed by the byte.
+
+The field and the plumbing stay — `consumeQuota` returns early on a `null`
+limit and touches nothing, and the tests assert the absence rather than being
+deleted, so a limit coming back has to come back through a failing test. But
+reinstating one means taking back something people were told they had, which is
+a different kind of change from setting it in the first place.

--- a/packages/shared/src/limits.ts
+++ b/packages/shared/src/limits.ts
@@ -47,13 +47,21 @@ export interface PlanLimits {
    */
   correctionsPer24h: Limit
   /**
-   * Image and voice messages per rolling 24 hours.
+   * Messages carrying a photo, a video or a voice note, per rolling 24 hours.
    *
-   * Capped on the free tier where corrections are not, and the difference is
-   * cost: a correction is text someone else benefits from, while an
-   * attachment is bytes we store and serve forever. Set high enough that a
-   * normal conversation never meets it — this is a ceiling on abuse, not a
-   * paywall, and v1 offered both features free.
+   * `null` on every tier since 4 September 2026 — Behic's call: a message is a
+   * message, and whether it has something attached is not the user's problem.
+   * The free tier's 50 went with it.
+   *
+   * It counted messages, never files: six photos in one message spent one
+   * unit, the way a pronunciation answer's two takes always did.
+   *
+   * The field stays, and so does the plumbing around it, because the cost it
+   * was answering has not gone anywhere: an attachment is bytes we store and
+   * serve forever, and video raised the per-file ceiling to
+   * `MAX_VIDEO_BYTES`. What bounds storage now is that ceiling alone. If a
+   * ceiling has to come back, it comes back here and nothing else changes —
+   * but it will be taking back something people were told they had.
    */
   mediaPer24h: Limit
   /**
@@ -164,7 +172,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     initiationsPer24h: 5,
     translationsPer24h: 20,
     correctionsPer24h: null,
-    mediaPer24h: 50,
+    mediaPer24h: null,
     advancedFilters: false,
     profileViewerIdentities: false,
     incognito: false,


### PR DESCRIPTION
`PLAN_LIMITS.free.mediaPer24h` was 50. It is `null` on every tier now — Behic's call, in his own words: a message is a message, and whether it has something attached is not the user's problem.

It never counted files. Six photos in one message spent one unit, the way a pronunciation answer's two takes always did, so the number people actually met was a number of *messages*. That is why the pricing page read as a cap on messages, and why the line was wrong: replies and corrections are listed as unlimited two lines above it.

## What this gives up

The count was the ceiling on abuse. The per-file byte ceiling is now the only thing bounding storage, and video raised that ceiling to 64 MB. One account can upload as many 64 MB videos as it has hours in the day; nothing in the code stops it, and storage is billed by the byte. This is written into `decisions.md` rather than left implicit, because reinstating a limit later means taking back something people were told they had.

## What stays

The field and the plumbing. `consumeQuota` returns early on a `null` limit and touches nothing, so the code path is dormant rather than deleted, and a ceiling can come back by changing one number.

The four tests that asserted a unit was spent now assert the bucket is empty. Kept rather than deleted, so a limit reappearing has to do it through a failing test. One changes what it protects rather than its number: a rejected slow take used to be pinned as "must not burn a unit" and is now pinned as "must not leave half an answer behind", which was always the thing that mattered.

Website copy follows in langx/website#135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)