### PR TITLE
The chats-row swipe on gesture-handler and Reanimated

### DIFF
--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -746,6 +746,19 @@ export default function ChatScreen() {
   )
 
   const onReply = useCallback((message: MessageDto) => setReplyingTo(message), [])
+  /**
+   * Stable, for the same reason `onLongPress` below is.
+   *
+   * It was an inline arrow passed straight into a `memo`'d `MessageBubble`, so
+   * every bubble's props were unequal on every render — which meant every
+   * keystroke in the composer re-rendered every visible bubble, on the same JS
+   * thread the swipe gesture used to run on. `setViewing` is a setter and is
+   * already stable, so this needs no ref.
+   */
+  const onOpenMedia = useCallback(
+    (items: Media[], index: number) => setViewing({ items, index }),
+    [],
+  )
 
   /**
    * Centre the window on what it was opened for, once — not on every page it
@@ -1015,7 +1028,7 @@ export default function ChatScreen() {
                     onLongPress={onLongPress}
                     onReply={onReply}
                     onJumpTo={onJumpTo}
-                    onOpenMedia={(items, index) => setViewing({ items, index })}
+                    onOpenMedia={onOpenMedia}
                   />
                 )
               }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -15,6 +15,7 @@ import { Stack } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import { useEffect, useRef, useState } from 'react'
 import { Text } from 'react-native'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { ApiRequestError } from '../src/api/client'
 import { AlertHost } from '../src/components/AlertHost'
@@ -73,13 +74,21 @@ function createQueryClient(): QueryClient {
 
 export default function RootLayout() {
   return (
-    <SafeAreaProvider>
-      <I18nProvider>
-        <ThemeProvider>
-          <RootShell />
-        </ThemeProvider>
-      </I18nProvider>
-    </SafeAreaProvider>
+    /*
+     * Outside `SafeAreaProvider`, which is where gesture-handler's own docs put
+     * it: it has to be the outermost view for a gesture anywhere in the tree to
+     * be recognised. `flex: 1` is required — without it the view collapses and
+     * the whole app renders as nothing.
+     */
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <I18nProvider>
+          <ThemeProvider>
+            <RootShell />
+          </ThemeProvider>
+        </I18nProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   )
 }
 

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -2,5 +2,15 @@ module.exports = function (api) {
   api.cache(true)
   return {
     presets: [['babel-preset-expo', { jsxImportSource: 'react' }]],
+    /**
+     * Reanimated's worklets are compiled here, not at runtime: the plugin is
+     * what turns a `'worklet'`-marked function into something the UI thread can
+     * run. Without it every `useAnimatedStyle` in the app throws on the first
+     * frame, which is why this file grew a `plugins` key the day
+     * `SwipeableRow` stopped using `PanResponder`.
+     *
+     * Last in the list, which the plugin's own docs require.
+     */
+    plugins: ['react-native-worklets/plugin'],
   }
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -54,6 +54,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-native": "catalog:",
+    "react-native-gesture-handler": "~2.32.0",
     "react-native-purchases": "^10.8.1",
     "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "~5.7.0",

--- a/apps/mobile/src/components/MessageBubble.tsx
+++ b/apps/mobile/src/components/MessageBubble.tsx
@@ -1,15 +1,14 @@
 import Feather from '@expo/vector-icons/Feather'
 import { memo, useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react'
-import {
-  Animated,
-  PanResponder,
-  Platform,
-  Pressable,
-  StyleSheet,
-  Text,
-  View,
-  type ViewStyle,
-} from 'react-native'
+import { Animated, Platform, Pressable, StyleSheet, Text, View, type ViewStyle } from 'react-native'
+import { Gesture, GestureDetector } from 'react-native-gesture-handler'
+import Reanimated, {
+  interpolate,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated'
 import type { MessageDto } from '../api/queries'
 import { diffCorrection } from '../lib/correctionDiff'
 import { attachmentsOf, type Media } from '@langx/shared'
@@ -17,7 +16,7 @@ import { isBigEmoji } from '../lib/singleEmoji'
 import type { AnchorRect } from '../lib/messageMenu'
 import {
   SWIPE_ACTIVATE_PX,
-  shouldCaptureSwipe,
+  SWIPE_LOCK_PX,
   swipeReleased,
   swipeToReplyEnabled,
   swipeTranslation,
@@ -115,26 +114,27 @@ export const MessageBubble = memo(function MessageBubble({
    * half of making it work on a touchscreen: without it the browser claims the
    * horizontal pan for its own scrolling before the responder ever sees it.
    */
-  const translateX = useRef(new Animated.Value(0)).current
-  const responder = useMemo(() => {
-    const settle = () =>
-      Animated.spring(translateX, { toValue: 0, useNativeDriver: true, bounciness: 0 }).start()
-    return PanResponder.create({
-      // Never on start: that would swallow the tap and the long press.
-      onStartShouldSetPanResponder: () => false,
-      onMoveShouldSetPanResponder: (_event, gesture) => shouldCaptureSwipe(gesture.dx, gesture.dy),
-      onPanResponderMove: (_event, gesture) => translateX.setValue(swipeTranslation(gesture.dx)),
-      onPanResponderRelease: (_event, gesture) => {
-        if (swipeReleased(gesture.dx)) onReply(message)
-        settle()
-      },
-      onPanResponderTerminate: settle,
-      // The list asking for the responder back mid-scroll wins, always.
-      onPanResponderTerminationRequest: () => true,
+  const translateX = useSharedValue(0)
+  const pan = Gesture.Pan()
+    .enabled(swipeToReplyEnabled(Platform.OS, HAS_TOUCH))
+    /*
+     * The same two thresholds `shouldCaptureSwipe` applied, now decided
+     * natively — which is what stops the drag from competing with the list's
+     * own scroll on the JS thread.
+     *
+     * A single positive number, not a pair: reply is a rightwards gesture
+     * only, and leaving the other direction unclaimed keeps it free for a
+     * later action, exactly as `shouldCaptureSwipe` said.
+     */
+    .activeOffsetX(SWIPE_LOCK_PX)
+    .failOffsetY([-SWIPE_LOCK_PX, SWIPE_LOCK_PX])
+    .onUpdate((event) => {
+      translateX.value = swipeTranslation(event.translationX)
     })
-  }, [message, onReply, translateX])
-
-  const pan = swipeToReplyEnabled(Platform.OS, HAS_TOUCH) ? responder.panHandlers : {}
+    .onEnd((event) => {
+      if (swipeReleased(event.translationX)) runOnJS(onReply)(message)
+      translateX.value = withSpring(0, { damping: 20, stiffness: 220, overshootClamping: true })
+    })
   const flash = highlighted ? styles.highlighted : null
 
   /**
@@ -145,9 +145,11 @@ export const MessageBubble = memo(function MessageBubble({
   /**
    * A bounce on arrival that a tap can replay.
    *
-   * RN's `Animated`, not Reanimated: Reanimated 4 is a dependency that nothing
-   * imports, and pulling it in for one spring would put its worklets bundle
-   * into the shipped web build. `Button` already does exactly this shape.
+   * RN's `Animated`, still, even though Reanimated is now imported a few lines
+   * up for the swipe. This is a one-shot spring on a property nothing else
+   * reads and no gesture drives — the case `Animated` handles perfectly well
+   * with `useNativeDriver` — and moving it would buy nothing. `Button` does
+   * exactly this shape.
    *
    * A tap is free to take: every `Pressable` in this file has only
    * `onLongPress`, and the shell's `PanResponder` returns false from
@@ -178,15 +180,23 @@ export const MessageBubble = memo(function MessageBubble({
 
   /**
    * The arrow WhatsApp shows under the bubble as it slides. Driven by the same
-   * `Animated.Value` as the bubble, so it fades in exactly as far as the
-   * gesture has travelled and reaches full strength at the point where letting
-   * go actually replies.
+   * value as the bubble, so it fades in exactly as far as the gesture has
+   * travelled and reaches full strength at the point where letting go actually
+   * replies.
+   *
+   * This is where the old version had a real bug rather than only a slow one:
+   * `translateX` was `setValue`-driven, spring-animated with
+   * `useNativeDriver: true`, *and* read here by a JS-side `interpolate` — the
+   * classic "this animated node has been moved to the native side" mismatch.
+   * The arrow simply stopped following after the first swipe. On the UI thread
+   * there is one value and one reader.
    */
-  const arrowOpacity = translateX.interpolate({
-    inputRange: [0, SWIPE_ACTIVATE_PX],
-    outputRange: [0, 1],
-    extrapolate: 'clamp',
-  })
+  const arrowStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(translateX.value, [0, SWIPE_ACTIVATE_PX], [0, 1], 'clamp'),
+  }))
+  const sliderStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
+  }))
 
   /**
    * Every branch below is the same shell: the arrow underneath, the bubble on
@@ -194,12 +204,14 @@ export const MessageBubble = memo(function MessageBubble({
    */
   const shell = (children: ReactNode): ReactNode => (
     <View style={styles.row}>
-      <Animated.View style={[styles.arrow, { opacity: arrowOpacity }]} pointerEvents="none">
+      <Reanimated.View style={[styles.arrow, arrowStyle]} pointerEvents="none">
         <Feather name="corner-up-left" size={15} color={colors.textMuted} />
-      </Animated.View>
-      <Animated.View ref={box} style={styles.slider} {...pan}>
-        <Animated.View style={{ transform: [{ translateX }] }}>{children}</Animated.View>
-      </Animated.View>
+      </Reanimated.View>
+      <GestureDetector gesture={pan}>
+        <Animated.View ref={box} style={styles.slider}>
+          <Reanimated.View style={sliderStyle}>{children}</Reanimated.View>
+        </Animated.View>
+      </GestureDetector>
     </View>
   )
 

--- a/apps/mobile/src/components/SwipeableRow.tsx
+++ b/apps/mobile/src/components/SwipeableRow.tsx
@@ -1,22 +1,21 @@
 import Feather from '@expo/vector-icons/Feather'
-import { useEffect, useRef, type ReactNode } from 'react'
-import {
-  Animated,
-  PanResponder,
-  Platform,
-  Pressable,
-  Text,
-  View,
-  type AccessibilityActionEvent,
-} from 'react-native'
+import { useEffect, type ReactNode } from 'react'
+import { Platform, Pressable, Text, View, type AccessibilityActionEvent } from 'react-native'
+import { Gesture, GestureDetector } from 'react-native-gesture-handler'
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated'
 import { makeStyles } from '../lib/theme'
 import {
+  ACTION_LOCK_PX,
   ACTION_WIDTH_PX,
   drawerWidth,
   rowSwipeEnabled,
   rowTranslation,
   settleOffset,
-  shouldCaptureRowSwipe,
 } from '../lib/swipeAction'
 
 /**
@@ -59,11 +58,24 @@ interface SwipeableRowProps {
  * Which row is open lives in the list, not here: two rows open at once is two
  * sets of buttons and no way to tell which the next tap belongs to.
  *
- * RN's `PanResponder` and `Animated`, not gesture-handler and not Reanimated:
- * `react-native-gesture-handler` is not a dependency at all (only a transitive
- * peer of expo-router's drawer, unreachable under pnpm's isolated layout), and
- * `ui/Skeleton.tsx` records why pulling Reanimated in would put its worklets
- * bundle into the shipped web build.
+ * **gesture-handler and Reanimated, and it used to be `PanResponder` and
+ * `Animated`.** That was not a tuning problem. `translateX.setValue` ran on
+ * the JS thread for every finger move while the release spring ran with
+ * `useNativeDriver: true` — the drag was bridge-bound and the settle was not,
+ * so the row lagged behind the thumb and then caught up in one jump. The
+ * capture threshold made it worse: 12px had to be travelled before anything
+ * moved and nothing gave those 12px back, so the row started behind the finger
+ * and stayed there.
+ *
+ * Now the pan is recognised natively (`activeOffsetX`/`failOffsetY`, which is
+ * also what removes the dead zone), the offset is a shared value, and the
+ * settle is a spring on the UI thread. The geometry stays in
+ * `lib/swipeAction.ts`, still plain maths and still tested without a renderer —
+ * it is worklet-safe as written.
+ *
+ * The cost is real and was argued against here for a year: Reanimated's
+ * worklets bundle now enters the shipped web build. See `docs/decisions.md` →
+ * *The row swipe runs on the UI thread*.
  *
  * Off for a mouse. `rowSwipeEnabled` states why; the actions are still reachable
  * through `accessibilityActions` and through whatever menu the row itself
@@ -71,60 +83,61 @@ interface SwipeableRowProps {
  */
 export function SwipeableRow({ right, left, open, onOpenChange, children }: SwipeableRowProps) {
   const styles = useStyles()
-  const translateX = useRef(new Animated.Value(0)).current
-  /**
-   * Where the row is resting. Read during the gesture without re-rendering,
-   * and — unlike the old version, which only ever started from zero — added to
-   * `gesture.dx`, because `dx` is measured from the start of *this* drag and an
-   * already-open row would otherwise jump back to nearly closed on the second.
-   */
-  const restingAt = useRef(0)
+  /** Where the row is now, and where it is resting between gestures. */
+  const translateX = useSharedValue(0)
+  const restingAt = useSharedValue(0)
 
   const enabled = rowSwipeEnabled(Platform.OS, HAS_TOUCH)
   const rightWidth = drawerWidth(right.length)
   const leftWidth = drawerWidth(left.length)
 
-  /** Kept fresh for the responder, which is built once and closes over nothing else. */
-  const geometry = useRef({ rightWidth, leftWidth, onOpenChange })
-  geometry.current = { rightWidth, leftWidth, onOpenChange }
-
   const settle = (to: number): void => {
-    restingAt.current = to
-    Animated.spring(translateX, { toValue: to, useNativeDriver: true, bounciness: 0 }).start()
+    restingAt.value = to
+    // `bounciness: 0`'s successor: a drawer that overshoots its own width
+    // shows the row's background through the gap it opens.
+    translateX.value = withSpring(to, { damping: 20, stiffness: 220, overshootClamping: true })
   }
 
   // The list closes this row by flipping `open`; the row is what animates.
   useEffect(() => {
-    // `settle` touches two refs and one `Animated.Value`, all stable, so it is
-    // deliberately not a dependency — listing it would rebuild this on every
-    // render and close the row mid-gesture.
-    if (!open && restingAt.current !== 0) settle(0)
+    // `settle` touches two shared values, both stable, so it is deliberately
+    // not a dependency — listing it would rebuild this on every render.
+    if (!open && restingAt.value !== 0) settle(0)
   }, [open])
 
-  const pan = useRef(
-    PanResponder.create({
-      // Never on start: that would swallow the tap that opens the thread and
-      // the long press that opens the menu.
-      onStartShouldSetPanResponder: () => false,
-      onMoveShouldSetPanResponder: (_event, gesture) =>
-        enabled && shouldCaptureRowSwipe(gesture.dx, gesture.dy),
-      // The list asking for the responder back mid-scroll wins, always.
-      onPanResponderTerminationRequest: () => true,
-      onPanResponderMove: (_event, gesture) => {
-        const { rightWidth: r, leftWidth: l } = geometry.current
-        translateX.setValue(rowTranslation(restingAt.current + gesture.dx, r, l))
-      },
-      onPanResponderRelease: (_event, gesture) => {
-        const { rightWidth: r, leftWidth: l, onOpenChange: notify } = geometry.current
-        const to = settleOffset(restingAt.current + gesture.dx, r, l)
-        settle(to)
-        notify(to !== 0)
-      },
-      onPanResponderTerminate: () => {
-        settle(restingAt.current)
-      },
-    }),
-  ).current
+  const pan = Gesture.Pan()
+    .enabled(enabled)
+    /*
+     * The capture rule, now native and now free of the dead zone.
+     * `activeOffsetX` is the same 12px `shouldCaptureRowSwipe` used, but
+     * gesture-handler reports `translationX` from where the gesture *began*
+     * rather than from where it was recognised — so those first pixels are
+     * given back and the row starts under the thumb rather than behind it.
+     *
+     * `failOffsetY` is the other half of what `HORIZONTAL_BIAS` was doing: a
+     * flick that has gone further down than across is the list scrolling, and
+     * failing rather than competing is what keeps the scroll smooth.
+     */
+    .activeOffsetX([-ACTION_LOCK_PX, ACTION_LOCK_PX])
+    .failOffsetY([-ACTION_LOCK_PX, ACTION_LOCK_PX])
+    .onUpdate((event) => {
+      translateX.value = rowTranslation(restingAt.value + event.translationX, rightWidth, leftWidth)
+    })
+    .onEnd((event) => {
+      const to = settleOffset(
+        restingAt.value + event.translationX,
+        rightWidth,
+        leftWidth,
+        event.velocityX,
+      )
+      restingAt.value = to
+      translateX.value = withSpring(to, { damping: 20, stiffness: 220, overshootClamping: true })
+      // The list's state lives in React, so crossing back costs one hop —
+      // once, on release, rather than on every frame.
+      runOnJS(onOpenChange)(to !== 0)
+    })
+
+  const movingStyle = useAnimatedStyle(() => ({ transform: [{ translateX: translateX.value }] }))
 
   /**
    * The actions again, for anyone not using a gesture. Swipe-only actions are
@@ -159,14 +172,15 @@ export function SwipeableRow({ right, left, open, onOpenChange, children }: Swip
         glass, and the buttons sit visible on every row at rest with the row's
         own text printed on top of them.
       */}
-      <Animated.View
-        accessibilityActions={all.map((action) => ({ name: action.id, label: action.label }))}
-        onAccessibilityAction={onAccessibilityAction}
-        style={[styles.moving, { transform: [{ translateX }] }]}
-        {...pan.panHandlers}
-      >
-        {children}
-      </Animated.View>
+      <GestureDetector gesture={pan}>
+        <Animated.View
+          accessibilityActions={all.map((action) => ({ name: action.id, label: action.label }))}
+          onAccessibilityAction={onAccessibilityAction}
+          style={[styles.moving, movingStyle]}
+        >
+          {children}
+        </Animated.View>
+      </GestureDetector>
     </View>
   )
 }

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -17,8 +17,10 @@ interface ButtonProps {
  * v3 tightens the rule: yellow appears exactly once per screen, on this.
  *
  * The press animates scale as well as colour. RN's `Animated` rather than
- * Reanimated, following `Skeleton`: a transform on the native driver is all
- * this needs, and Reanimated is imported by nothing else in the app.
+ * Reanimated, following `Skeleton`: a transform on the native driver is all a
+ * press needs. Reanimated *is* in the bundle now — `SwipeableRow` pulled it in
+ * for a gesture that tracks a finger — but that is a reason to leave this
+ * alone rather than to rewrite it.
  */
 export function Button({
   label,

--- a/apps/mobile/src/components/ui/Skeleton.tsx
+++ b/apps/mobile/src/components/ui/Skeleton.tsx
@@ -9,9 +9,13 @@ import { makeStyles, radius } from '../../lib/theme'
  *
  * RN's `Animated` rather than Reanimated, following `ToastHost`. Opacity with
  * `useNativeDriver` already runs off the JS thread, which is the only thing
- * Reanimated would have bought — and Reanimated 4 is imported by nothing in
- * this app, so reaching for it here would put its worklets bundle into the
- * shipped web build for a nicer easing curve.
+ * Reanimated would have bought here.
+ *
+ * The second half of that argument no longer holds: `SwipeableRow` now imports
+ * Reanimated, so its worklets bundle is in the shipped web build whatever this
+ * file does. That was paid for a gesture that has to track a finger; a pulse
+ * on a placeholder is not one, and there is still nothing to gain by
+ * rewriting it.
  */
 export function Skeleton({
   width,

--- a/apps/mobile/src/lib/swipeAction.test.ts
+++ b/apps/mobile/src/lib/swipeAction.test.ts
@@ -1,37 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
-  ACTION_LOCK_PX,
   ACTION_WIDTH_PX,
   drawerWidth,
   rowSwipeEnabled,
   rowTranslation,
   settleOffset,
-  shouldCaptureRowSwipe,
 } from './swipeAction'
 
 const ONE = drawerWidth(1)
 const TWO = drawerWidth(2)
-
-describe('shouldCaptureRowSwipe', () => {
-  it('ignores movement that has not committed yet', () => {
-    expect(shouldCaptureRowSwipe(ACTION_LOCK_PX, 0)).toBe(false)
-    expect(shouldCaptureRowSwipe(-ACTION_LOCK_PX, 0)).toBe(false)
-  })
-
-  it('takes a clear horizontal drag either way', () => {
-    expect(shouldCaptureRowSwipe(40, 5)).toBe(true)
-    expect(shouldCaptureRowSwipe(-40, 5)).toBe(true)
-  })
-
-  /**
-   * The whole answer to "why does the list not scroll any more". A flick down a
-   * long list is never perfectly vertical.
-   */
-  it('leaves a diagonal flick to the list', () => {
-    expect(shouldCaptureRowSwipe(30, 30)).toBe(false)
-    expect(shouldCaptureRowSwipe(-30, 25)).toBe(false)
-  })
-})
 
 describe('drawerWidth', () => {
   it('is one width per button', () => {
@@ -86,6 +63,28 @@ describe('settleOffset', () => {
     for (const x of [-160, -80, -30, 30, 80, 160]) {
       expect([0, ONE, -TWO]).toContain(settleOffset(x, ONE, TWO))
     }
+  })
+
+  /**
+   * The half that was missing, and the half the complaint was actually about:
+   * with two actions the drawer is 168px, so distance alone asked for 67px of
+   * travel — more than a natural flick moves before the thumb lifts.
+   */
+  it('opens on a fast flick that stopped short', () => {
+    expect(settleOffset(30, ONE, TWO, 900)).toBe(ONE)
+    expect(settleOffset(-30, ONE, TWO, -900)).toBe(-TWO)
+    // The same short pull, made slowly, still closes.
+    expect(settleOffset(30, ONE, TWO, 100)).toBe(0)
+  })
+
+  it('closes on a fast flick back, however far it had been dragged', () => {
+    expect(settleOffset(ONE, ONE, TWO, -900)).toBe(0)
+    expect(settleOffset(-TWO, ONE, TWO, 900)).toBe(0)
+  })
+
+  it('cannot be flicked into a side that has no actions', () => {
+    expect(settleOffset(300, 0, TWO, 900)).toBe(0)
+    expect(settleOffset(-300, ONE, 0, -900)).toBe(0)
   })
 
   it('cannot open a side that has no actions', () => {

--- a/apps/mobile/src/lib/swipeAction.ts
+++ b/apps/mobile/src/lib/swipeAction.ts
@@ -18,27 +18,35 @@
 
 /** One action button's width, and therefore the unit the row opens in. */
 export const ACTION_WIDTH_PX = 84
-/** Movement below this is still undecided. */
+/**
+ * Movement below this is still undecided.
+ *
+ * Read by `Gesture.Pan().activeOffsetX(...)` and `.failOffsetY(...)` rather
+ * than by a predicate here — the same two questions, asked natively before the
+ * gesture reaches JS, which is also what gives those first pixels back to the
+ * row instead of leaving it trailing the thumb by them.
+ */
 export const ACTION_LOCK_PX = 12
 /** How much of the overshoot past a fully open drawer still moves the row. */
 const RUBBER = 0.15
 /** Past this much of a drawer's width, releasing opens it rather than closing. */
 const OPEN_AT = 0.4
 /**
- * How much more horizontal than vertical the movement has to be.
+ * A flick this fast opens the drawer however far it actually travelled, in
+ * points per second.
  *
- * Same 1.5 as `swipeToReply`, and for the same reason: a flick down a long list
- * is never perfectly vertical, and at 1.0 a slightly diagonal one reads as a
- * swipe and eats the scroll.
+ * Distance alone was the whole of the complaint that this row "wants to be
+ * pulled all the way": with two actions the drawer is 168px, so `OPEN_AT`
+ * asked for 67px of travel — and a natural flick moves the thumb perhaps 60px
+ * before it lifts. The row then sprang shut on a gesture that felt decisive,
+ * which reads as the swipe having failed rather than as a threshold missed.
+ *
+ * 500 is roughly the speed of a deliberate flick and roughly twice that of the
+ * drag somebody makes while deciding, which is the distinction worth drawing:
+ * a slow half-open drag still asks the distance question.
  */
-const HORIZONTAL_BIAS = 1.5
-
+const FLICK_VELOCITY = 500
 export type SwipeDirection = 'left' | 'right'
-
-/** Is this a row swipe, or the list scrolling? */
-export function shouldCaptureRowSwipe(dx: number, dy: number): boolean {
-  return Math.abs(dx) > ACTION_LOCK_PX && Math.abs(dx) > Math.abs(dy) * HORIZONTAL_BIAS
-}
 
 /** How wide the drawer on one side is, given how many buttons it holds. */
 export function drawerWidth(actionCount: number): number {
@@ -63,8 +71,25 @@ export function rowTranslation(x: number, right: number, left: number): number {
  * Where the row comes to rest when the finger lifts: closed, or one of the two
  * drawers fully open. Never anywhere in between — a half-open row is a row
  * whose buttons are half-tappable.
+ *
+ * `velocity` is how fast the finger was moving when it lifted, in points per
+ * second, and it is what makes a flick work. A gesture that is fast **and
+ * heading the right way** opens the drawer it is heading towards regardless of
+ * distance; a fast flick heading *back* closes the row regardless of where it
+ * had got to, which is the same rule read in the other direction.
+ *
+ * Defaulted, so every existing caller and every existing test still describes
+ * a slow drag.
  */
-export function settleOffset(x: number, right: number, left: number): number {
+export function settleOffset(x: number, right: number, left: number, velocity = 0): number {
+  const flickedRight = velocity >= FLICK_VELOCITY
+  const flickedLeft = velocity <= -FLICK_VELOCITY
+
+  if (flickedRight && right > 0 && x > 0) return right
+  if (flickedLeft && left > 0 && x < 0) return -left
+  // A flick back towards centre closes, however far the row had been dragged.
+  if ((flickedLeft && x > 0) || (flickedRight && x < 0)) return 0
+
   if (x > 0) return right > 0 && x >= right * OPEN_AT ? right : 0
   if (x < 0) return left > 0 && -x >= left * OPEN_AT ? -left : 0
   return 0

--- a/apps/mobile/src/lib/swipeToReply.test.ts
+++ b/apps/mobile/src/lib/swipeToReply.test.ts
@@ -2,31 +2,10 @@ import { describe, expect, it } from 'vitest'
 import {
   SWIPE_ACTIVATE_PX,
   SWIPE_MAX_PX,
-  shouldCaptureSwipe,
   swipeReleased,
   swipeToReplyEnabled,
   swipeTranslation,
 } from './swipeToReply'
-
-describe('shouldCaptureSwipe', () => {
-  it('ignores movement too small to have a direction yet', () => {
-    expect(shouldCaptureSwipe(4, 0)).toBe(false)
-  })
-
-  it('takes a clearly horizontal drag to the right', () => {
-    expect(shouldCaptureSwipe(40, 5)).toBe(true)
-  })
-
-  /** The case that decides whether the thread still scrolls. */
-  it('leaves a diagonal flick to the list', () => {
-    expect(shouldCaptureSwipe(30, 25)).toBe(false)
-    expect(shouldCaptureSwipe(30, -25)).toBe(false)
-  })
-
-  it('never captures a leftward drag', () => {
-    expect(shouldCaptureSwipe(-40, 2)).toBe(false)
-  })
-})
 
 describe('swipeTranslation', () => {
   it('follows the finger up to the limit', () => {

--- a/apps/mobile/src/lib/swipeToReply.ts
+++ b/apps/mobile/src/lib/swipeToReply.ts
@@ -2,29 +2,17 @@
 export const SWIPE_ACTIVATE_PX = 56
 /** Where the bubble stops following the finger one-to-one. */
 export const SWIPE_MAX_PX = 80
-/** Movement below this is still undecided. */
+/**
+ * Movement below this is still undecided.
+ *
+ * Now read by `Gesture.Pan().activeOffsetX(...)` and `.failOffsetY(...)`
+ * rather than by a predicate here: the same two questions — has it gone far
+ * enough sideways, and has it gone too far down to still be a swipe — are
+ * asked natively, before the gesture is ever handed to JS.
+ */
 export const SWIPE_LOCK_PX = 10
 /** How much of the overshoot past `SWIPE_MAX_PX` still moves the bubble. */
 const RUBBER = 0.15
-/**
- * How much more horizontal than vertical the movement has to be.
- *
- * This ratio is the whole answer to "why does the thread not scroll any more".
- * A flick up a long thread is never perfectly vertical, and at 1.0 a slightly
- * diagonal one reads as a swipe and eats the scroll.
- */
-const HORIZONTAL_BIAS = 1.5
-
-/**
- * Is this a reply swipe, or the list scrolling?
- *
- * Rightwards only. One accepted sign keeps the test above meaningful and
- * leaves the other direction free for a later action.
- */
-export function shouldCaptureSwipe(dx: number, dy: number): boolean {
-  return dx > SWIPE_LOCK_PX && dx > Math.abs(dy) * HORIZONTAL_BIAS
-}
-
 /** Follows the finger, then resists — so the limit is felt, not hit. */
 export function swipeTranslation(dx: number): number {
   if (dx <= 0) return 0

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2781,6 +2781,51 @@ pictures — two recordings can, because that is the answer's two takes — sinc
 mixing kinds would make a message's type, and so its preview line and its
 notification, a coin toss between "photo" and "voice message".
 
+## The row swipe runs on the UI thread, and Reanimated is the price
+
+Three comments in this repo argued against exactly this change —
+`SwipeableRow`, `ui/Skeleton` and `MessageBubble` all said that Reanimated 4
+was a dependency nothing imported and that pulling it in would put its worklets
+bundle into the shipped web build. The reasoning was sound and the conclusion
+has been reversed, so all three are rewritten rather than left to contradict
+the code beside them.
+
+**What the JS-thread version actually cost.** `translateX.setValue(...)` ran on
+the JS thread for every finger move while the release spring ran with
+`useNativeDriver: true`. The drag was bridge-bound and the settle was not, so
+the row lagged the thumb and then caught up in one jump — on the same thread
+that re-renders the list, which on the chats tab is doing real work. The
+capture threshold compounded it: 12px had to be travelled before anything
+moved and nothing gave those pixels back, so the row started behind the finger
+and stayed there. `MessageBubble`'s swipe-to-reply had a fault the row did not:
+its `translateX` was `setValue`-driven, spring-animated on the native driver,
+**and** read by a JS-side `interpolate` for the reply arrow — the classic "this
+animated node has been moved to the native side" mismatch, which is why the
+arrow stopped following after the first swipe.
+
+**Velocity was the missing half.** `settleOffset` was distance-only: past 40%
+of the drawer it opened, and with two actions that drawer is 168px, so it asked
+for 67px of travel. A natural flick moves the thumb perhaps 60px before it
+lifts, and the row sprang shut on a gesture that felt decisive — which reads as
+the swipe failing, not as a threshold missed. It now takes the release velocity
+too, and that single argument answers most of the complaint. It is plain maths
+and stays tested without a renderer, as does all the other geometry: those
+functions are worklet-safe as written, which is why the move cost no logic.
+
+**What it costs.** The web bundle, measured with `expo export --platform web`
+before and after: 3,595,072 → 4,639,644 bytes raw, 915,242 → 1,116,102
+gzipped. About 200 KB gzipped, 22% more. That is the price the three comments
+were protecting against and it is real; what changed is the other side of the
+trade, once the gesture was understood to be janky rather than merely
+old-fashioned. `Skeleton` and `Button` keep RN's `Animated`: the bundle is paid
+for either way now, and a pulse and a press are not gestures that track a
+finger.
+
+**It needs a new binary.** `runtimeVersion` is `{ policy: 'fingerprint' }`, and
+`react-native-gesture-handler` is a native module, so installed apps are
+offered no update at all until a build carrying it ships — the same constraint
+`expo-video` had, and it belongs in the release note.
+
 ## A video is one file, and playing it needs a new build
 
 **No thumbnail.** The obvious build is a poster image uploaded beside the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,7 +314,7 @@ importers:
         version: 57.0.15(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       expo-router:
         specifier: ~57.0.16
-        version: 57.0.16(d180e4998bf01277a0f5cf81d105f027)
+        version: 57.0.16(7ebf1288f7b28cbce4e83a2c26c4ba3b)
       expo-secure-store:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.16)
@@ -348,6 +348,9 @@ importers:
       react-native:
         specifier: 'catalog:'
         version: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
+      react-native-gesture-handler:
+        specifier: ~2.32.0
+        version: 2.32.0(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       react-native-purchases:
         specifier: ^10.8.1
         version: 10.8.1(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
@@ -1169,6 +1172,10 @@ packages:
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@dicebear/core': ^9.0.0
+
+  '@egjs/hammerjs@2.0.17':
+    resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
+    engines: {node: '>=0.8.0'}
 
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
@@ -2249,6 +2256,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/hammerjs@2.0.46':
+    resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -3596,6 +3606,9 @@ packages:
   hermes-parser@0.36.1:
     resolution: {integrity: sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ==}
 
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -4461,6 +4474,9 @@ packages:
     peerDependencies:
       react: '>=17.0.0'
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -4475,8 +4491,8 @@ packages:
       react-native-gesture-handler: '>= 2.0.0'
       react-native-reanimated: '>= 2.0.0'
 
-  react-native-gesture-handler@3.2.1:
-    resolution: {integrity: sha512-VEWscxUN29aeccbD2McF0LSXrwOhSdisaSRFiEWg0O/3WrVghNJp/tOtLrCgzb9gfcZ3xdA+K2Sp8F5G3iHx/Q==}
+  react-native-gesture-handler@2.32.0:
+    resolution: {integrity: sha512-uYIMOKlKENORq2SABE+jIjbPU+h5I/sQKcq2v16zRq848nwEp1fWRVwML4QWqijc8UcXJC25o54S8GQd4Mf2OA==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -6278,6 +6294,10 @@ snapshots:
     dependencies:
       '@dicebear/core': 9.4.3
 
+  '@egjs/hammerjs@2.0.17':
+    dependencies:
+      '@types/hammerjs': 2.0.46
+
   '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
@@ -6457,7 +6477,7 @@ snapshots:
       ws: 8.21.3
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 57.0.16(d180e4998bf01277a0f5cf81d105f027)
+      expo-router: 57.0.16(7ebf1288f7b28cbce4e83a2c26c4ba3b)
       react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -6734,7 +6754,7 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@expo/metro-runtime': 57.0.13(@expo/log-box@57.0.3)(expo@57.0.16)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
-      expo-router: 57.0.16(d180e4998bf01277a0f5cf81d105f027)
+      expo-router: 57.0.16(7ebf1288f7b28cbce4e83a2c26c4ba3b)
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -7478,6 +7498,8 @@ snapshots:
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/hammerjs@2.0.46': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -8547,7 +8569,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-router@57.0.16(d180e4998bf01277a0f5cf81d105f027):
+  expo-router@57.0.16(7ebf1288f7b28cbce4e83a2c26c4ba3b):
     dependencies:
       '@expo/log-box': 57.0.3(@expo/dom-webview@57.0.1)(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       '@expo/metro-runtime': 57.0.13(@expo/log-box@57.0.3)(expo@57.0.16)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
@@ -8574,7 +8596,7 @@ snapshots:
       react-fast-compare: 3.2.2
       react-is: 19.2.8
       react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
-      react-native-drawer-layout: 4.2.10(react-native-gesture-handler@3.2.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-reanimated@4.5.1(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
+      react-native-drawer-layout: 4.2.10(react-native-gesture-handler@2.32.0(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-reanimated@4.5.1(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       react-native-safe-area-context: 5.7.0(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       react-native-screens: 4.26.2(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       server-only: 0.0.1
@@ -8584,7 +8606,7 @@ snapshots:
       vaul: 1.1.2(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
       react-dom: 19.2.3(react@19.2.3)
-      react-native-gesture-handler: 3.2.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
+      react-native-gesture-handler: 2.32.0(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       react-native-reanimated: 4.5.1(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
@@ -8931,6 +8953,10 @@ snapshots:
   hermes-parser@0.36.1:
     dependencies:
       hermes-estree: 0.36.1
+
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -9942,22 +9968,26 @@ snapshots:
     dependencies:
       react: 19.2.3
 
+  react-is@16.13.1: {}
+
   react-is@18.3.1: {}
 
   react-is@19.2.8: {}
 
-  react-native-drawer-layout@4.2.10(react-native-gesture-handler@3.2.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-reanimated@4.5.1(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
+  react-native-drawer-layout@4.2.10(react-native-gesture-handler@2.32.0(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-reanimated@4.5.1(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
     dependencies:
       color: 4.2.3
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
-      react-native-gesture-handler: 3.2.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
+      react-native-gesture-handler: 2.32.0(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       react-native-reanimated: 4.5.1(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       use-latest-callback: 0.2.6(react@19.2.3)
 
-  react-native-gesture-handler@3.2.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
+  react-native-gesture-handler@2.32.0(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
     dependencies:
+      '@egjs/hammerjs': 2.0.17
       '@types/react-test-renderer': 19.1.0
+      hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)


### PR DESCRIPTION
Part 7 of the batch, on its own branch because it adds a native module:
`react-native-gesture-handler`. `runtimeVersion` is a fingerprint, so
**nothing here reaches an installed app until a new binary ships** — which
is why it is not in #1120, where everything else goes out over the air.

## The complaint

The chats-row swipe needs a long, near-perfect pull before anything opens.
Two causes, both structural rather than tuning:

- `translateX.setValue(...)` ran on the JS thread for every finger move
  while the release spring ran with `useNativeDriver: true`. The drag was
  bridge-bound and the settle was not, so the row lagged the thumb and
  then caught up in one jump — on the same thread that re-renders the
  list.
- `settleOffset` was distance-only: past 40% of a 168px two-action
  drawer, so it asked for 67px of travel where a natural flick moves
  perhaps 60 before the thumb lifts. **Velocity was the missing half**,
  and that one argument answers most of the complaint. It is plain maths
  and stays tested without a renderer.

Plus a 12px capture threshold that nothing gave back, so the row started
behind the finger and stayed there — now handled by `activeOffsetX` /
`failOffsetY`, natively, which returns those pixels.

## And a real bug in swipe-to-reply

`MessageBubble`'s `translateX` was `setValue`-driven, spring-animated on
the native driver, **and** read by a JS-side `interpolate` for the reply
arrow — the "this animated node has been moved to the native side"
mismatch. That is why the arrow stopped following after the first swipe.

## What it costs, measured

`expo export --platform web`, before and after:

| | raw | gzipped |
| --- | --- | --- |
| before | 3,595,072 | 915,242 |
| after | 4,639,644 | 1,116,102 |

About 200 KB gzipped, 22% more. Three comments in the repo argued against
exactly this and are rewritten rather than left contradicting the code
beside them; `docs/decisions.md` gets the entry, with the numbers above
rather than an assurance. `Skeleton` and `Button` keep RN's `Animated` —
the bundle is paid for either way now, and neither is a gesture that
tracks a finger.

## Also

`chat/[id].tsx` passed an inline `onOpenMedia` into a `memo`'d
`MessageBubble`, so every keystroke in the composer re-rendered every
visible bubble, on the same JS thread the gesture used to run on.

## Not yet verified on a device

The pure logic is tested and all four checks are green, but the gesture
itself needs a build: rebuild with `expo run:ios` — a Metro reload will
not pick up the new native module — then check that a short fast flick
opens the drawer, that a diagonal flick still scrolls, and that the
reply arrow keeps working after the first swipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)