### PR TITLE
Mark the swipe geometry as worklets, and stop the app aborting

### DIFF
--- a/apps/mobile/src/components/SwipeableRow.tsx
+++ b/apps/mobile/src/components/SwipeableRow.tsx
@@ -70,8 +70,14 @@ interface SwipeableRowProps {
  * Now the pan is recognised natively (`activeOffsetX`/`failOffsetY`, which is
  * also what removes the dead zone), the offset is a shared value, and the
  * settle is a spring on the UI thread. The geometry stays in
- * `lib/swipeAction.ts`, still plain maths and still tested without a renderer —
- * it is worklet-safe as written.
+ * `lib/swipeAction.ts`, still plain maths and still tested without a renderer,
+ * and **every function `onUpdate`/`onEnd` reaches carries `'worklet'`**. An
+ * earlier version of this comment said that file was "worklet-safe as
+ * written", which was wrong in the way that costs a release: those callbacks
+ * are compiled onto the UI thread, a plain function reached from there is a
+ * stub that throws, and the throw aborts the process rather than showing a
+ * red box. 2.0.0 (125) crashed on the first swipe. Anything new called from
+ * inside these two callbacks needs the directive too.
  *
  * The cost is real and was argued against here for a year: Reanimated's
  * worklets bundle now enters the shipped web build. See `docs/decisions.md` →

--- a/apps/mobile/src/lib/swipeAction.ts
+++ b/apps/mobile/src/lib/swipeAction.ts
@@ -7,6 +7,15 @@
  * scroll, and where the row is allowed to come to rest — are testable without
  * a renderer.
  *
+ * **The geometry functions are worklets, and that is not optional.** They are
+ * called from `Gesture.Pan().onUpdate`/`.onEnd`, which the worklets Babel
+ * plugin compiles to run on the UI thread. A plain function captured by a
+ * worklet arrives there as a stub that throws when called, and a throw on the
+ * UI runtime is not a red box — it is `SIGABRT`. That is what shipped in
+ * 2.0.0 (125): every swipe in the app killed it, in a build whose comments
+ * claimed this file was "worklet-safe as written". The directive is what
+ * makes it so; on Node it is an inert string, so the tests are unchanged.
+ *
  * **The row rests open.** It used to commit on release: swipe far enough and
  * the action fired as the row sprang back. That is fine for one action a side
  * and impossible for two, since a single gesture cannot say which of them was
@@ -50,6 +59,7 @@ export type SwipeDirection = 'left' | 'right'
 
 /** How wide the drawer on one side is, given how many buttons it holds. */
 export function drawerWidth(actionCount: number): number {
+  'worklet'
   return Math.max(0, actionCount) * ACTION_WIDTH_PX
 }
 
@@ -61,6 +71,7 @@ export function drawerWidth(actionCount: number): number {
  * opened at all, and the rubber band is all that is left of the gesture there.
  */
 export function rowTranslation(x: number, right: number, left: number): number {
+  'worklet'
   const limit = x >= 0 ? right : left
   const distance = Math.abs(x)
   const eased = distance <= limit ? distance : limit + (distance - limit) * RUBBER
@@ -82,6 +93,7 @@ export function rowTranslation(x: number, right: number, left: number): number {
  * a slow drag.
  */
 export function settleOffset(x: number, right: number, left: number, velocity = 0): number {
+  'worklet'
   const flickedRight = velocity >= FLICK_VELOCITY
   const flickedLeft = velocity <= -FLICK_VELOCITY
 

--- a/apps/mobile/src/lib/swipeToReply.ts
+++ b/apps/mobile/src/lib/swipeToReply.ts
@@ -1,3 +1,12 @@
+/**
+ * Swiping a bubble to reply to it.
+ *
+ * **`swipeTranslation` and `swipeReleased` are worklets, and that is not
+ * optional** — the same rule, and the same crash, as `swipeAction`: they are
+ * called from `Gesture.Pan().onUpdate`/`.onEnd`, which run on the UI thread,
+ * and a plain function reached from there throws where nothing can catch it.
+ */
+
 /** Past this, the gesture is a reply rather than a scroll. */
 export const SWIPE_ACTIVATE_PX = 56
 /** Where the bubble stops following the finger one-to-one. */
@@ -15,11 +24,13 @@ export const SWIPE_LOCK_PX = 10
 const RUBBER = 0.15
 /** Follows the finger, then resists — so the limit is felt, not hit. */
 export function swipeTranslation(dx: number): number {
+  'worklet'
   if (dx <= 0) return 0
   return dx <= SWIPE_MAX_PX ? dx : SWIPE_MAX_PX + (dx - SWIPE_MAX_PX) * RUBBER
 }
 
 export function swipeReleased(dx: number): boolean {
+  'worklet'
   return dx >= SWIPE_ACTIVATE_PX
 }
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2809,8 +2809,7 @@ for 67px of travel. A natural flick moves the thumb perhaps 60px before it
 lifts, and the row sprang shut on a gesture that felt decisive — which reads as
 the swipe failing, not as a threshold missed. It now takes the release velocity
 too, and that single argument answers most of the complaint. It is plain maths
-and stays tested without a renderer, as does all the other geometry: those
-functions are worklet-safe as written, which is why the move cost no logic.
+and stays tested without a renderer, as does all the other geometry.
 
 **What it costs.** The web bundle, measured with `expo export --platform web`
 before and after: 3,595,072 → 4,639,644 bytes raw, 915,242 → 1,116,102
@@ -2825,6 +2824,31 @@ finger.
 `react-native-gesture-handler` is a native module, so installed apps are
 offered no update at all until a build carrying it ships — the same constraint
 `expo-video` had, and it belongs in the release note.
+
+**And then it crashed the app.** The paragraph above used to end "those
+functions are worklet-safe as written, which is why the move cost no logic".
+That sentence was wrong, and it shipped: 2.0.0 (125) aborted on the first
+swipe, anywhere in the app. The TestFlight report (incident 37EFEA45, iOS
+26.6.1) is `EXC_CRASH (SIGABRT)` with a stack that names every step —
+`RNGestureHandler handleGesture:` → `REANodesManager dispatchEvent:` →
+`UIEventHandlerRegistry::processEvent` → `worklets::runSyncOnRuntime` → Hermes
+`throwPendingError` → `abort`.
+
+`react-native-worklets/plugin` auto-workletises `Gesture.Pan().onUpdate` and
+`.onEnd` — they are in the plugin's own list of builder methods — so those two
+callbacks are compiled to run on the UI runtime. A plain function they call is
+captured as a stub that throws when invoked, and a JS exception on the UI
+runtime has no handler above it: it leaves Hermes as a C++ exception and
+terminates the process. There is no red box even in development, and nothing
+in the type system says a word about it.
+
+So the rule, which is the whole lesson: **anything a gesture callback calls is
+a worklet and needs the directive** — `rowTranslation`, `settleOffset`,
+`swipeTranslation` and `swipeReleased` all carry `'worklet'` now. On Node the
+directive is an inert string, so the tests that made this code look proven
+still run unchanged — and that is exactly why they proved nothing here. What
+was missing was one swipe on a device: the simulator build in the tree and the
+last device build both predated the commit.
 
 ## A video is one file, and playing it needs a new build
 


### PR DESCRIPTION
2.0.0 (125) dies on the first swipe, anywhere in the app — the chat-list row and swipe-to-reply alike. TestFlight incident 37EFEA45 (iPhone 14 Pro Max, iOS 26.6.1) is `EXC_CRASH (SIGABRT)` and its stack names every step:

```
RNGestureHandler handleGesture:
  → REANodesManager dispatchEvent:
  → UIEventHandlerRegistry::processEvent
  → worklets::runSyncOnRuntime
  → Hermes throwPendingError → __cxa_throw → abort
```

`react-native-worklets/plugin` auto-workletises `Gesture.Pan().onUpdate` and `.onEnd` (both are in the plugin's own `gestureHandlerBuilderMethods`), so those callbacks run on the UI runtime. `rowTranslation`, `settleOffset`, `swipeTranslation` and `swipeReleased` are called from inside them and carried no `'worklet'` directive, so each arrived there as a stub that throws when invoked — and a JS exception on that runtime has no handler above it.

The comment claiming this geometry was "worklet-safe as written" is why nobody looked; it is rewritten in all three places to state the rule instead.

JS-only, so this ships to the installed 125/126 binaries as an OTA update.

## Verification
- `pnpm test` (617 pass), `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`
- swipe on the device after the OTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)