### PR TITLE
One unread number, a browser voice note that plays, and a feed video that opens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,13 @@ STORAGE_ACCESS_KEY_ID=
 STORAGE_SECRET_ACCESS_KEY=
 STORAGE_PUBLIC_BASE_URL=
 
+# Where ffmpeg lives, for the only thing this server converts: a voice note
+# recorded in a browser is WebM/Opus and no iPhone can decode it. The Docker
+# image installs ffmpeg, so this default is already right in production. Without
+# it those notes are stored as recorded and the app says they will not play —
+# every other kind of attachment is untouched either way.
+FFMPEG_PATH=ffmpeg
+
 # ─── API: translation (Faz 6) ────────────────────────────────────────────────
 # Google Cloud Console → a project with the Cloud Translation API enabled →
 # IAM & Admin → Service Accounts → create one with the "Cloud Translation

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,17 @@ FROM node:24-slim AS runtime
 ENV NODE_ENV=production
 WORKDIR /app
 
+# The one native binary this image needs, and only for one thing: a voice note
+# recorded in a browser is WebM/Opus, which no iPhone can decode, so the API
+# converts it to AAC before storing it (`modules/media/transcodeAudio`). It is
+# a couple of hundred megabytes on an otherwise lean image, which is the reason
+# it is installed here in the runtime stage rather than in the build one, where
+# it would be baked into a layer nothing runs. Missing ffmpeg is not fatal —
+# those notes are then stored as recorded.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg \
+  && rm -rf /var/lib/apt/lists/*
+
 # The bundle is ESM with a .js extension, so package.json and its
 # `"type": "module"` have to travel with it or Node parses it as CommonJS and
 # dies on the first import. packages/shared is deliberately absent — the build

--- a/apps/api/scripts/transcode-web-notes.ts
+++ b/apps/api/scripts/transcode-web-notes.ts
@@ -1,0 +1,176 @@
+/**
+ * Converts the voice notes that were recorded in a browser before the server
+ * started doing it on the way in.
+ *
+ * Those are WebM/Opus, which no iPhone can decode — the bubble showed a
+ * spinner that never resolved, and after the client fix it says the note will
+ * not play. This is what makes the ones already stored play instead.
+ *
+ * Four collections and two shapes: `messages`, `posts` and `postCorrections`
+ * keep a list in `attachments` with the first file repeated in `media`, while
+ * a `pronunciationAnswers` row has `media` and `slowMedia` as separate fields.
+ * Both are walked here rather than in `normalizeAttachments`, which takes a
+ * list and knows nothing about rows.
+ *
+ * Idempotent: a row whose files are already `audio/mp4` matches nothing. Safe
+ * to re-run after a failure, since each row is written only once its new
+ * object exists.
+ *
+ *   pnpm --filter @langx/api exec tsx scripts/transcode-web-notes.ts        # dry run
+ *     ... --confirm         # actually convert and write
+ *     ... --limit 25
+ *
+ * Against production, with the overlay — `.env.prod` is the small set of
+ * values that differ, and a later --env-file wins:
+ *
+ *   pnpm exec tsx --env-file=../../.env --env-file=../../.env.prod \
+ *     scripts/transcode-web-notes.ts --confirm
+ */
+import { execFile } from 'node:child_process'
+import type { Db, Document } from 'mongodb'
+import type { Media } from '@langx/shared'
+import { connectToDatabase } from '../src/db/client'
+import { COLLECTIONS } from '../src/db/collections'
+import { loadEnv } from '../src/env'
+import {
+  createAttachmentNormalizer,
+  type AttachmentNormalizer,
+} from '../src/modules/media/transcodeAudio'
+import { createStorageProvider } from '../src/storage/createStorageProvider'
+import { supportsPut } from '../src/storage/StorageProvider'
+
+const WEB_AUDIO = { $in: ['audio/webm', 'audio/ogg'] }
+
+interface Summary {
+  seen: number
+  converted: number
+  unchanged: number
+}
+
+function argOf(flag: string): string | undefined {
+  const at = process.argv.indexOf(flag)
+  return at >= 0 ? process.argv[at + 1] : undefined
+}
+
+/** The three collections that keep a list of attachments. */
+async function convertLists(
+  db: Db,
+  collection: string,
+  normalize: AttachmentNormalizer,
+  confirm: boolean,
+  limit: number,
+  summary: Summary,
+): Promise<void> {
+  const rows = await db
+    .collection<Document>(collection)
+    .find({ 'attachments.contentType': WEB_AUDIO })
+    .limit(limit)
+    .toArray()
+
+  for (const row of rows) {
+    summary.seen += 1
+    const attachments = (row.attachments ?? []) as Media[]
+    if (!confirm) {
+      console.log(`  would convert ${collection}/${String(row._id)}`)
+      continue
+    }
+    const converted = await normalize(attachments)
+    if (converted.every((item, index) => item.url === attachments[index]?.url)) {
+      summary.unchanged += 1
+      console.log(`  unchanged ${collection}/${String(row._id)} — see the log above for why`)
+      continue
+    }
+    await db.collection<Document>(collection).updateOne(
+      { _id: row._id },
+      // `media` is the first file repeated, for builds that predate the list;
+      // leaving it behind would keep the old URL alive on exactly the installs
+      // least able to cope with it.
+      { $set: { attachments: converted, ...(converted[0] ? { media: converted[0] } : {}) } },
+    )
+    summary.converted += 1
+    console.log(`  converted ${collection}/${String(row._id)}`)
+  }
+}
+
+/** The one collection where a recording is two fields rather than a list. */
+async function convertAnswers(
+  db: Db,
+  normalize: AttachmentNormalizer,
+  confirm: boolean,
+  limit: number,
+  summary: Summary,
+): Promise<void> {
+  const rows = await db
+    .collection<Document>(COLLECTIONS.pronunciationAnswers)
+    .find({ $or: [{ 'media.contentType': WEB_AUDIO }, { 'slowMedia.contentType': WEB_AUDIO }] })
+    .limit(limit)
+    .toArray()
+
+  for (const row of rows) {
+    summary.seen += 1
+    const takes = [row.media as Media, ...(row.slowMedia ? [row.slowMedia as Media] : [])]
+    if (!confirm) {
+      console.log(`  would convert pronunciationAnswers/${String(row._id)}`)
+      continue
+    }
+    const [media = takes[0], slowMedia] = await normalize(takes)
+    if (!media || media.url === takes[0]?.url) {
+      summary.unchanged += 1
+      continue
+    }
+    await db
+      .collection<Document>(COLLECTIONS.pronunciationAnswers)
+      .updateOne({ _id: row._id }, { $set: { media, ...(slowMedia ? { slowMedia } : {}) } })
+    summary.converted += 1
+    console.log(`  converted pronunciationAnswers/${String(row._id)}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const confirm = process.argv.includes('--confirm')
+  const limit = Number(argOf('--limit') ?? 1000)
+
+  const env = loadEnv(process.env)
+  const storage = createStorageProvider(env)
+  if (!supportsPut(storage)) {
+    throw new Error('Storage is not configured — set the STORAGE_* variables')
+  }
+
+  const normalize = createAttachmentNormalizer(storage, env.FFMPEG_PATH, (error, message) => {
+    console.warn(`  ${message}:`, error)
+  })
+
+  // Checked here rather than discovered a hundred rows in: without ffmpeg
+  // every row comes back "unchanged", which reads like there was nothing to
+  // do. The server is right to carry on without it; a script whose only job is
+  // this conversion is not.
+  await new Promise<void>((resolve, reject) => {
+    execFile(env.FFMPEG_PATH, ['-version'], (error) =>
+      error
+        ? reject(new Error(`Cannot run ffmpeg at "${env.FFMPEG_PATH}" — set FFMPEG_PATH`))
+        : resolve(),
+    )
+  })
+
+  const { db, close } = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
+  const summary: Summary = { seen: 0, converted: 0, unchanged: 0 }
+
+  try {
+    console.log(confirm ? 'Converting web voice notes…' : 'Dry run — nothing will be written.')
+    for (const collection of [
+      COLLECTIONS.messages,
+      COLLECTIONS.posts,
+      COLLECTIONS.postCorrections,
+    ]) {
+      await convertLists(db, collection, normalize, confirm, limit, summary)
+    }
+    await convertAnswers(db, normalize, confirm, limit, summary)
+  } finally {
+    await close()
+  }
+
+  console.log(summary)
+  if (!confirm) console.log('Re-run with --confirm to write.')
+}
+
+await main()

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -43,6 +43,10 @@ import type { RevenueCatClient } from './modules/billing/revenueCatClient'
 import { LoggingPushSender, type PushSender } from './modules/push/devices'
 import { ConsoleEmailSender, type EmailSender } from './email/sender'
 import type { StorageProvider } from './storage/StorageProvider'
+import {
+  createAttachmentNormalizer,
+  type AttachmentNormalizer,
+} from './modules/media/transcodeAudio'
 import type { TranslationProvider } from './translation/TranslationProvider'
 import { attachSocketServer } from './ws'
 import type { AppServer } from './ws/types'
@@ -53,6 +57,13 @@ declare module 'fastify' {
     auth: Auth
     env: Env
     storage: StorageProvider
+    /**
+     * The attachments as they should be stored, which is only ever different
+     * for a voice note recorded in a browser — see `media/transcodeAudio`.
+     * Decorated rather than built per call so the ffmpeg path and the logger
+     * are settled once, and so a test can hand the insert paths their own.
+     */
+    normalizeAttachments: AttachmentNormalizer
     translation: TranslationProvider
     revenueCat: RevenueCatClient
     push: PushSender
@@ -139,6 +150,12 @@ export async function buildApp({
   app.decorate('auth', auth)
   app.decorate('env', env)
   app.decorate('storage', storage)
+  app.decorate(
+    'normalizeAttachments',
+    createAttachmentNormalizer(storage, env.FFMPEG_PATH, (err, message) =>
+      app.log.warn({ err }, message),
+    ),
+  )
   app.decorate('translation', translation)
   app.decorate('revenueCat', revenueCat)
   app.decorate('push', push)

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -124,6 +124,15 @@ const envSchema = z.object({
   STORAGE_SECRET_ACCESS_KEY: emptyToUndefined(z.string().optional()),
   STORAGE_PUBLIC_BASE_URL: emptyToUndefined(z.url().optional()),
 
+  /*
+   * How to run ffmpeg, for the one thing this server transcodes: a voice note
+   * recorded in a browser is WebM/Opus, which no iPhone can decode. The
+   * Dockerfile installs it, so the default is right in production; a
+   * self-hoster without it loses nothing but that conversion, and the app
+   * already says when a note will not play. See `modules/media/transcodeAudio`.
+   */
+  FFMPEG_PATH: z.string().min(1).default('ffmpeg'),
+
   // Faz 6: translation. Left unset, `/translate` returns a clear
   // TRANSLATION_NOT_CONFIGURED-style error; every other route still works.
   // The service-account key's *content* goes here (not a file path like

--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -13,6 +13,7 @@ import { COLLECTIONS } from '../../db/collections'
 import { decodeDateIdCursor, encodeDateIdCursor } from '../../lib/dateIdCursor'
 import { ApiError } from '../../lib/ApiError'
 import { assertAttachmentsAllowed } from '../media/assertMedia'
+import type { AttachmentNormalizer } from '../media/transcodeAudio'
 import { blockedUserIds } from '../moderation/blocks'
 import { awardForSend } from '../tokens/awards'
 import { assertConversationAccess, assertMediaUnlocked } from './access'
@@ -252,6 +253,7 @@ export async function sendMediaMessage(
   senderId: string,
   input: SendMediaMessageInput,
   storagePublicBaseUrl: string | undefined,
+  normalizeAttachments?: AttachmentNormalizer,
 ): Promise<SendResult> {
   const conversation = await assertConversationAccess(db, input.conversationId, senderId)
   // The belt to the upload URL's braces. A URL signed a moment before the
@@ -266,8 +268,19 @@ export async function sendMediaMessage(
 
   const replyTo = await resolveReplyTo(db, conversation, input.replyToMessageId)
 
+  /*
+   * After the checks above and before the insert, which is the only correct
+   * place for it: a URL that is not ours must never be fetched by this server,
+   * and the row must not name a file that does not exist yet. In practice this
+   * changes exactly one thing — a voice note recorded in a browser becomes AAC
+   * so an iPhone can play it. Everything else comes back as it went in.
+   */
+  const attachments = normalizeAttachments
+    ? await normalizeAttachments(input.attachments)
+    : input.attachments
+
   // Non-empty by schema; the guard is for `noUncheckedIndexedAccess`.
-  const first = input.attachments[0]
+  const first = attachments[0]
 
   const message: Message = {
     _id: new ObjectId(),
@@ -275,7 +288,7 @@ export async function sendMediaMessage(
     senderId,
     type: kind,
     body: input.body ?? '',
-    attachments: input.attachments,
+    attachments,
     /*
      * Written twice, on purpose, and only for as long as binaries that predate
      * `attachments` are installed: they read `media` and would show an empty

--- a/apps/api/src/modules/feed/feed.ts
+++ b/apps/api/src/modules/feed/feed.ts
@@ -27,6 +27,7 @@ import { settleReferral } from '../referrals/settle'
 import { recordQualifyingAction } from '../tokens/streak'
 import type { StorageProvider } from '../../storage/StorageProvider'
 import { assertAttachable, deleteObjects } from './attachments'
+import type { AttachmentNormalizer } from '../media/transcodeAudio'
 import { readCommentSummary } from './comments'
 import type { PostCommentDoc } from './documents'
 import type { Post, PostCorrectionDoc, PronunciationAnswerDoc } from './documents'
@@ -341,6 +342,7 @@ export async function createPost(
   userId: string,
   input: CreatePostInput,
   storagePublicBaseUrl?: string,
+  normalizeAttachments?: AttachmentNormalizer,
 ): Promise<FeedPost> {
   const profile = await db.collection<Profile>(COLLECTIONS.profiles).findOne({ _id: userId })
   if (!profile) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Complete onboarding first')
@@ -351,10 +353,13 @@ export async function createPost(
     throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Post in a language you are learning')
   }
 
-  const attachments = input.attachments ?? []
-  if (attachments.length > 0) {
-    await assertAttachable(db, userId, profile, attachments, storagePublicBaseUrl)
+  const picked = input.attachments ?? []
+  if (picked.length > 0) {
+    await assertAttachable(db, userId, profile, picked, storagePublicBaseUrl)
   }
+  // Checked first, stored second — see `sendMediaMessage` for why the order is
+  // the whole of it. A voice note recorded in a browser becomes AAC here.
+  const attachments = normalizeAttachments ? await normalizeAttachments(picked) : picked
 
   const doc: Post = {
     _id: new ObjectId(),
@@ -393,6 +398,7 @@ export async function correctPost(
   postId: string,
   input: CreatePostCorrectionInput,
   storagePublicBaseUrl?: string,
+  normalizeAttachments?: AttachmentNormalizer,
 ): Promise<PostCorrection> {
   if (!ObjectId.isValid(postId)) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Post not found')
   const _id = new ObjectId(postId)
@@ -413,12 +419,13 @@ export async function correctPost(
     throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'You cannot correct your own post')
   }
 
-  const attachments = input.attachments ?? []
-  if (attachments.length > 0) {
+  const picked = input.attachments ?? []
+  if (picked.length > 0) {
     const profile = await db.collection<Profile>(COLLECTIONS.profiles).findOne({ _id: userId })
     if (!profile) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Complete onboarding first')
-    await assertAttachable(db, userId, profile, attachments, storagePublicBaseUrl)
+    await assertAttachable(db, userId, profile, picked, storagePublicBaseUrl)
   }
+  const attachments = normalizeAttachments ? await normalizeAttachments(picked) : picked
 
   const doc: PostCorrectionDoc = {
     _id: new ObjectId(),

--- a/apps/api/src/modules/feed/pronunciation.ts
+++ b/apps/api/src/modules/feed/pronunciation.ts
@@ -17,6 +17,7 @@ import { awardTokens } from '../tokens/ledger'
 import { settleReferral } from '../referrals/settle'
 import { recordQualifyingAction } from '../tokens/streak'
 import { assertAttachable, deleteObjects } from './attachments'
+import type { AttachmentNormalizer } from '../media/transcodeAudio'
 import type { Post, PronunciationAnswerDoc } from './documents'
 import { answerDto, loadAuthors, postDto } from './dto'
 import { EMPTY_LIKE_SUMMARY, readLikeSummary } from './likes'
@@ -82,6 +83,7 @@ export async function answerPronunciation(
   postId: string,
   input: CreatePronunciationAnswerInput,
   storagePublicBaseUrl?: string,
+  normalizeAttachments?: AttachmentNormalizer,
 ): Promise<PronunciationAnswer> {
   if (!ObjectId.isValid(postId)) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Post not found')
   const _id = new ObjectId(postId)
@@ -108,21 +110,25 @@ export async function answerPronunciation(
   // `'audio'` is what stops a photo of a mouth being submitted as a recording.
   // Both takes together, so they cost one unit and neither is charged for
   // before the other has been checked.
-  await assertAttachable(
-    db,
-    userId,
-    profile,
-    [input.media, ...(input.slowMedia ? [input.slowMedia] : [])],
-    storagePublicBaseUrl,
-    'audio',
-  )
+  const takes = [input.media, ...(input.slowMedia ? [input.slowMedia] : [])]
+  await assertAttachable(db, userId, profile, takes, storagePublicBaseUrl, 'audio')
+
+  /*
+   * The one place a recording is two fields rather than a list, so the pair
+   * goes through together and comes back apart. This is the page most likely
+   * to be recorded on a laptop — somebody demonstrating a word into a browser
+   * — and therefore the one that needed the conversion most.
+   */
+  const [media = input.media, slowMedia] = normalizeAttachments
+    ? await normalizeAttachments(takes)
+    : takes
 
   const doc: PronunciationAnswerDoc = {
     _id: new ObjectId(),
     postId: _id,
     authorId: userId,
-    media: input.media,
-    ...(input.slowMedia ? { slowMedia: input.slowMedia } : {}),
+    media,
+    ...(slowMedia ? { slowMedia } : {}),
     ...(input.note ? { note: input.note } : {}),
     createdAt: new Date(),
   }

--- a/apps/api/src/modules/media/transcodeAudio.test.ts
+++ b/apps/api/src/modules/media/transcodeAudio.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Media } from '@langx/shared'
+import {
+  needsTranscode,
+  normalizeAttachments,
+  transcodedKey,
+  type TranscodeDeps,
+} from './transcodeAudio'
+
+const BUCKET = 'https://cdn.example.com'
+
+function webmNote(overrides: Partial<Media> = {}): Media {
+  return {
+    url: `${BUCKET}/messages/c1/a.webm`,
+    contentType: 'audio/webm',
+    sizeBytes: 40_000,
+    durationSeconds: 7,
+    ...overrides,
+  }
+}
+
+/**
+ * ffmpeg and S3 are both injected, so this suite never runs a binary and never
+ * reaches a bucket — which is also the only way it could run at all: presigning
+ * is local, but a GET and a PUT are real network calls.
+ */
+function deps(overrides: Partial<TranscodeDeps> = {}) {
+  const spies = {
+    get: vi.fn(() => Promise.resolve(new Uint8Array([1, 2, 3]))),
+    put: vi.fn((key: string) => Promise.resolve(`${BUCKET}/${key}`)),
+    del: vi.fn(() => Promise.resolve()),
+    transcode: vi.fn(() => Promise.resolve(new Uint8Array([9, 9]))),
+    warn: vi.fn(),
+  }
+  const all: TranscodeDeps = {
+    ...spies,
+    keyOf: (url: string) => (url.startsWith(`${BUCKET}/`) ? url.slice(BUCKET.length + 1) : null),
+    ...overrides,
+  }
+  // Returned beside the object rather than read back off it, so the
+  // assertions never pull an unbound method out of a value under test.
+  return { deps: all, ...spies, ...overrides }
+}
+
+describe('needsTranscode', () => {
+  it('is the two containers a browser records and no iPhone decodes', () => {
+    expect(needsTranscode('audio/webm')).toBe(true)
+    expect(needsTranscode('audio/ogg')).toBe(true)
+    // With the codec parameter `MediaRecorder` likes to append.
+    expect(needsTranscode('audio/webm;codecs=opus')).toBe(true)
+  })
+
+  it('leaves what both phones already record alone', () => {
+    for (const type of ['audio/mp4', 'audio/m4a', 'audio/aac', 'audio/mpeg']) {
+      expect(needsTranscode(type), type).toBe(false)
+    }
+  })
+})
+
+describe('transcodedKey', () => {
+  // Same prefix, because `keyFromPublicUrl` recognises our own objects by it
+  // and the account purge deletes nothing it does not recognise.
+  it('keeps the directory and the name, and takes the .m4a extension', () => {
+    expect(transcodedKey('messages/c1/a.webm')).toBe('messages/c1/a.m4a')
+    expect(transcodedKey('posts/u1/b.ogg')).toBe('posts/u1/b.m4a')
+  })
+})
+
+describe('normalizeAttachments', () => {
+  it('rewrites a browser note to AAC and removes the original', async () => {
+    const { deps: d, del } = deps()
+    const [note] = await normalizeAttachments(d, [webmNote()])
+
+    expect(note).toEqual({
+      url: `${BUCKET}/messages/c1/a.m4a`,
+      contentType: 'audio/mp4',
+      // The converted file's own size, not the one the upload was signed for.
+      sizeBytes: 2,
+      // Kept: the recorder measured it and ffmpeg does not change it.
+      durationSeconds: 7,
+    })
+    expect(del).toHaveBeenCalledWith('messages/c1/a.webm')
+  })
+
+  it('leaves everything else untouched, without fetching it', async () => {
+    const { deps: d, get } = deps()
+    const items: Media[] = [
+      { url: `${BUCKET}/messages/c1/a.m4a`, contentType: 'audio/mp4', sizeBytes: 1000 },
+      { url: `${BUCKET}/messages/c1/a.jpg`, contentType: 'image/jpeg', sizeBytes: 2000 },
+    ]
+
+    expect(await normalizeAttachments(d, items)).toEqual(items)
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  // The whole bargain: a missing ffmpeg, a timeout or a file it cannot read
+  // costs the conversion, never the message.
+  it('stores the original when the conversion cannot be made', async () => {
+    const { deps: d, put, del } = deps({ transcode: vi.fn(() => Promise.resolve(null)) })
+    const original = webmNote()
+
+    expect(await normalizeAttachments(d, [original])).toEqual([original])
+    expect(put).not.toHaveBeenCalled()
+    expect(del).not.toHaveBeenCalled()
+  })
+
+  it('stores the original when the bytes cannot be read back', async () => {
+    const { deps: d, warn } = deps({
+      get: vi.fn(() => Promise.reject(new Error('bucket said no'))),
+    })
+    const original = webmNote()
+
+    expect(await normalizeAttachments(d, [original])).toEqual([original])
+    expect(warn).toHaveBeenCalled()
+  })
+
+  // A URL outside our bucket cannot reach this in production — `assertMedia`
+  // rejects it first — and if it ever did, this server must not fetch it.
+  it('never touches a URL that is not ours', async () => {
+    const { deps: d, get } = deps()
+    const foreign = webmNote({ url: 'https://elsewhere.example/a.webm' })
+
+    expect(await normalizeAttachments(d, [foreign])).toEqual([foreign])
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it('keeps the note when only the original could not be deleted', async () => {
+    const { deps: d, warn } = deps({
+      del: vi.fn(() => Promise.reject(new Error('delete failed'))),
+    })
+    const [note] = await normalizeAttachments(d, [webmNote()])
+
+    // A leaked object costs bytes; losing the note costs the message.
+    expect(note?.contentType).toBe('audio/mp4')
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('converts both takes of a pronunciation answer', async () => {
+    const { deps: d } = deps()
+    const converted = await normalizeAttachments(d, [
+      webmNote(),
+      webmNote({ url: `${BUCKET}/posts/u1/slow.webm` }),
+    ])
+
+    expect(converted.map((m) => m.contentType)).toEqual(['audio/mp4', 'audio/mp4'])
+    expect(converted[1]?.url).toBe(`${BUCKET}/posts/u1/slow.m4a`)
+  })
+})

--- a/apps/api/src/modules/media/transcodeAudio.ts
+++ b/apps/api/src/modules/media/transcodeAudio.ts
@@ -1,0 +1,192 @@
+import { execFile } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { MAX_AUDIO_BYTES, type Media } from '@langx/shared'
+import { supportsPut, type StorageProvider } from '../../storage/StorageProvider'
+
+/**
+ * Making a browser's voice note playable on a phone.
+ *
+ * `MediaRecorder` on Chrome and Firefox produces WebM/Opus and nothing else —
+ * expo-audio's web recorder asks for `audio/webm` and gets it — while iOS has
+ * no Opus or WebM decoder at any level. So a note recorded on the site arrived
+ * in a thread as a bubble an iPhone could not play, and the app's own honest
+ * answer for that ("this will not play on this device") is a worse product
+ * than the note simply working.
+ *
+ * `docs/architecture.md` says video is stored exactly as uploaded, with no
+ * transcoding, and that still holds — a video is tens of megabytes and both
+ * containers we accept play everywhere. This is the one exception, and it is
+ * cheap for the same reason: a two-minute voice note is under a megabyte and
+ * an Opus→AAC remux is about a second of CPU.
+ *
+ * **Synchronous, inside the send.** A queue would need a claim (two Fly
+ * machines), a second socket event for chat, and something the feed does not
+ * have at all — there is no `post:*` event, so a post's note would stay wrong
+ * until the reader refetched. Doing it before the insert means the row is
+ * right the first time anything reads it, and the only cost is latency inside
+ * the client's twelve-second ack budget.
+ *
+ * **It never fails the send.** No ffmpeg on the host, a timeout, a file it
+ * cannot read: the original is stored, exactly as before this existed, and the
+ * bubble goes back to saying it cannot play it. That is the same bargain the
+ * rest of the optional services make — see `docs/self-host.md`.
+ */
+
+/** What a browser records, and what no iPhone will decode. */
+const TRANSCODE_FROM = new Set(['audio/webm', 'audio/ogg'])
+/** AAC in MP4: what both phones record natively, so one playback path serves all of it. */
+export const TRANSCODE_TO = 'audio/mp4'
+/**
+ * Well inside `SOCKET_ACK_TIMEOUT_MS`, which is 12s and is what the sender
+ * actually waits. A two-minute note takes about a second; anything near this
+ * is a machine in trouble, and the send is worth more than the conversion.
+ */
+const TRANSCODE_TIMEOUT_MS = 8_000
+
+export function needsTranscode(contentType: string): boolean {
+  return TRANSCODE_FROM.has(contentType.split(';')[0]?.trim().toLowerCase() ?? '')
+}
+
+/**
+ * The key the converted file takes.
+ *
+ * Same directory and same name, new extension — `keyFromPublicUrl` recognises
+ * our objects by the bucket prefix, so the URL has to stay inside it, and
+ * `objectExtension` already maps `audio/mp4` to `.m4a`.
+ */
+export function transcodedKey(key: string): string {
+  return `${key.replace(/\.[^./]+$/, '')}.m4a`
+}
+
+export interface TranscodeDeps {
+  get(key: string): Promise<Uint8Array>
+  put(key: string, body: Uint8Array, contentType: string): Promise<string>
+  del(key: string): Promise<void>
+  keyOf(url: string): string | null
+  /** Returns `null` when the conversion could not be made, for any reason. */
+  transcode(input: Uint8Array): Promise<Uint8Array | null>
+  warn(error: unknown, message: string): void
+}
+
+/**
+ * Runs ffmpeg over bytes we hold, and hands back AAC in MP4.
+ *
+ * Through temp files rather than pipes: the MP4 muxer rewinds to write the
+ * index once it knows the durations, and a pipe cannot seek. `-f ipod` is the
+ * spelling that makes ffmpeg emit the `.m4a` flavour of MP4 rather than one
+ * announcing itself as video.
+ */
+export function ffmpegTranscoder(
+  ffmpegPath: string,
+  warn: (error: unknown, message: string) => void,
+): (input: Uint8Array) => Promise<Uint8Array | null> {
+  return async (input: Uint8Array): Promise<Uint8Array | null> => {
+    const dir = await mkdtemp(join(tmpdir(), 'langx-audio-'))
+    const source = join(dir, 'in')
+    const target = join(dir, 'out.m4a')
+    try {
+      await writeFile(source, input)
+      await new Promise<void>((resolve, reject) => {
+        execFile(
+          ffmpegPath,
+          [
+            '-nostdin',
+            '-y',
+            '-i',
+            source,
+            '-vn',
+            '-c:a',
+            'aac',
+            '-b:a',
+            '96k',
+            '-f',
+            'ipod',
+            target,
+          ],
+          { timeout: TRANSCODE_TIMEOUT_MS },
+          (error) => (error ? reject(new Error(error.message)) : resolve()),
+        )
+      })
+      const output = await readFile(target)
+      // A conversion that came out empty, or somehow larger than the ceiling
+      // the upload was signed against, is not something to store.
+      if (output.byteLength === 0 || output.byteLength > MAX_AUDIO_BYTES) return null
+      return new Uint8Array(output)
+    } catch (error) {
+      warn(error, 'voice note transcode failed; storing the original')
+      return null
+    } finally {
+      await rm(dir, { force: true, recursive: true })
+    }
+  }
+}
+
+/**
+ * The attachments as they should be stored.
+ *
+ * Called after the allowlist and bucket checks and before the insert, which is
+ * the order that matters: a URL that is not ours must never be fetched by this
+ * server, and a row must never mention a file that is not there yet.
+ */
+export async function normalizeAttachments(
+  deps: TranscodeDeps,
+  attachments: readonly Media[],
+): Promise<Media[]> {
+  return await Promise.all(attachments.map((media) => normalizeOne(deps, media)))
+}
+
+async function normalizeOne(deps: TranscodeDeps, media: Media): Promise<Media> {
+  if (!needsTranscode(media.contentType)) return media
+  const key = deps.keyOf(media.url)
+  if (!key) return media
+
+  try {
+    const converted = await deps.transcode(await deps.get(key))
+    if (!converted) return media
+
+    const url = await deps.put(transcodedKey(key), converted, TRANSCODE_TO)
+    // Best-effort, and after the new object exists: a leaked original costs
+    // bytes, while deleting first and then failing to write costs the note.
+    // `deleteAttachment` swallows in the same way and for the same reason.
+    try {
+      await deps.del(key)
+    } catch (error) {
+      deps.warn(error, 'could not remove the original of a transcoded voice note')
+    }
+
+    return { ...media, url, contentType: TRANSCODE_TO, sizeBytes: converted.byteLength }
+  } catch (error) {
+    deps.warn(error, 'could not transcode a voice note; storing the original')
+    return media
+  }
+}
+
+/**
+ * The normaliser this app runs with, or the identity function.
+ *
+ * Identity when storage cannot be read and written server-side, which is the
+ * unconfigured case a self-hoster boots into. ffmpeg's own absence is not
+ * checked here — it shows up as a failed conversion on the first note, once,
+ * and the note is stored as recorded.
+ */
+export function createAttachmentNormalizer(
+  storage: StorageProvider,
+  ffmpegPath: string,
+  warn: (error: unknown, message: string) => void,
+): AttachmentNormalizer {
+  if (!supportsPut(storage)) return (attachments) => Promise.resolve([...attachments])
+  const deps: TranscodeDeps = {
+    get: (key) => storage.getObject(key),
+    put: (key, body, contentType) => storage.putObject(key, body, contentType),
+    del: (key) => storage.deleteObject(key),
+    keyOf: (url) => storage.keyFromPublicUrl(url),
+    transcode: ffmpegTranscoder(ffmpegPath, warn),
+    warn,
+  }
+  return (attachments) => normalizeAttachments(deps, attachments)
+}
+
+/** What the insert paths are handed, so a test can pass a plain function. */
+export type AttachmentNormalizer = (attachments: readonly Media[]) => Promise<Media[]>

--- a/apps/api/src/routes/feed.test.ts
+++ b/apps/api/src/routes/feed.test.ts
@@ -1021,6 +1021,52 @@ describe('community feed', () => {
       expect(both.json<{ slowMedia?: { url: string } }>().slowMedia?.url).toContain('slow.m4a')
     })
 
+    it('stores both takes as the normaliser leaves them', async () => {
+      const asker = await newUser('pron-normalise-asker@example.com')
+      const helper = await newUser('pron-normalise-helper@example.com')
+      const askId = (await ask(asker, 'squirrel')).json<{ _id: string }>()._id
+
+      /*
+       * An answer is the one place a recording is two fields rather than a
+       * list, so it is the one place the pair could come back in the wrong
+       * order or lose a take. It is also the page most likely to be recorded
+       * in a browser, which is what the conversion exists for.
+       */
+      const real = app.normalizeAttachments
+      app.normalizeAttachments = (items) =>
+        Promise.resolve(
+          items.map((item) => ({
+            ...item,
+            url: item.url.replace('.webm', '.m4a'),
+            contentType: 'audio/mp4',
+          })),
+        )
+
+      try {
+        const webm = (name: string) => ({
+          url: `https://cdn.example.com/posts/u/${name}.webm`,
+          contentType: 'audio/webm',
+          sizeBytes: 4096,
+          durationSeconds: 3,
+        })
+        const response = await answer(helper, askId, {
+          media: webm('fast'),
+          slowMedia: webm('slow'),
+        })
+
+        expect(response.statusCode, response.body).toBe(201)
+        const body = response.json<{
+          media: { url: string; contentType: string }
+          slowMedia?: { url: string }
+        }>()
+        expect(body.media.contentType).toBe('audio/mp4')
+        expect(body.media.url).toContain('fast.m4a')
+        expect(body.slowMedia?.url).toContain('slow.m4a')
+      } finally {
+        app.normalizeAttachments = real
+      }
+    })
+
     it('refuses an answer with no recording, and an image as one', async () => {
       const asker = await newUser('pron-bad-asker@example.com')
       const helper = await newUser('pron-bad-helper@example.com')

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -73,6 +73,7 @@ export const feedRoutes: FastifyPluginAsyncZod = async (app) => {
             request.userId,
             request.body,
             app.env.STORAGE_PUBLIC_BASE_URL,
+            app.normalizeAttachments,
           ),
         )
     },
@@ -104,6 +105,7 @@ export const feedRoutes: FastifyPluginAsyncZod = async (app) => {
         request.params.id,
         request.body,
         app.env.STORAGE_PUBLIC_BASE_URL,
+        app.normalizeAttachments,
       )
       return reply.code(201).send(correction)
     },
@@ -208,6 +210,7 @@ export const feedRoutes: FastifyPluginAsyncZod = async (app) => {
         request.params.id,
         request.body,
         app.env.STORAGE_PUBLIC_BASE_URL,
+        app.normalizeAttachments,
       )
       return reply.code(201).send(answer)
     },

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -589,6 +589,40 @@ describe('Faz 5 — conversation/message history REST', () => {
     expect(body.unread[b.userId]).toBe(0)
   })
 
+  it('reading tells the sender and the reader own other devices', async () => {
+    const a = await newUser('read-fanout-a@example.com')
+    const b = await newUser('read-fanout-b@example.com')
+    const conversation = await startConversation(a, b.userId, 'hey b')
+
+    /*
+     * Both rooms matter and they mean different things. The sender's room
+     * gets a read receipt; the reader's own room gets "your unread total
+     * dropped", which is what a second device of theirs needs to hear before
+     * it will stop drawing a badge for a thread already read elsewhere.
+     */
+    const rooms: string[] = []
+    const io = app.io as unknown as { to: (room: string) => { emit: (event: string) => void } }
+    const realTo = io.to.bind(io)
+    io.to = (room: string) => {
+      rooms.push(room)
+      return realTo(room)
+    }
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/conversations/${conversation._id}/read`,
+        headers: { cookie: b.cookie },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+    } finally {
+      io.to = realTo
+    }
+
+    expect(rooms).toContain(`user:${a.userId}`)
+    expect(rooms).toContain(`user:${b.userId}`)
+  })
+
   it('reading over REST marks the thread delivered as well as read', async () => {
     const a = await newUser('read-implies-a@example.com')
     const b = await newUser('read-implies-b@example.com')

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -1045,6 +1045,45 @@ describe('Faz 5 — conversation/message history REST', () => {
       expect(result.message.media?.url).toBe(image.url)
     })
 
+    it('stores a browser voice note as what the normaliser made of it', async () => {
+      const { a, conversationId } = await pair('media-transcode')
+      const { sendMediaMessage } = await import('../modules/chat/messages')
+
+      /*
+       * The real one shells out to ffmpeg and reads the bucket back, neither
+       * of which belongs in this suite — what matters here is that the send
+       * stores the converted attachment rather than the picked one, in both
+       * the list and the field repeated beside it.
+       */
+      const webm = {
+        url: `${BUCKET}/messages/x/a.webm`,
+        contentType: 'audio/webm',
+        sizeBytes: 40_000,
+        durationSeconds: 7,
+      }
+      const result = await sendMediaMessage(
+        handle.db,
+        a.userId,
+        { conversationId, attachments: [webm] },
+        BUCKET,
+        () =>
+          Promise.resolve([
+            {
+              ...webm,
+              url: `${BUCKET}/messages/x/a.m4a`,
+              contentType: 'audio/mp4',
+              sizeBytes: 9_000,
+            },
+          ]),
+      )
+
+      expect(result.message.attachments?.[0]?.contentType).toBe('audio/mp4')
+      expect(result.message.media?.url).toBe(`${BUCKET}/messages/x/a.m4a`)
+      // Still a voice note: the kind came from the bytes before the swap, and
+      // AAC and Opus are both audio.
+      expect(result.message.type).toBe('audio')
+    })
+
     it('refuses a voice note sent alongside a photo', async () => {
       const { a, conversationId } = await pair('media-mixed')
       const { sendMediaMessage } = await import('../modules/chat/messages')

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -181,14 +181,24 @@ export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
   app.post('/conversations/:id/read', { preHandler: requireMember }, async (request, reply) => {
     const { id } = request.params as { id: string }
     const conversation = await markConversationRead(app.mongo.db, request.userId, id)
+    const readAt = new Date().toISOString()
     const otherId = conversation.participants.find((p) => p !== request.userId)
     if (otherId) {
       app.io.to(`user:${otherId}`).emit('conversation:read', {
         conversationId: id,
         readBy: request.userId,
-        readAt: new Date().toISOString(),
+        readAt,
       })
     }
+    // And the reader's own other devices, which is not the same thing: the
+    // sender learns their message was read, while a second phone learns its
+    // unread total just dropped. Without this it keeps a badge for messages
+    // that were read on another device until something else invalidates.
+    app.io.to(`user:${request.userId}`).emit('conversation:read', {
+      conversationId: id,
+      readBy: request.userId,
+      readAt,
+    })
     return reply.send(conversation)
   })
 }

--- a/apps/api/src/storage/StorageProvider.ts
+++ b/apps/api/src/storage/StorageProvider.ts
@@ -26,6 +26,17 @@ export interface StorageProviderWithPut extends StorageProvider {
   putObject(key: string, body: Uint8Array, contentType: string): Promise<string>
 
   /**
+   * Reads an object's bytes back into this process.
+   *
+   * The mirror of `putObject` and it exists for one caller: a voice note
+   * recorded in a browser arrives as WebM/Opus, which no iPhone can decode, so
+   * it is fetched, transcoded to AAC and written back. Everything else about
+   * this bucket is write-once — nothing else needs the bytes after the client
+   * has sent them.
+   */
+  getObject(key: string): Promise<Uint8Array>
+
+  /**
    * Removes an object. Used by the account purge — a deleted account's photos
    * have to leave the bucket, or "your data is permanently removed" is not
    * true and the URLs stay publicly fetchable forever.

--- a/apps/api/src/storage/s3StorageProvider.ts
+++ b/apps/api/src/storage/s3StorageProvider.ts
@@ -1,4 +1,9 @@
-import { DeleteObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import type { StorageProviderWithPut, UploadUrl } from './StorageProvider'
 
@@ -67,6 +72,12 @@ export class S3StorageProvider implements StorageProviderWithPut {
       }),
     )
     return `${this.#publicBaseUrl}/${key}`
+  }
+
+  async getObject(key: string): Promise<Uint8Array> {
+    const result = await this.#client.send(new GetObjectCommand({ Bucket: this.#bucket, Key: key }))
+    if (!result.Body) throw new Error(`Object ${key} has no body`)
+    return await result.Body.transformToByteArray()
   }
 
   async deleteObject(key: string): Promise<void> {

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -207,7 +207,13 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
               quota.nextAvailableAt ? { retryAt: quota.nextAvailableAt.toISOString() } : undefined,
             )
           }
-          return sendMediaMessage(app.mongo.db, userId, input, app.env.STORAGE_PUBLIC_BASE_URL)
+          return sendMediaMessage(
+            app.mongo.db,
+            userId,
+            input,
+            app.env.STORAGE_PUBLIC_BASE_URL,
+            app.normalizeAttachments,
+          )
         })
         .then(({ message, conversation }) => {
           void fanOutMessage(app, io, conversation, message, { pushWhenAway: true })

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -301,14 +301,23 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
         .parseAsync(payload)
         .then(({ conversationId }) =>
           markConversationRead(app.mongo.db, userId, conversationId).then((conversation) => {
+            const readAt = new Date().toISOString()
             const otherId = conversation.participants.find((id) => id !== userId)
             if (otherId) {
               io.to(userRoom(otherId)).emit('conversation:read', {
                 conversationId,
                 readBy: userId,
-                readAt: new Date().toISOString(),
+                readAt,
               })
             }
+            // The reader's own room as well — a second device of theirs is
+            // holding an unread badge for messages that have just been read.
+            // See the REST twin in `routes/messages.ts`.
+            io.to(userRoom(userId)).emit('conversation:read', {
+              conversationId,
+              readBy: userId,
+              readAt,
+            })
             ack?.({ ok: true })
           }),
         )

--- a/apps/mobile/app/(app)/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(app)/(tabs)/_layout.tsx
@@ -41,12 +41,22 @@ export default function TabsLayout() {
   // Spread rather than passed as `undefined`: the option is typed as present
   // or absent, and an explicit `undefined` is neither.
   const badge = unreadBadge(unread.data)
-  // The icon follows the same number as the tab, from the same query — see
-  // `syncIconBadge`. Whatever changes the total invalidates that query, so
-  // this runs on read, on a new message and on archive alike.
+  /*
+   * The icon follows the same number as the tab, from the same query — see
+   * `syncIconBadge`. Whatever changes the total invalidates that query, so
+   * this runs on read, on a new message and on archive alike.
+   *
+   * Keyed on `dataUpdatedAt` as well as the number, because the icon has a
+   * second writer: a push notification carries its own `badge` and sets it
+   * without asking this app. When the phone comes back and the refetch
+   * returns the same total it already held, the value is unchanged, this
+   * effect would not run, and the number the push left behind would stand —
+   * which is how the icon, the tab and the row ended up disagreeing. The
+   * timestamp moves on every fetch, so a confirmed total always overwrites.
+   */
   useEffect(() => {
     if (unread.data !== undefined) void syncIconBadge(unread.data)
-  }, [unread.data])
+  }, [unread.data, unread.dataUpdatedAt])
 
   return (
     <Tabs

--- a/apps/mobile/app/(app)/(tabs)/feed.tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed.tsx
@@ -8,6 +8,7 @@ import { Button } from '../../../src/components/ui/Button'
 import { uploadPostMedia } from '../../../src/api/queries'
 import {
   advanceUpload,
+  sameDisplayedProgress,
   UPLOAD_START,
   uploadSent,
   type ActiveUpload,
@@ -285,12 +286,21 @@ export default function FeedScreen() {
         uploaded.push(
           await uploadPostMedia({
             ...item,
+            /*
+             * Returning `current` unchanged when the label would not move is
+             * not an optimisation to be tidy about: this state lives on the
+             * screen that owns the feed's `FlatList`, so every chunk event
+             * re-rendered every visible post — during an upload, which is
+             * exactly when the phone is busy.
+             */
             onProgress: (loaded, total) =>
-              setUploadProgress((current) =>
-                current && current.index === index
-                  ? { index, progress: advanceUpload(current.progress, loaded, total) }
-                  : current,
-              ),
+              setUploadProgress((current) => {
+                if (!current || current.index !== index) return current
+                const next = advanceUpload(current.progress, loaded, total)
+                return sameDisplayedProgress(current.progress, next)
+                  ? current
+                  : { index, progress: next }
+              }),
           }),
         )
         setUploadProgress({ index, progress: uploadSent(UPLOAD_START) })
@@ -756,6 +766,15 @@ export default function FeedScreen() {
                           onOpen={(index) =>
                             setViewing({ items: attachmentsOf(item.topCorrection!), index })
                           }
+                          /*
+                           * The same preview the post above it draws. Without
+                           * this a correction's video came out in `controls`
+                           * mode, where `onOpen` is deliberately ignored — so
+                           * it was the one video on the screen that could not
+                           * be opened, for no reason a reader could see.
+                           */
+                          videoMode="preview"
+                          videoPlaying={shouldPlay(item._id, playingPosts)}
                         />
                       </View>
                     ) : null}

--- a/apps/mobile/app/(app)/post/[id].tsx
+++ b/apps/mobile/app/(app)/post/[id].tsx
@@ -495,6 +495,14 @@ export default function PostScreen() {
                   <MediaGallery
                     items={attachmentsOf(item)}
                     onOpen={(index) => setViewing({ items: attachmentsOf(item), index })}
+                    /*
+                     * As the post's own attachment above, and for the same
+                     * reason: in `controls` mode `onOpen` is ignored, so a
+                     * correction's video was the one thing on this screen that
+                     * would not open.
+                     */
+                    videoMode="preview"
+                    videoPlaying={focused}
                   />
                 </View>
               ) : null}

--- a/apps/mobile/src/components/AttachmentPreview.tsx
+++ b/apps/mobile/src/components/AttachmentPreview.tsx
@@ -33,7 +33,7 @@ export interface PendingAttachment {
  * the grounds that in a thread picking is sending; it does not any more, so
  * the two hold a file the same way and the row that shows it is one component.
  */
-function VideoThumb({ uri }: { uri: string }) {
+function VideoThumb({ uri, uploading }: { uri: string; uploading: boolean }) {
   const styles = useStyles()
   const { colors } = useTheme()
   /*
@@ -54,9 +54,17 @@ function VideoThumb({ uri }: { uri: string }) {
         contentFit="cover"
         nativeControls={false}
       />
-      <View style={styles.playBadge} pointerEvents="none">
-        <Feather name="play" size={12} color={colors.bg} />
-      </View>
+      {/*
+        Not while it is uploading. The badge sits in the corner of the same
+        64pt square the progress label is centred in, so the two shared it —
+        a play triangle showing through a scrim under a number that moved
+        around it. The upload is the only thing worth saying at that moment.
+      */}
+      {uploading ? null : (
+        <View style={styles.playBadge} pointerEvents="none">
+          <Feather name="play" size={12} color={colors.bg} />
+        </View>
+      )}
     </View>
   )
 }
@@ -87,7 +95,7 @@ function AttachmentThumb({
       {attachment.kind === 'image' ? (
         <Image source={{ uri: attachment.uri }} style={styles.thumb} contentFit="cover" />
       ) : attachment.kind === 'video' ? (
-        <VideoThumb uri={attachment.uri} />
+        <VideoThumb uri={attachment.uri} uploading={progress !== null} />
       ) : (
         // A recording has no picture, so the square says what it is instead of
         // showing a grey box that looks like a photo that failed to load.
@@ -113,14 +121,16 @@ function AttachmentThumb({
          */
         <View style={[styles.thumb, styles.uploading]} pointerEvents="none">
           {/*
-            The same three waits `PendingMediaBubble` names: reading the file
-            into memory has no number to give, so it says so rather than
-            sitting at 0%.
+            A number and nothing else, unlike `PendingMediaBubble`, which has a
+            bubble's width to spell it out in. Reading the file into memory has
+            no number to give and says so with an ellipsis rather than sitting
+            at a 0% it does not mean; once the bytes are up, `sending` is the
+            round-trip, and 100% is true for the whole of it.
           */}
-          <Text style={styles.uploadingText} numberOfLines={2}>
+          <Text style={styles.uploadingText} numberOfLines={1}>
             {progress.phase === 'reading'
-              ? t('composer.preparingUpload')
-              : t('composer.uploadingPercent', { percent: percentOf(progress) })}
+              ? t('composer.percentPending')
+              : t('composer.percentOnly', { percent: percentOf(progress) })}
           </Text>
         </View>
       )}
@@ -192,10 +202,27 @@ const useStyles = makeStyles(({ colors, radius, spacing }) => ({
   uploading: {
     alignItems: 'center',
     backgroundColor: 'rgba(0,0,0,0.55)',
+    bottom: 0,
     justifyContent: 'center',
+    // Spelled out rather than left to the static-position fallback, which is
+    // what `PendingMediaBubble`'s veil does and what keeps the scrim exactly
+    // over the square when the label inside it changes width.
+    left: 0,
     position: 'absolute',
+    right: 0,
+    top: 0,
   },
-  uploadingText: { color: '#fff', fontSize: 11, fontWeight: '700' },
+  /*
+   * Tabular figures, because the whole point is that it does not move. With
+   * proportional ones the centred string re-measures on every tick — 9%, 49%,
+   * 100% are three different widths — and the number visibly slides.
+   */
+  uploadingText: {
+    color: '#fff',
+    fontSize: 13,
+    fontVariant: ['tabular-nums'],
+    fontWeight: '700',
+  },
   previewRow: {
     alignItems: 'center',
     flexDirection: 'row',

--- a/apps/mobile/src/components/MediaBubble.tsx
+++ b/apps/mobile/src/components/MediaBubble.tsx
@@ -355,6 +355,14 @@ export function VideoBubble({
       contentFit="contain"
       nativeControls={!preview}
       fullscreenOptions={{ enable: !preview }}
+      /*
+       * In preview mode the tap belongs to the `Pressable` wrapped around
+       * this, and a native video surface will happily swallow it — which is
+       * why a one-video post could not be opened while a video in a grid,
+       * whose tile has an overlay above the surface, always could. With no
+       * controls of its own there is nothing here that wants a touch.
+       */
+      pointerEvents={preview ? 'none' : 'auto'}
     />
   )
 
@@ -370,6 +378,19 @@ export function VideoBubble({
           style={styles.videoFill}
         >
           {view}
+          {/*
+            The glyph the grid tile has always had, and the single video never
+            did. A preview only plays while its post is on screen, so the rest
+            of the time it is a still frame with no controls and nothing to say
+            it is a video at all — and before the player is ready it is not
+            even a frame, just the box's fill. That is the whole of "the video
+            looks broken".
+          */}
+          {playing ? null : (
+            <View style={styles.tilePlay} pointerEvents="none">
+              <Text style={styles.tilePlayGlyph}>▶</Text>
+            </View>
+          )}
         </Pressable>
       ) : (
         view

--- a/apps/mobile/src/components/MediaBubble.tsx
+++ b/apps/mobile/src/components/MediaBubble.tsx
@@ -2,7 +2,7 @@ import { useAudioPlayer, useAudioPlayerStatus } from 'expo-audio'
 import { Image } from 'expo-image'
 import { useVideoPlayer, VideoView } from 'expo-video'
 import { useEffect, useState } from 'react'
-import { Pressable, Text, View } from 'react-native'
+import { Platform, Pressable, Text, View } from 'react-native'
 import { isImageContentType, isVideoContentType, type Media } from '@langx/shared'
 import { audioProgress } from '../lib/audioProgress'
 import { ensurePlaybackAudioMode } from '../lib/audioSession'
@@ -57,7 +57,9 @@ export function AudioBubble({ media, mine = false }: { media: Media; mine?: bool
   /** A `play()` that threw; the status alone cannot report one. */
   const [failed, setFailed] = useState(false)
 
-  const { total, elapsed, fraction, canReplay, state } = audioProgress(media, status)
+  // `Platform.OS` passed in rather than read there, so `audioProgress` stays
+  // free of `react-native` and testable without a renderer.
+  const { total, elapsed, fraction, canReplay, state } = audioProgress(media, status, Platform.OS)
   // Both v3 bubbles are light tints, so the glyphs read in plain `text`; the
   // accent on your own progress is the only mark of whose note it is.
   const tint = mine ? colors.accent : colors.text

--- a/apps/mobile/src/components/PhotoViewer.tsx
+++ b/apps/mobile/src/components/PhotoViewer.tsx
@@ -59,15 +59,22 @@ export interface PhotoViewerProps {
 }
 
 /**
- * The opened video, playing straight away.
+ * The opened video, playing straight away and again after that.
  *
  * Autoplay here and not in the bubble: opening one is the request to watch it,
  * where scrolling past one is not.
+ *
+ * Looping, like the feed's inline preview and unlike a thread's. What gets
+ * posted here is a few seconds of a word being said, and this is the only
+ * place it has sound — so the thing somebody opened it for is the thing they
+ * will want twice. Ending on a frozen last frame with a scrub bar under it
+ * makes them find the start again by hand. The controls are still there for
+ * anyone who wants to stop.
  */
 function FullscreenVideo({ url }: { url: string }) {
   const styles = useStyles()
   const player = useVideoPlayer(url, (instance) => {
-    instance.loop = false
+    instance.loop = true
     instance.play()
   })
 

--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -240,13 +240,23 @@ export function useSocket({ enabled = true }: { enabled?: boolean } = {}): void 
       /**
        * Still invalidated, unlike `message:new` above. This fires once when
        * someone opens a thread, not once per message, so refetching the
-       * loaded pages is cheap here — and the event is delivered only to the
-       * *other* participant, carrying `readBy`, which is not the unread count
-       * this client draws. Patching it would change nothing visible.
+       * loaded pages is cheap here.
+       *
+       * It reaches two audiences now. For the *other* participant it carries
+       * `readBy` and means "they have seen it", which is a tick on a bubble.
+       * For the reader's own other devices — the second half, added because a
+       * phone left holding a badge for a thread read on a laptop keeps it —
+       * it means their unread total has dropped, and that number is the
+       * server's to give.
        */
       socket.on('conversation:read', ({ conversationId }: { conversationId: string }) => {
         void queryClient.invalidateQueries({ queryKey: keys.messages(conversationId) })
         void queryClient.invalidateQueries({ queryKey: ['conversations'] })
+        // This now also reaches the reader's own other devices, where it
+        // means "your unread total just dropped" rather than "they saw it".
+        // The badge cannot be recomputed from here, so it goes back to the
+        // server — the same reason this event is invalidated, not patched.
+        invalidateUnread(queryClient)
       })
     })()
 

--- a/apps/mobile/src/hooks/useVoiceRecorder.ts
+++ b/apps/mobile/src/hooks/useVoiceRecorder.ts
@@ -1,7 +1,7 @@
 import { AudioModule, RecordingPresets, useAudioRecorder, useAudioRecorderState } from 'expo-audio'
 import { Platform } from 'react-native'
 import { ensurePlaybackAudioMode, ensureRecordingAudioMode } from '../lib/audioSession'
-import { nativeRecordingType, webRecordingType } from '../lib/recordingFormat'
+import { nativeRecordingType, webRecorderMimeType, webRecordingType } from '../lib/recordingFormat'
 import { currentTranslate } from '../i18n/runtime'
 import { useCallback, useState } from 'react'
 import { MAX_AUDIO_SECONDS } from '@langx/shared'
@@ -31,8 +31,31 @@ function mediaRecorderSupports(type: string): boolean {
   return recorder?.isTypeSupported?.(type) ?? false
 }
 
+/**
+ * The preset, with the web asked for AAC where it can produce it.
+ *
+ * `HIGH_QUALITY` is AAC in MP4 on both phones and `audio/webm` on the web, and
+ * that last part is not a label — expo-audio hands it to `MediaRecorder`, so
+ * every note recorded in a browser really was Opus, which no iPhone can
+ * decode. The server converts them now; this shortens the path wherever the
+ * browser can simply record the right thing.
+ *
+ * Outside the hook because `useAudioRecorder` keys on the options object, and
+ * a fresh one per render restarts the recorder mid-recording.
+ */
+const WEB_MIME_TYPE = webRecorderMimeType(mediaRecorderSupports)
+const RECORDING_OPTIONS = {
+  ...RecordingPresets.HIGH_QUALITY,
+  web: {
+    ...RecordingPresets.HIGH_QUALITY.web,
+    // Spread rather than passed as `undefined`: the option is typed as present
+    // or absent, and leaving it absent is what keeps the preset's own value.
+    ...(WEB_MIME_TYPE ? { mimeType: WEB_MIME_TYPE } : {}),
+  },
+}
+
 export function useVoiceRecorder() {
-  const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY)
+  const recorder = useAudioRecorder(RECORDING_OPTIONS)
   const state = useAudioRecorderState(recorder)
   const [error, setError] = useState<string | null>(null)
 

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -54,6 +54,8 @@ export const ar: Localized<EnMessages> = {
     removeAttachment: 'إزالة المرفق',
     preparingUpload: 'جارٍ التحضير…',
     uploadingPercent: 'جارٍ الرفع… {percent}%',
+    percentOnly: '{percent}٪',
+    percentPending: '…',
     attachMedia: 'إرفاق صور أو مقاطع فيديو',
   },
 

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -41,6 +41,8 @@ export const de: Localized<EnMessages> = {
     removeAttachment: 'Anhang entfernen',
     preparingUpload: 'Wird vorbereitet…',
     uploadingPercent: 'Wird hochgeladen… {percent} %',
+    percentOnly: '{percent} %',
+    percentPending: '…',
     attachMedia: 'Fotos oder Videos anhängen',
   },
 

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -65,6 +65,15 @@ export const en = {
     removeAttachment: 'Remove attachment',
     preparingUpload: 'Preparing…',
     uploadingPercent: 'Uploading… {percent}%',
+    /*
+     * The same two waits, for a 64pt square rather than a chat bubble. The
+     * sentence does not fit there: it wraps, and where it wraps changes with
+     * the digit count, so the label re-lays-out on every tick and lands on
+     * the video badge underneath. A percentage on its own says the same
+     * thing and holds still.
+     */
+    percentOnly: '{percent}%',
+    percentPending: '…',
     attachMedia: 'Attach photos or videos',
   },
 

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -44,6 +44,8 @@ export const es: Localized<EnMessages> = {
     removeAttachment: 'Quitar el archivo adjunto',
     preparingUpload: 'Preparando…',
     uploadingPercent: 'Subiendo… {percent}%',
+    percentOnly: '{percent}%',
+    percentPending: '…',
     attachMedia: 'Adjuntar fotos o vídeos',
   },
 

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -41,6 +41,8 @@ export const fr: Localized<EnMessages> = {
     removeAttachment: 'Retirer la pièce jointe',
     preparingUpload: 'Préparation…',
     uploadingPercent: 'Envoi… {percent} %',
+    percentOnly: '{percent} %',
+    percentPending: '…',
     attachMedia: 'Joindre des photos ou des vidéos',
   },
 

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -41,6 +41,8 @@ export const ptBR: Localized<EnMessages> = {
     removeAttachment: 'Remover anexo',
     preparingUpload: 'Preparando…',
     uploadingPercent: 'Enviando… {percent}%',
+    percentOnly: '{percent}%',
+    percentPending: '…',
     attachMedia: 'Anexar fotos ou vídeos',
   },
 

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -51,6 +51,8 @@ export const ru: Localized<EnMessages> = {
     removeAttachment: 'Убрать вложение',
     preparingUpload: 'Подготовка…',
     uploadingPercent: 'Загрузка… {percent}%',
+    percentOnly: '{percent}%',
+    percentPending: '…',
     attachMedia: 'Прикрепить фото или видео',
   },
 

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -55,6 +55,8 @@ export const tr: Localized<EnMessages> = {
     removeAttachment: 'Eki kaldır',
     preparingUpload: 'Hazırlanıyor…',
     uploadingPercent: 'Yükleniyor… %{percent}',
+    percentOnly: '%{percent}',
+    percentPending: '…',
     attachMedia: 'Fotoğraf veya video ekle',
   },
 

--- a/apps/mobile/src/lib/audioProgress.test.ts
+++ b/apps/mobile/src/lib/audioProgress.test.ts
@@ -45,6 +45,34 @@ describe('audioProgress', () => {
     expect(audioProgress({ contentType: 'audio/m4a' }, { isLoaded: true }).state).toBe('idle')
   })
 
+  /*
+   * The real case, and the one the check used to get wrong: `audio/webm` is on
+   * the server's allowlist because a browser's recorder produces nothing else,
+   * so asking that list whether an iPhone can play it always answered yes.
+   */
+  it('is per platform: a browser note plays everywhere but on iOS', () => {
+    const webm = { contentType: 'audio/webm' }
+    expect(audioProgress(webm, { isLoaded: true }, 'ios').state).toBe('unsupported')
+    expect(audioProgress(webm, { isLoaded: true }, 'android').state).toBe('idle')
+    expect(audioProgress(webm, { isLoaded: true }, 'web').state).toBe('idle')
+  })
+
+  /*
+   * A failed item reports `isBuffering: true` on iOS — it is neither likely to
+   * keep up nor holding a buffer — so without reading the verdict itself the
+   * bubble showed a spinner for a note that was never going to play.
+   */
+  it('believes the player when it says the item failed', () => {
+    expect(
+      audioProgress({}, { isLoaded: false, isBuffering: true, playbackState: 'failed' }).state,
+    ).toBe('error')
+    expect(audioProgress({}, { isLoaded: false, isBuffering: true, error: 'boom' }).state).toBe(
+      'error',
+    )
+    // And a failure outranks playing, which cannot both be true.
+    expect(audioProgress({}, { playing: true, playbackState: 'failed' }).state).toBe('error')
+  })
+
   it('reports playing over everything but an undecodable type', () => {
     expect(audioProgress({}, { isLoaded: true, playing: true }).state).toBe('playing')
   })

--- a/apps/mobile/src/lib/audioProgress.ts
+++ b/apps/mobile/src/lib/audioProgress.ts
@@ -9,6 +9,30 @@ export interface AudioStatus {
   currentTime?: number
   didJustFinish?: boolean
   reasonForWaitingToPlay?: string | null
+  /** `'failed'` is AVFoundation giving up on the item. */
+  playbackState?: string
+  /** The message it gave up with, or `null`. */
+  error?: string | null
+}
+
+/**
+ * Whether this platform can decode this file at all.
+ *
+ * Not the server's allowlist, which is what this used to ask and why the
+ * branch below never once fired: `audio/webm` is *in* that list, because a
+ * browser's recorder has no other output and refusing the upload would mean
+ * refusing to record. iOS has no Opus or WebM decoder at any level, so the one
+ * case the check exists for was the one case it answered wrong.
+ *
+ * The server converts those notes now, so this is the fallback for the two
+ * cases conversion cannot reach: a note stored before it existed, and a host
+ * with no ffmpeg.
+ */
+export function canDecodeAudio(platform: string, contentType: string | undefined): boolean {
+  if (!contentType) return true
+  const type = contentType.split(';')[0]?.trim().toLowerCase() ?? ''
+  if (platform === 'ios' && (type === 'audio/webm' || type === 'audio/ogg')) return false
+  return isAudioContentType(type)
 }
 
 export interface AudioProgress {
@@ -40,6 +64,7 @@ const END_EPSILON_SECONDS = 0.25
 export function audioProgress(
   media: { contentType?: string | undefined; durationSeconds?: number | undefined },
   status: AudioStatus,
+  platform = 'ios',
 ): AudioProgress {
   const stored = usable(media.durationSeconds)
   const reported = usable(status.duration)
@@ -53,17 +78,26 @@ export function audioProgress(
     // With no total there is nothing to compare against, so the player's own
     // "it ended" is the only thing left to ask.
     canReplay: total > 0 ? elapsed >= total - END_EPSILON_SECONDS : Boolean(status.didJustFinish),
-    state: stateOf(media, status),
+    state: stateOf(media, status, platform),
   }
 }
 
 function stateOf(
   media: { contentType?: string | undefined },
   status: AudioStatus,
+  platform: string,
 ): AudioProgress['state'] {
-  // A type the platform will not decode — a WebM note opened on an iPhone is
-  // the case that used to present as a play button that did nothing at all.
-  if (media.contentType && !isAudioContentType(media.contentType)) return 'unsupported'
+  // A type this platform will not decode — a WebM note opened on an iPhone.
+  if (!canDecodeAudio(platform, media.contentType)) return 'unsupported'
+  /*
+   * The player's own verdict, and it has to be read before anything else.
+   * When AVFoundation fails an item it reports `isLoaded: false` *and*
+   * `isBuffering: true` — a failed item is neither likely to keep up nor
+   * holding any buffer, which is exactly what its "am I buffering" test asks.
+   * So the branch below read a dead player as a loading one and the bubble sat
+   * on `⋯` forever, which is the shape the original bug came back in.
+   */
+  if (status.playbackState === 'failed' || status.error) return 'error'
   if (status.playing) return 'playing'
   if (status.isLoaded === false) {
     // `reasonForWaitingToPlay` is how the player says "still fetching" as

--- a/apps/mobile/src/lib/missedEvents.test.ts
+++ b/apps/mobile/src/lib/missedEvents.test.ts
@@ -22,15 +22,21 @@ describe('resumedFromBackground', () => {
 
 describe('invalidateMissedEvents', () => {
   /**
-   * Every list tab and every cache under a thread, including a jump window —
-   * and nothing else. `me` is the control: a resume is not a reason to ask
-   * who the user is again.
+   * Every list tab, the unread total the tab badge and the app icon read, and
+   * every cache under a thread including a jump window — and nothing else.
+   * `me` is the control: a resume is not a reason to ask who the user is
+   * again.
    */
   it('marks every chat list and thread cache stale, and nothing else', async () => {
     const client = new QueryClient()
     const stale = [
       ['conversations', 'all'],
-      ['conversations', 'unread'],
+      ['conversations', 'unreplied'],
+      // The tab badge and the app icon read this one, and it is the whole
+      // reason the three counts used to disagree after a resume. It looked
+      // covered here for a while by `['conversations', 'unread']` — which is
+      // not a key anything writes: the filters are all/unreplied/archived.
+      ['unread'],
       ['messages', 'c1'],
       ['messages', 'c1', 'around', 'm9'],
     ]

--- a/apps/mobile/src/lib/missedEvents.ts
+++ b/apps/mobile/src/lib/missedEvents.ts
@@ -35,6 +35,16 @@ export function resumedFromBackground(previous: AppStateName, next: AppStateName
  * the rest stale for their next mount. The infinite-query "every loaded page"
  * cost that `useSocket` refuses to pay per message is paid once per gap here.
  *
+ * `['unread']` is the third, and leaving it out is what made the app show
+ * three different unread counts at once. It sits outside the `['conversations']`
+ * prefix deliberately (`api/queries` says why — the socket's page-walking
+ * patcher would choke on a bare number), so nothing here reached it, and the
+ * only things that invalidate it are socket events. A message that arrives
+ * while the phone is in the background is precisely *not* a socket event: it
+ * is a push. So the row refetched and read 5, the tab badge kept the 1 it had
+ * from the last `message:new`, and the icon kept whatever the push wrote.
+ * Same gap, same resync.
+ *
  * The literals rather than `keys` from `api/queries`: that module reaches the
  * API client, which the test setup cannot load.
  */
@@ -42,5 +52,6 @@ export async function invalidateMissedEvents(queryClient: QueryClient): Promise<
   await Promise.all([
     queryClient.invalidateQueries({ queryKey: ['conversations'] }),
     queryClient.invalidateQueries({ queryKey: ['messages'] }),
+    queryClient.invalidateQueries({ queryKey: ['unread'] }),
   ])
 }

--- a/apps/mobile/src/lib/recordingFormat.test.ts
+++ b/apps/mobile/src/lib/recordingFormat.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { isAllowedAudioType, nativeRecordingType, webRecordingType } from './recordingFormat'
+import {
+  isAllowedAudioType,
+  nativeRecordingType,
+  webRecorderMimeType,
+  webRecordingType,
+} from './recordingFormat'
 
 describe('recordingFormat', () => {
   it('calls a native recording what it is: AAC in MP4', () => {
@@ -28,5 +33,24 @@ describe('recordingFormat', () => {
   it('knows what the allowlist holds', () => {
     expect(isAllowedAudioType('audio/m4a')).toBe(true)
     expect(isAllowedAudioType('audio/flac')).toBe(false)
+  })
+})
+
+describe('webRecorderMimeType', () => {
+  it('asks for AAC with the codec spelled out where the browser can', () => {
+    expect(webRecorderMimeType(() => true)).toBe('audio/mp4;codecs=mp4a.40.2')
+  })
+
+  // `isTypeSupported('audio/mp4')` is true in browsers that then produce
+  // something else, so the codec is asked for first and this is the fallback.
+  it('falls back to bare audio/mp4', () => {
+    expect(webRecorderMimeType((type) => type === 'audio/mp4')).toBe('audio/mp4')
+  })
+
+  // Firefox. Undefined leaves the preset's own `audio/webm` in place, which is
+  // what the server converts.
+  it('asks for nothing when the browser can produce neither', () => {
+    expect(webRecorderMimeType(() => false)).toBeUndefined()
+    expect(webRecorderMimeType()).toBeUndefined()
   })
 })

--- a/apps/mobile/src/lib/recordingFormat.ts
+++ b/apps/mobile/src/lib/recordingFormat.ts
@@ -22,6 +22,31 @@ export function nativeRecordingType(): string {
 }
 
 /**
+ * What to *ask* a browser's `MediaRecorder` for.
+ *
+ * `webRecordingType` below labels what came out; this decides what goes in,
+ * and until it existed nothing did. `RecordingPresets.HIGH_QUALITY` names
+ * `audio/webm` for the web, expo-audio passes that straight to `MediaRecorder`
+ * whenever the browser supports it, and every browser that matters supports
+ * it — so the preference for `audio/mp4` a few lines down could never once
+ * have been reached. Chrome from 126 and every Safari can record AAC in MP4,
+ * which is the only thing an iPhone will play, so asking is free.
+ *
+ * The codec has to be spelled out: `isTypeSupported('audio/mp4')` is true in
+ * browsers that then hand back something else, and `mp4a.40.2` is plain AAC-LC.
+ * Firefox says no to all of it and keeps recording WebM, which the server
+ * converts — this only shortens the path where the browser can take it.
+ */
+export function webRecorderMimeType(
+  isTypeSupported?: (type: string) => boolean,
+): string | undefined {
+  const aac = 'audio/mp4;codecs=mp4a.40.2'
+  if (isTypeSupported?.(aac)) return aac
+  if (isTypeSupported?.('audio/mp4')) return 'audio/mp4'
+  return undefined
+}
+
+/**
  * Web: the recorder's own answer, narrowed to what the server accepts.
  *
  * `audio/mp4` is preferred where the browser can produce it — Safari and

--- a/apps/mobile/src/lib/uploadProgress.test.ts
+++ b/apps/mobile/src/lib/uploadProgress.test.ts
@@ -3,6 +3,7 @@ import {
   UPLOAD_START,
   advanceUpload,
   percentOf,
+  sameDisplayedProgress,
   thumbProgress,
   uploadFailed,
   uploadSent,
@@ -76,5 +77,33 @@ describe('thumbProgress', () => {
     expect(thumbProgress(0, active)).toEqual({ phase: 'sending', fraction: 1 })
     expect(thumbProgress(1, active)).toBe(active.progress)
     expect(thumbProgress(2, active)).toBeNull()
+  })
+})
+
+describe('sameDisplayedProgress', () => {
+  it('is true while the whole percent has not moved', () => {
+    expect(
+      sameDisplayedProgress(
+        { phase: 'uploading', fraction: 0.491 },
+        { phase: 'uploading', fraction: 0.499 },
+      ),
+    ).toBe(true)
+  })
+
+  it('is false across a percent boundary', () => {
+    expect(
+      sameDisplayedProgress(
+        { phase: 'uploading', fraction: 0.499 },
+        { phase: 'uploading', fraction: 0.5 },
+      ),
+    ).toBe(false)
+  })
+
+  // The label reads the phase too: `sending` and a finished `uploading` are
+  // both 100%, and only one of them says the round-trip is still going.
+  it('is false when only the phase changed', () => {
+    expect(
+      sameDisplayedProgress({ phase: 'uploading', fraction: 1 }, { phase: 'sending', fraction: 1 }),
+    ).toBe(false)
   })
 })

--- a/apps/mobile/src/lib/uploadProgress.ts
+++ b/apps/mobile/src/lib/uploadProgress.ts
@@ -52,6 +52,19 @@ export function percentOf(progress: UploadProgress): number {
 }
 
 /**
+ * Whether two progresses would draw the same thing.
+ *
+ * `XMLHttpRequest` fires a progress event per chunk — dozens a second on a
+ * video — and each one used to `setState` on the screen that owns the feed's
+ * `FlatList`, re-rendering every visible post to move a label that shows whole
+ * percents and often had not changed at all. The label is the only reader, so
+ * this is what "changed" means to it.
+ */
+export function sameDisplayedProgress(a: UploadProgress, b: UploadProgress): boolean {
+  return a.phase === b.phase && percentOf(a) === percentOf(b)
+}
+
+/**
  * Which of a composer's attachments is in flight, and how far along.
  *
  * The feed uploads its files one at a time on submit — a batch percentage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -659,7 +659,12 @@ the first of `attachments` so that a binary predating the list shows a photo
 rather than an empty bubble, and everything reads through `attachmentsOf`.
 Nothing is migrated — dropping `media` is a change of its own. Video is stored
 exactly as uploaded: no transcoding, and no thumbnail file, because the player
-already holds the first frame. Size is capped when the upload
+already holds the first frame. Audio has exactly one exception, and it is the
+only thing this server converts: a voice note recorded in a browser is
+WebM/Opus, which no iPhone can decode at any level, so `normalizeAttachments`
+fetches it, runs ffmpeg over it and stores AAC in MP4 instead — before the
+insert, so the row is right the first time anything reads it. Everything else
+comes back as it went in, and a host without ffmpeg stores the original. Size is capped when the upload
 URL is _signed_ rather than after the bytes have been paid for, and
 `PLAN_LIMITS.mediaPer24h` caps the count on the free tier — a ceiling on abuse
 rather than a paywall, since v1 offered both free. Corrections stay uncapped

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2307,6 +2307,42 @@ keeps the JS thread alive in the background — the chat screen can be the
 focused route with nobody looking at it, and marking a message read there
 clears a badge for something never seen.
 
+## One unread number, three places, and the resync that only covered two
+
+The phone showed a dot on the icon, a `1` on the Chats tab and a `5` on the
+one conversation in the list, all at the same time and all from the same
+field: `conversations.unread[userId]`, which `countUnread` sums for
+`/me/unread` and for a push's `badge`. Nothing was counted twice — the three
+readers were simply refreshed on different paths, and one of them had a hole.
+
+The chat rows live under `['conversations']`, which `invalidateMissedEvents`
+refetches when the app comes back from the background. The tab badge and the
+icon read `['unread']`, which sits outside that prefix on purpose: the socket
+patches `['conversations']` with `setQueriesData` and the patcher walks
+`data.pages`, so a bare number under that prefix would be handed to it and
+throw. The consequence went unnoticed. The only things that invalidated
+`['unread']` were socket events, and a message that arrives while the phone is
+in the background is precisely _not_ one — it is a push. So the row came back
+correct, the badge kept the number it had when the app was last awake, and the
+icon kept whatever the push had written.
+
+The test that looked like it covered this listed `['conversations', 'unread']`
+among the keys it expected to go stale — a key nothing writes, since the
+filters are `all`/`unreplied`/`archived`. It passed for the same reason it was
+meaningless.
+
+So `invalidateMissedEvents` invalidates `['unread']` too, and the icon effect
+is keyed on `dataUpdatedAt` as well as the value: the icon has a second writer
+in the push payload, and a refetch that confirms the number it already held
+must still overwrite what that push left behind. A gap is a gap for all three.
+
+**And a read on one device is news on your other ones.** `conversation:read`
+went only to the other participant, where it means "they have seen it". The
+reader's own second device is holding a badge for messages that no longer
+count, and it has no way to know: it hears nothing, and the total is the
+server's to give. Both emitters now also publish to the reader's own room, and
+the client invalidates the badge when it arrives.
+
 ## The root overlays carry a paint order, not just a place in the tree
 
 The first iOS device test sent a message while the app sat on another tab and

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2817,6 +2817,62 @@ pictures — two recordings can, because that is the answer's two takes — sinc
 mixing kinds would make a message's type, and so its preview line and its
 notification, a coin toss between "photo" and "voice message".
 
+## The one thing this server converts: a browser's voice note
+
+A note recorded on the site did not play on an iPhone. The bubble showed `⋯`
+and never resolved — not the "this will not play" the app already had a string
+for, which made it look like a network problem rather than a file the phone
+could not open.
+
+Two faults, and they had been covering for each other.
+
+**The file really was unplayable.** `webRecordingType` prefers `audio/mp4`
+where a browser can produce it, and that preference had never once been
+reached: it labels what came _out_ of `MediaRecorder`, while what goes _in_ is
+`RecordingPresets.HIGH_QUALITY`, which names `audio/webm` for the web and which
+expo-audio passes straight through. So every browser note was Opus, honestly
+labelled and undecodable on iOS. `useVoiceRecorder` now asks for
+`audio/mp4;codecs=mp4a.40.2` where `isTypeSupported` says yes — Chrome from 126
+and every Safari — which is free and shortens the path.
+
+**And the bubble read a dead player as a loading one.** When AVFoundation fails
+an item it reports `isLoaded: false` _and_ `isBuffering: true`: its "am I
+buffering" test asks whether the item is neither likely to keep up nor holding
+a buffer, and a failed item is both. `audioProgress` read that as `'loading'`.
+It reads `playbackState === 'failed'` first now. The `'unsupported'` branch
+beside it was dead in a more embarrassing way — it asked the _server's_
+allowlist whether the platform could decode the type, and `audio/webm` is on
+that list precisely because a browser has no other output, so the one case the
+check existed for was the one case it answered wrong. `canDecodeAudio` takes
+the platform.
+
+**Firefox still records WebM, so the server converts.** `docs/architecture.md`
+says media is stored exactly as uploaded and that stays true of everything
+else; this is the exception, and it is affordable for the same reason video is
+not. A two-minute note is under a megabyte and an Opus→AAC pass is about a
+second of CPU, against a video's tens of megabytes and minutes.
+
+Synchronous, inside the send, rather than a job: a queue would need a claim
+across two Fly machines, a second socket event for chat, and something the feed
+does not have at all — there is no `post:*` event, so a post's note would stay
+wrong until its reader happened to refetch. Converting before the insert means
+the row is right the first time anything reads it, and the cost is latency
+inside the twelve seconds the client already waits for its ack. ffmpeg gets
+eight of them.
+
+It never fails a send. No ffmpeg, a timeout, bytes that cannot be read back:
+the original is stored, exactly as before any of this existed, and the bubble
+says what it now says correctly. That is the same bargain every optional
+service in `self-host.md` makes. The old original is deleted only _after_ the
+new object exists — a leaked file costs bytes, and the other order costs the
+note.
+
+`scripts/transcode-web-notes.ts` does the same to the rows already stored. It
+walks four collections in two shapes: `messages`, `posts` and `postCorrections`
+keep a list with the first file repeated in `media`, while a pronunciation
+answer keeps `media` and `slowMedia` as separate fields — which is also the
+page most likely to have been recorded in a browser in the first place.
+
 ## The row swipe runs on the UI thread, and Reanimated is the price
 
 Three comments in this repo argued against exactly this change —
@@ -2912,8 +2968,9 @@ that can be bypassed by omitting a field is not a ceiling.
 **mp4 and quicktime, not webm.** iOS has no VP8 or VP9 decoder at any level, so
 accepting webm would store files half the recipients cannot open with nothing
 anywhere saying why. `audio/webm` is accepted only because a browser's recorder
-has no other output; the video picker hands us whatever the camera wrote, so it
-has no such excuse. The same `preferredAssetRepresentationMode: Compatible`
+has no other output — and that turned out to be the same bug wearing the other
+hat, which the entry below is about; the video picker hands us whatever the
+camera wrote, so it has no such excuse. The same `preferredAssetRepresentationMode: Compatible`
 that fixed HEIC does the second half of this on iOS: it makes PhotoKit export
 an HEVC `.mov` as H.264, without which an iPhone-to-Android video is a black
 frame.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -17,7 +17,9 @@ means verification links and notification mail are printed to the log, no
 unsubscribe secret means those links are signed with the auth secret instead,
 no translation credentials means `/translate` returns a clear "not configured"
 error, no RevenueCat means everyone stays on the free tier, no push credentials
-means notifications are logged instead of sent. That is deliberate — a self-hoster should be able to
+means notifications are logged instead of sent, and no ffmpeg on the host means
+a voice note recorded in a browser is stored as recorded — WebM, which iPhones
+cannot play, and which the app then says it cannot play. That is deliberate — a self-hoster should be able to
 get a working instance before deciding which paid services they want.
 
 ## Quick start


### PR DESCRIPTION
Three things reported from the iPhone today, in one branch — each its own commit.

## A browser's voice note did not play on an iPhone (`dfe28d14`)

The bubble showed `⋯` forever. Two faults covering for each other:

- **The file was undecodable.** `webRecordingType` prefers `audio/mp4`, but it labels what came *out* of `MediaRecorder`; what goes *in* is `RecordingPresets.HIGH_QUALITY`, which names `audio/webm` for web and which expo-audio passes straight through. Every browser note was Opus. `useVoiceRecorder` now asks for `audio/mp4;codecs=mp4a.40.2` where the browser supports it.
- **The bubble read a dead player as a loading one.** A failed item reports `isLoaded: false` **and** `isBuffering: true` on iOS. `audioProgress` reads `playbackState === 'failed'` first now, and the `'unsupported'` branch — which asked the *server's* allowlist, where `audio/webm` naturally is — takes the platform.
- **Firefox still records WebM**, so the API transcodes to AAC before the insert (`modules/media/transcodeAudio`, ffmpeg in the Docker runtime stage). It never fails a send: no ffmpeg, a timeout or unreadable bytes store the original, as before.
- `scripts/transcode-web-notes.ts` converts what is already stored — dry run by default.

## The three unread counts disagreed (`434e0f86`)

Icon dot, tab `1`, row `5`, one field. `['unread']` sits outside the `['conversations']` prefix on purpose, so `invalidateMissedEvents` never reached it — and a message that arrives while the phone is backgrounded is a push, not a socket event. The icon effect is keyed on `dataUpdatedAt` too, since the push writes the icon itself. `conversation:read` now also reaches the reader's own other devices.

## Feed video and the upload label (`aae3b33e`)

Percentage only on the tile (tabular figures, badge hidden under the scrim); `pointerEvents="none"` on the preview surface so a single video opens; a ▶ while it is not playing; `videoMode="preview"` for corrections, which could not be opened at all; the fullscreen video loops.

## Verification
- `pnpm -r test` — 1793 pass (shared 266, mobile 625, api 902)
- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`
- Needs a deploy for the API half; the mobile half is JS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)