### PR TITLE
Judge a voice note by its bytes, because its label lies

### DIFF
--- a/apps/api/scripts/transcode-web-notes.ts
+++ b/apps/api/scripts/transcode-web-notes.ts
@@ -1,10 +1,11 @@
 /**
- * Converts the voice notes that were recorded in a browser before the server
- * started doing it on the way in.
+ * Converts the voice notes an iPhone cannot decode into ones it can.
  *
- * Those are WebM/Opus, which no iPhone can decode — the bubble showed a
- * spinner that never resolved, and after the client fix it says the note will
- * not play. This is what makes the ones already stored play instead.
+ * Those are WebM/Opus, and they are **not** reliably labelled as such: the note
+ * this was written for was stored as `audio/m4a`, under a `.m4a` key, with
+ * Opus inside, because an older web build labelled every recording `audio/m4a`
+ * whatever the browser had produced. So every voice note is fetched and judged
+ * on its bytes; the ones already playable are left exactly as they are.
  *
  * Four collections and two shapes: `messages`, `posts` and `postCorrections`
  * keep a list in `attachments` with the first file repeated in `media`, while
@@ -39,7 +40,15 @@ import {
 import { createStorageProvider } from '../src/storage/createStorageProvider'
 import { supportsPut } from '../src/storage/StorageProvider'
 
-const WEB_AUDIO = { $in: ['audio/webm', 'audio/ogg'] }
+/*
+ * Every voice note, not the ones labelled WebM — the label is exactly what
+ * cannot be trusted here. The first note this was written for said
+ * `audio/m4a`, sat under a `.m4a` key, and was Opus inside; an older web build
+ * labelled every recording `audio/m4a` whatever `MediaRecorder` produced. The
+ * normaliser fetches each file and decides on the bytes, and leaves anything
+ * already playable alone.
+ */
+const ANY_AUDIO = { $regex: '^audio/' }
 
 interface Summary {
   seen: number
@@ -63,7 +72,7 @@ async function convertLists(
 ): Promise<void> {
   const rows = await db
     .collection<Document>(collection)
-    .find({ 'attachments.contentType': WEB_AUDIO })
+    .find({ 'attachments.contentType': ANY_AUDIO })
     .limit(limit)
     .toArray()
 
@@ -77,7 +86,7 @@ async function convertLists(
     const converted = await normalize(attachments)
     if (converted.every((item, index) => item.url === attachments[index]?.url)) {
       summary.unchanged += 1
-      console.log(`  unchanged ${collection}/${String(row._id)} — see the log above for why`)
+      console.log(`  already playable ${collection}/${String(row._id)}`)
       continue
     }
     await db.collection<Document>(collection).updateOne(
@@ -102,7 +111,7 @@ async function convertAnswers(
 ): Promise<void> {
   const rows = await db
     .collection<Document>(COLLECTIONS.pronunciationAnswers)
-    .find({ $or: [{ 'media.contentType': WEB_AUDIO }, { 'slowMedia.contentType': WEB_AUDIO }] })
+    .find({ $or: [{ 'media.contentType': ANY_AUDIO }, { 'slowMedia.contentType': ANY_AUDIO }] })
     .limit(limit)
     .toArray()
 

--- a/apps/api/src/modules/media/transcodeAudio.test.ts
+++ b/apps/api/src/modules/media/transcodeAudio.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { Media } from '@langx/shared'
 import {
-  needsTranscode,
+  isUndecodableOnIos,
   normalizeAttachments,
   transcodedKey,
   type TranscodeDeps,
 } from './transcodeAudio'
 
 const BUCKET = 'https://cdn.example.com'
+/** EBML, which is what a browser's recording starts with. */
+const WEBM_BYTES = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 0x01, 0x02])
+/** An MP4 box header, which is what a phone's recording starts with. */
+const AAC_BYTES = new Uint8Array([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70])
 
 function webmNote(overrides: Partial<Media> = {}): Media {
   return {
@@ -26,7 +30,7 @@ function webmNote(overrides: Partial<Media> = {}): Media {
  */
 function deps(overrides: Partial<TranscodeDeps> = {}) {
   const spies = {
-    get: vi.fn(() => Promise.resolve(new Uint8Array([1, 2, 3]))),
+    get: vi.fn(() => Promise.resolve(WEBM_BYTES)),
     put: vi.fn((key: string) => Promise.resolve(`${BUCKET}/${key}`)),
     del: vi.fn(() => Promise.resolve()),
     transcode: vi.fn(() => Promise.resolve(new Uint8Array([9, 9]))),
@@ -42,18 +46,12 @@ function deps(overrides: Partial<TranscodeDeps> = {}) {
   return { deps: all, ...spies, ...overrides }
 }
 
-describe('needsTranscode', () => {
-  it('is the two containers a browser records and no iPhone decodes', () => {
-    expect(needsTranscode('audio/webm')).toBe(true)
-    expect(needsTranscode('audio/ogg')).toBe(true)
-    // With the codec parameter `MediaRecorder` likes to append.
-    expect(needsTranscode('audio/webm;codecs=opus')).toBe(true)
-  })
-
-  it('leaves what both phones already record alone', () => {
-    for (const type of ['audio/mp4', 'audio/m4a', 'audio/aac', 'audio/mpeg']) {
-      expect(needsTranscode(type), type).toBe(false)
-    }
+describe('isUndecodableOnIos', () => {
+  it('knows WebM and Ogg by their magic, and nothing else', () => {
+    expect(isUndecodableOnIos(WEBM_BYTES)).toBe(true)
+    expect(isUndecodableOnIos(new Uint8Array([0x4f, 0x67, 0x67, 0x53, 0x00]))).toBe(true)
+    expect(isUndecodableOnIos(AAC_BYTES)).toBe(false)
+    expect(isUndecodableOnIos(new Uint8Array())).toBe(false)
   })
 })
 
@@ -82,15 +80,40 @@ describe('normalizeAttachments', () => {
     expect(del).toHaveBeenCalledWith('messages/c1/a.webm')
   })
 
-  it('leaves everything else untouched, without fetching it', async () => {
-    const { deps: d, get } = deps()
+  /*
+   * The case the label check missed entirely: an older web build called every
+   * recording `audio/m4a` whatever the browser produced, so this is a `.m4a`
+   * key holding Opus — and it is the note that was reported.
+   */
+  it('converts a note whose label lies about what is inside it', async () => {
+    const { deps: d, put, del } = deps()
+    const mislabelled: Media = {
+      url: `${BUCKET}/messages/c1/a.m4a`,
+      contentType: 'audio/m4a',
+      sizeBytes: 2243,
+      durationSeconds: 3,
+    }
+
+    const [note] = await normalizeAttachments(d, [mislabelled])
+    expect(note?.contentType).toBe('audio/mp4')
+    expect(note?.url).toBe(`${BUCKET}/messages/c1/a.m4a`)
+    expect(put).toHaveBeenCalledWith('messages/c1/a.m4a', expect.anything(), 'audio/mp4')
+    // The converted file went to the key the original was under, so deleting
+    // "the original" would delete what was just written.
+    expect(del).not.toHaveBeenCalled()
+  })
+
+  it('leaves a real AAC note alone, and never fetches a picture', async () => {
+    const { deps: d, get, put } = deps({ get: vi.fn(() => Promise.resolve(AAC_BYTES)) })
     const items: Media[] = [
       { url: `${BUCKET}/messages/c1/a.m4a`, contentType: 'audio/mp4', sizeBytes: 1000 },
       { url: `${BUCKET}/messages/c1/a.jpg`, contentType: 'image/jpeg', sizeBytes: 2000 },
     ]
 
     expect(await normalizeAttachments(d, items)).toEqual(items)
-    expect(get).not.toHaveBeenCalled()
+    // Once, for the audio; never for the picture.
+    expect(get).toHaveBeenCalledTimes(1)
+    expect(put).not.toHaveBeenCalled()
   })
 
   // The whole bargain: a missing ffmpeg, a timeout or a file it cannot read

--- a/apps/api/src/modules/media/transcodeAudio.ts
+++ b/apps/api/src/modules/media/transcodeAudio.ts
@@ -34,8 +34,8 @@ import { supportsPut, type StorageProvider } from '../../storage/StorageProvider
  * rest of the optional services make — see `docs/self-host.md`.
  */
 
-/** What a browser records, and what no iPhone will decode. */
-const TRANSCODE_FROM = new Set(['audio/webm', 'audio/ogg'])
+/** Every audio type the upload endpoint signs, honest label or not. */
+const AUDIO_PREFIX = 'audio/'
 /** AAC in MP4: what both phones record natively, so one playback path serves all of it. */
 export const TRANSCODE_TO = 'audio/mp4'
 /**
@@ -45,8 +45,35 @@ export const TRANSCODE_TO = 'audio/mp4'
  */
 const TRANSCODE_TIMEOUT_MS = 8_000
 
-export function needsTranscode(contentType: string): boolean {
-  return TRANSCODE_FROM.has(contentType.split(';')[0]?.trim().toLowerCase() ?? '')
+/**
+ * Whether a file is worth looking inside, which is every voice note.
+ *
+ * The label is not enough, and the note that started this proves it: it was
+ * stored as `audio/m4a`, under a `.m4a` key, and the bytes were WebM. An older
+ * web build labelled every recording `audio/m4a` regardless of what
+ * `MediaRecorder` had produced, so the one attribute a reader could check was
+ * the one thing that had been guessed. A file that says `.m4a` and is Opus is
+ * exactly a bubble that will not play with nothing anywhere saying why.
+ *
+ * The cost is a GET per voice note — a hundred kilobytes or so, from a bucket
+ * in the next region, inside a send that already waits on a socket ack. A
+ * photo, a video and a note that turns out to be AAC are all untouched.
+ */
+function worthSniffing(contentType: string): boolean {
+  return contentType.split(';')[0]?.trim().toLowerCase().startsWith(AUDIO_PREFIX) ?? false
+}
+
+/**
+ * What the bytes actually are, for the two containers iOS cannot open.
+ *
+ * `1A 45 DF A3` is EBML, which is Matroska and therefore WebM; `OggS` is Ogg.
+ * Anything else — AAC in MP4, ADTS, MP3 — is left alone, so this says "no"
+ * for every honest file and does not have to recognise them.
+ */
+export function isUndecodableOnIos(bytes: Uint8Array): boolean {
+  const ebml = [0x1a, 0x45, 0xdf, 0xa3]
+  const ogg = [0x4f, 0x67, 0x67, 0x53]
+  return [ebml, ogg].some((magic) => magic.every((byte, index) => bytes[index] === byte))
 }
 
 /**
@@ -138,22 +165,37 @@ export async function normalizeAttachments(
 }
 
 async function normalizeOne(deps: TranscodeDeps, media: Media): Promise<Media> {
-  if (!needsTranscode(media.contentType)) return media
+  if (!worthSniffing(media.contentType)) return media
   const key = deps.keyOf(media.url)
   if (!key) return media
 
   try {
-    const converted = await deps.transcode(await deps.get(key))
+    const bytes = await deps.get(key)
+    // The label may say anything; this is what the phone will actually be
+    // handed. An honest `audio/mp4` and a mislabelled one both end here.
+    if (!isUndecodableOnIos(bytes)) return media
+
+    const converted = await deps.transcode(bytes)
     if (!converted) return media
 
-    const url = await deps.put(transcodedKey(key), converted, TRANSCODE_TO)
-    // Best-effort, and after the new object exists: a leaked original costs
-    // bytes, while deleting first and then failing to write costs the note.
-    // `deleteAttachment` swallows in the same way and for the same reason.
-    try {
-      await deps.del(key)
-    } catch (error) {
-      deps.warn(error, 'could not remove the original of a transcoded voice note')
+    const target = transcodedKey(key)
+    const url = await deps.put(target, converted, TRANSCODE_TO)
+
+    /*
+     * Only when the conversion landed somewhere else. A mislabelled note is
+     * already under a `.m4a` key, so the new object *is* the old one — and
+     * deleting it here would delete the file just written, which is the one
+     * way this could lose a message rather than merely fail to improve it.
+     */
+    if (target !== key) {
+      // Best-effort, and after the new object exists: a leaked original costs
+      // bytes, while deleting first and then failing to write costs the note.
+      // `deleteAttachment` swallows in the same way and for the same reason.
+      try {
+        await deps.del(key)
+      } catch (error) {
+        deps.warn(error, 'could not remove the original of a transcoded voice note')
+      }
     }
 
     return { ...media, url, contentType: TRANSCODE_TO, sizeBytes: converted.byteLength }

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2846,6 +2846,19 @@ that list precisely because a browser has no other output, so the one case the
 check existed for was the one case it answered wrong. `canDecodeAudio` takes
 the platform.
 
+**And the label was not even true.** The note that started this was stored as
+`audio/m4a`, under a `.m4a` key, with WebM/Opus inside — 2,243 bytes for three
+seconds, which is not a bitrate AAC has. An older web build labelled every
+recording `audio/m4a` whatever `MediaRecorder` had produced, so the one
+attribute anything downstream could check was the one that had been guessed. A
+conversion keyed on `contentType` would have walked straight past it, and the
+first run of the backfill found nothing at all. So the server fetches every
+voice note and decides on its first four bytes — EBML or `OggS` — which also
+means it never has to recognise the formats that are fine. The converted file
+then lands on the key it came from, and the delete-the-original step is skipped
+when that is the same key, because otherwise it would delete what was just
+written.
+
 **Firefox still records WebM, so the server converts.** `docs/architecture.md`
 says media is stored exactly as uploaded and that stays true of everything
 else; this is the exception, and it is affordable for the same reason video is


### PR DESCRIPTION
Follow-up to #1123, found by running the backfill against production: it reported **zero** rows to convert, while the note that started this was sitting in the thread.

It is stored as `contentType: 'audio/m4a'`, under a `.m4a` key, 2,243 bytes for three seconds — and the bytes are WebM/Opus:

```
00000000: 1a45 dfa3 ... 4282 8477 6562 6d   .E.........webm
$ ffprobe → codec_name=opus, format_name=matroska,webm
```

An older web build labelled every recording `audio/m4a` regardless of what `MediaRecorder` produced, so the one attribute anything downstream could check was the one that had been guessed.

- Every voice note is now fetched and judged on its first four bytes (EBML / `OggS`). It never has to recognise the containers that are fine.
- A photo or video is untouched; an honest AAC note costs one GET.
- The delete-the-original step is skipped when the conversion lands on the key it came from — which a mislabelled note always does. Without it, this would delete the file it had just written.

## Verification
- `pnpm --filter @langx/api test` — 902 pass, including a case for a `.m4a` key holding Opus
- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)