### PR TITLE
Time the launch and every route, and keep the identifiers out of it

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/chats.tsx
+++ b/apps/mobile/app/(app)/(tabs)/chats.tsx
@@ -37,6 +37,7 @@ import { relativeTimeCompact } from '../../../src/lib/format'
 import { useLocale, useT } from '../../../src/i18n'
 import type { MessageKey } from '../../../src/i18n/runtime'
 import { usePullToRefresh } from '../../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 /** v3 draws chat avatars at 52, one step up from the 48 default. */
 const AVATAR_SIZE = 52
@@ -49,6 +50,7 @@ const EMPTY_COPY: Record<ConversationFilter, { title: MessageKey; body: MessageK
 }
 
 export default function ChatsScreen() {
+  useScreenInteractive()
   const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()

--- a/apps/mobile/app/(app)/(tabs)/discover.tsx
+++ b/apps/mobile/app/(app)/(tabs)/discover.tsx
@@ -49,6 +49,7 @@ import { listState } from '../../../src/lib/listState'
 import { makeStyles, useTheme } from '../../../src/lib/theme'
 import { useDisplayNames, useT, type MessageKey } from '../../../src/i18n'
 import { usePullToRefresh } from '../../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 const SORTS: { key: DiscoverySort; label: MessageKey }[] = [
   { key: 'recommended', label: 'discover.forYou' },
@@ -77,6 +78,7 @@ function LanguageLine({ item }: { item: DiscoveryItem }) {
 }
 
 export default function DiscoverScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const { colors } = useTheme()
   const t = useT()

--- a/apps/mobile/app/(app)/(tabs)/feed.tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed.tsx
@@ -56,6 +56,7 @@ import { confirmAlert } from '../../../src/lib/alert'
 import { showToast } from '../../../src/lib/toast'
 import { relativeTime } from '../../../src/lib/format'
 import { usePullToRefresh } from '../../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 /**
  * The two halves of the feed. A `Record` keyed on `PostKind` rather than a list
@@ -138,6 +139,7 @@ function ComposerLabel({
 }
 
 export default function FeedScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const names = useDisplayNames()

--- a/apps/mobile/app/(app)/(tabs)/me.tsx
+++ b/apps/mobile/app/(app)/(tabs)/me.tsx
@@ -36,8 +36,10 @@ import { openPaywall } from '../../../src/lib/paywall'
 import { makeStyles, useTheme } from '../../../src/lib/theme'
 import { useDisplayNames, useT } from '../../../src/i18n'
 import { usePullToRefresh } from '../../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 export default function MeScreen() {
+  useScreenInteractive()
   const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()

--- a/apps/mobile/app/(app)/app-language.tsx
+++ b/apps/mobile/app/(app)/app-language.tsx
@@ -7,6 +7,7 @@ import { Screen } from '../../src/components/ui/Screen'
 import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
 import { goBackTo } from '../../src/lib/navigation'
 import { useTheme } from '../../src/lib/theme'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * `auto` leads because it is what almost everyone wants and what nobody has to
@@ -28,6 +29,7 @@ const LOCALE_OPTIONS = ['auto', ...SUPPORTED_LOCALES] as const
  * change language when somebody else signs in. See `I18nProvider`.
  */
 export default function AppLanguageScreen() {
+  useScreenInteractive()
   const t = useT()
   const { colors } = useTheme()
   const { preference, setPreference, deviceLocale } = useLocalePreference()

--- a/apps/mobile/app/(app)/badges.tsx
+++ b/apps/mobile/app/(app)/badges.tsx
@@ -10,6 +10,7 @@ import { badgeShareText } from '../../src/lib/shareText'
 import { makeStyles } from '../../src/lib/theme'
 import { badgeLabel, useLocale, useT } from '../../src/i18n'
 import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Badges, and what the next one takes.
@@ -21,6 +22,7 @@ import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
  * to the wallet, streaks to the streak page — and this one scrolls.
  */
 export default function BadgesScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const { locale } = useLocale()

--- a/apps/mobile/app/(app)/blocked.tsx
+++ b/apps/mobile/app/(app)/blocked.tsx
@@ -12,6 +12,7 @@ import { showToast } from '../../src/lib/toast'
 import { makeStyles } from '../../src/lib/theme'
 import { useLocale, useT } from '../../src/i18n'
 import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Blocking is one tap from a profile; unblocking has to live somewhere, and it
@@ -19,6 +20,7 @@ import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
  * Without this screen a block is irreversible in practice.
  */
 export default function BlockedScreen() {
+  useScreenInteractive()
   const styles = useStyles()
 
   const blocks = useBlocks()

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -93,8 +93,10 @@ import { dayLabel, messageRows, type MessageRow } from '../../../src/lib/message
 import { useLocale, useT, type MessageKey } from '../../../src/i18n'
 import { planJump } from '../../../src/lib/messageJump'
 import { makeStyles, useTheme } from '../../../src/lib/theme'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 export default function ChatScreen() {
+  useScreenInteractive()
   const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()

--- a/apps/mobile/app/(app)/corrections.tsx
+++ b/apps/mobile/app/(app)/corrections.tsx
@@ -16,6 +16,7 @@ import { dayLabel } from '../../src/lib/messageGroups'
 import { goBackTo, openPost } from '../../src/lib/navigation'
 import { listState } from '../../src/lib/listState'
 import { makeStyles } from '../../src/lib/theme'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * What you have written: your corrections, and your own posts.
@@ -37,6 +38,7 @@ import { makeStyles } from '../../src/lib/theme'
  * disagreeing with the tile.
  */
 export default function WritingScreen() {
+  useScreenInteractive()
   const t = useT()
   const { locale } = useLocale()
   const styles = useStyles()

--- a/apps/mobile/app/(app)/edit-profile.tsx
+++ b/apps/mobile/app/(app)/edit-profile.tsx
@@ -38,6 +38,7 @@ import { pickImageAsset } from '../../src/lib/pickMediaAsset'
 import { showToast } from '../../src/lib/toast'
 import { makeStyles } from '../../src/lib/theme'
 import { genderLabel, interestLabel, levelShortLabel, useDisplayNames, useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Splitting the form out of the loading state is not cosmetic.
@@ -56,6 +57,7 @@ import { genderLabel, interestLabel, levelShortLabel, useDisplayNames, useT } fr
 const DISCLOSABLE_GENDERS = ['female', 'male', 'other'] as const
 
 export default function EditProfileScreen() {
+  useScreenInteractive()
   const styles = useStyles()
 
   const me = useMe()

--- a/apps/mobile/app/(app)/filters.tsx
+++ b/apps/mobile/app/(app)/filters.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../src/lib/discoveryFilters'
 import { makeStyles, useTheme } from '../../src/lib/theme'
 import { genderLabel, levelShortLabel, useDisplayNames, useLocale, useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /** Explicit `undefined` means "clear this filter" — see `set` below. */
 type FilterPatch = { [K in keyof DiscoveryFilters]?: DiscoveryFilters[K] | undefined }
@@ -57,6 +58,7 @@ function SectionTitle({ title, locked }: { title: string; locked?: boolean }) {
 }
 
 export default function FiltersScreen() {
+  useScreenInteractive()
   const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()

--- a/apps/mobile/app/(app)/follows.tsx
+++ b/apps/mobile/app/(app)/follows.tsx
@@ -12,6 +12,7 @@ import { goBackTo, openProfile } from '../../src/lib/navigation'
 import { makeStyles } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
 import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 type Tab = 'followers' | 'following'
 
@@ -23,6 +24,7 @@ type Tab = 'followers' | 'following'
  * for a URL nobody types.
  */
 export default function FollowsScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const { userId, tab, from } = useLocalSearchParams<{ userId: string; tab?: Tab; from?: string }>()

--- a/apps/mobile/app/(app)/intro.tsx
+++ b/apps/mobile/app/(app)/intro.tsx
@@ -1,6 +1,7 @@
 import { router } from 'expo-router'
 import { IntroCarousel } from '../../src/components/IntroCarousel'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Settings' "Show intro again", as a screen inside the signed-in group.
@@ -20,6 +21,7 @@ import { useT } from '../../src/i18n'
  * place that can reach here, so it is also where finishing belongs.
  */
 export default function IntroReplayScreen() {
+  useScreenInteractive()
   const t = useT()
 
   return (

--- a/apps/mobile/app/(app)/invite.tsx
+++ b/apps/mobile/app/(app)/invite.tsx
@@ -15,6 +15,7 @@ import { showAlert } from '../../src/lib/alert'
 import { goBackTo } from '../../src/lib/navigation'
 import { shareLink } from '../../src/lib/share'
 import { makeStyles } from '../../src/lib/theme'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 const RULES = TOKEN_RULES.referral
 
@@ -32,6 +33,7 @@ const RULES = TOKEN_RULES.referral
  * second copy to keep in step for no gain.
  */
 export default function InviteScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const { locale } = useLocale()

--- a/apps/mobile/app/(app)/kitchen.tsx
+++ b/apps/mobile/app/(app)/kitchen.tsx
@@ -17,6 +17,7 @@ import { goBackTo } from '../../src/lib/navigation'
 import { openExternal } from '../../src/lib/openExternal'
 import { makeStyles, useTheme } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Our Kitchen — where the project is made, and everything around it: the people
@@ -28,6 +29,7 @@ import { useT } from '../../src/i18n'
  * every row goes through the in-app browser rather than switching away.
  */
 export default function KitchenScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const { colors } = useTheme()
   const t = useT()

--- a/apps/mobile/app/(app)/legal.tsx
+++ b/apps/mobile/app/(app)/legal.tsx
@@ -6,6 +6,7 @@ import { useT } from '../../src/i18n'
 import { LEGAL_LINKS } from '../../src/lib/externalLinks'
 import { goBackTo } from '../../src/lib/navigation'
 import { openExternal } from '../../src/lib/openExternal'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * The legal links, on their own screen.
@@ -15,6 +16,7 @@ import { openExternal } from '../../src/lib/openExternal'
  * the way, and one row that says what is behind it is as findable as five.
  */
 export default function LegalScreen() {
+  useScreenInteractive()
   const t = useT()
 
   return (

--- a/apps/mobile/app/(app)/likes.tsx
+++ b/apps/mobile/app/(app)/likes.tsx
@@ -11,6 +11,7 @@ import { goBackTo, openProfile } from '../../src/lib/navigation'
 import { makeStyles } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
 import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Who liked one post or one correction.
@@ -23,6 +24,7 @@ import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
  * contradiction on screen; counting the rows removes it.
  */
 export default function LikesScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const { targetType, targetId, from } = useLocalSearchParams<{

--- a/apps/mobile/app/(app)/link-device.tsx
+++ b/apps/mobile/app/(app)/link-device.tsx
@@ -13,6 +13,7 @@ import { sessionLabel } from '../../src/lib/sessionLabel'
 import { makeStyles, useTheme } from '../../src/lib/theme'
 import { showToast } from '../../src/lib/toast'
 import { useLocale, useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Approve a sign-in somewhere else.
@@ -28,6 +29,7 @@ import { useLocale, useT } from '../../src/i18n'
  * button rather than a silent redirect after a scan.
  */
 export default function LinkDeviceScreen() {
+  useScreenInteractive()
   /*
    * Two names for one thing, and both are read. Better Auth's own
    * `verification_uri_complete` uses `user_code`; `code` is what a hand-typed

--- a/apps/mobile/app/(app)/paywall.tsx
+++ b/apps/mobile/app/(app)/paywall.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../src/lib/purchases'
 import { makeStyles, useTheme } from '../../src/lib/theme'
 import { useT, type MessageKey } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Both dated 7 June 2024 and, per `architecture.md:101`, **still missing the
@@ -177,6 +178,7 @@ function parseFeature(raw: string | undefined): PlanFeature | null {
 }
 
 export default function PaywallScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
 

--- a/apps/mobile/app/(app)/post/[id].tsx
+++ b/apps/mobile/app/(app)/post/[id].tsx
@@ -48,6 +48,7 @@ import {
   UPLOAD_START,
   type UploadProgress,
 } from '../../../src/lib/uploadProgress'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 /** The folded diff line — same drawing as the feed's top-correction panel. */
 function CorrectedLine({ original, corrected }: { original: string; corrected: string }) {
@@ -77,6 +78,7 @@ function CorrectedLine({ original, corrected }: { original: string; corrected: s
  * rest live, and until it existed the card's "See all N" was a label on nothing.
  */
 export default function PostScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const { colors } = useTheme()
   const t = useT()

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -43,8 +43,10 @@ import {
   useDisplayNames,
   useT,
 } from '../../../src/i18n'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 export default function ProfileScreen() {
+  useScreenInteractive()
   const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()

--- a/apps/mobile/app/(app)/settings/about.tsx
+++ b/apps/mobile/app/(app)/settings/about.tsx
@@ -1,5 +1,7 @@
 import { SettingsSectionPage } from '../../../src/components/settings/SettingsSectionPage'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 export default function AboutSettingsScreen() {
+  useScreenInteractive()
   return <SettingsSectionPage id="about" />
 }

--- a/apps/mobile/app/(app)/settings/account.tsx
+++ b/apps/mobile/app/(app)/settings/account.tsx
@@ -1,5 +1,7 @@
 import { SettingsSectionPage } from '../../../src/components/settings/SettingsSectionPage'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 export default function AccountSettingsScreen() {
+  useScreenInteractive()
   return <SettingsSectionPage id="account" />
 }

--- a/apps/mobile/app/(app)/settings/appearance.tsx
+++ b/apps/mobile/app/(app)/settings/appearance.tsx
@@ -1,5 +1,7 @@
 import { SettingsSectionPage } from '../../../src/components/settings/SettingsSectionPage'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 export default function AppearanceSettingsScreen() {
+  useScreenInteractive()
   return <SettingsSectionPage id="appearance" />
 }

--- a/apps/mobile/app/(app)/settings/delete-account.tsx
+++ b/apps/mobile/app/(app)/settings/delete-account.tsx
@@ -16,6 +16,7 @@ import { FLAG_KEYS, readBoolFlag } from '../../../src/lib/localFlags'
 import { goBackTo } from '../../../src/lib/navigation'
 import { makeStyles, useTheme } from '../../../src/lib/theme'
 import { showToast } from '../../../src/lib/toast'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 /**
  * The front door to deleting an account, which used to be one tap behind a
@@ -36,6 +37,7 @@ import { showToast } from '../../../src/lib/toast'
  * apply and the promise in `docs/legal/promise-change.md` stays true.
  */
 export default function DeleteAccountScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const { colors } = useTheme()
   const t = useT()

--- a/apps/mobile/app/(app)/settings/index.tsx
+++ b/apps/mobile/app/(app)/settings/index.tsx
@@ -12,6 +12,7 @@ import { useT } from '../../../src/i18n'
 import { goBackTo } from '../../../src/lib/navigation'
 import { matchSettings, SETTINGS_SECTIONS } from '../../../src/lib/settingsRegistry'
 import { makeStyles, useTheme } from '../../../src/lib/theme'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 /**
  * Settings, as categories.
@@ -26,6 +27,7 @@ import { makeStyles, useTheme } from '../../../src/lib/theme'
  * in a hurry.
  */
 export default function SettingsScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const { colors } = useTheme()

--- a/apps/mobile/app/(app)/settings/notifications.tsx
+++ b/apps/mobile/app/(app)/settings/notifications.tsx
@@ -1,5 +1,7 @@
 import { SettingsSectionPage } from '../../../src/components/settings/SettingsSectionPage'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 export default function NotificationsSettingsScreen() {
+  useScreenInteractive()
   return <SettingsSectionPage id="notifications" />
 }

--- a/apps/mobile/app/(app)/settings/plan.tsx
+++ b/apps/mobile/app/(app)/settings/plan.tsx
@@ -1,5 +1,7 @@
 import { SettingsSectionPage } from '../../../src/components/settings/SettingsSectionPage'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 export default function PlanSettingsScreen() {
+  useScreenInteractive()
   return <SettingsSectionPage id="plan" />
 }

--- a/apps/mobile/app/(app)/settings/privacy.tsx
+++ b/apps/mobile/app/(app)/settings/privacy.tsx
@@ -1,5 +1,7 @@
 import { SettingsSectionPage } from '../../../src/components/settings/SettingsSectionPage'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 
 export default function PrivacySettingsScreen() {
+  useScreenInteractive()
   return <SettingsSectionPage id="privacy" />
 }

--- a/apps/mobile/app/(app)/share-profile.tsx
+++ b/apps/mobile/app/(app)/share-profile.tsx
@@ -13,6 +13,7 @@ import { goBackTo } from '../../src/lib/navigation'
 import { shareLink } from '../../src/lib/share'
 import { makeStyles } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * The link, big enough to point a camera at.
@@ -28,6 +29,7 @@ import { useT } from '../../src/i18n'
  * OTA update, for a picture.
  */
 export default function ShareProfileScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const me = useMe()

--- a/apps/mobile/app/(app)/starred.tsx
+++ b/apps/mobile/app/(app)/starred.tsx
@@ -8,6 +8,7 @@ import { dayLabel } from '../../src/lib/messageGroups'
 import { useLocale, useT } from '../../src/i18n'
 import { goBackTo } from '../../src/lib/navigation'
 import { makeStyles, useTheme } from '../../src/lib/theme'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Every starred message, newest first, across every conversation.
@@ -18,6 +19,7 @@ import { makeStyles, useTheme } from '../../src/lib/theme'
  * quote uses; the star does not copy the message, it points at it.
  */
 export default function StarredScreen() {
+  useScreenInteractive()
   const { colors } = useTheme()
   const styles = useStyles()
   const starred = useStarred()

--- a/apps/mobile/app/(app)/streak.tsx
+++ b/apps/mobile/app/(app)/streak.tsx
@@ -17,6 +17,7 @@ import { shareLink } from '../../src/lib/share'
 import { streakShareText } from '../../src/lib/shareText'
 import { streakHistory, type StreakHistoryRow } from '../../src/lib/streakHistory'
 import { makeStyles, useTheme } from '../../src/lib/theme'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 const STREAK_TABS: readonly StreakMetric[] = STREAK_METRICS
 
@@ -32,6 +33,7 @@ const DAYS = 60
  * a calendar and a list are not substitutes for one another.
  */
 export default function StreakScreen() {
+  useScreenInteractive()
   const t = useT()
   const { locale } = useLocale()
   const styles = useStyles()

--- a/apps/mobile/app/(app)/tokens.tsx
+++ b/apps/mobile/app/(app)/tokens.tsx
@@ -14,6 +14,7 @@ import { dayLabel } from '../../src/lib/messageGroups'
 import { makeStyles, useTheme } from '../../src/lib/theme'
 import { useLocale, useT } from '../../src/i18n'
 import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Where the tokens came from: the totals, the pool, and the ledger a day at a
@@ -24,6 +25,7 @@ import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
  * day — so the thing you can act on was below the thing you can only read.
  */
 export default function TokensScreen() {
+  useScreenInteractive()
   const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()

--- a/apps/mobile/app/(app)/viewers.tsx
+++ b/apps/mobile/app/(app)/viewers.tsx
@@ -11,8 +11,10 @@ import { openPaywall } from '../../src/lib/paywall'
 import { makeStyles } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
 import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 export default function ViewersScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
 

--- a/apps/mobile/app/(app)/wallet.tsx
+++ b/apps/mobile/app/(app)/wallet.tsx
@@ -30,6 +30,7 @@ import { makeStyles, useTheme } from '../../src/lib/theme'
 import { periodLabel, useLocale, useT } from '../../src/i18n'
 import { leaderboardShareText } from '../../src/lib/shareText'
 import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * The wallet: what you have, and what it buys.
@@ -48,6 +49,7 @@ import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
 const PERIOD_TABS: readonly PeriodType[] = ['week', 'month', 'year', 'all']
 
 export default function WalletScreen() {
+  useScreenInteractive()
   const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()

--- a/apps/mobile/app/(auth)/check-email.tsx
+++ b/apps/mobile/app/(auth)/check-email.tsx
@@ -6,8 +6,10 @@ import { makeStyles } from '../../src/lib/theme'
 import { Button } from '../../src/components/ui/Button'
 import { authClient } from '../../src/lib/auth-client'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 export default function CheckEmail() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const { email } = useLocalSearchParams<{ email: string }>()

--- a/apps/mobile/app/(auth)/forgot-password.tsx
+++ b/apps/mobile/app/(auth)/forgot-password.tsx
@@ -7,8 +7,10 @@ import { Button } from '../../src/components/ui/Button'
 import { FormField } from '../../src/components/ui/FormField'
 import { authClient } from '../../src/lib/auth-client'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 export default function ForgotPassword() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const [email, setEmail] = useState('')

--- a/apps/mobile/app/(auth)/intro.tsx
+++ b/apps/mobile/app/(auth)/intro.tsx
@@ -1,6 +1,7 @@
 import { router } from 'expo-router'
 import { IntroCarousel } from '../../src/components/IntroCarousel'
 import { FLAG_KEYS, setBoolFlag } from '../../src/lib/localFlags'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * The intro as the signed-out entry point plays it: once, before sign-in.
@@ -12,6 +13,7 @@ import { FLAG_KEYS, setBoolFlag } from '../../src/lib/localFlags'
  * there is one `index`, in `app/`.
  */
 export default function IntroScreen() {
+  useScreenInteractive()
   function finish(): void {
     // Not awaited: the flag is a convenience and a slow write must not hold the
     // user on a screen they have asked to leave. If it fails they see the intro

--- a/apps/mobile/app/(auth)/qr.tsx
+++ b/apps/mobile/app/(auth)/qr.tsx
@@ -10,6 +10,7 @@ import { API_URL } from '../../src/lib/apiUrl'
 import { authClient } from '../../src/lib/auth-client'
 import { makeStyles } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Sign in here by approving it on a phone that is already signed in.
@@ -23,6 +24,7 @@ import { useT } from '../../src/i18n'
  * — a native module, so a new binary — and this ships over the air.
  */
 export default function QrSignInScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const [state, setState] = useState<'starting' | 'waiting' | 'expired' | 'error'>('starting')

--- a/apps/mobile/app/(auth)/reset-password.tsx
+++ b/apps/mobile/app/(auth)/reset-password.tsx
@@ -12,6 +12,7 @@ import {
   passwordPairReady,
 } from '../../src/lib/passwordForm'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Reached via the email link's redirect: the server validates the token
@@ -19,6 +20,7 @@ import { useT } from '../../src/i18n'
  * See api/routes/password.mjs's `requestPasswordReset`.
  */
 export default function ResetPassword() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const { token, error: linkError } = useLocalSearchParams<{ token?: string; error?: string }>()

--- a/apps/mobile/app/(auth)/sign-in.tsx
+++ b/apps/mobile/app/(auth)/sign-in.tsx
@@ -11,8 +11,10 @@ import { isNativeAppleSignInAvailable, requestAppleIdentity } from '../../src/li
 import { authClient } from '../../src/lib/auth-client'
 import { authErrorKey, oauthReturnErrorKey } from '../../src/lib/errors'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 export default function SignIn() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const { start: browse } = useGuestBrowse()

--- a/apps/mobile/app/(auth)/sign-up.tsx
+++ b/apps/mobile/app/(auth)/sign-up.tsx
@@ -18,6 +18,7 @@ import {
   passwordPairReady,
 } from '../../src/lib/passwordForm'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Pulled from the same table Settings renders, so a URL that moves moves here
@@ -28,6 +29,7 @@ const TERMS_LINK = LEGAL_LINKS.find((link) => link.labelKey === 'legal.terms')!
 const PRIVACY_LINK = LEGAL_LINKS.find((link) => link.labelKey === 'legal.privacy')!
 
 export default function SignUp() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const [name, setName] = useState('')

--- a/apps/mobile/app/(auth)/verify-email-success.tsx
+++ b/apps/mobile/app/(auth)/verify-email-success.tsx
@@ -2,6 +2,7 @@ import { Link, useLocalSearchParams } from 'expo-router'
 import { Text, View } from 'react-native'
 import { makeStyles } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Landing screen after tapping the emailed verification link.
@@ -15,6 +16,7 @@ import { useT } from '../../src/i18n'
  * them at sign-in rather than leaving them on a bare browser tab.
  */
 export default function VerifyEmailSuccess() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
   const { error } = useLocalSearchParams<{ error?: string }>()

--- a/apps/mobile/app/(auth)/welcome.tsx
+++ b/apps/mobile/app/(auth)/welcome.tsx
@@ -5,6 +5,7 @@ import { Screen } from '../../src/components/ui/Screen'
 import { useGuestBrowse } from '../../src/hooks/useGuestBrowse'
 import { useT } from '../../src/i18n'
 import { makeStyles } from '../../src/lib/theme'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * The first thing somebody sees, once the intro has played.
@@ -17,6 +18,7 @@ import { makeStyles } from '../../src/lib/theme'
  * nothing.
  */
 export default function WelcomeScreen() {
+  useScreenInteractive()
   const t = useT()
   const styles = useStyles()
   const { start: browse, starting } = useGuestBrowse()

--- a/apps/mobile/app/(onboarding)/about-you.tsx
+++ b/apps/mobile/app/(onboarding)/about-you.tsx
@@ -9,8 +9,10 @@ import { Screen } from '../../src/components/ui/Screen'
 import { updateDraft, useOnboardingDraft } from '../../src/hooks/useOnboardingDraft'
 import { makeStyles } from '../../src/lib/theme'
 import { genderLabel, useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 export default function AboutYouStep() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
 

--- a/apps/mobile/app/(onboarding)/done.tsx
+++ b/apps/mobile/app/(onboarding)/done.tsx
@@ -6,6 +6,7 @@ import { Button } from '../../src/components/ui/Button'
 import { Screen } from '../../src/components/ui/Screen'
 import { makeStyles } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * The end of the wizard, and three things at once: the moment of arrival, the
@@ -22,6 +23,7 @@ import { useT } from '../../src/i18n'
  * short of full would say otherwise.
  */
 export default function DoneStep() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
 

--- a/apps/mobile/app/(onboarding)/handle.tsx
+++ b/apps/mobile/app/(onboarding)/handle.tsx
@@ -20,6 +20,7 @@ import { track } from '../../src/lib/analytics'
 import { normalizeInviteCode } from '../../src/lib/inviteLink'
 import { makeStyles } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 function useDebounced<T>(value: T, delay = 400): T {
   const [debounced, setDebounced] = useState(value)
@@ -39,6 +40,7 @@ function useDebounced<T>(value: T, delay = 400): T {
  * user having to remember what it was.
  */
 export default function HandleStep() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
 

--- a/apps/mobile/app/(onboarding)/languages.tsx
+++ b/apps/mobile/app/(onboarding)/languages.tsx
@@ -13,6 +13,7 @@ import { SegmentedControl } from '../../src/components/ui/SegmentedControl'
 import { updateDraft, useOnboardingDraft } from '../../src/hooks/useOnboardingDraft'
 import { makeStyles } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 type LanguageTab = 'native' | 'learning'
 
@@ -26,6 +27,7 @@ type LanguageTab = 'native' | 'learning'
  * Levels stay on their own step — they only exist because of this one.
  */
 export default function LanguagesStep() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
 

--- a/apps/mobile/app/(onboarding)/levels.tsx
+++ b/apps/mobile/app/(onboarding)/levels.tsx
@@ -16,6 +16,7 @@ import { Screen } from '../../src/components/ui/Screen'
 import { updateDraft, useOnboardingDraft } from '../../src/hooks/useOnboardingDraft'
 import { makeStyles, useTheme } from '../../src/lib/theme'
 import { levelShortLabel, useDisplayNames, useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Step 2 of 5: how far along you are in each learning language.
@@ -27,6 +28,7 @@ import { levelShortLabel, useDisplayNames, useT } from '../../src/i18n'
  * that quietly decides who finds them.
  */
 export default function LevelsStep() {
+  useScreenInteractive()
   const styles = useStyles()
   const { colors } = useTheme()
   const t = useT()

--- a/apps/mobile/app/(onboarding)/photo.tsx
+++ b/apps/mobile/app/(onboarding)/photo.tsx
@@ -13,6 +13,7 @@ import { showAlert } from '../../src/lib/alert'
 import { pickImageAsset } from '../../src/lib/pickMediaAsset'
 import { makeStyles } from '../../src/lib/theme'
 import { interestLabel, useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
  * Step 4 of 5, and both halves of it are skippable.
@@ -29,6 +30,7 @@ import { interestLabel, useT } from '../../src/i18n'
  * draft and `POST /profiles` writes it, running the same bucket check.
  */
 export default function PhotoStep() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
 

--- a/apps/mobile/app/(onboarding)/welcome-back.tsx
+++ b/apps/mobile/app/(onboarding)/welcome-back.tsx
@@ -11,6 +11,7 @@ import { Button } from '../../src/components/ui/Button'
 import { Screen } from '../../src/components/ui/Screen'
 import { makeStyles } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 function Line({
   icon,
@@ -52,6 +53,7 @@ function Line({
  * are the whole argument for having migrated anything at all.
  */
 export default function WelcomeBackScreen() {
+  useScreenInteractive()
   const styles = useStyles()
   const t = useT()
 

--- a/apps/mobile/app/[username].tsx
+++ b/apps/mobile/app/[username].tsx
@@ -21,6 +21,7 @@ import { FLAG_KEYS, writeFlag } from '../src/lib/localFlags'
 import { openExternal } from '../src/lib/openExternal'
 import { makeStyles } from '../src/lib/theme'
 import { useDisplayNames, useT } from '../src/i18n'
+import { useScreenInteractive } from '../src/hooks/useScreenInteractive'
 
 /**
  * `/<handle>` — the address somebody shares for their own profile.
@@ -41,6 +42,7 @@ import { useDisplayNames, useT } from '../src/i18n'
  * to a screen instead of to them.
  */
 export default function SharedProfileScreen() {
+  useScreenInteractive()
   const params = useLocalSearchParams<{ username: string; invite?: string }>()
   const handle = (params.username ?? '').toLowerCase()
   /*

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -9,6 +9,7 @@
 import { Nunito_700Bold } from '@expo-google-fonts/nunito/700Bold'
 import { Nunito_800ExtraBold } from '@expo-google-fonts/nunito/800ExtraBold'
 import { useFonts } from 'expo-font'
+import { ObserveRoot } from 'expo-observe'
 import * as SplashScreen from 'expo-splash-screen'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Stack } from 'expo-router'
@@ -32,6 +33,7 @@ import { shouldGateGuest } from '../src/lib/guestGate'
 import { forgetPurchasesIdentity, identifyForPurchases } from '../src/lib/purchases'
 import { forgetAnalyticsIdentity, identifyForAnalytics, startAnalytics } from '../src/lib/analytics'
 import { ensurePlaybackAudioMode } from '../src/lib/audioSession'
+import { configureObserve } from '../src/lib/observe'
 import { useScreenTracking } from '../src/hooks/useScreenTracking'
 import { isAccountSwitch } from '../src/lib/sessionSwitch'
 import { ThemeProvider, useTheme } from '../src/lib/theme'
@@ -56,6 +58,13 @@ const BOOT_STALL_MS = 10_000
  */
 void SplashScreen.preventAutoHideAsync().catch(() => undefined)
 
+/*
+ * Module scope, and it has to be: the `expo-router` integration is read once
+ * when `ObserveRoot`'s provider mounts and throws if the answer changes after
+ * that, so there is no effect early enough to do this in.
+ */
+configureObserve()
+
 function createQueryClient(): QueryClient {
   return new QueryClient({
     defaultOptions: {
@@ -72,7 +81,7 @@ function createQueryClient(): QueryClient {
   })
 }
 
-export default function RootLayout() {
+function RootLayout() {
   return (
     /*
      * Outside `SafeAreaProvider`, which is where gesture-handler's own docs put
@@ -91,6 +100,27 @@ export default function RootLayout() {
     </GestureHandlerRootView>
   )
 }
+
+/**
+ * EAS Observe's root. The HOC times the launch itself — the gap between the
+ * process starting and this tree's first render (Time to First Render) — which
+ * is why it wraps the default export rather than being mounted as a provider
+ * somewhere inside it: anything below has already cost the measurement the
+ * part it exists to measure.
+ *
+ * Time to Interactive is *not* marked here. With the `expo-router`
+ * integration on, `markInteractive` is attributed to whichever route it is
+ * called from, and this component sits above the navigator — there is no route
+ * here to attribute it to. Each screen asks for its own; see
+ * `useScreenInteractive`.
+ *
+ * A no-op where there is no native module: `expo-observe` ships a web shim
+ * whose every method returns without doing anything, so the static web export
+ * and its prerender pass are unaffected. Metrics from debug builds are also
+ * held back unless `dispatchInDebug` is turned on in `configureObserve`, so
+ * what this reports is production only.
+ */
+export default ObserveRoot.wrap(RootLayout)
 
 /**
  * Split from `RootLayout` only so it sits *inside* `ThemeProvider` and can call

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -42,6 +42,7 @@
     "expo-location": "~57.0.14",
     "expo-network": "~57.0.1",
     "expo-notifications": "~57.0.15",
+    "expo-observe": "~57.0.19",
     "expo-router": "~57.0.16",
     "expo-secure-store": "~57.0.1",
     "expo-splash-screen": "~57.0.8",

--- a/apps/mobile/src/hooks/useScreenInteractive.ts
+++ b/apps/mobile/src/hooks/useScreenInteractive.ts
@@ -1,0 +1,29 @@
+import { useObserve } from 'expo-observe'
+import { useEffect } from 'react'
+
+/**
+ * "This screen is now something a person can use" — EAS Observe's `tti`.
+ *
+ * Called from inside a screen component and nowhere else. `useObserve()` reads
+ * the route it is rendered under to tag the metric, so the same call from a
+ * layout or from above the navigator has no screen to attribute anything to
+ * and is dropped with a warning. That is why this is a hook every screen calls
+ * rather than one call at the root: only the screen knows it is the screen.
+ *
+ * Marking on mount is the default because that is when most of these screens
+ * are genuinely usable — they render their own skeletons and stay interactive
+ * throughout. Pass `ready` on a screen where the first paint is not usable
+ * (a form that cannot be submitted until its options arrive, say) and the mark
+ * moves to the first render where that is true.
+ *
+ * Only the first mark per navigation is recorded, and one from an unfocused
+ * screen is discarded, so calling it too eagerly costs a truthful number but
+ * never a duplicate.
+ */
+export function useScreenInteractive(ready = true): void {
+  const { markInteractive } = useObserve()
+
+  useEffect(() => {
+    if (ready) markInteractive()
+  }, [ready, markInteractive])
+}

--- a/apps/mobile/src/lib/observe.ts
+++ b/apps/mobile/src/lib/observe.ts
@@ -1,0 +1,67 @@
+import { Observe } from 'expo-observe'
+
+/**
+ * Route and query parameter names that must never leave the device inside a
+ * navigation metric.
+ *
+ * The `expo-router` integration tags every `cold_ttr` / `warm_ttr` / `tti`
+ * event with the resolved `url` and *all* serializable params, and those events
+ * are dispatched to EAS. `routeName` is a pattern (`/(app)/chat/[id]`) and is
+ * never affected, so filtering costs nothing but the ability to tell two
+ * sessions on the same route apart — which is the point.
+ *
+ * Naming even one of these in an event replaces `url` with `urlHidden: true`,
+ * so the resolved path goes as well. That is deliberate: `/reset-password` with
+ * the token stripped from `routeParams` but still sitting in the path would
+ * have leaked it anyway.
+ *
+ * Three kinds of thing are listed, and only these three:
+ *
+ *  - **credentials** — `token` is a live password-reset token and `code` /
+ *    `user_code` are the device-linking codes, all three of which grant
+ *    something to whoever holds them;
+ *  - **identity** — `email`, `handle`, `username` and `userId` name a person,
+ *    and a metric stream is not a place to build a list of who uses the app;
+ *  - **content ids** — `id`, `targetId` and `at` point at one conversation,
+ *    post or message. Innocuous alone, but "this account was in this chat" is
+ *    exactly the sort of thing that should not be reconstructable from a
+ *    performance dataset.
+ *
+ * Anything not listed here (`tab`, `from`, `feature`, `invite`, `error`,
+ * `targetType`) is a fixed vocabulary with no per-person value, and those are
+ * the params actually worth having when a route turns out to be slow.
+ */
+export const OBSERVE_FILTERED_PARAMS = [
+  'at',
+  'code',
+  'email',
+  'handle',
+  'id',
+  'targetId',
+  'token',
+  'user_code',
+  'userId',
+  'username',
+] as const
+
+/**
+ * Turns on EAS Observe's `expo-router` integration.
+ *
+ * **Must be called at module scope, before anything mounts.** The provider
+ * inside `ObserveRoot` reads the flag once when it mounts and throws if the
+ * answer changes afterwards, so this cannot move into an effect.
+ *
+ * With the integration on, `cold_ttr` and `warm_ttr` are recorded for every
+ * route by a listener on the router's own navigation events — no per-screen
+ * code. `tti` is the one that needs asking for: see `useScreenInteractive`.
+ *
+ * A no-op on web, where `expo-observe`'s shim discards the config and
+ * `useObserve()` falls back to the app-wide `markInteractive`.
+ */
+export function configureObserve(): void {
+  Observe.configure({
+    integrations: {
+      'expo-router': { filteredParams: [...OBSERVE_FILTERED_PARAMS] },
+    },
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       expo-notifications:
         specifier: ~57.0.15
         version: 57.0.15(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo-observe:
+        specifier: ~57.0.19
+        version: 57.0.19(expo-router@57.0.16)(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       expo-router:
         specifier: ~57.0.16
         version: 57.0.16(7ebf1288f7b28cbce4e83a2c26c4ba3b)
@@ -3084,6 +3087,13 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-app-metrics@57.0.17:
+    resolution: {integrity: sha512-f8Esns6Dv0ivT3yCZavg59lXrUDQKOTvIzzj9SDPQitBmITU+L0QxyMachklkyHbk4WowSFYqBLWjazQ9Va/OQ==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+
   expo-apple-authentication@57.0.1:
     resolution: {integrity: sha512-pqAIaiTa/ycNl+XqNg5UMVT5TBgl6q6djTtoIcUmDItjVBA1IDHsQEs+leo+8+fG5hhuempZLSqBVVn+RJKKWA==}
     peerDependencies:
@@ -3159,6 +3169,9 @@ packages:
 
   expo-eas-client@57.0.2:
     resolution: {integrity: sha512-EfFiqUr0o9TvTOgMbqDiV1oIdG/d7kirhqtwa7roGmm9wF+CpXUz20d9YGzO6KzJWUYgdUgu4B6Ocv0jNJUdnQ==}
+
+  expo-eas-client@57.0.3:
+    resolution: {integrity: sha512-cyC2AZg85DfAt4Ge7jIRmxmL62dUXob4EnrLZatrl+xJ6AuObqjMYf3hx5JYFfvro4ajkFo25qNREPTdiHCYQQ==}
 
   expo-file-system@57.0.6:
     resolution: {integrity: sha512-pm8PMYEW6BnVOCBJ7df9FcDmQtE1tqImuYphlfYe1ipQRLYtdCayRczJcbKIsnB3mqEyp4gC2gWmMbsAsAOjVg==}
@@ -3263,6 +3276,20 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
+
+  expo-observe@57.0.19:
+    resolution: {integrity: sha512-g2+t6+jyYYrK7tPDwMjwkMX9XVel/xTViJlc53wJeb5b0dIfqGm6RVPcEokaG5Yhm07Da4i4QLbEhy7pdsLQow==}
+    peerDependencies:
+      '@react-navigation/native': ^7.0.0
+      expo: '*'
+      expo-router: '*'
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      '@react-navigation/native':
+        optional: true
+      expo-router:
+        optional: true
 
   expo-router@57.0.16:
     resolution: {integrity: sha512-k2ykpt91f2tVuaK+NTlyZPpy7ZL+VigGdgcrnTg+3KMDLBItXFAZezubeOe93CiirjJpXt5ktgQz8QMSse22HA==}
@@ -8368,6 +8395,13 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
 
+  expo-app-metrics@57.0.17(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      expo: 57.0.16(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.13)(expo-router@57.0.16)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo-updates-interface: 57.0.1(expo@57.0.16)
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
+
   expo-apple-authentication@57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
     dependencies:
       expo: 57.0.16(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.13)(expo-router@57.0.16)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
@@ -8453,6 +8487,8 @@ snapshots:
       ua-parser-js: 0.7.41
 
   expo-eas-client@57.0.2: {}
+
+  expo-eas-client@57.0.3: {}
 
   expo-file-system@57.0.6(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)):
     dependencies:
@@ -8568,6 +8604,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  expo-observe@57.0.19(expo-router@57.0.16)(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      expo: 57.0.16(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.13)(expo-router@57.0.16)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo-app-metrics: 57.0.17(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
+      expo-eas-client: 57.0.3
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.87.1(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
+    optionalDependencies:
+      expo-router: 57.0.16(7ebf1288f7b28cbce4e83a2c26c4ba3b)
 
   expo-router@57.0.16(7ebf1288f7b28cbce4e83a2c26c4ba3b):
     dependencies:


### PR DESCRIPTION
Sets up [EAS Observe](https://docs.expo.dev/eas/observe/get-started/) with the
[Expo Router integration](https://docs.expo.dev/eas/observe/integrations/expo-router/),
so production startup and navigation cost is measurable instead of guessed at.

## What it measures

| Metric | Where it comes from |
| --- | --- |
| Time to First Render | `ObserveRoot.wrap` on the root layout's default export |
| `cold_ttr` / `warm_ttr`, per route | the integration, off the router's own navigation events — no per-screen code |
| `tti`, per route | `useScreenInteractive()` in each screen |

`ObserveRoot` has to wrap the export rather than mount inside it: anything
below has already spent the interval it exists to measure.

`Observe.configure()` runs at module scope in `src/lib/observe.ts`.
`ObserveRoot`'s provider reads the integration flag once when it mounts and
throws if the answer changes afterwards, so there is no effect early enough to
do it in.

## Why the hook is in 52 files and not at the root

`useObserve()` attributes the mark to the route it is rendered under. A single
call above the navigator has no route to belong to and is dropped with a
warning, so TTI has to be asked for per screen.

`app/index.tsx` and `(onboarding)/learning.tsx` are left out — both are
redirects, never a destination.

The hook marks on mount, which is honest for screens that render their own
skeletons and stay usable throughout. It takes a readiness flag
(`useScreenInteractive(ready)`) for the ones where that stops being true; no
screen passes one yet, so TTI on the data-backed screens currently excludes
their first fetch. Worth revisiting once there are real numbers to look at.

## What is filtered

Ten route and query params never leave the device inside a navigation event:

- **credentials** — `token` (a live password-reset token, in the path),
  `code` and `user_code` (device-linking codes)
- **identity** — `email`, `handle`, `username`, `userId`
- **content ids** — `id`, `targetId`, `at`

Naming any of them also drops the resolved `url` from the event, which is the
point: the token sits in the path as well. `routeName` is a pattern
(`/(app)/chat/[id]`) and is unaffected, so the dashboard still groups by
route. The params left in (`tab`, `from`, `feature`, `invite`, `error`,
`targetType`) are a fixed vocabulary with no per-person value — and they are
the ones actually worth having when a route turns out to be slow.

## Notes

- Nothing is dispatched from debug builds, and the web build is unaffected:
  `expo-observe` ships a shim whose every method returns without doing
  anything.
- **This cannot ship over the air.** The new native module changes the
  fingerprint runtime version, so it needs a new binary before any metric
  appears.
- `expo install --fix` was deliberately not run. It would bump fifteen
  unrelated packages (`react-native`, `expo-router`, `expo-updates` among
  them) inside SDK 57 — a separate change.

## Checks

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and `pnpm test`
(266 + 625 + 902) all pass. `expo export --platform web` renders every route,
which exercises all 52 instrumented screens through the prerender pass.

Metric delivery itself is unverified — that needs a production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
