### PR TITLE
Put the sign-up form on a screen that scrolls

### DIFF
--- a/apps/mobile/app/(auth)/sign-up.tsx
+++ b/apps/mobile/app/(auth)/sign-up.tsx
@@ -2,9 +2,10 @@ import { MINIMUM_AGE } from '@langx/shared'
 import * as Linking from 'expo-linking'
 import { Link, router } from 'expo-router'
 import { useState } from 'react'
-import { KeyboardAvoidingView, Platform, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
 import { makeStyles } from '../../src/lib/theme'
 import { Button } from '../../src/components/ui/Button'
+import { Screen } from '../../src/components/ui/Screen'
 import { Checkbox } from '../../src/components/ui/Checkbox'
 import { LEGAL_LINKS } from '../../src/lib/externalLinks'
 import { openExternal } from '../../src/lib/openExternal'
@@ -88,10 +89,7 @@ export default function SignUp() {
     !loading && !!name && !!email && passwordPairReady(password, confirmation) && accepted
 
   return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-    >
+    <Screen scroll style={styles.form}>
       <Text style={styles.title}>{t('auth.createAccount')}</Text>
       <Text style={styles.subtitle}>{t('auth.minimumAge', { age: MINIMUM_AGE })}</Text>
 
@@ -170,18 +168,20 @@ export default function SignUp() {
           {t('auth.signIn')}
         </Link>
       </View>
-    </KeyboardAvoidingView>
+    </Screen>
   )
 }
 
 const useStyles = makeStyles(({ colors, font, spacing }) => ({
-  container: {
-    backgroundColor: colors.bg,
-    flex: 1,
-    gap: spacing.lg,
-    justifyContent: 'center',
-    padding: spacing.xl,
-  },
+  /**
+   * Only the gap. `Screen` owns the background, the safe-area inset, the
+   * horizontal padding and the scrolling — which is the point: this screen
+   * used to centre a form taller than the phone inside a bare
+   * `KeyboardAvoidingView`, so the overflow went equally out of the top and
+   * the bottom and put the title under the Dynamic Island, with no scroll to
+   * bring it back.
+   */
+  form: { gap: spacing.lg },
   title: { ...font.title, color: colors.text, fontSize: 28, lineHeight: 36 },
   subtitle: {
     ...font.body,


### PR DESCRIPTION
The title read under the Dynamic Island and nothing could bring it back.

The screen's root was a bare `KeyboardAvoidingView` styled `flex: 1`, `justifyContent: 'center'`, `padding: xl` — no safe-area inset and no scroll — and the form is taller than an iPhone: name, email, password, confirmation, the terms checkbox, the button, the social buttons, the footer. Centring content that overflows pushes it out of **both** ends equally, so the top went above the safe area, and with no ScrollView there was nothing to scroll back. Opening the keyboard shortened the box and took more of it.

## The fix

`Screen` already owns all of this — the safe-area padding, the centred column, the scrolling, and `automaticallyAdjustKeyboardInsets` — so the fix is to use it and delete the rest. `KeyboardAvoidingView` goes with it, which is the conclusion `useKeyboardInset` already writes down for the screens that do not scroll: RN derives the overlap from its own layout frame, and that frame is relative to its parent rather than to the window.

The screen keeps one style of its own, the gap between fields. Thirteen lines out, thirteen in.

The form now sits at the top of the scroll rather than centred, which is what a form longer than the screen should do.

## Scope

Six siblings under `(auth)` still centre without an inset — `sign-in`, `forgot-password`, `reset-password`, `check-email`, `verify-email-success` and `welcome`. None overflows today; each is one longer translation or one smaller device away from the same bug. Left alone rather than swept in, so this stays reviewable against the screenshot that found it.

## Checked

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and `pnpm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)