### PR TITLE
Carry the card fonts and logo into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,19 @@ RUN apt-get update \
 # TypeScript source that Node cannot resolve.
 COPY --from=build --chown=node:node /out ./
 
+# The share-card fonts and logo, which `pnpm deploy` does not carry.
+#
+# `/out` is the built bundle plus production `node_modules`, and nothing else:
+# a file that is only ever `readFile`d at runtime is invisible to both esbuild
+# and pnpm, so these three arrived in every local run and in no image. The
+# symptom was a card request failing with "Card asset not found: badge.png"
+# while the same code drew cards perfectly from source.
+#
+# `dist/assets` rather than anywhere else because `modules/cards/render.ts`
+# already looks beside the bundle — that is the root which is the same whether
+# the code runs from `dist/index.js` or from source under tsx.
+COPY --from=build --chown=node:node /app/apps/api/assets ./dist/assets
+
 USER node
 EXPOSE 8080
 CMD ["node", "dist/index.js"]

--- a/apps/api/src/modules/cards/assets.test.ts
+++ b/apps/api/src/modules/cards/assets.test.ts
@@ -1,0 +1,34 @@
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../../../..')
+
+/**
+ * The fonts and the logo are read from disk at runtime, which makes them
+ * invisible to both esbuild and `pnpm deploy` — so they reach every local run
+ * and, until this was fixed, no container. Cards rendered perfectly from
+ * source and failed in production with "Card asset not found: badge.png".
+ *
+ * Nothing else can catch that: the unit tests draw cards from the source tree,
+ * where the files are always present, and a container is not built during CI.
+ * This asserts the one line that carries them across instead.
+ */
+describe('card assets reach the runtime image', () => {
+  it('are copied beside the bundle, where render.ts looks for them', async () => {
+    const dockerfile = await readFile(join(REPO_ROOT, 'Dockerfile'), 'utf8')
+    expect(dockerfile).toContain('/app/apps/api/assets ./dist/assets')
+  })
+
+  it('exist under the path the Dockerfile copies from', async () => {
+    for (const asset of [
+      'badge.png',
+      'fonts/Nunito_800ExtraBold.ttf',
+      'fonts/Nunito_600SemiBold.ttf',
+    ]) {
+      const bytes = await readFile(join(REPO_ROOT, 'apps/api/assets', asset))
+      expect(bytes.byteLength).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
A share card asked for in production failed with `Card asset not found: badge.png`, while the same code drew all three shapes correctly from source.

`modules/cards/render.ts` reads the two Nunito faces and the logo with `readFile` at runtime, which puts them out of reach of both tools that assemble the container: esbuild only follows imports, and `pnpm deploy` only collects the built bundle and production dependencies. The files were therefore present in every local run, every test and every CI job — and in no image ever built.

One `COPY`, into `dist/assets`: the root `render.ts` already looks in, and the only one that means the same thing whether the code runs from the bundle or from source under tsx.

The new test asserts the Dockerfile line rather than a render, because the rendering tests already pass — they draw from the source tree, where the assets cannot be missing. Nothing in CI builds a container, so the line that carries them across is the thing worth pinning.

Found by trying it on production from the simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)