### PR TITLE
Wait for the sheet to close before offering the picture

### DIFF
--- a/apps/api/src/modules/cards/design.ts
+++ b/apps/api/src/modules/cards/design.ts
@@ -51,6 +51,21 @@ function glyphImage(kind: CardKind, colour: string): string {
  * timeline before either is read. Taken from `theme/tokens.ts` — a card is the
  * app's own colours leaving the app, and a second palette would drift.
  */
+/**
+ * How big the code is, in units, per shape.
+ *
+ * Not one number and not derived from `dense`: the code is a square, and what
+ * limits it is the clear ground left below the panel, which each shape has a
+ * different amount of. A story is mostly ground and takes a code you can scan
+ * across a room; a square is nearly all panel, and a wide card is 675 tall
+ * with the panel taking most of that, so both take a smaller one.
+ *
+ * The square's code has always sat over the panel's bottom corner and still
+ * does. That overlap is the layout rather than a collision: it reads as a tile
+ * laid on top, which is why making it bigger did not need the panel moved.
+ */
+const QR_UNITS: Record<CardShape, number> = { story: 22, square: 18, wide: 17 }
+
 const GROUND: Record<CardKind, string> = {
   streak: '#f79009',
   badge: '#7a5af8',
@@ -114,6 +129,7 @@ export async function cardElement(
    * its own — three layouts would be three things to keep in step.
    */
   const dense = width / height > 1.3 ? 0.62 : 1
+  const qrUnits = QR_UNITS[shape]
   const badge = await loadBadge()
   const ground = GROUND[kind]
   const onGround = ON_GROUND[kind]
@@ -269,9 +285,29 @@ export async function cardElement(
                     borderRadius: unit * 3,
                     display: 'flex',
                     justifyContent: 'center',
-                    padding: unit * 1.5,
+                    padding: unit * 2,
                   },
-                  children: [el('img', { src: qr, width: unit * 14, height: unit * 14 })],
+                  /*
+                   * Big enough to scan off a screen, which is where most of
+                   * these are read: a story is looked at on someone else's
+                   * phone, held at arm's length, for a few seconds. At the
+                   * original 14 units the code was a seventh of the short side
+                   * and wanted a steady hand and a close lens.
+                   *
+                   * Smaller on the wide card, and not by `dense` — that scales
+                   * the vertical axis, and this is a square. A wide card is
+                   * only 675 tall with the panel taking most of it, so 22
+                   * units of code plus its quiet zone reaches up into the
+                   * panel's bottom corner. 17 clears it and is still half
+                   * again what it was.
+                   */
+                  children: [
+                    el('img', {
+                      src: qr,
+                      width: unit * qrUnits,
+                      height: unit * qrUnits,
+                    }),
+                  ],
                 }),
               ],
             }),

--- a/apps/mobile/src/components/ShareCardSheet.tsx
+++ b/apps/mobile/src/components/ShareCardSheet.tsx
@@ -1,6 +1,6 @@
 import { CARD_SHAPES, type CardKind, type CardShape } from '@langx/shared'
 import { useState } from 'react'
-import { ActivityIndicator, Modal, Pressable, Text } from 'react-native'
+import { ActivityIndicator, Modal, Platform, Pressable, Text } from 'react-native'
 import { useCreateShareCard } from '../api/queries'
 import { useT, type MessageKey } from '../i18n'
 import { shareLink } from '../lib/share'
@@ -48,6 +48,28 @@ export function ShareCardSheet({
   const t = useT()
   const createCard = useCreateShareCard()
   const [busy, setBusy] = useState<CardShape | null>(null)
+  const [pending, setPending] = useState<ShareContent | null>(null)
+
+  /**
+   * Close this sheet, then hand the sentence to the platform share sheet —
+   * and in that order, with the dismissal actually finished in between.
+   *
+   * iOS refuses to present `UIActivityViewController` while another
+   * presentation is still animating away, and it refuses **silently**: no
+   * throw, the promise resolves, and no sheet ever appears. Closing and
+   * sharing in the same tick therefore looked exactly like a share that had
+   * worked — the card was rendered, stored and returned, and then nothing
+   * happened. `onDismiss` fires after the dismissal completes and is the only
+   * moment that is reliably safe.
+   *
+   * Android has no such rule and never fires `onDismiss`, so there it goes out
+   * straight away rather than waiting for a callback that will not come.
+   */
+  function shareAfterClose(content: ShareContent): void {
+    onClose()
+    if (Platform.OS === 'ios') setPending(content)
+    else void shareLink(content)
+  }
 
   async function pick(shape: CardShape): Promise<void> {
     if (!request || busy) return
@@ -59,15 +81,13 @@ export function ShareCardSheet({
         headline: request.headline,
         caption: request.caption,
       })
-      onClose()
       // The page, not the picture: `app.langx.io/s/<id>` unfurls with a title
       // and gives whoever taps it somewhere to go.
-      await shareLink({ message: request.fallback.message, url: card.shareUrl })
+      shareAfterClose({ message: request.fallback.message, url: card.shareUrl })
     } catch (caught) {
       void caught
-      onClose()
       showToast(t('share.cardFailed'))
-      await shareLink(request.fallback)
+      shareAfterClose(request.fallback)
     } finally {
       setBusy(null)
     }
@@ -79,6 +99,12 @@ export function ShareCardSheet({
       transparent
       animationType="slide"
       onRequestClose={onClose}
+      onDismiss={() => {
+        if (!pending) return
+        const content = pending
+        setPending(null)
+        void shareLink(content)
+      }}
       accessibilityViewIsModal
     >
       <Pressable style={styles.backdrop} accessibilityLabel={t('common.cancel')} onPress={onClose}>
@@ -104,9 +130,8 @@ export function ShareCardSheet({
             accessibilityRole="button"
             disabled={busy !== null}
             onPress={() => {
-              const fallback = request?.fallback
-              onClose()
-              if (fallback) void shareLink(fallback)
+              if (request) shareAfterClose(request.fallback)
+              else onClose()
             }}
             style={({ pressed }) => [styles.row, pressed && styles.pressed]}
           >


### PR DESCRIPTION
Picking a shape rendered the card, stored it in B2 and returned it — and then nothing happened. No share sheet, no error, no toast. Verified on production: the PNG is in the bucket (1080×1920) and `app.langx.io/s/<id>` serves it with full OG tags. The only missing part was the only part the person could see.

`onClose()` and `shareLink()` ran in the same tick, so iOS was asked to present `UIActivityViewController` while the modal underneath was still animating away. It refuses that, and refuses it **silently**: nothing throws, the promise resolves, no sheet appears — indistinguishable from a share that worked and was dismissed. That is why it survived both the unit tests and a manual pass.

The share now waits for `onDismiss`, which fires once the modal is really gone. Android never fires it and has no such restriction, so there the share goes out immediately rather than waiting for a callback that will not come.

"Just the link" had the same bug and the same fix — it was the older path and had been failing on iOS in exactly the same way.

Found by trying it on production from the simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)