### PR TITLE
Fill in the name the account already gave us

### DIFF
--- a/apps/mobile/app/(onboarding)/about-you.tsx
+++ b/apps/mobile/app/(onboarding)/about-you.tsx
@@ -1,12 +1,19 @@
 import { GENDERS, MINIMUM_AGE, birthDateSchema } from '@langx/shared'
 import { router } from 'expo-router'
+import { useEffect, useRef } from 'react'
 import { Pressable, Text, View } from 'react-native'
 import { BirthDateField } from '../../src/components/BirthDateField'
 import { StepProgress } from '../../src/components/StepProgress'
 import { Button } from '../../src/components/ui/Button'
 import { FormField } from '../../src/components/ui/FormField'
 import { Screen } from '../../src/components/ui/Screen'
-import { updateDraft, useOnboardingDraft } from '../../src/hooks/useOnboardingDraft'
+import {
+  isDraftHydrated,
+  updateDraft,
+  useOnboardingDraft,
+} from '../../src/hooks/useOnboardingDraft'
+import { authClient } from '../../src/lib/auth-client'
+import { displayNameToSeed } from '../../src/lib/seedDisplayName'
 import { makeStyles } from '../../src/lib/theme'
 import { genderLabel, useT } from '../../src/i18n'
 import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
@@ -17,6 +24,35 @@ export default function AboutYouStep() {
   const t = useT()
 
   const draft = useOnboardingDraft()
+  const accountName = authClient.useSession().data?.user.name?.trim() ?? ''
+  const seeded = useRef(false)
+
+  /**
+   * The name the account already has, filled in rather than asked for twice.
+   *
+   * Sign-up takes a name, and Google and Apple hand one over without being
+   * asked — so by the time anyone reaches this screen the answer is on file.
+   * It is seeded rather than removed because an Apple account often carries a
+   * full legal name and this is the field other people see: worth offering,
+   * not worth forcing.
+   *
+   * **After hydration, never before.** `hydrateDraft` merges stored values
+   * under anything this session has touched, so a name written here first
+   * would count as touched and beat the one the person typed on an earlier
+   * launch. The ref then stops it running again, which is what lets someone
+   * clear the field and have it stay clear.
+   */
+  useEffect(() => {
+    const seed = displayNameToSeed({
+      current: draft.displayName,
+      accountName,
+      hydrated: isDraftHydrated(),
+      alreadySeeded: seeded.current,
+    })
+    if (seed === null) return
+    seeded.current = true
+    updateDraft({ displayName: seed })
+  }, [accountName, draft])
 
   /**
    * The same schema the server will run, so the two cannot drift: a date that

--- a/apps/mobile/src/lib/seedDisplayName.test.ts
+++ b/apps/mobile/src/lib/seedDisplayName.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { displayNameToSeed } from './seedDisplayName'
+
+const base = { current: '', accountName: 'Emily', hydrated: true, alreadySeeded: false }
+
+describe('displayNameToSeed', () => {
+  it('offers the account name to an empty, hydrated draft', () => {
+    expect(displayNameToSeed(base)).toBe('Emily')
+  })
+
+  it('waits for hydration, so a stored name is never overwritten', () => {
+    expect(displayNameToSeed({ ...base, hydrated: false })).toBeNull()
+  })
+
+  it('leaves a draft that already has a name alone', () => {
+    expect(displayNameToSeed({ ...base, current: 'Em' })).toBeNull()
+  })
+
+  it('treats a whitespace-only draft as empty', () => {
+    expect(displayNameToSeed({ ...base, current: '   ' })).toBe('Emily')
+  })
+
+  it('does nothing when the account has no name', () => {
+    expect(displayNameToSeed({ ...base, accountName: '   ' })).toBeNull()
+  })
+
+  it('does not run twice, so a cleared field stays cleared', () => {
+    expect(displayNameToSeed({ ...base, alreadySeeded: true })).toBeNull()
+  })
+
+  it('trims what it offers', () => {
+    expect(displayNameToSeed({ ...base, accountName: '  Emily  ' })).toBe('Emily')
+  })
+})

--- a/apps/mobile/src/lib/seedDisplayName.ts
+++ b/apps/mobile/src/lib/seedDisplayName.ts
@@ -1,0 +1,32 @@
+/**
+ * Whether the account's name should be dropped into an empty onboarding draft,
+ * and what to drop in.
+ *
+ * Pure and separate from the screen because the ordering is the whole point
+ * and it is invisible when wrong. `hydrateDraft` merges the stored draft
+ * *underneath* anything this session has touched, so a name written before
+ * hydration finishes counts as touched and quietly beats the one the person
+ * typed on an earlier launch. Nothing would look broken; they would just find
+ * a different name than the one they left.
+ *
+ * Returns `null` for "leave it alone", which covers every case that is not
+ * "hydrated, nothing typed yet, and an account name to offer".
+ */
+export function displayNameToSeed(input: {
+  /** What the draft holds right now. */
+  current: string
+  /** The name on the account — from sign-up, or from Google or Apple. */
+  accountName: string
+  /** Whether the stored draft has been merged in yet. */
+  hydrated: boolean
+  /** Whether this has already run once for this screen. */
+  alreadySeeded: boolean
+}): string | null {
+  if (input.alreadySeeded || !input.hydrated) return null
+  const account = input.accountName.trim()
+  if (account.length === 0) return null
+  // A draft with something in it is somebody's answer, whether they typed it
+  // now or two launches ago.
+  if (input.current.trim().length > 0) return null
+  return account
+}


### PR DESCRIPTION
Sign-up asks for a name, and Google and Apple hand one over without being asked — and then the next onboarding screen asked for it again. The answer was already on file both times.

**Filled in rather than removed.** An Apple account often carries a full legal name, and this is the field other people see: worth offering, not worth forcing. Anyone who wants a shorter one types over it.

**After hydration, never before** — the part that would have been invisible when wrong. `hydrateDraft` merges the stored draft *underneath* anything this session has touched, so a name seeded on mount would count as touched and quietly beat the one the person typed on an earlier launch. Nothing would look broken; they would just find a different name than the one they left.

The decision is a pure `displayNameToSeed` rather than three conditions inside the effect, so that ordering is something a test can hold still. Seven cases, including the whitespace-only draft and the "cleared field stays cleared" one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)