### PR TITLE
Share a card as its picture, not its link

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -229,6 +229,17 @@ const config: ExpoConfig = {
     // nothing to configure, but without the entry the module is not linked
     // into a build.
     '@react-native-community/datetimepicker',
+    /*
+     * The system share sheet for a file — a share *card* goes out as its PNG
+     * rather than as a link, because Instagram only offers Story / Post for an
+     * image (`ShareCardSheet.tsx`). Its config plugin exists to add a share
+     * *extension* — receiving things shared into the app — and does nothing
+     * unless `ios.enabled` / `android.enabled` is set, which they are not:
+     * that is a target with its own bundle id and app group, and nothing here
+     * wants it. Listed anyway, for the same fingerprint reason as the three
+     * above.
+     */
+    'expo-sharing',
     // Microphone access is only ever requested when the user taps record, but
     // the string has to be declared here or iOS terminates the app the first
     // time it is asked for.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "private": true,
   "license": "BSD-3-Clause",
-  "description": "LangX v2 client \u2014 iOS, Android and web from one Expo codebase",
+  "description": "LangX v2 client — iOS, Android and web from one Expo codebase",
   "main": "expo-router/entry",
   "scripts": {
     "dev": "expo start",
@@ -47,6 +47,7 @@
     "expo-observe": "~57.0.19",
     "expo-router": "~57.0.19",
     "expo-secure-store": "~57.0.3",
+    "expo-sharing": "~57.0.18",
     "expo-splash-screen": "~57.0.8",
     "expo-status-bar": "~57.0.1",
     "expo-system-ui": "~57.0.3",

--- a/apps/mobile/src/components/ShareCardSheet.tsx
+++ b/apps/mobile/src/components/ShareCardSheet.tsx
@@ -1,9 +1,10 @@
 import { CARD_SHAPES, type CardKind, type CardShape } from '@langx/shared'
+import { File, Paths } from 'expo-file-system'
 import { useState } from 'react'
 import { ActivityIndicator, Modal, Platform, Pressable, Text } from 'react-native'
 import { useCreateShareCard } from '../api/queries'
 import { useT, type MessageKey } from '../i18n'
-import { shareLink } from '../lib/share'
+import { shareImage, shareLink } from '../lib/share'
 import type { ShareContent } from '../lib/shareText'
 import { makeStyles } from '../lib/theme'
 import { showToast } from '../lib/toast'
@@ -24,6 +25,20 @@ export interface ShareCardRequest {
   fallback: ShareContent
 }
 
+/** A share that has been decided on but not yet handed to the OS. */
+type PendingShare = () => Promise<void>
+
+/**
+ * Fetches the rendered card into the cache so the share sheet can be handed
+ * a file rather than a URL. Named by card id, so sharing the same card twice
+ * overwrites rather than accumulates; `idempotent` is what makes the second
+ * download land on the first one's name without complaint.
+ */
+async function downloadCard(id: string, imageUrl: string): Promise<File> {
+  const target = new File(Paths.cache, `langx-card-${id}.png`)
+  return File.downloadFileAsync(imageUrl, target, { idempotent: true })
+}
+
 /**
  * Choose where a card is going, then share it.
  *
@@ -32,10 +47,21 @@ export interface ShareCardRequest {
  * stamp, and a 16:9 card in a story is a band across an empty screen. One
  * question, three answers, and the picture is drawn to fit the answer.
  *
+ * **What goes into the sheet is the picture, as a file.** It used to be the
+ * card's page, `app.langx.io/s/<id>`, and that link is still what the page
+ * and "Just the link" hand out — but Instagram's share extension, given a
+ * URL, offers only "send in a message"; given an image it asks Story or Post,
+ * which is the whole point of drawing a 9:16 card. The PNG is downloaded into
+ * the cache and shared from there, on iOS and Android. The web keeps sharing
+ * the page: a browser cannot hand a file to Instagram anyway, and a URL is
+ * what `navigator.share` is good at.
+ *
  * **Sharing text remains possible and remains the fallback.** If the render
  * fails — storage not configured, the API unreachable — the sheet shares the
  * sentence and the link it always did rather than reporting an error for
- * something the user asked to *share*.
+ * something the user asked to *share*. If the render worked and only the
+ * download or the file share did not, the page link goes out instead, with no
+ * toast: the card exists and the link shows it.
  */
 export function ShareCardSheet({
   request,
@@ -48,7 +74,7 @@ export function ShareCardSheet({
   const t = useT()
   const createCard = useCreateShareCard()
   const [busy, setBusy] = useState<CardShape | null>(null)
-  const [pending, setPending] = useState<ShareContent | null>(null)
+  const [pending, setPending] = useState<PendingShare | null>(null)
 
   /**
    * Close this sheet, then hand the sentence to the platform share sheet —
@@ -65,10 +91,27 @@ export function ShareCardSheet({
    * Android has no such rule and never fires `onDismiss`, so there it goes out
    * straight away rather than waiting for a callback that will not come.
    */
-  function shareAfterClose(content: ShareContent): void {
+  function shareAfterClose(share: PendingShare): void {
     onClose()
-    if (Platform.OS === 'ios') setPending(content)
-    else void shareLink(content)
+    if (Platform.OS === 'ios') setPending(() => share)
+    else void share()
+  }
+
+  /** The picture as a file where the platform can take one, the page otherwise. */
+  function shareCard(card: { id: string; imageUrl: string; shareUrl: string }): PendingShare {
+    const page: ShareContent = { message: request?.fallback.message ?? '', url: card.shareUrl }
+    if (Platform.OS === 'web') return () => shareLink(page)
+    return async () => {
+      const file = await downloadCard(card.id, card.imageUrl).catch(() => null)
+      const shared = file ? await shareImage(file.uri) : false
+      if (!shared) await shareLink(page)
+      // The cache is not a gallery: the file has done its job either way.
+      try {
+        file?.delete()
+      } catch {
+        // A file that will not delete is a file the OS sweeps later.
+      }
+    }
   }
 
   async function pick(shape: CardShape): Promise<void> {
@@ -81,13 +124,12 @@ export function ShareCardSheet({
         headline: request.headline,
         caption: request.caption,
       })
-      // The page, not the picture: `app.langx.io/s/<id>` unfurls with a title
-      // and gives whoever taps it somewhere to go.
-      shareAfterClose({ message: request.fallback.message, url: card.shareUrl })
+      shareAfterClose(shareCard(card))
     } catch (caught) {
       void caught
       showToast(t('share.cardFailed'))
-      shareAfterClose(request.fallback)
+      const fallback = request.fallback
+      shareAfterClose(() => shareLink(fallback))
     } finally {
       setBusy(null)
     }
@@ -101,9 +143,9 @@ export function ShareCardSheet({
       onRequestClose={onClose}
       onDismiss={() => {
         if (!pending) return
-        const content = pending
+        const share = pending
         setPending(null)
-        void shareLink(content)
+        void share()
       }}
       accessibilityViewIsModal
     >
@@ -130,8 +172,9 @@ export function ShareCardSheet({
             accessibilityRole="button"
             disabled={busy !== null}
             onPress={() => {
-              if (request) shareAfterClose(request.fallback)
-              else onClose()
+              if (!request) return onClose()
+              const fallback = request.fallback
+              shareAfterClose(() => shareLink(fallback))
             }}
             style={({ pressed }) => [styles.row, pressed && styles.pressed]}
           >

--- a/apps/mobile/src/lib/share.ts
+++ b/apps/mobile/src/lib/share.ts
@@ -1,4 +1,5 @@
 import * as Clipboard from 'expo-clipboard'
+import * as Sharing from 'expo-sharing'
 import { Share } from 'react-native'
 import { currentTranslate } from '../i18n/runtime'
 import { isShareCancel, type ShareContent } from './shareText'
@@ -32,5 +33,32 @@ export async function shareLink({ message, url }: ShareContent): Promise<void> {
       return
     }
     showToast(currentTranslate()(url ? 'share.copied' : 'share.copiedText'))
+  }
+}
+
+/**
+ * Opens the platform share sheet with a picture — a local file, already on
+ * the device — and nothing else.
+ *
+ * The other call site, and the reason a card is shared as bytes rather than
+ * as its page: handed a URL, Instagram's share extension offers only "send in
+ * a message"; handed an image it asks Story or Post, which is where a streak
+ * card was going all along. `expo-sharing` shares exactly one item, so no
+ * sentence and no link travel with it — the card carries the handle and the
+ * profile QR, and "Just the link" is still on the sheet for anyone who wants
+ * the URL.
+ *
+ * Resolves `false` when the sheet could not be opened at all — no share
+ * target on this platform, or the OS refused — so the caller can fall back to
+ * the link. Closing the sheet is not a failure: `expo-sharing` resolves on
+ * cancel, unlike `navigator.share`, so there is no `isShareCancel` here.
+ */
+export async function shareImage(fileUri: string): Promise<boolean> {
+  try {
+    if (!(await Sharing.isAvailableAsync())) return false
+    await Sharing.shareAsync(fileUri, { mimeType: 'image/png', UTI: 'public.png' })
+    return true
+  } catch {
+    return false
   }
 }

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2153,13 +2153,28 @@ Three shapes, because there is no ratio that survives all three destinations: a
 9:16 card on a timeline is a stamp and a 16:9 card in a story is a band across
 an empty screen. The app asks where it is going before the picture is drawn.
 
-**What gets shared is a page, not the picture.** `app.langx.io/s/<id>` carries
-the OpenGraph tags, shows the card and offers the download; a raw
+**What the link points at is a page, not the picture.** `app.langx.io/s/<id>`
+carries the OpenGraph tags, shows the card and offers the download; a raw
 `media.langx.io` URL unfurls as a bare image with no title and gives whoever
 taps it nowhere to go. That page is a Cloudflare Pages Function rather than an
 Expo route, because the web build is a static export — every route ships the
 same empty shell and fills it in on the client, so a crawler fetching one sees
 no title and no image. Meta tags have to be in the bytes the crawler is handed.
+
+**What goes into the share sheet is the picture, as a file** — a reversal of
+the paragraph above, on 5 September 2026, after trying to post one. Handed the
+page URL, Instagram's share extension offers exactly one thing: send it in a
+message. Handed an image it asks Story or Post, which is what a 9:16 card was
+drawn for. So on iOS and Android the app downloads the PNG into the cache and
+hands the file to `expo-sharing`; the page is still what "Just the link" sends,
+what the web build shares (a browser cannot hand a file to Instagram), and what
+goes out when the download or the file share fails. The cost is the one the
+first paragraph of this section was proud of avoiding: `expo-sharing` is a
+native module, so this needed a build and a store submission rather than an
+update. It is a small one — no permission, no plugin configuration — and the
+fingerprint runtime version keeps the update away from binaries that lack it.
+A file share carries no sentence and no URL; the card carries the handle and
+the profile QR, so the referral rule below still holds.
 
 The card carries the sharer's profile QR. That is what makes it worth posting
 rather than just nice to look at: a story is watched on one phone and scanned

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,9 @@ importers:
       expo-secure-store:
         specifier: ~57.0.3
         version: 57.0.3(expo@57.0.20)
+      expo-sharing:
+        specifier: ~57.0.18
+        version: 57.0.18(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       expo-splash-screen:
         specifier: ~57.0.8
         version: 57.0.8(expo@57.0.20)(typescript@6.0.3)
@@ -3470,6 +3473,13 @@ packages:
   expo-server@57.0.3:
     resolution: {integrity: sha512-aK+LdKzauHSGmsOStZtyxdzv0zWssCkxTw3m4QuOhfDSJsZaMRTd9O41d8ixU/QfELTbaJ0oRNcF7JFV/7O9YQ==}
     engines: {node: '>=20.16.0'}
+
+  expo-sharing@57.0.18:
+    resolution: {integrity: sha512-Q09Gab1yn+OLR7sqcHBNyjM/4MMQa290hDKCV2pf2THnTLkLLuUmC0AKgMgxygqU0uuzhOgVqfnE70dePCLq9A==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-splash-screen@57.0.8:
     resolution: {integrity: sha512-BEsrKg4niYBZa5AFzWRyGqxA4ZemtBOPwbCy+C336iGYYPuZYLEgWJGmm2xD1gRfCdrM/TP+l2ONd86Zvk3KyA==}
@@ -7445,7 +7455,9 @@ snapshots:
       metro-runtime: 0.84.5
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -8896,6 +8908,18 @@ snapshots:
       expo: 57.0.20(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-router@57.0.19)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
 
   expo-server@57.0.3: {}
+
+  expo-sharing@57.0.18(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
+    dependencies:
+      '@expo/config-plugins': 57.0.9(typescript@6.0.3)
+      '@expo/config-types': 57.0.2
+      '@expo/plist': 0.8.1
+      expo: 57.0.20(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-router@57.0.19)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      react: 19.2.3
+      react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   expo-splash-screen@57.0.8(expo@57.0.20)(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
Handed the card's page URL, Instagram's share extension offers only "send in a message"; handed an image it asks Story or Post. The share sheet now downloads the rendered PNG into the cache and hands the file to `expo-sharing` on iOS and Android. "Just the link", the web build, and every failure path still share the page link. `docs/decisions.md` records the reversal.

**Needs a store build**: `expo-sharing` is native. No permission, no plugin configuration; the fingerprint runtime version keeps the OTA away from binaries that lack it. Merge after #1135 so the OTA-able fixes reach phones first.

Verification: simulator share sheet shows the image (Instagram itself needs a physical phone with the app installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)