### PR TITLE
Sell subscriptions on the web through RevenueCat Web Billing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,6 +172,13 @@ GOOGLE_SERVICES_JSON=
 # renders and says purchasing is unavailable; nothing else in the app changes.
 EXPO_PUBLIC_REVENUECAT_IOS_KEY=
 EXPO_PUBLIC_REVENUECAT_ANDROID_KEY=
+# The browser buys from RevenueCat Web Billing, which is a third store and not
+# a third platform: its own RevenueCat app, its own Stripe connection, its own
+# products and offering, and a key starting `rcb_`. Unset, the web paywall says
+# purchasing is unavailable and nothing else changes. The Test Store key below
+# also works here in a development build, which is how the web checkout can be
+# exercised before Stripe is connected.
+EXPO_PUBLIC_REVENUECAT_WEB_KEY=
 EXPO_PUBLIC_REVENUECAT_TEST_STORE_KEY=
 # `1` is the client half of REVENUECAT_FAKE_STORE: the paywall lists every
 # package at obviously fake prices and buying one calls the API's fake store.

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -178,6 +178,7 @@ function RootShell() {
    * nothing on web or in a build without the native module.
    */
   const userId = session?.user?.id
+  const email = session?.user?.email
   const isGuest = shouldGateGuest(session?.user)
   useEffect(() => {
     /*
@@ -188,7 +189,12 @@ function RootShell() {
      * anything anyway; the paywall's buy button is behind `requireAccount`.
      */
     if (userId && !isGuest) {
-      void identifyForPurchases(userId)
+      // The email is the web checkout's only extra: RevenueCat collects one
+      // there whatever we do — it is how the receipt and the cancellation link
+      // are sent — so handing over the account's saves the buyer a field
+      // rather than disclosing anything the purchase would not have carried.
+      // The native SDKs ignore it; Apple and Google know who is paying.
+      void identifyForPurchases(userId, email)
       // The same rule for the same reason: analytics keyed by our user id is
       // what makes a deleted account's events findable, and a guest's id is
       // thrown away at registration.
@@ -197,7 +203,9 @@ function RootShell() {
       void forgetPurchasesIdentity()
       forgetAnalyticsIdentity()
     }
-  }, [userId])
+    // `email` too, so that changing it re-prefills the web checkout. The call
+    // is a no-op for the id it is already bound to, so this costs nothing.
+  }, [userId, email])
 
   /**
    * Empties the query cache when the person behind it changes.

--- a/apps/mobile/env.d.ts
+++ b/apps/mobile/env.d.ts
@@ -24,6 +24,14 @@ declare global {
        */
       readonly EXPO_PUBLIC_REVENUECAT_IOS_KEY?: string
       readonly EXPO_PUBLIC_REVENUECAT_ANDROID_KEY?: string
+      /**
+       * The Web Billing key — a third store rather than a third platform. It
+       * belongs to its own RevenueCat app, with its own Stripe connection,
+       * products and offering, and starts `rcb_` where the pair above start
+       * `appl_` and `goog_`. Unset, the web paywall says purchasing is
+       * unavailable and the two native builds are untouched.
+       */
+      readonly EXPO_PUBLIC_REVENUECAT_WEB_KEY?: string
       readonly EXPO_PUBLIC_REVENUECAT_TEST_STORE_KEY?: string
       /**
        * `'1'` replaces RevenueCat entirely with the local development harness

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -23,6 +23,7 @@
     "@expo/vector-icons": "^15.1.1",
     "@langx/shared": "workspace:*",
     "@react-native-community/datetimepicker": "9.1.0",
+    "@revenuecat/purchases-js": "^1.58.0",
     "@tanstack/react-query": "catalog:",
     "better-auth": "catalog:",
     "expo": "~57.0.20",

--- a/apps/mobile/src/hooks/useSettingsModel.ts
+++ b/apps/mobile/src/hooks/useSettingsModel.ts
@@ -25,6 +25,7 @@ import { FLAG_KEYS, readBoolFlag } from '../lib/localFlags'
 import { captureLocation, reportLocationFailure } from '../lib/location'
 import { pushEnabledOnThisDevice, setPushEnabledOnThisDevice } from '../lib/devicePush'
 import { manageSubscriptionUrl } from '../lib/manageSubscription'
+import { storeManagementUrl } from '../lib/purchases'
 import { openPaywall } from '../lib/paywall'
 import { useThemePreference } from '../lib/theme'
 import { syncIconBadge } from '../lib/iconBadge'
@@ -112,7 +113,31 @@ export function useSettingsModel() {
             label: entitlement.willRenew ? t('settings.renewsOn') : t('settings.endsOn'),
             value: new Date(entitlement.expiresAt).toLocaleDateString(activeLocale),
           }
-  const manageUrl = tier === 'free' ? null : manageSubscriptionUrl(null, Platform.OS)
+  /**
+   * RevenueCat's per-customer link, which only the web store has one of, and
+   * only for someone who bought there — so it is asked for rather than known,
+   * and only once there is a plan to manage. On iOS and Android it stays
+   * `null` and `manageSubscriptionUrl` falls back to the store's own address,
+   * exactly as before.
+   */
+  const [rcManageUrl, setRcManageUrl] = useState<string | null>(null)
+  const isPaid = tier !== 'free'
+  useEffect(() => {
+    if (!isPaid) {
+      setRcManageUrl(null)
+      return
+    }
+    let cancelled = false
+    void storeManagementUrl().then((url) => {
+      if (!cancelled) setRcManageUrl(url)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isPaid])
+  const manageUrl = isPaid
+    ? manageSubscriptionUrl({ managementURL: rcManageUrl }, Platform.OS)
+    : null
   const tips = useTips()
   const analytics = useAnalyticsPreference()
   // No row without a key: a switch that changes nothing is worse than none,

--- a/apps/mobile/src/lib/externalLinks.ts
+++ b/apps/mobile/src/lib/externalLinks.ts
@@ -32,10 +32,20 @@ export interface LinkSection {
 const SITE = 'https://langx.io'
 const REPO = 'https://github.com/langx/langx'
 
+/**
+ * The two documents a purchase is made under, named separately because they
+ * are read from more than the Legal list: the paywall links to both, and the
+ * web checkout is handed the terms so they are reachable from the last screen
+ * before a charge. Three spellings of the same address is how one of them ends
+ * up pointing at a page that has moved.
+ */
+export const PRIVACY_URL = `${SITE}/privacy-policy`
+export const TERMS_URL = `${SITE}/terms-conditions`
+
 /** The five the stores and the law expect to be reachable from inside the app. */
 export const LEGAL_LINKS: readonly ExternalLink[] = [
-  { icon: 'shield', labelKey: 'legal.privacy', url: `${SITE}/privacy-policy` },
-  { icon: 'file-text', labelKey: 'legal.terms', url: `${SITE}/terms-conditions` },
+  { icon: 'shield', labelKey: 'legal.privacy', url: PRIVACY_URL },
+  { icon: 'file-text', labelKey: 'legal.terms', url: TERMS_URL },
   { icon: 'coffee', labelKey: 'legal.cookies', url: `${SITE}/cookie-policy` },
   { icon: 'trash-2', labelKey: 'legal.dataDeletion', url: `${SITE}/data-deletion` },
   { icon: 'lock', labelKey: 'legal.security', url: `${REPO}/blob/main/SECURITY.md` },

--- a/apps/mobile/src/lib/purchases.ts
+++ b/apps/mobile/src/lib/purchases.ts
@@ -1,6 +1,22 @@
 import { packageDefinition, type BillingPeriod, type PaidPlanTier } from '@langx/shared'
 import { Platform } from 'react-native'
 import { fakeOffers, fakePurchase, isFakePurchasesEnabled } from './fakePurchases'
+import { trialDays } from './trialDays'
+/*
+ * The web store, behind a two-file module Metro resolves per platform: this
+ * import is the real RevenueCat Web Billing SDK in a browser build and an
+ * empty set of "no" answers in the native ones. See `webBilling.ts` for why it
+ * cannot be a `Platform.OS` branch in this file.
+ */
+import {
+  forgetWebBillingIdentity,
+  getWebBillingOffers,
+  identifyForWebBilling,
+  isWebBillingAvailable,
+  purchaseWebBillingOffer,
+  restoreWebBillingPurchases,
+  webBillingManagementUrl,
+} from './webBilling'
 // `import type` is erased at compile time, so naming the module here costs
 // nothing at runtime — the actual native module is still only pulled in by the
 // dynamic import in `loadSdk()`, on the platforms that have it.
@@ -26,16 +42,24 @@ import type * as PurchasesSdk from 'react-native-purchases'
  * `packagesById` — passing an opaque SDK object through React props is how a
  * UI ends up unable to be tested without the native module present.
  *
- * Each function below opens with the same `isFakePurchasesEnabled()` check,
- * which is the local development harness (`./fakePurchases`) taking the whole
- * module over. Branching here rather than at the call sites is what keeps the
- * promise the paragraph above makes: the paywall still has exactly one surface
- * onto billing and cannot tell which store it is talking to, so what the
- * harness exercises is the screen that ships.
+ * Each function below opens with the same two checks, in the same order: the
+ * local development harness (`./fakePurchases`), then the web store
+ * (`./webBilling`), then the native SDK this file wraps directly. Branching
+ * here rather than at the call sites is what keeps the promise the paragraph
+ * above makes: the paywall still has exactly one surface onto billing and
+ * cannot tell which of the three it is talking to, so what the harness
+ * exercises is the screen that ships, and the screen that ships is the same one
+ * in a browser.
  */
 
-/** `react-native-purchases` is native-only; the browser build needs RevenueCat's separate JS SDK, which this app does not ship. */
-const isSupportedPlatform = Platform.OS === 'ios' || Platform.OS === 'android'
+/**
+ * `react-native-purchases` is native-only; the browser sells through
+ * RevenueCat Web Billing and its own SDK, which is what `./webBilling` wraps.
+ * Everything below therefore has three answers, not two, and the fake store
+ * still takes precedence over both real ones.
+ */
+const isNativePlatform = Platform.OS === 'ios' || Platform.OS === 'android'
+const isWebPlatform = Platform.OS === 'web'
 
 /**
  * A released build uses the per-platform key for its real store app. Until
@@ -51,7 +75,7 @@ const isSupportedPlatform = Platform.OS === 'ios' || Platform.OS === 'android'
  * purchasing is unavailable, which is the degradation rule 1 promises.
  */
 function apiKey(): string | null {
-  if (!isSupportedPlatform) return null
+  if (!isNativePlatform) return null
   const platformKey =
     Platform.OS === 'ios'
       ? process.env.EXPO_PUBLIC_REVENUECAT_IOS_KEY
@@ -62,6 +86,7 @@ function apiKey(): string | null {
 
 export function isPurchasesAvailable(): boolean {
   if (isFakePurchasesEnabled()) return true
+  if (isWebPlatform) return isWebBillingAvailable()
   return apiKey() !== null
 }
 
@@ -89,15 +114,6 @@ export interface PurchaseOffer {
 }
 
 /**
- * A month counted as 30 days and a year as 365.
- *
- * The screen says "30 days free", which is what every other subscription app
- * says and what people compare against. The alternative is a message per unit
- * in eight languages, for trial lengths we do not sell.
- */
-const DAYS_PER_PERIOD_UNIT: Record<string, number> = { DAY: 1, WEEK: 7, MONTH: 30, YEAR: 365 }
-
-/**
  * The free-trial length of an introductory offer, or `null` when there is none.
  *
  * `introPrice` describes *any* introductory offer — pay-as-you-go and
@@ -105,12 +121,14 @@ const DAYS_PER_PERIOD_UNIT: Record<string, number> = { DAY: 1, WEEK: 7, MONTH: 3
  * discounted first period is a real thing the stores can sell and this app
  * currently does not, and calling one a free trial would be a false claim
  * rather than a missing feature.
+ *
+ * The unit-to-days conversion moved to `./trialDays` when the web store
+ * arrived: the two SDKs do not spell `MONTH` the same way, and the paywall's
+ * "30 days free" has to mean the same thing whichever one answered.
  */
 function freeTrialDays(intro: PurchasesSdk.PurchasesIntroPrice | null): number | null {
   if (intro === null || intro.price !== 0) return null
-  const days = DAYS_PER_PERIOD_UNIT[intro.periodUnit.toUpperCase()]
-  if (days === undefined || intro.periodNumberOfUnits <= 0) return null
-  return days * intro.periodNumberOfUnits
+  return trialDays(intro.periodUnit, intro.periodNumberOfUnits)
 }
 
 export type PurchaseOutcome = 'purchased' | 'cancelled' | 'unavailable' | 'failed'
@@ -121,7 +139,10 @@ const packagesById = new Map<string, unknown>()
 type PurchasesModule = typeof PurchasesSdk
 
 async function loadSdk(): Promise<PurchasesModule | null> {
-  if (!isPurchasesAvailable()) return null
+  // `apiKey()`, not `isPurchasesAvailable()`: the latter is now also true on
+  // web, and this module is the native one. Every caller has already handled
+  // the fake store and the web store before it gets here.
+  if (apiKey() === null) return null
   try {
     return await import('react-native-purchases')
   } catch {
@@ -143,12 +164,13 @@ async function loadSdk(): Promise<PurchasesModule | null> {
  *
  * Safe to call repeatedly; it no-ops once the current user is already bound.
  */
-export async function identifyForPurchases(userId: string): Promise<void> {
+export async function identifyForPurchases(userId: string, email?: string): Promise<void> {
   // Nothing to bind under the harness: its purchases are made by an
   // authenticated API call, so the app user id *is* the session's user id and
   // cannot drift from it — which is the failure this function exists to
   // prevent, made structurally impossible rather than handled.
   if (isFakePurchasesEnabled()) return
+  if (isWebPlatform) return identifyForWebBilling(userId, email)
   if (configuredFor === userId) return
   const sdk = await loadSdk()
   if (!sdk) return
@@ -172,6 +194,7 @@ export async function identifyForPurchases(userId: string): Promise<void> {
 /** Clears the binding on sign-out so the next account does not inherit it. */
 export async function forgetPurchasesIdentity(): Promise<void> {
   if (isFakePurchasesEnabled()) return
+  if (isWebPlatform) return forgetWebBillingIdentity()
   if (configuredFor === null) return
   const sdk = await loadSdk()
   configuredFor = null
@@ -191,6 +214,7 @@ export async function forgetPurchasesIdentity(): Promise<void> {
  */
 export async function getOffers(): Promise<PurchaseOffer[]> {
   if (isFakePurchasesEnabled()) return fakeOffers()
+  if (isWebPlatform) return getWebBillingOffers()
   const sdk = await loadSdk()
   if (!sdk) return []
 
@@ -232,6 +256,7 @@ export async function getOffers(): Promise<PurchaseOffer[]> {
  */
 export async function purchaseOffer(offerId: string): Promise<PurchaseOutcome> {
   if (isFakePurchasesEnabled()) return fakePurchase(offerId)
+  if (isWebPlatform) return purchaseWebBillingOffer(offerId)
   const sdk = await loadSdk()
   const pkg = packagesById.get(offerId)
   if (!sdk || !pkg) return 'unavailable'
@@ -256,6 +281,7 @@ export async function restorePurchases(): Promise<boolean> {
   // would be misleading: the caller reconciles with the server straight
   // afterwards, and under the harness the server is the only record there was.
   if (isFakePurchasesEnabled()) return true
+  if (isWebPlatform) return restoreWebBillingPurchases()
   const sdk = await loadSdk()
   if (!sdk) return false
   try {
@@ -264,6 +290,22 @@ export async function restorePurchases(): Promise<boolean> {
   } catch {
     return false
   }
+}
+
+/**
+ * RevenueCat's own link for cancelling or changing a plan, or `null` when it
+ * has none to give.
+ *
+ * Web only, deliberately. A subscription lives in the store that sold it and
+ * both native stores publish one address for all of them, which is what
+ * `manageSubscription.ts` already returns without asking anybody. Stripe has no
+ * such address: the portal is per-customer and RevenueCat hosts it, so this is
+ * the *only* way a web subscriber can cancel from inside the app — and a paid
+ * plan with no way out is not something to ship.
+ */
+export async function storeManagementUrl(): Promise<string | null> {
+  if (!isWebPlatform) return null
+  return webBillingManagementUrl()
 }
 
 function isUserCancelled(error: unknown): boolean {

--- a/apps/mobile/src/lib/trialDays.test.ts
+++ b/apps/mobile/src/lib/trialDays.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { trialDays } from './trialDays'
+
+describe('trialDays', () => {
+  it('counts a month as 30 days and a year as 365', () => {
+    expect(trialDays('MONTH', 1)).toBe(30)
+    expect(trialDays('YEAR', 1)).toBe(365)
+  })
+
+  it('reads either SDK spelling of the same unit', () => {
+    // `react-native-purchases` says WEEK, `@revenuecat/purchases-js` says week.
+    expect(trialDays('WEEK', 1)).toBe(trialDays('week', 1))
+    expect(trialDays('day', 7)).toBe(7)
+  })
+
+  it('multiplies by the count', () => {
+    expect(trialDays('DAY', 7)).toBe(7)
+    expect(trialDays('month', 3)).toBe(90)
+  })
+
+  it('refuses a unit it does not know', () => {
+    expect(trialDays('FORTNIGHT', 1)).toBeNull()
+  })
+
+  it('refuses a count that is not a real one', () => {
+    expect(trialDays('MONTH', 0)).toBeNull()
+    expect(trialDays('MONTH', -1)).toBeNull()
+  })
+})

--- a/apps/mobile/src/lib/trialDays.ts
+++ b/apps/mobile/src/lib/trialDays.ts
@@ -1,0 +1,26 @@
+/**
+ * How many days of free trial a store's "count × unit" period amounts to.
+ *
+ * A month counts as 30 days and a year as 365. The screen says "30 days free",
+ * which is what every other subscription app says and what people compare
+ * against. The alternative is a message per unit in eight languages, for trial
+ * lengths we do not sell.
+ *
+ * Pure, and in a file of its own, because two SDKs need it and neither spells
+ * the unit the way the other does: `react-native-purchases` reports `MONTH`,
+ * RevenueCat's web SDK reports `month`. Folding the case here rather than at
+ * each call site is what keeps the 30-and-365 convention written down once —
+ * two copies of it is how one of them quietly stops matching what the paywall
+ * claims.
+ */
+const DAYS_PER_PERIOD_UNIT: Record<string, number> = { DAY: 1, WEEK: 7, MONTH: 30, YEAR: 365 }
+
+/**
+ * `null` for a unit this does not recognise, or a count that is not a real
+ * one — a trial length we cannot state is one the paywall must not claim.
+ */
+export function trialDays(unit: string, count: number): number | null {
+  const days = DAYS_PER_PERIOD_UNIT[unit.toUpperCase()]
+  if (days === undefined || count <= 0) return null
+  return days * count
+}

--- a/apps/mobile/src/lib/webBilling.ts
+++ b/apps/mobile/src/lib/webBilling.ts
@@ -1,0 +1,61 @@
+import type { PurchaseOffer, PurchaseOutcome } from './purchases'
+
+/**
+ * The native side of a two-file module. Metro picks `webBilling.web.ts` for
+ * the browser build and this one for iOS and Android, exactly as it does for
+ * `BirthDateField`.
+ *
+ * The split is not cosmetic. RevenueCat sells the web through a **separate
+ * SDK** — `@revenuecat/purchases-js`, a browser package that reaches for
+ * `document` and bundles a Stripe checkout — and a single file branching on
+ * `Platform.OS` would still hand that package to Metro for the native bundles,
+ * where it can neither run nor be tree-shaken away by a `Platform.OS === 'web'`
+ * that is only knowable at runtime. Here there is no import to shake: the
+ * native bundle contains this file, and this file contains nothing.
+ *
+ * Every function answers the way `purchases.ts` already answers when billing
+ * is not configured, so a caller that reaches one of these on a phone is not a
+ * bug to handle — it is the degradation rule in CLAUDE.md, unchanged.
+ *
+ * **`react-native-purchases` looks like it makes all of this unnecessary, and
+ * it does not.** Since v10 it ships a browser mode that bridges to the same
+ * `@revenuecat/purchases-js` through `purchases-js-hybrid-mappings`, so one
+ * file branching on `Platform.OS` compiles and very nearly works. What it gets
+ * wrong is the case that matters most: the bridge reports a cancelled checkout
+ * as the numeric `1` and the wrapper compares it against the string `"1"`
+ * (`PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR`), so `userCancelled` comes
+ * back `false` and someone who simply closed the payment sheet is told their
+ * purchase failed — the exact thing `purchaseOffer`'s doc comment says a
+ * paywall must never do. The bridge also drops `customerEmail`,
+ * `selectedLocale` and `termsAndConditionsUrl` on the floor. Verified against
+ * 10.8.1 / 1.58.0 on 5 September 2026; check both again before collapsing
+ * these two files into one.
+ */
+
+export function isWebBillingAvailable(): boolean {
+  return false
+}
+
+export function identifyForWebBilling(_userId: string, _email?: string): Promise<void> {
+  return Promise.resolve()
+}
+
+export function forgetWebBillingIdentity(): Promise<void> {
+  return Promise.resolve()
+}
+
+export function getWebBillingOffers(): Promise<PurchaseOffer[]> {
+  return Promise.resolve([])
+}
+
+export function purchaseWebBillingOffer(_offerId: string): Promise<PurchaseOutcome> {
+  return Promise.resolve('unavailable')
+}
+
+export function restoreWebBillingPurchases(): Promise<boolean> {
+  return Promise.resolve(false)
+}
+
+export function webBillingManagementUrl(): Promise<string | null> {
+  return Promise.resolve(null)
+}

--- a/apps/mobile/src/lib/webBilling.web.ts
+++ b/apps/mobile/src/lib/webBilling.web.ts
@@ -1,0 +1,345 @@
+import { packageDefinition, type Locale } from '@langx/shared'
+// `import type` is erased at compile time, so naming the module here costs
+// nothing: the browser package is still only fetched by the dynamic import in
+// `loadSdk()`. This file is the web build's, but the rule is the same one
+// `purchases.ts` follows for the native SDK.
+import type * as PurchasesSdk from '@revenuecat/purchases-js'
+import { currentLocale } from '../i18n/runtime'
+import { TERMS_URL } from './externalLinks'
+import type { PurchaseOffer, PurchaseOutcome } from './purchases'
+import type * as WebBillingContract from './webBilling'
+import { trialDays } from './trialDays'
+
+/**
+ * Buying on the web, through RevenueCat Web Billing.
+ *
+ * This is the browser half of the module whose native half is `webBilling.ts`;
+ * `purchases.ts` calls into whichever one Metro resolved and never learns
+ * which. Everything here is therefore shaped by the same two rules that file
+ * states, and one more that is only true on the web:
+ *
+ *  1. **Optional services degrade, they do not crash** (CLAUDE.md). No web key
+ *     configured means every call answers "nothing available" and the paywall
+ *     says so honestly.
+ *  2. **The SDK is imported lazily.** `@revenuecat/purchases-js` carries a
+ *     Stripe checkout with it, and a person who never opens the paywall should
+ *     not download one.
+ *  3. **A different store sells this.** Web Billing is its own RevenueCat app
+ *     with its own products, its own offering and its own key — an `rcb_` one,
+ *     never the `appl_`/`goog_` pair. What ties the three stores back together
+ *     is the `app_user_id`, which is why `identifyForWebBilling` matters here
+ *     for exactly the reason `identifyForPurchases` does on a phone: a purchase
+ *     under the wrong id is real in Stripe, real in RevenueCat and invisible to
+ *     this app forever.
+ *
+ * The SDK's types do not escape this file. Screens get the same plain
+ * `PurchaseOffer` shape the native path produces, and the `Package` objects
+ * stay in `packagesById`.
+ */
+
+/**
+ * The Web Billing SDK key, or `null` when there is none.
+ *
+ * The Test Store fallback is worth having here in a way it is not on native:
+ * `@revenuecat/purchases-js` accepts a `test_` key (it validates `rcb_`,
+ * `test_`, `strp_` and `pdl_` prefixes alike), so the whole web paywall —
+ * offering, checkout, entitlement, webhook — can be exercised from a laptop
+ * before Stripe is connected on RevenueCat's side.
+ *
+ * `__DEV__` gates it for the reason `fakePurchases.ts` gives: Expo inlines
+ * `EXPO_PUBLIC_*` at build time, so a key left set in a shell would otherwise
+ * ride a `pnpm build:web` into the published bundle and sell simulated
+ * subscriptions to real people.
+ */
+function apiKey(): string | null {
+  const webKey = process.env.EXPO_PUBLIC_REVENUECAT_WEB_KEY
+  if (webKey) return webKey
+  return __DEV__ ? process.env.EXPO_PUBLIC_REVENUECAT_TEST_STORE_KEY || null : null
+}
+
+export function isWebBillingAvailable(): boolean {
+  return apiKey() !== null
+}
+
+/**
+ * The locale to draw RevenueCat's checkout in.
+ *
+ * `Record<Locale, string>` is the enforcement: a ninth app language stops this
+ * file compiling rather than quietly checking out in English. The values are
+ * the SDK's own locale keys, which are not always ours — it ships one
+ * Portuguese rather than a Brazilian and a European one.
+ */
+const CHECKOUT_LOCALES: Record<Locale, string> = {
+  en: 'en',
+  tr: 'tr',
+  es: 'es',
+  ru: 'ru',
+  ar: 'ar',
+  fr: 'fr',
+  de: 'de',
+  'pt-BR': 'pt',
+}
+
+type PurchasesModule = typeof PurchasesSdk
+
+let sdk: PurchasesModule | null = null
+
+async function loadSdk(): Promise<PurchasesModule | null> {
+  if (!isWebBillingAvailable()) return null
+  if (sdk) return sdk
+  try {
+    sdk = await import('@revenuecat/purchases-js')
+    return sdk
+  } catch {
+    // A chunk that fails to load — a reload while offline, a deploy that moved
+    // it mid-session — is billing being unavailable, not an error to throw at
+    // whichever screen asked first. `sdk` stays null, so the next call retries.
+    return null
+  }
+}
+
+/**
+ * The in-flight or finished `identifyForWebBilling`, so that everything else
+ * can wait for it.
+ *
+ * The identity is bound in the root layout's effect and the paywall asks for
+ * offerings from its own, which is a race the native path gets away with
+ * because a `getOfferings()` before `configure()` merely returns nothing and
+ * the screen is re-rendered soon after. Here it would be a paywall that says
+ * "no plans" on the first open and lists them on the second — so the two are
+ * ordered rather than left to chance.
+ */
+let binding: Promise<void> | null = null
+let configuredFor: string | null = null
+
+/** The email to prefill at checkout, so the buyer types one less thing. */
+let customerEmail: string | null = null
+
+const packagesById = new Map<string, PurchasesSdk.Package>()
+
+/**
+ * Binds the SDK to the signed-in user, and to nobody else.
+ *
+ * **The RevenueCat app user id must equal the Better Auth user id**, for the
+ * reason spelled out on the native `identifyForPurchases`: the webhook writes
+ * `profiles.entitlement` by `app_user_id` and `/billing/refresh` looks the
+ * subscriber up by it. A web checkout completed under an anonymous id is money
+ * taken for an entitlement this app can never see.
+ *
+ * Safe to call repeatedly; it no-ops once the current user is already bound.
+ */
+export function identifyForWebBilling(userId: string, email?: string): Promise<void> {
+  if (email) customerEmail = email
+  if (configuredFor === userId) return binding ?? Promise.resolve()
+  binding = bind(userId)
+  return binding
+}
+
+async function bind(userId: string): Promise<void> {
+  const module = await loadSdk()
+  const key = apiKey()
+  if (!module || !key) return
+
+  try {
+    const { Purchases } = module
+    // `configure` warns and replaces the instance when called twice, so the
+    // already-configured case goes through `changeUser` instead — the one that
+    // exists for a browser two people sign into in turn.
+    if (Purchases.isConfigured()) await Purchases.getSharedInstance().changeUser(userId)
+    else Purchases.configure({ apiKey: key, appUserId: userId })
+    configuredFor = userId
+  } catch {
+    // Billing that cannot start is billing that is unavailable, not a crash.
+    configuredFor = null
+  }
+}
+
+/**
+ * Clears the binding on sign-out so the next account does not inherit it.
+ *
+ * Deliberately synchronous inside, on the already-loaded module rather than on
+ * `loadSdk()`: an SDK that was never loaded has nothing configured to close,
+ * and awaiting one here would open a window in which a sign-in that follows
+ * quickly configures the SDK and *then* has this close it out from under it.
+ */
+export function forgetWebBillingIdentity(): Promise<void> {
+  if (configuredFor === null) return Promise.resolve()
+  configuredFor = null
+  customerEmail = null
+  binding = null
+  packagesById.clear()
+  try {
+    if (sdk?.Purchases.isConfigured()) sdk.Purchases.getSharedInstance().close()
+  } catch {
+    // Nothing useful to do: the local binding is already cleared above.
+  }
+  return Promise.resolve()
+}
+
+/** The configured instance, or `null` for every "cannot sell right now" case. */
+async function instance(): Promise<PurchasesSdk.Purchases | null> {
+  const module = await loadSdk()
+  if (!module) return null
+  // Ordered against the root layout's binding rather than racing it — see
+  // `binding` above.
+  if (binding) await binding
+  if (!module.Purchases.isConfigured()) return null
+  return module.Purchases.getSharedInstance()
+}
+
+/**
+ * The current offering's packages, filtered to the ones this app knows how to
+ * sell. `[]` for every failure, because the paywall renders the same honest
+ * empty state for all of them.
+ *
+ * The identifiers come from the *web* offering in the RevenueCat dashboard and
+ * have to match `PACKAGES` — the same table the two native stores are matched
+ * against. A package the dashboard offers and `PACKAGES` does not know is
+ * skipped rather than guessed at: showing it under the wrong tier would sell
+ * the wrong thing.
+ */
+export async function getWebBillingOffers(): Promise<PurchaseOffer[]> {
+  const purchases = await instance()
+  if (!purchases) return []
+
+  try {
+    const offerings = await purchases.getOfferings()
+    const available = offerings.current?.availablePackages ?? []
+    packagesById.clear()
+
+    const offers: PurchaseOffer[] = []
+    for (const pkg of available) {
+      const definition = packageDefinition(pkg.identifier)
+      if (definition === null || definition.tier === 'free') continue
+      packagesById.set(pkg.identifier, pkg)
+      const product = pkg.webBillingProduct
+      offers.push({
+        id: pkg.identifier,
+        tier: definition.tier,
+        // The store's own text, in the buyer's currency. Never formatted here:
+        // the price a person reads has to be the one the checkout charges.
+        priceString: product.price.formattedPrice,
+        period: definition.period,
+        price: product.price.amountMicros / MICROS_PER_UNIT,
+        freeTrialDays: freeTrialDays(product.freeTrialPhase),
+      })
+    }
+    return offers
+  } catch {
+    return []
+  }
+}
+
+/** RevenueCat reports web prices in millionths, so $9.99 arrives as 9990000. */
+const MICROS_PER_UNIT = 1_000_000
+
+/**
+ * The free-trial length of a subscription's trial phase, or `null` when it has
+ * none.
+ *
+ * A phase with no period is not a trial anyone can be told about, and a claim
+ * the paywall cannot state precisely is one it must not make at all — the same
+ * judgement the native path applies to a discounted first period.
+ */
+function freeTrialDays(phase: PurchasesSdk.PricingPhase | null): number | null {
+  if (!phase?.period) return null
+  return trialDays(phase.period.unit, phase.period.number)
+}
+
+/**
+ * Buys one package, through RevenueCat's own checkout.
+ *
+ * The SDK renders it over the page and takes the card itself, so no card
+ * detail ever reaches this app — which is what `docs/store/privacy-data-safety.md`
+ * already claims of the two native stores and now has to stay true of the
+ * third.
+ *
+ * Closing that checkout is a deliberate choice and arrives here as a
+ * `UserCancelledError`. It is not a failure and must not be reported as one:
+ * showing an error for someone's own decision is how a paywall teaches people
+ * it is broken.
+ */
+export async function purchaseWebBillingOffer(offerId: string): Promise<PurchaseOutcome> {
+  const module = await loadSdk()
+  const purchases = await instance()
+  const rcPackage = packagesById.get(offerId)
+  if (!module || !purchases || !rcPackage) return 'unavailable'
+
+  try {
+    await purchases.purchase({
+      rcPackage,
+      // Prefilled from the account rather than asked for again. The checkout
+      // collects an email either way — it is how the receipt and the
+      // management link are sent — so this saves a field, it does not hand
+      // over anything the purchase would not have carried.
+      ...(customerEmail ? { customerEmail } : {}),
+      selectedLocale: CHECKOUT_LOCALES[currentLocale()],
+      defaultLocale: CHECKOUT_LOCALES.en,
+      // Required on a screen that sells a subscription, and the checkout is
+      // the last screen before the charge — the paywall's own links are behind
+      // it at that point.
+      termsAndConditionsUrl: TERMS_URL,
+    })
+    return 'purchased'
+  } catch (error) {
+    if (error instanceof module.PurchasesError) {
+      return error.errorCode === module.ErrorCode.UserCancelledError ? 'cancelled' : 'failed'
+    }
+    return 'failed'
+  }
+}
+
+/**
+ * There is no device receipt to restore from in a browser: what the button
+ * means here is "look again", and the looking is done by RevenueCat's own
+ * customer record and then by the server's `/billing/refresh`, which the
+ * paywall runs straight afterwards either way.
+ *
+ * So the honest answer is whether that lookup worked, not whether it found
+ * something — `false` is what makes the screen say there was nothing to
+ * restore, and a subscription the server is about to report is not nothing.
+ */
+export async function restoreWebBillingPurchases(): Promise<boolean> {
+  const purchases = await instance()
+  if (!purchases) return false
+  try {
+    await purchases.getCustomerInfo()
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Where a web subscriber cancels or changes their plan.
+ *
+ * Neither store URL means anything here, and there is no cancel endpoint of
+ * our own — RevenueCat hosts the portal that Stripe's subscription is managed
+ * from, and this link is the only way to reach it. `null` when the customer
+ * has no active web subscription, which Settings must render as *no row*.
+ */
+export async function webBillingManagementUrl(): Promise<string | null> {
+  const purchases = await instance()
+  if (!purchases) return null
+  try {
+    return (await purchases.getCustomerInfo()).managementURL
+  } catch {
+    return null
+  }
+}
+
+/**
+ * TypeScript checks every caller against the *native* file — Metro picks this
+ * one, `tsc` never does — so nothing but this line makes the two agree. A
+ * signature that drifts fails to compile here, rather than at runtime in
+ * somebody's browser.
+ */
+const _sameShape = {
+  isWebBillingAvailable,
+  identifyForWebBilling,
+  forgetWebBillingIdentity,
+  getWebBillingOffers,
+  purchaseWebBillingOffer,
+  restoreWebBillingPurchases,
+  webBillingManagementUrl,
+} satisfies typeof WebBillingContract

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -371,12 +371,18 @@ leaves `gender` and `city`.
 
 ### Entitlement flow
 
-1. The client shows offerings via `react-native-purchases`. **The RevenueCat
-   appUserID must equal the Better Auth user id** — `Purchases.logIn(userId)`
-   after sign-in. Without it a subscription bought on the web is invisible on
-   iOS.
-2. Purchase: StoreKit/Play Billing natively, RevenueCat Web + the connected
-   Stripe Billing account on the web.
+1. The client shows offerings via `react-native-purchases` natively and
+   `@revenuecat/purchases-js` in the browser — one surface, `lib/purchases.ts`,
+   with the web half split into `lib/webBilling.web.ts` so that the browser SDK
+   never reaches a native bundle. **The RevenueCat appUserID must equal the
+   Better Auth user id** on all three, `Purchases.logIn(userId)` after sign-in.
+   Without it a subscription bought on the web is invisible on iOS.
+2. Purchase: StoreKit/Play Billing natively, RevenueCat Web Billing + the
+   connected Stripe Billing account on the web. Three stores, one
+   `app_user_id`, one set of package identifiers (`PACKAGES`) and one set of
+   entitlement ids (`ENTITLEMENT_TIERS`) — everything after this step is
+   store-agnostic, which is why the webhook and `/billing/refresh` needed no
+   change when the web was added.
 3. **Webhook → `POST /webhooks/revenuecat`**: signature verified, processed
    idempotently by `event.id`, written to `subscriptions`, `profiles.
 entitlement` updated.

--- a/docs/billing-testing.md
+++ b/docs/billing-testing.md
@@ -80,6 +80,42 @@ Purchases live in memory and are lost when the API restarts. Persisting them
 would mean a collection and an index that exist only for a harness; re-buying
 after a restart is the cheaper trade.
 
+## The web checkout, without Stripe
+
+The harness above is not the only way to buy on a laptop, and since the web
+paywall shipped it is no longer the closest one. `@revenuecat/purchases-js`
+accepts a **Test Store key** — it validates `rcb_`, `test_`, `strp_` and `pdl_`
+prefixes alike — so setting nothing but
+
+```bash
+# apps/mobile/.env, the file Expo reads
+EXPO_PUBLIC_REVENUECAT_TEST_STORE_KEY=test_...
+```
+
+and opening the paywall in a browser gets the real SDK, the real `default`
+offering, RevenueCat's own checkout over the page, and a real webhook. The
+key is picked up on web through the same `__DEV__`-only fallback the native
+path uses, so it cannot follow a `pnpm build:web` into production.
+
+Verified on 5 September 2026 against the project's Test Store app: all five
+`PACKAGES` identifiers came back, closing the checkout arrived as
+`ErrorCode.UserCancelledError` (which is what makes the paywall say nothing
+rather than "purchase failed"), and completing one wrote `pro` onto the
+subscriber with `store: "test_store"`.
+
+Two things it still cannot rehearse, both of which need the `rcb_` key:
+
+- **The management link.** The Test Store has no customer portal, so
+  `getCustomerInfo().managementURL` is `null` and Settings correctly shows no
+  _Manage subscription_ row. With Web Billing it is the only cancellation path
+  a web subscriber has — there are no store URLs to fall back on.
+- **Money.** Nothing reaches Stripe, so nothing exercises tax, currency or the
+  card form.
+
+The fake store below is still the right tool when the API is what is under
+test, or when there is no network: it is the only one of the three that runs
+`processRevenueCatWebhook` without leaving the machine.
+
 ## Replaying a webhook
 
 `POST /billing/test-event` skips the HTTP hop, so it never checks the shared

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -634,7 +634,7 @@ of it runs together.
       Stripe (`newchapter.tech`, `acct_1O1p6JFsZedeNj7H`) connected by Behic on
       5 September 2026 and the configuration created the same day:
       `appae15d832dc`, USD default, billing address collected only when
-      required, automatic tax off
+      required
 - [x] Create the web products at the same prices as the App Store and Play
       products they mirror, and add them to the **`default` offering** under
       exactly the package identifiers in `packages/shared/src/billing.ts` →
@@ -668,12 +668,24 @@ of it runs together.
       later, so this is a wait rather than a rebuild. Second, `$rc_lifetime`
       has no web product: it only ever existed on the Test Store, and the
       loyalty gift is a promotional grant rather than a purchase
-- [ ] Decide two checkout settings left at their defaults, both under _Web →
-      LangX (RevenueCat Billing) → Billing_: **automatic tax** (Stripe Tax,
-      which costs per transaction and needs registrations), and **renewal
-      emails** — all three are off, and the "upcoming yearly renewal" one is
-      the notice several jurisdictions expect for an annual subscription. The
-      invoice footer, which names the legal entity, is also empty
+- [x] **Automatic tax is on**, as of 5 September 2026: provider Stripe Tax,
+      tax code `txcd_10103000` (_Software as a service — personal use_), which
+      is what LangX is — individuals subscribing for themselves. Stripe charges
+      its own fee per calculation. The code is a tax classification rather than
+      a technical setting, so it is worth an accountant's eye before the first
+      real sale; the other candidates on the list are `txcd_10000000` (General
+      — Electronically Supplied Services) and `txcd_10103001` (SaaS, business
+      use)
+- [ ] **Stripe Tax has its own setup, on Stripe's side**, and this switch does
+      not do it: an origin address, and a registration per jurisdiction you
+      actually collect in. Until those exist Stripe Tax computes nothing, so
+      the checkout looks the same and no tax is added. Stripe dashboard →
+      _Tax_. Behic's, because it turns on a tax obligation
+- [ ] Decide the settings still left at their defaults, under _Web → LangX
+      (RevenueCat Billing) → Billing_: **renewal emails** — all three are off,
+      and the "upcoming yearly renewal" one is the notice several jurisdictions
+      expect for an annual subscription — and the **invoice footer**, which
+      names the legal entity and is empty
 - [ ] Buy once on `app.langx.io` with a real card, then check `subscriptions`
       for the event (`store: "rc_billing"`), the tier on the profile, and that
       Settings' _Manage subscription_ row opens RevenueCat's portal. The Test

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -623,13 +623,63 @@ of it runs together.
       Billing note: the first 500 000 characters a month are free, then $20
       per million; the 20/300/1000 daily quotas and the 30-day cache bound
       the spend
-- [ ] **Buying on the web is not built at all**, and no key changes that:
-      `react-native-purchases` is native-only, so `purchases.ts` returns early
-      on `Platform.OS === 'web'` and the paywall says purchasing is
-      unavailable. It needs RevenueCat Web Billing — a Stripe connection on
-      their side, web products and packages, `@revenuecat/purchases-js` as a
-      dependency, and a third branch in `purchases.ts`. A project of its own,
-      not a configuration gap
+- [x] **Buying on the web is built**, as of 5 September 2026:
+      `@revenuecat/purchases-js` is a dependency, `lib/webBilling.web.ts` is
+      the browser store behind `purchases.ts`, and the paywall, the restore
+      control and Settings' _Manage subscription_ row all work in a browser.
+      Nothing on the server changed — the webhook, `subscriptions` and
+      `/billing/refresh` were already store-agnostic. It is switched off for
+      want of a key until the next web deploy; the items below are the rest of it
+- [x] RevenueCat → project LangX (`94ab2b94`) → **Web → RevenueCat Billing**.
+      Stripe (`newchapter.tech`, `acct_1O1p6JFsZedeNj7H`) connected by Behic on
+      5 September 2026 and the configuration created the same day:
+      `appae15d832dc`, USD default, billing address collected only when
+      required, automatic tax off
+- [x] Create the web products at the same prices as the App Store and Play
+      products they mirror, and add them to the **`default` offering** under
+      exactly the package identifiers in `packages/shared/src/billing.ts` →
+      `PACKAGES`: `$rc_monthly`, `$rc_annual`, `$rc_lifetime`,
+      `pro_plus_monthly`, `pro_plus_yearly`. A package the dashboard offers and
+      `PACKAGES` does not know is skipped by `getWebBillingOffers` — visibly,
+      rather than sold at the wrong price under the wrong tier. A package
+      `PACKAGES` knows that the web offering lacks simply does not appear in a
+      browser, which is the honest answer if `$rc_lifetime` turns out to have
+      no Web Billing equivalent
+- [x] Attach the same entitlements the native products grant: `pro`, and
+      **both** `pro_plus` and `pro` for the two Pro+ products. The overlap is
+      deliberate and `ENTITLEMENT_PRECEDENCE` resolves it; a Pro+ web product
+      granting only `pro_plus` is a subscriber every `pro` guard refuses
+- [x] Set the checkout's terms URL to `https://langx.io/terms-conditions`,
+      under _Billing → Terms consent_. It feeds an optional "agree before
+      paying" checkbox that is left **off**; the footer link a customer
+      actually sees is the one the client passes per purchase. There is no
+      privacy-policy field on this screen
+- [x] Copy the Web Billing app's public key — it starts `rcb_` — into
+      `EXPO_PUBLIC_REVENUECAT_WEB_KEY` in `apps/mobile/.env`, the file Expo
+      reads. Done 5 September 2026, **on this machine only**: the value is
+      inlined at build time, so the next `pnpm build:web` and `deploy:web` are
+      what actually turn web purchasing on. Until that deploy, production keeps
+      saying purchasing is unavailable
+- [ ] Two currency gaps, both worth knowing before launch. RevenueCat Billing
+      offers EUR, JPY, GBP, AUD, CAD, BRL, KRW, CNY, MXN, SEK, PLN, MYR, PHP,
+      CHF and SAR — and **no TRY**, so a Turkish customer buying on the web is
+      charged in USD at their card's rate while the same person on the App
+      Store pays the hand-set lira price. A currency can be added to a product
+      later, so this is a wait rather than a rebuild. Second, `$rc_lifetime`
+      has no web product: it only ever existed on the Test Store, and the
+      loyalty gift is a promotional grant rather than a purchase
+- [ ] Decide two checkout settings left at their defaults, both under _Web →
+      LangX (RevenueCat Billing) → Billing_: **automatic tax** (Stripe Tax,
+      which costs per transaction and needs registrations), and **renewal
+      emails** — all three are off, and the "upcoming yearly renewal" one is
+      the notice several jurisdictions expect for an annual subscription. The
+      invoice footer, which names the legal entity, is also empty
+- [ ] Buy once on `app.langx.io` with a real card, then check `subscriptions`
+      for the event (`store: "rc_billing"`), the tier on the profile, and that
+      Settings' _Manage subscription_ row opens RevenueCat's portal. The Test
+      Store has no portal, so that row is the one thing a `test_` key cannot
+      rehearse — `docs/billing-testing.md` → _The web checkout, without Stripe_
+      covers everything it can
 
 ## Migration cutover
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@react-native-community/datetimepicker':
         specifier: 9.1.0
         version: 9.1.0(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
+      '@revenuecat/purchases-js':
+        specifier: ^1.58.0
+        version: 1.58.0
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.102.6(react@19.2.3)
@@ -2167,6 +2170,9 @@ packages:
 
   '@revenuecat/purchases-js@1.54.0':
     resolution: {integrity: sha512-eYCzHLGeJ4DTMvSKjnOi2CpTTtCBAYfM/g0eYjWr5SU+oTXF8QBqpFvBFT5aEoH9/GiP9svL00gT9L7Ck7B+aQ==}
+
+  '@revenuecat/purchases-js@1.58.0':
+    resolution: {integrity: sha512-IHnicw4RnyK3w2VCxfOiFUiH6oMP9sNAury6cuyoQlUYu/Fx+hSsEXCGEnFwmRpKdpF3kiPWOIQ+qK/EX/6JYw==}
 
   '@revenuecat/purchases-typescript-internal@18.33.1':
     resolution: {integrity: sha512-TobtSjmMQUiPgNqcWZJfCyQgmCzhP77+KuvTZUKBcLlSTtoYTOFy5GnaOd5YPvwNHeFYL09nzgleg67n866pzw==}
@@ -7587,6 +7593,8 @@ snapshots:
       '@revenuecat/purchases-js': 1.54.0
 
   '@revenuecat/purchases-js@1.54.0': {}
+
+  '@revenuecat/purchases-js@1.58.0': {}
 
   '@revenuecat/purchases-typescript-internal@18.33.1': {}
 


### PR DESCRIPTION
The paywall rendered in a browser and said purchasing was unavailable, because `react-native-purchases` is native-only. RevenueCat sells the web through a separate browser SDK, so this adds one behind the surface that already exists rather than a second surface.

## What changed

- **`lib/webBilling.ts` + `lib/webBilling.web.ts`** — one module split by Metro's platform extension, the way `BirthDateField` already is. The split keeps `@revenuecat/purchases-js` — a browser package carrying a Stripe checkout — out of the iOS and Android bundles; a `Platform.OS` branch inside one file would still hand it to Metro for those builds. The web file ends with a `satisfies` against the native one, because TypeScript checks every caller against the file Metro never picks.
- **`purchases.ts`** stays the app's only surface onto billing and now answers in three ways instead of two: the fake store, then the web store, then the native SDK.
- **Settings → Manage subscription** asks RevenueCat for the customer's own portal link. Neither store URL means anything to a Stripe subscriber and there is no cancel endpoint of our own, so without this a web subscriber has no way to cancel from inside the app.
- **`lib/trialDays.ts`** holds the unit-to-days conversion behind "7 days free". The two SDKs spell the same period differently (`MONTH` vs `month`) and the claim has to mean the same thing whichever answered.

Nothing on the server changed — the webhook, `subscriptions` and `/billing/refresh` were already store-agnostic, and a web purchase arrives as `store: "rc_billing"` through the same path.

## Why not just use `react-native-purchases`

Since v10 it ships a browser mode bridging to the same `@revenuecat/purchases-js`, so one file branching on `Platform.OS` compiles and very nearly works. It gets the case that matters most wrong: the bridge reports a cancelled checkout as numeric `1` and the wrapper compares against the string `"1"`, so `userCancelled` comes back `false` and someone who simply closed the payment sheet is told their purchase failed. It also drops `customerEmail`, `selectedLocale` and `termsAndConditionsUrl`. The reasoning is recorded in `webBilling.ts` so the split is not "simplified" away later.

## Dashboard side, done

RevenueCat Billing configuration `appae15d832dc` with Stripe connected; four web products mirroring the App Store prices ($6.99 / $49.99 / $12.99 / $94.99, one-week trial on the yearlies), attached to the existing `default` offering packages and to the same entitlements; checkout terms URL set; automatic tax on with Stripe Tax.

Verified live against the real `rcb_` key: four packages with `PACKAGES`-matching identifiers, correct prices and trials, the checkout rendering in Turkish, and closing it mapping to `cancelled`. No payment was made.

## Not switched on yet

`EXPO_PUBLIC_REVENUECAT_WEB_KEY` is inlined at build time, so the next `build:web` + `deploy:web` is what turns web purchasing on. Unset, the web paywall says purchasing is unavailable and the native builds are untouched — the degradation rule in CLAUDE.md.

Remaining items are tracked in `docs/release-runbook.md`: RevenueCat Billing offers no TRY, so Turkish web buyers are charged in USD; Stripe Tax still needs an origin address and registrations on Stripe's side; renewal emails and the invoice footer are unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)