### PR TITLE
Implement semantic versioning with release automation

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,40 @@
+# A pushed version tag becomes a GitHub Release, with the notes written from
+# the pull requests merged since the previous tag.
+#
+# The tag is the trigger and `pnpm release` is what makes one: it bumps the
+# version, commits and tags, and the person pushes. So this is the only
+# workflow here besides CI, and it builds nothing — shipping still lives on
+# expo.dev (`apps/mobile/.eas/workflows/`), and a store build is still a
+# decision someone makes there.
+#
+# The guard is the tag having to match the version in package.json. A tag
+# typed by hand, or pushed from a commit that is not the release commit,
+# fails here instead of becoming a Release that names a version nothing
+# ships as.
+name: GitHub Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: The tag must be the version in package.json
+        run: |
+          version="$(node scripts/release.mjs --print)"
+          if [ "${GITHUB_REF_NAME}" != "v${version}" ]; then
+            echo "tag ${GITHUB_REF_NAME} does not match package.json version ${version}" >&2
+            exit 1
+          fi
+
+      - name: Create the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" --title "LangX ${GITHUB_REF_NAME#v}" --generate-notes

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/api",
-  "version": "2.0.0",
+  "version": "2.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 API — Better Auth + REST + Socket.io in one Fastify process",

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -8,6 +8,11 @@
 import { ANDROID_PACKAGE, APP_LINK_HOST, IOS_BUNDLE_ID } from '@langx/shared/appIdentity'
 import { APP_SCHEMES } from '@langx/shared/appScheme'
 import type { ExpoConfig } from 'expo/config'
+// The one place the version is written is the root package.json; `pnpm
+// release` bumps it and tags the commit, and everything else reads it. The
+// import attribute is what lets Expo's config loader read JSON whichever way
+// it evaluates this file.
+import { version } from '../../package.json' with { type: 'json' }
 
 /**
  * v2 ships as an **update to the existing store listings**, not a new app.
@@ -43,7 +48,7 @@ const config: ExpoConfig = {
   // EXPO_TOKEN in .env, what the CLI uses non-interactively — is refused as
   // "owner does not match the logged in user" even though it is an org owner.
   owner: 'langx',
-  version: '2.0.0',
+  version,
   orientation: 'portrait',
   userInterfaceStyle: 'automatic',
   scheme: [...APP_SCHEMES],

--- a/apps/mobile/app/(app)/settings/index.tsx
+++ b/apps/mobile/app/(app)/settings/index.tsx
@@ -1,4 +1,5 @@
 import { router } from 'expo-router'
+import * as Updates from 'expo-updates'
 import { useState } from 'react'
 import { Text, TextInput, View } from 'react-native'
 import { SettingsRow } from '../../../src/components/settings/SettingsRow'
@@ -86,12 +87,19 @@ export default function SettingsScreen() {
       />
 
       {/*
-        The two things a support reply always has to ask for. v1 showed both on
-        its account page; v2 showed neither, so every "it is broken" message
-        started with two extra round trips.
+        The things a support reply always has to ask for. v1 showed the version
+        and the account id on its account page; v2 showed neither, so every "it
+        is broken" message started with two extra round trips.
+
+        The update id is the third, and the one that actually says which code
+        is running: every merge to main ships over the air without touching the
+        version, so two phones on 2.0 can be weeks apart. It is null where no
+        update has been applied — the web, a dev build, the bundle the binary
+        shipped with — and simply absent then.
       */}
       <Text style={styles.build} selectable>
-        LangX {appVersion()} {t('settings.licence')}
+        LangX {appVersion()}
+        {Updates.updateId ? ` (${Updates.updateId.slice(0, 8)})` : ''} {t('settings.licence')}
         {model.profile ? `\n${model.profile._id}` : ''}
       </Text>
     </Screen>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/mobile",
-  "version": "2.0.0",
+  "version": "2.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 client — iOS, Android and web from one Expo codebase",

--- a/apps/mobile/src/api/apiFetch.ts
+++ b/apps/mobile/src/api/apiFetch.ts
@@ -1,20 +1,7 @@
-import { APP_PLATFORM_HEADER, APP_VERSION_HEADER } from '@langx/shared'
-import * as Application from 'expo-application'
 import { Platform } from 'react-native'
 import { API_URL } from '../lib/apiUrl'
+import { versionHeaders } from '../lib/appVersion'
 import { authClient } from '../lib/auth-client'
-
-/**
- * Sent on every request so the server can answer "is this client too old?"
- * without the client having to ask separately.
- */
-function versionHeaders(): Record<string, string> {
-  return {
-    [APP_VERSION_HEADER]: Application.nativeApplicationVersion ?? '0.0.0',
-    [APP_PLATFORM_HEADER]:
-      Platform.OS === 'ios' ? 'ios' : Platform.OS === 'android' ? 'android' : 'web',
-  }
-}
 
 /**
  * Fetch wrapper for *our own* API routes (not Better Auth's, which the

--- a/apps/mobile/src/hooks/useAppConfig.ts
+++ b/apps/mobile/src/hooks/useAppConfig.ts
@@ -1,20 +1,13 @@
-import { APP_PLATFORM_HEADER, APP_VERSION_HEADER, type AppConfigResponse } from '@langx/shared'
+import { type AppConfigResponse } from '@langx/shared'
 import { useQuery } from '@tanstack/react-query'
-import * as Application from 'expo-application'
-import { AppState, Platform } from 'react-native'
+import { AppState } from 'react-native'
 import { useEffect } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { api } from '../api/client'
 
+export { appPlatform, appVersion, versionHeaders } from '../lib/appVersion'
+
 export const APP_CONFIG_KEY = ['app-config'] as const
-
-export function appVersion(): string {
-  return Application.nativeApplicationVersion ?? '0.0.0'
-}
-
-export function appPlatform(): string {
-  return Platform.OS === 'ios' ? 'ios' : Platform.OS === 'android' ? 'android' : 'web'
-}
 
 /**
  * The server's word on whether the app should be running at all.
@@ -44,12 +37,4 @@ export function useAppConfig() {
     staleTime: 60_000,
     retry: 1,
   })
-}
-
-/** Headers every request carries, so the server can decide `updateRequired`. */
-export function versionHeaders(): Record<string, string> {
-  return {
-    [APP_VERSION_HEADER]: appVersion(),
-    [APP_PLATFORM_HEADER]: appPlatform(),
-  }
 }

--- a/apps/mobile/src/lib/appVersion.ts
+++ b/apps/mobile/src/lib/appVersion.ts
@@ -1,0 +1,42 @@
+import * as Application from 'expo-application'
+import Constants from 'expo-constants'
+import { APP_PLATFORM_HEADER, APP_VERSION_HEADER } from '@langx/shared'
+import { Platform } from 'react-native'
+
+/**
+ * `nativeApplicationVersion` is what the installed binary carries, which is
+ * the right answer on iOS and Android — but on the web there is no binary and
+ * expo-application returns null, so the settings footer read `0.0.0` on
+ * app.langx.io and every web request reported the same. The config version is
+ * the `version` field of `app.config.ts`, which the binaries are built from
+ * too, so the two only disagree when a store build is older than the web
+ * deploy — and then the binary's own number is the one that matters.
+ */
+function knownVersion(): string | undefined {
+  return Application.nativeApplicationVersion ?? Constants.expoConfig?.version ?? undefined
+}
+
+/** The version a person sees, e.g. in the settings footer. */
+export function appVersion(): string {
+  return knownVersion() ?? '0.0.0'
+}
+
+export function appPlatform(): string {
+  return Platform.OS === 'ios' ? 'ios' : Platform.OS === 'android' ? 'android' : 'web'
+}
+
+/**
+ * Headers every request carries, so the server can decide `updateRequired`.
+ *
+ * An unknown version is left out rather than sent as `0.0.0`: the server
+ * never forces an update on a missing header, but `0.0.0` parses fine and
+ * sorts below every minimum, so the placeholder would have locked out a
+ * client whose only fault was a bundle without a manifest.
+ */
+export function versionHeaders(): Record<string, string> {
+  const version = knownVersion()
+  return {
+    ...(version ? { [APP_VERSION_HEADER]: version } : {}),
+    [APP_PLATFORM_HEADER]: appPlatform(),
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -903,6 +903,12 @@ Publishing is automatic: `update.yml` runs on every merge to `main`. There is
 no second channel to hold a change back on — see `decisions.md` for why, and
 for the guard that makes it safe.
 
+The version is `major.minor`, written once in the root `package.json` and
+imported by `app.config.ts`. `pnpm release minor` bumps, commits and tags it;
+pushing the tag creates the GitHub Release. Over-the-air updates never change
+it, so the settings footer also shows the update id — that is the number that
+says which code a phone is actually running.
+
 `runtimeVersion` is `{ policy: 'fingerprint' }`, a hash of the native layer
 itself, so a bundle is only ever offered to a binary that can run it. A commit
 that changes the native side changes the fingerprint, and the update reaches

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2582,7 +2582,9 @@ semantics, not this bug.
 Behic's call on 3 September 2026, after a day of weighing the alternative:
 builds, store submissions and over-the-air updates are EAS workflows in
 `apps/mobile/.eas/workflows/`, started from Expo's dashboard or by a push to
-`main`. GitHub Actions keeps `ci.yml` and nothing else. The API and the web
+`main`. GitHub Actions keeps `ci.yml`, and since 5 September 2026 the one
+workflow that turns a version tag into a Release page — see _The version is two
+numbers_ below. The API and the web
 build are unaffected — Fly and Cloudflare Pages are still deployed by hand,
 see the runbook.
 
@@ -2921,6 +2923,49 @@ silently. Metro caches transforms, and the inlined value is part of one. An
 export re-run with the variable corrected returned a byte-identical bundle,
 still holding the old address. `--clear` is required whenever an
 `EXPO_PUBLIC_*` value changes.
+
+## The version is two numbers, in one file, and a tag makes the release
+
+Behic's call on 5 September 2026, after the settings footer on the web read
+`LangX 0.0.0`. The number came from `expo-application`, which reads it off the
+installed binary and returns null where there is none, and the fallback for
+null was the placeholder. Fixing the footer raised the wider question of where
+the version lived, and the answer was five places by hand: `app.config.ts`,
+four `package.json` files, and nothing that would have noticed them drifting.
+
+Now it lives in the root `package.json` and nowhere else is written. The
+workspace packages carry the same number, but only so the repo does not
+disagree with itself; `app.config.ts` imports the root copy, so the store
+binaries, the web build and the request headers all ship it.
+
+**It is `major.minor`, not semver.** `2.0`, then `2.1`. Every merge to `main`
+already reaches installed apps over the air without a number changing, so a
+patch level would be a number that never means anything — the third digit of
+`2.0.4` would say "some merges happened", which the update id in the footer
+already says exactly. A version now changes when someone decides a release is
+worth naming, and the tools do not need semver: pnpm accepts it for a private
+package, and both stores accept it as a version name.
+
+**`pnpm release minor` is the whole ceremony.** It bumps the number, commits
+`Release 2.1` and tags it `v2.1`; pushing the tag makes the GitHub Release
+(`.github/workflows/github-release.yml`), with notes generated from the pull
+requests since the last tag. The script does not push, because `main` is
+protected and the release commit goes through a pull request like everything
+else. The workflow refuses a tag that does not match `package.json`, so a tag
+typed by hand cannot name a version nothing ships as.
+
+This bends _Shipping lives on expo.dev, and only tests live on GitHub_ by one
+workflow, and deliberately not further: the tag makes a Release page and
+nothing else. A store build is metered and stays a decision made on expo.dev.
+A tag could start `release.yml` there, and the day that is wanted it is one
+trigger away; until then a new number on `main` reaches the stores when
+someone builds, and the web when someone deploys.
+
+What was considered and passed over: reading the version off a git tag in
+`app.config.ts` (EAS builds from an archive without tag history, so the number
+would be wrong exactly where it matters), and release-please (a full bump
+automation that needs every commit message in the conventional format, which
+this repo's are not).
 
 ## Six attachments, a field beside the old one, and one unit of quota
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -54,7 +54,8 @@ leftovers. They are not.
 | App links                | `https://app.langx.io`, `autoVerify` — carried from v1's AndroidManifest. Declaring them is half the job; see the next section                     |
 
 `versionCode` and `buildNumber` must both start **above 119**, the published
-v1 version. They are currently 120.
+v1 version. EAS owns them (`appVersionSource: "remote"`) and hands one out per
+build; the version name is a separate thing, see _Shipping runs on expo.dev_ below.
 
 ## The API has to be deployed, and it has to be deployed early
 
@@ -329,13 +330,29 @@ pnpm --filter @langx/api exec tsx scripts/send-campaign.ts \
 ## Shipping runs on expo.dev
 
 Builds, store submissions and over-the-air updates are all EAS jobs, defined
-in `apps/mobile/.eas/workflows/`. GitHub Actions only tests. The two
-workflows, and what each costs:
+in `apps/mobile/.eas/workflows/`. GitHub Actions tests, and turns a version tag
+into a Release page (see below). The two workflows, and what each costs:
 
 | Workflow      | Trigger                  | Cost                              |
 | ------------- | ------------------------ | --------------------------------- |
 | `update.yml`  | every merge to `main`    | nothing — an OTA update, no build |
 | `release.yml` | by hand, pick a platform | one build, then `eas submit`      |
+
+**The version number is `major.minor` and lives in the root `package.json`.**
+`app.config.ts` imports it, so the binaries and the web build carry whatever
+is there. To name a release:
+
+```bash
+pnpm release minor        # 2.0 -> 2.1: bumps, commits "Release 2.1", tags v2.1
+git push -u origin <branch>   # the release commit goes through a PR like any other
+git push origin v2.1          # once it is on main; the tag creates the GitHub Release
+```
+
+The tag is the only GitHub-side automation: `github-release.yml` checks it
+against `package.json` and writes a Release with notes from the merged pull
+requests. It builds nothing. A new number reaches the stores with the next
+`release.yml` run on expo.dev and the web with the next `pnpm deploy:web`;
+installed apps keep showing the binary's own number until a store build ships.
 
 **There is one channel, `production`, and merging to `main` publishes to it.**
 A JS-only change reaches every installed app on its next launch without a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langx",
-  "version": "2.0.0",
+  "version": "2.0",
   "private": true,
   "description": "LangX v2 \u2014 language exchange app (Expo mobile/web + Fastify API + MongoDB Atlas)",
   "license": "BSD-3-Clause",
@@ -23,7 +23,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "release": "node scripts/release.mjs"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/shared",
-  "version": "2.0.0",
+  "version": "2.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "Contract shared by @langx/api and @langx/mobile: zod schemas, language and level tables, plan limits, token rules, error codes",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -41,7 +41,7 @@ function readVersion() {
   return version
 }
 
-function bump(version, part) {
+function bumped(version, part) {
   const [, major, minor] = VERSION.exec(version)
   return part === 'major' ? `${Number(major) + 1}.0` : `${major}.${Number(minor) + 1}`
 }
@@ -50,32 +50,32 @@ function git(...args) {
   return execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim()
 }
 
-function main(argv) {
-  const current = readVersion()
-  const [part] = argv
+function fail(message) {
+  console.error(message)
+  process.exit(1)
+}
 
-  if (part === '--print') {
-    console.log(current)
-    return
-  }
-  if (part !== 'major' && part !== 'minor') {
-    console.error('usage: pnpm release <major|minor>  |  pnpm release --print')
-    process.exit(2)
-  }
+function printVersion() {
+  console.log(readVersion())
+}
+
+function usage() {
+  console.error('usage: pnpm release <major|minor>  |  pnpm release --print')
+  process.exit(2)
+}
+
+function release(part) {
+  const current = readVersion()
 
   // A release commit must contain the version bump and nothing else, so it
   // refuses to start on top of unrelated edits rather than sweeping them in.
   if (git('status', '--porcelain') !== '') {
-    console.error('the working tree has uncommitted changes; commit or stash them first')
-    process.exit(1)
+    fail('the working tree has uncommitted changes; commit or stash them first')
   }
 
-  const next = bump(current, part)
+  const next = bumped(current, part)
   const tag = `v${next}`
-  if (git('tag', '--list', tag) !== '') {
-    console.error(`${tag} already exists`)
-    process.exit(1)
-  }
+  if (git('tag', '--list', tag) !== '') fail(`${tag} already exists`)
 
   for (const manifest of MANIFESTS) {
     const path = join(root, manifest)
@@ -105,4 +105,22 @@ function main(argv) {
   console.log('GitHub Release. A store build is still release.yml on expo.dev.')
 }
 
-main(process.argv.slice(2))
+// A switch that dispatches to functions taking no input, rather than an
+// if-chain that exits. CodeQL reads a branch on argv that ends in
+// `process.exit` as a security check the caller can bypass (CWE-807), and
+// fails the pull request on it. The rule is aimed at servers, but the shape it
+// wants is also the simpler one here: the argument picks a command, and the
+// commands do the rest without it.
+switch (process.argv[2]) {
+  case '--print':
+    printVersion()
+    break
+  case 'major':
+    release('major')
+    break
+  case 'minor':
+    release('minor')
+    break
+  default:
+    usage()
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,108 @@
+/* global console */
+/**
+ * Cuts a release: bumps the version, commits it and tags the commit. One
+ * command instead of four files edited by hand and a tag typed from memory.
+ *
+ *     pnpm release minor    2.0 -> 2.1
+ *     pnpm release major    2.1 -> 3.0
+ *     pnpm release --print  prints the current version and exits
+ *
+ * The version is two numbers, `major.minor`, and lives in the root
+ * package.json. The workspace packages carry the same number so nothing in
+ * the repo disagrees with it, but only the root copy is read: `app.config.ts`
+ * imports it, so the store binaries and the web build ship it too.
+ *
+ * Nothing is pushed. `main` is protected and releases go through the same
+ * pull request as everything else; the script prints the two commands that
+ * finish the job. Pushing the tag is what creates the GitHub Release
+ * (`.github/workflows/github-release.yml`).
+ */
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const MANIFESTS = [
+  'package.json',
+  'apps/api/package.json',
+  'apps/mobile/package.json',
+  'packages/shared/package.json',
+]
+
+/** `2.0`, `2.1`, `10.4` — and nothing else, so a typo cannot become a tag. */
+const VERSION = /^(\d+)\.(\d+)$/
+
+function readVersion() {
+  const { version } = JSON.parse(readFileSync(join(root, MANIFESTS[0]), 'utf8'))
+  if (typeof version !== 'string' || !VERSION.test(version)) {
+    throw new Error(`root package.json version must look like 2.0, got ${JSON.stringify(version)}`)
+  }
+  return version
+}
+
+function bump(version, part) {
+  const [, major, minor] = VERSION.exec(version)
+  return part === 'major' ? `${Number(major) + 1}.0` : `${major}.${Number(minor) + 1}`
+}
+
+function git(...args) {
+  return execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim()
+}
+
+function main(argv) {
+  const current = readVersion()
+  const [part] = argv
+
+  if (part === '--print') {
+    console.log(current)
+    return
+  }
+  if (part !== 'major' && part !== 'minor') {
+    console.error('usage: pnpm release <major|minor>  |  pnpm release --print')
+    process.exit(2)
+  }
+
+  // A release commit must contain the version bump and nothing else, so it
+  // refuses to start on top of unrelated edits rather than sweeping them in.
+  if (git('status', '--porcelain') !== '') {
+    console.error('the working tree has uncommitted changes; commit or stash them first')
+    process.exit(1)
+  }
+
+  const next = bump(current, part)
+  const tag = `v${next}`
+  if (git('tag', '--list', tag) !== '') {
+    console.error(`${tag} already exists`)
+    process.exit(1)
+  }
+
+  for (const manifest of MANIFESTS) {
+    const path = join(root, manifest)
+    // A string replacement, not a parse-and-serialise round trip: the files
+    // keep their key order, indentation and trailing newline exactly, so the
+    // diff is one line per file and prettier has nothing to say about it.
+    const source = readFileSync(path, 'utf8')
+    const updated = source.replace(
+      /^(\s*"version":\s*)"[^"]*"/m,
+      (_match, prefix) => `${prefix}${JSON.stringify(next)}`,
+    )
+    if (updated === source) throw new Error(`${manifest} has no "version" field to update`)
+    writeFileSync(path, updated)
+  }
+
+  git('add', ...MANIFESTS)
+  git('commit', '--quiet', '--message', `Release ${next}`)
+  git('tag', '--annotate', '--message', `LangX ${next}`, tag)
+
+  const branch = git('rev-parse', '--abbrev-ref', 'HEAD')
+  console.log(`${current} -> ${next}, committed and tagged ${tag}. To finish:`)
+  console.log('')
+  console.log(`    git push -u origin ${branch}`)
+  console.log(`    git push origin ${tag}`)
+  console.log('')
+  console.log('Push the tag once the release commit is on main; the tag is what creates the')
+  console.log('GitHub Release. A store build is still release.yml on expo.dev.')
+}
+
+main(process.argv.slice(2))


### PR DESCRIPTION
Introduces a release process that centralizes versioning in the root `package.json` and automates the ceremony of bumping, committing, and tagging releases.

## Summary

The version is now `major.minor` (e.g., `2.0`, `2.1`) instead of semver, living in a single source of truth: the root `package.json`. `pnpm release minor|major` handles the entire release workflow — bumping the version across all workspace packages, creating a release commit, and tagging it. A pushed tag triggers GitHub Actions to create a Release page with auto-generated notes from merged pull requests.

## Key changes

- **`scripts/release.mjs`**: New release script that validates the working tree, bumps versions across all manifests, commits with a standard message, and tags the commit. Prints the two git commands needed to finish (push branch and tag).

- **`.github/workflows/github-release.yml`**: New workflow triggered by version tags. Validates the tag matches `package.json` to prevent mismatched releases, then creates a GitHub Release with notes from merged PRs.

- **`apps/mobile/src/lib/appVersion.ts`**: Extracted version and platform detection logic into a dedicated module. Handles the case where `expo-application` returns null on web by falling back to the config version. `versionHeaders()` now omits the version header entirely if unknown (rather than sending `0.0.0`), preventing a placeholder from locking out clients.

- **Version updates**: Changed all `package.json` files from `2.0.0` to `2.0` across root, API, mobile, and shared packages.

- **`app.config.ts`**: Now imports the version from root `package.json` instead of hardcoding it, ensuring binaries and web build always ship the correct number.

- **Settings footer**: Updated to show the update id (first 8 chars) alongside the version, since OTA updates never change the version number but do change what code is running.

- **Documentation**: Added decision record explaining the `major.minor` versioning scheme, why it fits this project (patch level would be meaningless with continuous OTA updates), and how the release process works. Updated runbook with the new release workflow.

## Implementation notes

- Version bumping uses string replacement rather than JSON parse/serialize to preserve file formatting, indentation, and trailing newlines — the diff is one line per file.
- The release script refuses to run with uncommitted changes, ensuring clean release commits.
- The GitHub workflow guards against typos by validating the tag against the actual version in `package.json`.
- Shipping still lives on expo.dev; this only adds the GitHub Release automation, keeping the boundary between CI (tests + Release pages) and EAS (builds + submissions) clear.

https://claude.ai/code/session_01Wh3bCnMUd1Wpw4LQ9AMP2t