### PR TITLE
Give the workspace packages a semver, because pnpm deploy needs one

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/api",
-  "version": "2.0",
+  "version": "2.0.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 API — Better Auth + REST + Socket.io in one Fastify process",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/mobile",
-  "version": "2.0",
+  "version": "2.0.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 client — iOS, Android and web from one Expo codebase",

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2933,18 +2933,26 @@ null was the placeholder. Fixing the footer raised the wider question of where
 the version lived, and the answer was five places by hand: `app.config.ts`,
 four `package.json` files, and nothing that would have noticed them drifting.
 
-Now it lives in the root `package.json` and nowhere else is written. The
-workspace packages carry the same number, but only so the repo does not
-disagree with itself; `app.config.ts` imports the root copy, so the store
-binaries, the web build and the request headers all ship it.
+Now it lives in the root `package.json` and nowhere else is written; the
+release script keeps the workspace packages in step, and `app.config.ts`
+imports the root copy, so the store binaries, the web build and the request
+headers all ship it.
 
 **It is `major.minor`, not semver.** `2.0`, then `2.1`. Every merge to `main`
 already reaches installed apps over the air without a number changing, so a
 patch level would be a number that never means anything — the third digit of
 `2.0.4` would say "some merges happened", which the update id in the footer
 already says exactly. A version now changes when someone decides a release is
-worth naming, and the tools do not need semver: pnpm accepts it for a private
-package, and both stores accept it as a version name.
+worth naming, and both stores accept two digits as a version name.
+
+pnpm does not, quite. `pnpm install` takes `2.0` on a private package, but
+`pnpm deploy` — the step that turns `apps/api` into the Fly image — matches
+`@langx/shared@workspace:*` by semver, and `2.0` matched nothing: the first
+deploy after the two digits reached the workspace manifests failed with
+`ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE`. So the three workspace
+`package.json` files carry `2.0.0`, the same number with a `.0` that nothing
+reads, and `pnpm release` writes it there. The root copy is what the version
+is; the trailing zero is what pnpm needs.
 
 **`pnpm release minor` is the whole ceremony.** It bumps the number, commits
 `Release 2.1` and tags it `v2.1`; pushing the tag makes the GitHub Release

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/shared",
-  "version": "2.0",
+  "version": "2.0.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "Contract shared by @langx/api and @langx/mobile: zod schemas, language and level tables, plan limits, token rules, error codes",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -8,9 +8,11 @@
  *     pnpm release --print  prints the current version and exits
  *
  * The version is two numbers, `major.minor`, and lives in the root
- * package.json. The workspace packages carry the same number so nothing in
- * the repo disagrees with it, but only the root copy is read: `app.config.ts`
- * imports it, so the store binaries and the web build ship it too.
+ * package.json; only that copy is read: `app.config.ts` imports it, so the
+ * store binaries and the web build ship it too. The workspace packages carry
+ * the same number with a `.0` on the end, because `pnpm deploy` matches
+ * `@langx/shared@workspace:*` by semver and `2.0` is not one — the API image
+ * stopped building the first time the two digits reached those files.
  *
  * Nothing is pushed. `main` is protected and releases go through the same
  * pull request as everything else; the script prints the two commands that
@@ -23,18 +25,20 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
-const MANIFESTS = [
-  'package.json',
+const ROOT_MANIFEST = 'package.json'
+/** Workspace packages: semver, `major.minor.0`, because pnpm needs one. */
+const WORKSPACE_MANIFESTS = [
   'apps/api/package.json',
   'apps/mobile/package.json',
   'packages/shared/package.json',
 ]
+const MANIFESTS = [ROOT_MANIFEST, ...WORKSPACE_MANIFESTS]
 
 /** `2.0`, `2.1`, `10.4` — and nothing else, so a typo cannot become a tag. */
 const VERSION = /^(\d+)\.(\d+)$/
 
 function readVersion() {
-  const { version } = JSON.parse(readFileSync(join(root, MANIFESTS[0]), 'utf8'))
+  const { version } = JSON.parse(readFileSync(join(root, ROOT_MANIFEST), 'utf8'))
   if (typeof version !== 'string' || !VERSION.test(version)) {
     throw new Error(`root package.json version must look like 2.0, got ${JSON.stringify(version)}`)
   }
@@ -79,13 +83,14 @@ function release(part) {
 
   for (const manifest of MANIFESTS) {
     const path = join(root, manifest)
+    const value = manifest === ROOT_MANIFEST ? next : `${next}.0`
     // A string replacement, not a parse-and-serialise round trip: the files
     // keep their key order, indentation and trailing newline exactly, so the
     // diff is one line per file and prettier has nothing to say about it.
     const source = readFileSync(path, 'utf8')
     const updated = source.replace(
       /^(\s*"version":\s*)"[^"]*"/m,
-      (_match, prefix) => `${prefix}${JSON.stringify(next)}`,
+      (_match, prefix) => `${prefix}${JSON.stringify(value)}`,
     )
     if (updated === source) throw new Error(`${manifest} has no "version" field to update`)
     writeFileSync(path, updated)


### PR DESCRIPTION
## What

- `apps/api`, `apps/mobile`, `packages/shared` `package.json` go from `2.0` to `2.0.0`. The root stays `2.0`.
- `scripts/release.mjs` writes the bare number to the root and `${next}.0` to the three workspace manifests.
- `docs/decisions.md`: the claim that pnpm accepts two digits is corrected.

## Why

`fly deploy -a langx-api` fails on main since #1150's neighbour, the version commit:

```
ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE  In apps/api: No matching version found for @langx/shared@workspace:* inside the workspace
```

`pnpm install` tolerates `2.0` on a private package; `pnpm deploy --legacy` resolves `workspace:*` by semver and matches nothing. Reproduced locally; with `2.0.0` on `packages/shared` the deploy step completes and `/out/node_modules/@langx/shared` is there.

Nothing reads the workspace copies. `app.config.ts` imports the root `2.0`, so the binaries and the footer are unchanged.

## Checks

- `pnpm install --frozen-lockfile --offline` still clean
- local `pnpm --filter @langx/api deploy --prod --legacy --config.node-linker=hoisted` succeeds
- prettier and eslint on the changed files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
