### PR TITLE
Show the derived city on the Me screen and keep the profile preview current

### DIFF
--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -1751,6 +1751,38 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
         return response.json<{ city?: string }>()
       }
 
+      /**
+       * The document as stored, `cityName` and all: the Me screen reads this
+       * field and applies `hideCity` itself. This is the test that would have
+       * caught the app reading `city` off a response that never carried it.
+       */
+      it('is on the own profile as cityName, regardless of the switch', async () => {
+        await seedCities()
+        const user = await onboardedUser('city-own@example.com', 'cityown')
+        await app.inject({
+          method: 'POST',
+          url: '/profiles/me/location',
+          headers: { cookie: user.cookie },
+          payload: { lat: 41.01, lng: 28.98 },
+        })
+        await app.inject({
+          method: 'PATCH',
+          url: '/profiles/me',
+          headers: { cookie: user.cookie },
+          payload: { privacy: { hideCity: true } },
+        })
+        const response = await app.inject({
+          method: 'GET',
+          url: '/profiles/me',
+          headers: { cookie: user.cookie },
+        })
+        expect(response.statusCode).toBe(200)
+        const own = response.json<{ cityName?: string; cityCountryCode?: string; city?: string }>()
+        expect(own.cityName).toBe('Istanbul')
+        expect(own.cityCountryCode).toBe('TR')
+        expect(own.city).toBeUndefined()
+      })
+
       it('is on a public profile by default', async () => {
         await seedCities()
         const them = await onboardedUser('city-shown@example.com', 'cityshown')

--- a/apps/mobile/app/(app)/(tabs)/me.tsx
+++ b/apps/mobile/app/(app)/(tabs)/me.tsx
@@ -105,8 +105,10 @@ export default function MeScreen() {
     `@${profile.handle}`,
     TIER_BADGES[tier],
     // Before the country, and only when there is one: it is worked out from a
-    // shared location, so most people have none and nobody typed it.
-    profile.city ?? null,
+    // shared location, so most people have none and nobody typed it. Withheld
+    // here too when "Hide my city" is on, so this line and what other people
+    // see cannot disagree about the setting.
+    profile.privacy.hideCity ? null : (profile.cityName ?? null),
     profile.country ? countryLabel(profile.country) : null,
   ]
     .filter(Boolean)

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -181,6 +181,29 @@ export function invalidateUnread(client: QueryClient): void {
   void client.invalidateQueries({ queryKey: keys.unread })
 }
 
+/**
+ * The caches that show this profile the way other people see it.
+ *
+ * `keys.me` is written from every profile mutation's response, but "Preview my
+ * profile" is the public screen, which reads three other queries — the
+ * profile by handle, its summary (the week chart) and its activity map — and
+ * with a 30-second `staleTime` those kept showing the old privacy switches
+ * until a pull-to-refresh. Invalidated rather than patched: the chart and the
+ * map are computed on the server from the switch, so the client has nothing
+ * correct to write. By handle, which is what the preview navigates with, and
+ * by id, which is what a deep link carries.
+ */
+function invalidateOwnPublicViews(queryClient: QueryClient, profile: MeProfile): void {
+  for (const key of [
+    keys.profile(profile.handle),
+    keys.profile(profile._id),
+    ['profileSummary', profile.handle],
+    ['profileActivity', profile.handle],
+  ]) {
+    void queryClient.invalidateQueries({ queryKey: key })
+  }
+}
+
 export async function markConversationRead(
   conversationId: string,
   queryClient: QueryClient,
@@ -226,10 +249,13 @@ export interface MeProfile {
   gender: Gender
   country?: string
   /**
-   * Read off the location, not typed. Absent for anyone not sharing one, and
-   * for anyone who turned it off in Settings.
+   * Read off the location, not typed, and named as the server stores it — the
+   * raw document is what `/profiles/me` sends. Absent for anyone not sharing a
+   * location. *Not* gated by `privacy.hideCity`: that switch is about other
+   * people, and the owner's screen applies it itself so the setting stays
+   * visible in the one place it can be checked.
    */
-  city?: string
+  cityName?: string
   timezone?: string
   photos?: { url: string }[]
   nativeLanguages: { code: string }[]
@@ -1579,6 +1605,8 @@ export function useShareLocation() {
       api.post<MeProfile>('/profiles/me/location', at),
     onSuccess: (profile) => {
       queryClient.setQueryData(keys.me, profile)
+      // The city on the public profile is read off this point.
+      invalidateOwnPublicViews(queryClient, profile)
       // The prefix every `keys.discovery(filters)` starts with: nearby results
       // are ordered by a distance that just changed, and which filter string
       // produced the cached page is not something this mutation can know.
@@ -1602,6 +1630,7 @@ export function useSetCountryFromLocation() {
       api.patch<MeProfile>('/profiles/me/country', { country, source: 'location' }),
     onSuccess: (profile) => {
       queryClient.setQueryData(keys.me, profile)
+      invalidateOwnPublicViews(queryClient, profile)
       void queryClient.invalidateQueries({ queryKey: ['discovery'] })
     },
   })
@@ -1613,17 +1642,30 @@ export function useStopSharingLocation() {
     mutationFn: () => api.delete<MeProfile>('/profiles/me/location'),
     onSuccess: (profile) => {
       queryClient.setQueryData(keys.me, profile)
+      invalidateOwnPublicViews(queryClient, profile)
       void queryClient.invalidateQueries({ queryKey: ['discovery'] })
     },
   })
 }
 
+/**
+ * What `PATCH /profiles/me` accepts, as far as the app needs to know: the
+ * privacy switches are named so a settings row can tell, from the mutation's
+ * `variables`, whether the request in flight is its own. Everything else stays
+ * loose — the server's `updateProfileSchema` is the real contract and strips
+ * what it does not know.
+ */
+export interface ProfilePatch extends Record<string, unknown> {
+  privacy?: Partial<MeProfile['privacy']>
+}
+
 export function useUpdateProfile() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (input: Record<string, unknown>) => api.patch<MeProfile>('/profiles/me', input),
+    mutationFn: (input: ProfilePatch) => api.patch<MeProfile>('/profiles/me', input),
     onSuccess: (profile) => {
       queryClient.setQueryData(keys.me, profile)
+      invalidateOwnPublicViews(queryClient, profile)
     },
   })
 }
@@ -1641,6 +1683,7 @@ export function useDiscloseGender() {
       api.post<MeProfile>('/profiles/me/gender', { gender }),
     onSuccess: (profile) => {
       queryClient.setQueryData(keys.me, profile)
+      invalidateOwnPublicViews(queryClient, profile)
       // The filter row reads `me.gender` to decide whether `onlyMyGender` does
       // anything, and discovery results change the moment it does.
       void queryClient.invalidateQueries({ queryKey: ['discovery'] })

--- a/apps/mobile/src/components/settings/SettingsRow.tsx
+++ b/apps/mobile/src/components/settings/SettingsRow.tsx
@@ -57,7 +57,16 @@ interface SettingsRowProps {
 export function SettingsRow({ id, model, last = false }: SettingsRowProps) {
   const styles = useStyles()
   const names = useDisplayNames()
-  const { t, profile, update } = model
+  const { t, profile, update, setPrivacy, pendingPrivacy } = model
+  /**
+   * A privacy toggle's value and busy state in one place: while its own
+   * request is in flight the switch shows what was asked for, so it moves
+   * under the finger, and settles on what the server answered.
+   */
+  const privacyToggle = (field: keyof NonNullable<typeof pendingPrivacy>, stored: boolean) => {
+    const pending = pendingPrivacy?.[field]
+    return { busy: pending !== undefined, value: pending ?? stored }
+  }
 
   switch (id) {
     case 'plan.current':
@@ -114,8 +123,8 @@ export function SettingsRow({ id, model, last = false }: SettingsRowProps) {
               <Toggle
                 accessibilityLabel={t('settings.incognito')}
                 disabled={!model.canIncognito}
-                value={profile?.privacy.incognito ?? false}
-                onValueChange={(incognito) => update.mutate({ privacy: { incognito } })}
+                {...privacyToggle('incognito', profile?.privacy.incognito ?? false)}
+                onValueChange={(incognito) => setPrivacy({ incognito })}
               />
             </View>
           }
@@ -133,10 +142,8 @@ export function SettingsRow({ id, model, last = false }: SettingsRowProps) {
           accessory={
             <Toggle
               accessibilityLabel={t('settings.activityMap')}
-              value={profile?.privacy.activityMapVisible ?? true}
-              onValueChange={(activityMapVisible) =>
-                update.mutate({ privacy: { activityMapVisible } })
-              }
+              {...privacyToggle('activityMapVisible', profile?.privacy.activityMapVisible ?? true)}
+              onValueChange={(activityMapVisible) => setPrivacy({ activityMapVisible })}
             />
           }
         />
@@ -154,8 +161,8 @@ export function SettingsRow({ id, model, last = false }: SettingsRowProps) {
           accessory={
             <Toggle
               accessibilityLabel={t('settings.showWeekChart')}
-              value={profile?.privacy.weekChartVisible ?? true}
-              onValueChange={(weekChartVisible) => update.mutate({ privacy: { weekChartVisible } })}
+              {...privacyToggle('weekChartVisible', profile?.privacy.weekChartVisible ?? true)}
+              onValueChange={(weekChartVisible) => setPrivacy({ weekChartVisible })}
             />
           }
         />
@@ -169,8 +176,8 @@ export function SettingsRow({ id, model, last = false }: SettingsRowProps) {
           accessory={
             <Toggle
               accessibilityLabel={t('settings.hideOnline')}
-              value={profile?.privacy.hideOnlineStatus ?? false}
-              onValueChange={(hideOnlineStatus) => update.mutate({ privacy: { hideOnlineStatus } })}
+              {...privacyToggle('hideOnlineStatus', profile?.privacy.hideOnlineStatus ?? false)}
+              onValueChange={(hideOnlineStatus) => setPrivacy({ hideOnlineStatus })}
             />
           }
         />
@@ -186,8 +193,8 @@ export function SettingsRow({ id, model, last = false }: SettingsRowProps) {
           accessory={
             <Toggle
               accessibilityLabel={t('settings.hideCity')}
-              value={profile?.privacy.hideCity ?? false}
-              onValueChange={(hideCity) => update.mutate({ privacy: { hideCity } })}
+              {...privacyToggle('hideCity', profile?.privacy.hideCity ?? false)}
+              onValueChange={(hideCity) => setPrivacy({ hideCity })}
             />
           }
         />

--- a/apps/mobile/src/components/ui/Toggle.tsx
+++ b/apps/mobile/src/components/ui/Toggle.tsx
@@ -1,10 +1,17 @@
-import { Pressable, View } from 'react-native'
-import { makeStyles } from '../../lib/theme'
+import { ActivityIndicator, Pressable, View } from 'react-native'
+import { makeStyles, useTheme } from '../../lib/theme'
 
 interface ToggleProps {
   value: boolean
   onValueChange: (next: boolean) => void
   disabled?: boolean
+  /**
+   * The change is on its way to the server. The knob becomes a spinner and
+   * presses are ignored until it lands: a privacy switch is the one control
+   * where a request that silently takes three seconds reads as a switch that
+   * did nothing, and a second tap then undoes the first.
+   */
+  busy?: boolean
   accessibilityLabel: string
 }
 
@@ -20,19 +27,26 @@ export function Toggle({
   value,
   onValueChange,
   disabled = false,
+  busy = false,
   accessibilityLabel,
 }: ToggleProps) {
+  const { colors } = useTheme()
   const styles = useStyles()
   return (
     <Pressable
       accessibilityRole="switch"
-      accessibilityState={{ checked: value, disabled }}
+      accessibilityState={{ checked: value, disabled: disabled || busy, busy }}
       accessibilityLabel={accessibilityLabel}
-      disabled={disabled}
+      disabled={disabled || busy}
       onPress={() => onValueChange(!value)}
       style={[styles.track, value ? styles.on : styles.off, disabled && styles.disabled]}
     >
-      <View style={styles.knob} />
+      {/* Same box as the knob, so the track does not change shape while it spins. */}
+      <View style={styles.knob}>
+        {busy ? (
+          <ActivityIndicator size="small" color={colors.accent} style={styles.spinner} />
+        ) : null}
+      </View>
     </Pressable>
   )
 }
@@ -54,13 +68,18 @@ const useStyles = makeStyles(({ colors, radius }) => ({
   off: { backgroundColor: colors.border, justifyContent: 'flex-start' },
   disabled: { opacity: 0.5 },
   knob: {
+    alignItems: 'center',
     backgroundColor: colors.knob,
     borderRadius: radius.pill,
     height: 21,
+    justifyContent: 'center',
     shadowColor: '#000000',
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.2,
     shadowRadius: 3,
     width: 21,
   },
+  // RN's "small" indicator is 20px; scaled so it sits inside the knob with a
+  // hairline of white around it rather than touching the edge.
+  spinner: { transform: [{ scale: 0.7 }] },
 }))

--- a/apps/mobile/src/hooks/useSettingsModel.ts
+++ b/apps/mobile/src/hooks/useSettingsModel.ts
@@ -3,6 +3,7 @@ import { router } from 'expo-router'
 import { useEffect, useState } from 'react'
 import { Linking, Platform } from 'react-native'
 import {
+  type MeProfile,
   useEffectiveTier,
   useHasFeature,
   useIsPro,
@@ -182,6 +183,27 @@ export function useSettingsModel() {
     showToast(t('settings.appIconChanged'))
   }
 
+  /**
+   * One privacy switch, flipped. The five rows share `update`, so the failure
+   * handling lives here once; the toggle's own busy state (read off
+   * `update.variables`) covers the time in between. A refused change is told
+   * rather than swallowed — the switch has already sprung back, and a silent
+   * spring-back looks like a bug in the switch rather than a request that
+   * failed.
+   */
+  function setPrivacy(patch: Partial<MeProfile['privacy']>): void {
+    update.mutate(
+      { privacy: patch },
+      { onError: () => void showAlert(t('settings.privacyFailed'), t('common.retry')) },
+    )
+  }
+
+  /**
+   * Which privacy field the in-flight `PATCH` is changing, if any — what each
+   * row reads to show *its* toggle as busy and not its neighbours'.
+   */
+  const pendingPrivacy = update.isPending ? update.variables?.privacy : undefined
+
   async function toggleLocation(next: boolean): Promise<void> {
     if (!next) {
       stopSharingLocation.mutate()
@@ -247,6 +269,8 @@ export function useSettingsModel() {
     theme,
     profile,
     update,
+    setPrivacy,
+    pendingPrivacy,
     iconSupported,
     appIcon,
     appIcons: APP_ICONS,

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -1135,6 +1135,7 @@ export const ar: Localized<EnMessages> = {
     updateLocation: 'تحديث موقعي',
     locationUpdated: 'حُدّث قبل {time}',
     updating: 'جارٍ التحديث…',
+    privacyFailed: 'تعذّر حفظ الإعداد',
     languageSection: 'اللغة',
     appLanguage: 'لغة التطبيق',
     translateTo: 'الترجمة إلى',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -999,6 +999,7 @@ export const de: Localized<EnMessages> = {
     updateLocation: 'Meinen Standort aktualisieren',
     locationUpdated: 'Vor {time} aktualisiert',
     updating: 'Wird aktualisiert…',
+    privacyFailed: 'Einstellung konnte nicht gespeichert werden',
     languageSection: 'Sprache',
     appLanguage: 'App-Sprache',
     translateTo: 'Übersetzen in',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -1019,6 +1019,7 @@ export const en = {
     updateLocation: 'Update my location',
     locationUpdated: 'Last updated {time} ago',
     updating: 'Updating…',
+    privacyFailed: 'Couldn’t save that setting',
     languageSection: 'Language',
     appLanguage: 'App language',
     translateTo: 'Translate into',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -976,6 +976,7 @@ export const es: Localized<EnMessages> = {
     updateLocation: 'Actualizar mi ubicación',
     locationUpdated: 'Actualizado hace {time}',
     updating: 'Actualizando…',
+    privacyFailed: 'No se pudo guardar el ajuste',
     languageSection: 'Idioma',
     appLanguage: 'Idioma de la app',
     translateTo: 'Traducir a',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -982,6 +982,7 @@ export const fr: Localized<EnMessages> = {
     updateLocation: 'Mettre à jour ma position',
     locationUpdated: 'Mis à jour il y a {time}',
     updating: 'Mise à jour…',
+    privacyFailed: 'Impossible d’enregistrer le réglage',
     languageSection: 'Langue',
     appLanguage: 'Langue de l’app',
     translateTo: 'Traduire en',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -970,6 +970,7 @@ export const ptBR: Localized<EnMessages> = {
     updateLocation: 'Atualizar minha localização',
     locationUpdated: 'Atualizado há {time}',
     updating: 'Atualizando…',
+    privacyFailed: 'Não foi possível salvar a configuração',
     languageSection: 'Idioma',
     appLanguage: 'Idioma do app',
     translateTo: 'Traduzir para',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -1092,6 +1092,7 @@ export const ru: Localized<EnMessages> = {
     updateLocation: 'Обновить местоположение',
     locationUpdated: 'Обновлено {time} назад',
     updating: 'Обновляем…',
+    privacyFailed: 'Не удалось сохранить настройку',
     languageSection: 'Язык',
     appLanguage: 'Язык приложения',
     translateTo: 'Переводить на',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -980,6 +980,7 @@ export const tr: Localized<EnMessages> = {
     updateLocation: 'Konumumu güncelle',
     locationUpdated: '{time} önce güncellendi',
     updating: 'Güncelleniyor…',
+    privacyFailed: 'Ayar kaydedilemedi',
     languageSection: 'Dil',
     appLanguage: 'Uygulama dili',
     translateTo: 'Çeviri dili',


### PR DESCRIPTION
## What

- **City on the own profile.** `GET /profiles/me` returns the stored document, where the city is `cityName`; the Me screen read `city`, which was never there. `MeProfile` now names the field as the server does, and the Me screen withholds it itself when "Hide my city" is on, so the owner sees the same thing other people do. The public profile was already correct.
- **API test** pinning `cityName` / `cityCountryCode` on the own-profile response, with the switch on — the coverage hole that let the mismatch through.
- **"Preview my profile" stays current.** Every profile mutation wrote `keys.me` only, while the preview reads the profile by handle, its summary (week chart) and its activity map, each kept for 30 s by `staleTime`. A single `invalidateOwnPublicViews` helper is now called from every mutation that changes what others see, including the location ones (the city is one of those things).
- **Busy state on privacy toggles.** `Toggle` gets `busy`: the knob spins and ignores presses while the PATCH is in flight. The five privacy rows go through one `setPrivacy` wrapper in the settings model, which reports a refused change instead of letting the switch silently spring back. New key `settings.privacyFailed` in all eight locales.

## Not in this PR

A production check of whether the `cities` collection is seeded. `setLocation` derives the city only when it is, and the seed script is run by hand. If the city is still blank after this ships, that is the first thing to look at.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` (shared 289, mobile 702, api 951) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
