### PR TITLE
Simplify the profile header, drop neighbourhoods from the city list, refresh location on nearby

### DIFF
--- a/apps/api/scripts/seed-cities.ts
+++ b/apps/api/scripts/seed-cities.ts
@@ -7,12 +7,14 @@
  * and the app credits it in "Our Kitchen".
  *
  * `cities15000` is every place with more than fifteen thousand people — about
- * twenty-four thousand of them. Big enough that a language-exchange user is
- * near one; small enough to sit in a collection without thought.
+ * thirty-two thousand of them once `SKIPPED_FEATURES` is applied. Big enough
+ * that a language-exchange user is near one; small enough to sit in a
+ * collection without thought.
  *
  * **Idempotent.** Every row is upserted by its own id, so a re-run after a
  * partial failure finishes the job and a re-run after a GeoNames update
- * refreshes what changed.
+ * refreshes what changed. Rows the export no longer has are deleted, and the
+ * profiles that pointed at them get their city worked out again.
  *
  * Usage:
  *   pnpm --filter @langx/api exec tsx scripts/seed-cities.ts                 # dry run
@@ -26,7 +28,8 @@ import type { Db } from 'mongodb'
 import { connectToDatabase } from '../src/db/client'
 import { COLLECTIONS } from '../src/db/collections'
 import { loadEnv } from '../src/env'
-import type { City } from '../src/modules/cities/cities'
+import { nearestCity, type City } from '../src/modules/cities/cities'
+import type { Profile } from '../src/modules/profiles/profiles'
 
 const SOURCE = 'https://download.geonames.org/export/dump/cities15000.zip'
 /** Written in batches so a run holds one batch in memory, not the whole file. */
@@ -37,7 +40,29 @@ const BATCH = 2000
  * https://download.geonames.org/export/dump/readme.txt — positional, and
  * unchanged for as long as the export has existed.
  */
-const COL = { id: 0, name: 1, ascii: 2, lat: 4, lng: 5, country: 8, admin1: 10, population: 14 }
+const COL = {
+  id: 0,
+  name: 1,
+  ascii: 2,
+  lat: 4,
+  lng: 5,
+  feature: 7,
+  country: 8,
+  admin1: 10,
+  population: 14,
+}
+
+/**
+ * Feature codes the export carries that nobody names as where they live.
+ *
+ * `PPLX` is a "section of populated place" — a neighbourhood, and there are
+ * two and a half thousand of them over fifteen thousand people. Left in, the
+ * nearest dozen places to a Toronto waterfront are all Toronto districts, the
+ * city itself is not among them, and the profile reads "Waterfront
+ * Communities-The Island". The rest are places that no longer exist as such:
+ * historical, abandoned, destroyed, and a former capital's historical entry.
+ */
+const SKIPPED_FEATURES = new Set(['PPLX', 'PPLH', 'PPLQ', 'PPLW', 'PPLCH'])
 
 function toCity(line: string): City | null {
   const parts = line.split('\t')
@@ -47,6 +72,7 @@ function toCity(line: string): City | null {
   const lng = Number(parts[COL.lng])
   const country = parts[COL.country]
   if (!id || !name || !country || !Number.isFinite(lat) || !Number.isFinite(lng)) return null
+  if (SKIPPED_FEATURES.has(parts[COL.feature] ?? '')) return null
   const admin1 = parts[COL.admin1]
   return {
     _id: `geonames:${id}`,
@@ -74,10 +100,18 @@ async function* lines(file: string): AsyncGenerator<string> {
   yield* createInterface({ input: stream, crlfDelay: Infinity })
 }
 
-async function seed(db: Db, file: string, apply: boolean): Promise<number> {
+interface Outcome {
+  written: number
+  pruned: number
+  /** Profiles whose city was worked out again because theirs was pruned. */
+  rehomed: number
+}
+
+async function seed(db: Db, file: string, apply: boolean): Promise<Outcome> {
   const collection = db.collection<City>(COLLECTIONS.cities)
   let batch: City[] = []
   let written = 0
+  const seen = new Set<string>()
 
   async function flush(): Promise<void> {
     if (batch.length === 0) return
@@ -96,11 +130,66 @@ async function seed(db: Db, file: string, apply: boolean): Promise<number> {
   for await (const line of lines(file)) {
     const city = toCity(line)
     if (!city) continue
+    seen.add(city._id)
     batch.push(city)
     if (batch.length >= BATCH) await flush()
   }
   await flush()
-  return written
+
+  /*
+   * What the export no longer has, or what the seed now skips, goes. Upserts
+   * alone would have left every neighbourhood from an earlier run in place,
+   * still winning `nearestCity`. The set of ids is small enough to send as a
+   * single `$nin` — this runs about once a year, from a laptop.
+   */
+  const stale = await collection
+    .find({ _id: { $nin: [...seen] } }, { projection: { _id: 1 } })
+    .map((row) => row._id)
+    .toArray()
+  // `rehome` does the delete, in the order it needs.
+  const rehomed = await rehome(db, stale, apply)
+  return { written, pruned: stale.length, rehomed }
+}
+
+/**
+ * Works the city out again for every profile that pointed at a pruned row.
+ *
+ * `setLocation` would do the same on the next fix, but "the next fix" can be
+ * weeks away, and until then the profile keeps naming a place the list no
+ * longer has. Same write shape as `setLocation`, and deliberately not
+ * `setLocation` itself: that also stamps `locationUpdatedAt`, and the person
+ * did not move. Runs before the delete, while the old rows are still there to
+ * lose to their real city.
+ */
+async function rehome(db: Db, staleIds: string[], apply: boolean): Promise<number> {
+  if (staleIds.length === 0) return 0
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  const affected = await profiles
+    .find({ cityId: { $in: staleIds } }, { projection: { _id: 1, location: 1 } })
+    .toArray()
+  if (!apply) return affected.length
+
+  // The pruned rows must not win again, so they are excluded from the lookup
+  // by removing them first — `nearestCity` has no exclusion list, and giving
+  // it one for a once-a-year script is the wrong trade.
+  await db.collection<City>(COLLECTIONS.cities).deleteMany({ _id: { $in: staleIds } })
+  for (const profile of affected) {
+    const city = profile.location ? await nearestCity(db, profile.location.coordinates) : null
+    await profiles.updateOne(
+      { _id: profile._id },
+      city
+        ? {
+            $set: {
+              cityId: city._id,
+              cityName: city.name,
+              cityCountryCode: city.countryCode,
+              country: city.countryCode,
+            },
+          }
+        : { $unset: { cityId: '', cityName: '', cityCountryCode: '' } },
+    )
+  }
+  return affected.length
 }
 
 async function main(): Promise<void> {
@@ -116,8 +205,13 @@ async function main(): Promise<void> {
   const env = loadEnv(process.env)
   const handle = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
   try {
-    const count = await seed(handle.db, file, apply)
-    console.log(`${apply ? 'Wrote' : 'Would write'} ${count} cities`)
+    const { written, pruned, rehomed } = await seed(handle.db, file, apply)
+    console.log(
+      `${apply ? 'Wrote' : 'Would write'} ${written} cities, ${apply ? 'pruned' : 'would prune'} ${pruned}`,
+    )
+    if (rehomed > 0) {
+      console.log(`${apply ? 'Rehomed' : 'Would rehome'} ${rehomed} profiles off pruned cities`)
+    }
     if (!apply) console.log('Dry run. Pass --apply to write.')
   } finally {
     await handle.close()

--- a/apps/mobile/app/(app)/(tabs)/discover.tsx
+++ b/apps/mobile/app/(app)/(tabs)/discover.tsx
@@ -5,9 +5,9 @@ import {
   NEARBY_RADIUS_OPTIONS_KM,
   type DiscoverySort,
 } from '@langx/shared'
-import { router, useLocalSearchParams } from 'expo-router'
+import { router, useFocusEffect, useLocalSearchParams } from 'expo-router'
 import { openProfile } from '../../../src/lib/navigation'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import Feather from '@expo/vector-icons/Feather'
 import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from 'react-native'
 import { useDiscovery, useHasFeature, useMe, useShareLocation } from '../../../src/api/queries'
@@ -75,6 +75,13 @@ function LanguageLine({ item }: { item: DiscoveryItem }) {
     </View>
   )
 }
+
+/**
+ * A fix younger than this is not retaken on focus. Long enough to cover the
+ * chip's own fix re-running the effect through `setSort`, short enough that
+ * leaving the tab and coming back does mean a new one.
+ */
+const FOCUS_REFRESH_DEBOUNCE_MS = 60_000
 
 export default function DiscoverScreen() {
   useScreenInteractive()
@@ -184,9 +191,40 @@ export default function DiscoverScreen() {
       await reportLocationFailure(fix.reason, t, 'location.needed')
       return false
     }
+    lastFixAt.current = Date.now()
     shareLocation.mutate({ lat: fix.lat, lng: fix.lng })
     return true
   }
+
+  /**
+   * When this screen last sent a fix, so the focus refresh below does not
+   * repeat one the chip just took: `setSort('nearby')` re-runs the effect.
+   */
+  const lastFixAt = useRef(0)
+
+  /*
+   * The tab remembers "nearby", so most nearby lists are opened without the
+   * chip ever being pressed — and were answered from wherever the person was
+   * when they last pressed it, until the foreground refresh's gap ran out.
+   * Coming back to a list sorted by distance is the same question as pressing
+   * the chip, so it gets the same fresh fix. Silent, and never a prompt: the
+   * chip is where permission is asked for, and a dialog on a tab switch is a
+   * dialog nobody can connect to anything they did.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      if (sort !== 'nearby' || !sharingLocation) return
+      if (Date.now() - lastFixAt.current < FOCUS_REFRESH_DEBOUNCE_MS) return
+      void (async () => {
+        const permission = await locationPermissionState()
+        if (!permission.granted) return
+        const fix = await captureLocation({ fresh: true, promptIfNeeded: false })
+        if (!fix.ok) return
+        lastFixAt.current = Date.now()
+        shareLocation.mutate({ lat: fix.lat, lng: fix.lng })
+      })()
+    }, [sort, sharingLocation, shareLocation]),
+  )
 
   /**
    * A free account never sends a Pro filter, even when one reaches it — a

--- a/apps/mobile/app/(app)/(tabs)/me.tsx
+++ b/apps/mobile/app/(app)/(tabs)/me.tsx
@@ -1,14 +1,8 @@
 import { LoadFailed } from '../../../src/components/LoadFailed'
-import {
-  countryFlag,
-  getCountry,
-  wornCosmetic,
-  TIER_BADGES,
-  TIER_NAMES,
-  tierUnlocking,
-} from '@langx/shared'
+import { wornCosmetic, TIER_BADGES, TIER_NAMES, tierUnlocking } from '@langx/shared'
 import Feather from '@expo/vector-icons/Feather'
 import { router } from 'expo-router'
+import { placeLabel } from '../../../src/lib/placeLabel'
 import { ActivityIndicator, Platform, Pressable, Text, View } from 'react-native'
 import {
   useBadges,
@@ -45,12 +39,6 @@ export default function MeScreen() {
   const t = useT()
   const { locale } = useLocale()
   const names = useDisplayNames()
-
-  /** "🇹🇷 Türkiye", not "🇹🇷 TR" — the flag and the code say the same thing twice. */
-  const countryLabel = (code: string): string => {
-    const country = getCountry(code)
-    return country ? `${countryFlag(country.code)} ${names.country(country.code)}` : code
-  }
 
   const me = useMe()
   const xp = useTokens()
@@ -104,12 +92,16 @@ export default function MeScreen() {
   const meta = [
     `@${profile.handle}`,
     TIER_BADGES[tier],
-    // Before the country, and only when there is one: it is worked out from a
-    // shared location, so most people have none and nobody typed it. Withheld
-    // here too when "Hide my city" is on, so this line and what other people
-    // see cannot disagree about the setting.
-    profile.privacy.hideCity ? null : (profile.cityName ?? null),
-    profile.country ? countryLabel(profile.country) : null,
+    // The city is worked out from a shared location, so most people have none
+    // and nobody typed it. Withheld here too when "Hide my city" is on, so this
+    // line and what other people see cannot disagree about the setting.
+    placeLabel(
+      {
+        city: profile.privacy.hideCity ? undefined : profile.cityName,
+        country: profile.country,
+      },
+      names.country,
+    ) ?? null,
   ]
     .filter(Boolean)
     .join(' · ')

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -1,5 +1,5 @@
 import Feather from '@expo/vector-icons/Feather'
-import { countryFlag, getCountry, wornCosmetic } from '@langx/shared'
+import { wornCosmetic } from '@langx/shared'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useState } from 'react'
 import { ActivityIndicator, Pressable, Text, TextInput, View } from 'react-native'
@@ -19,6 +19,7 @@ import {
 import { ActivityMap } from '../../../src/components/ActivityMap'
 import { Avatar } from '../../../src/components/ui/Avatar'
 import { PresenceLine } from '../../../src/components/PresenceLine'
+import { placeLabel } from '../../../src/lib/placeLabel'
 import { CosmeticTitle } from '../../../src/components/CosmeticTitle'
 import { Button } from '../../../src/components/ui/Button'
 import { LanguageColumns } from '../../../src/components/LanguageColumns'
@@ -35,7 +36,6 @@ import { shareLink } from '../../../src/lib/share'
 import { profileShareText } from '../../../src/lib/shareText'
 import { openPaywall } from '../../../src/lib/paywall'
 import { showToast } from '../../../src/lib/toast'
-import { days } from '../../../src/lib/format'
 import { makeStyles, useTheme } from '../../../src/lib/theme'
 import { accountAgeLabel, interestLabel, useDisplayNames, useT } from '../../../src/i18n'
 import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
@@ -46,12 +46,6 @@ export default function ProfileScreen() {
   const styles = useStyles()
   const t = useT()
   const names = useDisplayNames()
-
-  /** "🇹🇷 Türkiye", not "TR" — the code alone means nothing to a reader. */
-  const countryLabel = (code: string): string => {
-    const country = getCountry(code)
-    return country ? `${countryFlag(country.code)} ${names.country(country.code)}` : code
-  }
 
   // `from` is set by whoever pushed here — this screen is reachable from
   // Discover, Chats, the viewer list, the leaderboard and a chat header, so a
@@ -96,14 +90,13 @@ export default function ProfileScreen() {
   const isSelf = user?._id === me.data?._id
   const canSend = message.trim().length > 0 && !startConversation.isPending
 
-  // v3's identity block folds the badge chips into one muted line.
-  const metaLine = [
-    String(user.age),
-    user.city ?? null,
-    user.country ? countryLabel(user.country) : null,
-    user.streak.current > 0 ? `🔥 ${days(t, user.streak.current)}` : null,
-    user.emailVerified ? t('profile.verifiedEmail') : null,
-  ]
+  /*
+   * v3's identity block folds the badge chips into one muted line — and it
+   * has to stay one line. It used to carry the streak and "Verified email"
+   * too, wrapped on every phone, and said the streak twice: the tile below
+   * already has it. The verified mark is now beside the name.
+   */
+  const metaLine = [String(user.age), placeLabel(user, names.country) ?? null]
     .filter(Boolean)
     .join(' · ')
 
@@ -247,6 +240,18 @@ export default function ProfileScreen() {
         )}
         <View style={styles.nameRow}>
           <Text style={styles.name}>{user.displayName}</Text>
+          {/* A mark rather than the words: the words cost a third of the meta
+              line, and a check by the name is what every other app taught
+              people it means. The label is for the screen reader. */}
+          {user.emailVerified ? (
+            <Feather
+              name="check-circle"
+              size={16}
+              color={colors.success}
+              accessibilityLabel={t('profile.verifiedEmail')}
+              style={styles.verified}
+            />
+          ) : null}
           <CosmeticTitle cosmetic={wornCosmetic(user.equipped, user.cosmetics ?? [], 'title')} />
         </View>
         {/*
@@ -265,7 +270,13 @@ export default function ProfileScreen() {
           @{user.handle} · {t('profile.registeredLabel')}{' '}
           {accountAgeLabel(t, new Date(user.createdAt))}
         </Text>
-        {metaLine ? <Text style={styles.meta}>{metaLine}</Text> : null}
+        {/* One line, whatever the city is called — the tail is the country
+            name's job to lose, and the flag before it survives. */}
+        {metaLine ? (
+          <Text style={styles.meta} numberOfLines={1}>
+            {metaLine}
+          </Text>
+        ) : null}
         {user.tier !== 'free' ? (
           <View style={styles.tierRow}>
             <TierBadge tier={user.tier} />
@@ -445,15 +456,9 @@ export default function ProfileScreen() {
               {error ? <Text style={styles.error}>{error}</Text> : null}
             </>
           )}
-
-          <View style={styles.danger}>
-            <Pressable onPress={() => void confirmReport()} hitSlop={8}>
-              <Text style={styles.dangerText}>{t('common.report')}</Text>
-            </Pressable>
-            <Pressable onPress={() => void confirmBlock()} hitSlop={8}>
-              <Text style={styles.dangerText}>{t('common.block')}</Text>
-            </Pressable>
-          </View>
+          {/* Report and Block live in the top-right menu only. They used to be
+              repeated as a row down here, which made the bottom of every
+              profile read as a warning. */}
         </>
       )}
     </Screen>
@@ -480,6 +485,8 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   presence: { marginTop: 6 },
   nameRow: { alignItems: 'center', flexDirection: 'row', gap: 6, justifyContent: 'center' },
   name: { ...font.heading, color: colors.text, fontSize: 24, marginTop: 12 },
+  // Sits on the name's baseline row, which `marginTop` on the name shifts.
+  verified: { marginTop: 12 },
   handle: { color: colors.textMuted, fontSize: 14, marginTop: 2 },
   meta: { color: colors.textMuted, fontSize: 14, marginTop: 8, textAlign: 'center' },
   tierRow: { marginTop: spacing.sm },
@@ -535,14 +542,4 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
     lineHeight: 19,
     marginTop: spacing.xl,
   },
-  danger: {
-    borderTopColor: colors.border,
-    borderTopWidth: 1,
-    flexDirection: 'row',
-    gap: 32,
-    justifyContent: 'center',
-    marginTop: spacing.xxl,
-    paddingVertical: spacing.lg,
-  },
-  dangerText: { color: colors.danger, fontSize: 13, fontWeight: '600' },
 }))

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -928,7 +928,7 @@ export const ar: Localized<EnMessages> = {
     followingEmptyBody: 'تابع أحدهم لتظهر منشوراته في تدفقك.',
     followFailed: 'لم ينجح ذلك. حاول مرة أخرى.',
     notFound: 'الملف غير موجود.',
-    verifiedEmail: '✓ بريد مؤكَّد',
+    verifiedEmail: 'بريد مؤكَّد',
     registeredLabel: 'مسجّل',
     interests: 'الاهتمامات',
     registered: '· مسجّل {age}',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -803,7 +803,7 @@ export const de: Localized<EnMessages> = {
     followingEmptyBody: 'Folge jemandem, und die Beiträge erscheinen in deinem Feed.',
     followFailed: 'Das hat nicht geklappt. Versuch es noch einmal.',
     notFound: 'Profil nicht gefunden.',
-    verifiedEmail: '✓ E-Mail bestätigt',
+    verifiedEmail: 'E-Mail bestätigt',
     registeredLabel: 'Registriert',
     interests: 'Interessen',
     registered: '· registriert {age}',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -826,7 +826,7 @@ export const en = {
     followingEmptyBody: 'Follow someone and their posts appear in your feed.',
     followFailed: 'That did not work. Try again.',
     notFound: 'Profile not found.',
-    verifiedEmail: '✓ Verified email',
+    verifiedEmail: 'Verified email',
     registeredLabel: 'Registered',
     interests: 'Interests',
     registered: '· registered {age}',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -782,7 +782,7 @@ export const es: Localized<EnMessages> = {
     followingEmptyBody: 'Sigue a alguien y sus publicaciones aparecerán en tu feed.',
     followFailed: 'No funcionó. Inténtalo de nuevo.',
     notFound: 'Perfil no encontrado.',
-    verifiedEmail: '✓ Correo verificado',
+    verifiedEmail: 'Correo verificado',
     registeredLabel: 'Registrado',
     interests: 'Intereses',
     registered: '· registrado {age}',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -787,7 +787,7 @@ export const fr: Localized<EnMessages> = {
     followingEmptyBody: 'Suivez quelqu’un et ses publications apparaîtront dans votre fil.',
     followFailed: 'Cela n’a pas fonctionné. Réessayez.',
     notFound: 'Profil introuvable.',
-    verifiedEmail: '✓ E-mail vérifié',
+    verifiedEmail: 'E-mail vérifié',
     registeredLabel: 'Inscrit',
     interests: 'Centres d’intérêt',
     registered: '· inscrit {age}',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -775,7 +775,7 @@ export const ptBR: Localized<EnMessages> = {
     followingEmptyBody: 'Siga alguém e as publicações aparecerão no seu feed.',
     followFailed: 'Não deu certo. Tente de novo.',
     notFound: 'Perfil não encontrado.',
-    verifiedEmail: '✓ E-mail confirmado',
+    verifiedEmail: 'E-mail confirmado',
     registeredLabel: 'Cadastro',
     interests: 'Interesses',
     registered: '· cadastro {age}',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -891,7 +891,7 @@ export const ru: Localized<EnMessages> = {
     followingEmptyBody: 'Подпишитесь, и посты появятся в вашей ленте.',
     followFailed: 'Не получилось. Попробуйте ещё раз.',
     notFound: 'Профиль не найден.',
-    verifiedEmail: '✓ Почта подтверждена',
+    verifiedEmail: 'Почта подтверждена',
     registeredLabel: 'Зарегистрирован',
     interests: 'Интересы',
     registered: '· зарегистрирован {age}',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -786,7 +786,7 @@ export const tr: Localized<EnMessages> = {
     followingEmptyBody: 'Birini takip et, gönderileri akışında görünsün.',
     followFailed: 'Olmadı. Tekrar dene.',
     notFound: 'Profil bulunamadı.',
-    verifiedEmail: '✓ E-posta doğrulanmış',
+    verifiedEmail: 'E-posta doğrulanmış',
     registeredLabel: 'Kayıt',
     interests: 'İlgi alanları',
     registered: '· kayıt {age}',

--- a/apps/mobile/src/lib/placeLabel.test.ts
+++ b/apps/mobile/src/lib/placeLabel.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { placeLabel } from './placeLabel'
+
+const names = (code: string): string => ({ CA: 'Canada', TR: 'Türkiye' })[code] ?? code
+
+describe('placeLabel', () => {
+  it('puts the flag in front of the city, and leaves the country name out', () => {
+    expect(placeLabel({ city: 'Toronto', country: 'CA' }, names)).toBe('🇨🇦 Toronto')
+  })
+
+  it('names the country when there is no city', () => {
+    expect(placeLabel({ country: 'TR' }, names)).toBe('🇹🇷 Türkiye')
+  })
+
+  it('is nothing when nothing is known', () => {
+    expect(placeLabel({}, names)).toBeUndefined()
+  })
+
+  it('does not invent a flag for a code the list does not know', () => {
+    expect(placeLabel({ city: 'Somewhere', country: 'ZZ' }, names)).toBe('Somewhere')
+    expect(placeLabel({ country: 'ZZ' }, names)).toBe('ZZ')
+  })
+})

--- a/apps/mobile/src/lib/placeLabel.ts
+++ b/apps/mobile/src/lib/placeLabel.ts
@@ -1,0 +1,25 @@
+import { countryFlag, getCountry } from '@langx/shared'
+
+/**
+ * Where somebody is, as one item on a meta line: "🇨🇦 Toronto", or "🇨🇦 Canada"
+ * when there is no city to say.
+ *
+ * One item, not two. The line used to run "Waterfront Communities-The Island
+ * · 🇨🇦 Canada", the city and the country as separate entries, and wrapped to
+ * a second line on most phones. The flag already names the country to anyone
+ * who recognises it, and the country's name is only worth its width when it
+ * is the only thing known.
+ *
+ * `countryName` is passed in rather than imported: the localised name comes
+ * from `useDisplayNames`, a hook, and this has to stay a plain function so it
+ * is testable and usable from both profile screens.
+ */
+export function placeLabel(
+  { city, country }: { city?: string | undefined; country?: string | undefined },
+  countryName: (code: string) => string,
+): string | undefined {
+  const known = country ? getCountry(country) : undefined
+  if (!known) return city ?? country
+  const flag = countryFlag(known.code)
+  return `${flag} ${city ?? countryName(known.code)}`
+}

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -7,9 +7,12 @@ attribution obligations.
 ## Cities — GeoNames
 
 `cities` holds every place with a population over fifteen thousand — about
-twenty-four thousand rows. A profile's city is read off its stored coordinates
-against this list, and the discovery filter searches the same list, so the two
-ends of that filter cannot disagree.
+thirty-two thousand rows once the seed drops what nobody calls home: the
+export also lists neighbourhoods (`PPLX`, a "section of populated place") and
+historical, abandoned or destroyed places, and a Toronto waterfront district
+outranking Toronto is what happens when they are left in. A profile's city is
+read off its stored coordinates against this list, and the discovery filter
+searches the same list, so the two ends of that filter cannot disagree.
 
 |             |                                                             |
 | ----------- | ----------------------------------------------------------- |
@@ -25,7 +28,10 @@ The required notice, which must appear wherever the data is credited:
 
 Refreshing it is a re-run of the seed script against a newly downloaded export;
 every row is upserted by its own id, so ids are stable across updates and a
-profile's `cityId` survives.
+profile's `cityId` survives. A row the export no longer carries — or one the
+seed now skips — is deleted, and every profile that pointed at it has its city
+worked out again from its stored coordinates, so a city never outlives the
+list it came from.
 
 **Attribution is a licence condition, not a courtesy.** Removing it from any of
 the three places above is a licence breach, and the repo is public.

--- a/packages/shared/src/location.ts
+++ b/packages/shared/src/location.ts
@@ -39,15 +39,19 @@ export const LOCATION_PRECISION_DECIMALS = 2
 /**
  * How stale a shared location may get before the app quietly refreshes it.
  *
- * Six hours, and the number follows from `LOCATION_PRECISION_DECIMALS`: the
- * stored point is rounded to about a kilometre, so anything finer than a few
- * hours mostly writes the same cell back and spends a GPS wake-up to do it.
+ * One hour. It was six, on the argument that `LOCATION_PRECISION_DECIMALS`
+ * rounds the point to about a kilometre so a finer refresh mostly writes the
+ * same cell back — true, and also how a person who crossed a city after lunch
+ * stayed "nearby" the wrong people until the evening. An hour is the age the
+ * device's own cached fix is allowed to have (`captureLocation`'s `maxAge`),
+ * so a gap below it would only re-read the cache; this is the floor at which
+ * a refresh can actually learn something.
  *
  * There is no background permission — `app.config.ts` disables it on both
  * platforms and says why — so this is a floor on how often a *foreground*
  * refresh may happen, not a schedule.
  */
-export const LOCATION_REFRESH_MIN_GAP_MS = 6 * 60 * 60 * 1000
+export const LOCATION_REFRESH_MIN_GAP_MS = 60 * 60 * 1000
 
 export const NEARBY_MAX_KM = 500
 


### PR DESCRIPTION
## What

- **Profile header, one line.** The meta line was `36 · Waterfront Communities-The Island · 🇨🇦 Canada · 🔥 2 days · ✓ Verified email` and wrapped on every phone. Now it is the age and one place item — `🇨🇦 Toronto`, or `🇨🇦 Canada` when there is no city — built by a new `placeLabel` helper used on both the public profile and the Me screen. The streak is gone from the line (the tile below has it), the verified mark is a check icon beside the name, and the line is capped at one row.
- **Report / Block row removed** from the bottom of the public profile. Both are in the top-right menu already.
- **Neighbourhoods out of the city list.** GeoNames' `cities15000` includes ~2,400 `PPLX` "section of populated place" rows, and in a dense city the nearest dozen places are all districts, so `nearestCity` never saw the city itself. The seed skips those (plus historical, abandoned and destroyed places), deletes rows the export no longer has, and re-derives the city for every profile that pointed at a deleted row.
- **Location refreshes when Discover focuses on nearby.** The tab remembers the sort, so most nearby lists opened without the chip being pressed. A fresh fix is now taken on focus, silently, never with a prompt, debounced against the chip's own fix.
- **Foreground refresh gap 6h → 1h** (`LOCATION_REFRESH_MIN_GAP_MS`). An hour is the device cache's own `maxAge`, so anything smaller only re-reads the cache.

## Already applied to production

The updated seed was run against prod before this PR: 31,722 cities written, 2,414 pruned, 2 profiles rehomed (both now read "Toronto"). No API runtime change, so no API deploy is needed. Mobile goes out via the OTA workflow on merge.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` (shared 289, mobile 706, api 951) green locally. New unit test for `placeLabel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
