### PR TITLE
Move the bio under the week's chart on both profile screens

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/me.tsx
+++ b/apps/mobile/app/(app)/(tabs)/me.tsx
@@ -162,18 +162,10 @@ export default function MeScreen() {
       </View>
 
       {/*
-        The about text, on the owner's own screen. It was only ever drawn on
-        the public profile, so someone whose v1 bio had come back concluded
-        from here that it had not — the one screen that must not invite that
-        reading about its own owner. Same shape as the public profile's.
-      */}
-      {profile.bio ? <Text style={styles.bio}>{profile.bio}</Text> : null}
-
-      {/*
         The same two columns everybody else sees, in the same place — under the
-        bio, above the numbers. It used to be one compressed row further down,
-        which described a different-looking profile from the one being shown to
-        other people. Tapping it edits, since this is the owner.
+        header, above the numbers. It used to be one compressed row further
+        down, which described a different-looking profile from the one being
+        shown to other people. Tapping it edits, since this is the owner.
       */}
       <Pressable
         accessibilityRole="button"
@@ -219,6 +211,15 @@ export default function MeScreen() {
       </View>
 
       {summary ? <WeeklyChart week={summary.week} /> : null}
+
+      {/*
+        The about text, on the owner's own screen. It was only ever drawn on
+        the public profile, so someone whose v1 bio had come back concluded
+        from here that it had not — the one screen that must not invite that
+        reading about its own owner. Under the week's chart, in the same place
+        as on the public profile, so the two views of one profile read alike.
+      */}
+      {profile.bio ? <Text style={styles.bio}>{profile.bio}</Text> : null}
 
       {/* First of the rows, because it is the one that answers a question
           somebody actually arrives with: where the thing I asked went. */}
@@ -288,7 +289,9 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   heroText: { flex: 1, minWidth: 0 },
   name: { ...font.heading, color: colors.text, fontSize: 24 },
   handle: { color: colors.textMuted, fontSize: 14, marginTop: 2 },
-  bio: { ...font.body, color: colors.text, marginTop: spacing.sm },
+  // The chart above ends in a border and the rows below start with one, so the
+  // bio needs its own room on both sides to read as a paragraph, not a caption.
+  bio: { ...font.body, color: colors.text, marginBottom: spacing.md, marginTop: spacing.md },
   pressed: { opacity: 0.7 },
   tiles: {
     borderBottomColor: colors.border,

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -343,11 +343,11 @@ export default function ProfileScreen() {
       ) : null}
 
       {/*
-        The numbers, above the bio rather than under the interests where they
-        used to be: they are the quickest read of whether this person is here
-        to teach, and a reader deciding whether to write has usually decided
-        by the time they reach the languages. Always sent — there is no switch
-        for them any more; only the chart below has one.
+        The numbers, above the languages rather than under the interests where
+        they used to be: they are the quickest read of whether this person is
+        here to teach, and a reader deciding whether to write has usually
+        decided by the time they reach the languages. Always sent — there is no
+        switch for them any more; only the chart below has one.
       */}
       {summary.data ? (
         <View style={styles.stats}>
@@ -365,8 +365,6 @@ export default function ProfileScreen() {
           <StatTile label={t('tokens.title')} value={String(summary.data.tokens)} />
         </View>
       ) : null}
-
-      {user.bio ? <Text style={styles.bio}>{user.bio}</Text> : null}
 
       {/* v3's two-column language block, shared with the owner's own tab so
           the two views of one profile cannot drift apart. */}
@@ -390,6 +388,15 @@ export default function ProfileScreen() {
         same kind of thing at a different zoom.
       */}
       {summary.data?.week ? <WeeklyChart week={summary.data.week} /> : null}
+
+      {/*
+        The about text, under the chart rather than between the numbers and
+        the languages: the facts a reader scans first stay together at the top,
+        and the prose comes once they have decided to keep reading. Same place
+        as on the owner's own tab. With the chart switched off it simply
+        follows the interests.
+      */}
+      {user.bio ? <Text style={styles.bio}>{user.bio}</Text> : null}
 
       {/* Read-only, and drawn from the same component as your own — a second
           implementation of a grid is a second grid to keep in step. */}
@@ -498,8 +505,9 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   followCount: { color: colors.text, fontSize: 14, fontWeight: '700' },
   followingCount: { color: colors.textMuted, fontSize: 14, fontWeight: '600' },
   followButton: { marginTop: spacing.lg },
-  // A top margin as well as a bottom one: with no photos, `PhotoGallery`
-  // draws nothing, and the bio used to sit flush against the Follow button.
+  // A top margin as well as a bottom one: the chart above ends in a border and
+  // the activity map below starts flush, so without both the bio reads as a
+  // caption of whichever neighbour it happens to touch.
   bio: { ...font.body, color: colors.text, marginBottom: spacing.md, marginTop: spacing.md },
   sectionTitle: {
     color: colors.textFaint,


### PR DESCRIPTION
On the owner's tab the about text sat between the header and the language columns; on the public profile it sat between the stat tiles and the languages. Both screens now draw it directly under the "This week" chart, so the facts a reader scans first stay together at the top and the two views of one profile read alike.

- `me.tsx`: bio moved below `WeeklyChart`, above the Viewers row; given the same top/bottom margin as the public profile's.
- `profile/[handle].tsx`: bio moved below `WeeklyChart`, above the activity map. With the chart switched off it follows the interests.

Typecheck, eslint and prettier pass. No screen tests exist for these routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)