### PR TITLE
Deploy the web build to app.langx.io on every merge to main

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -48,7 +48,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      # Pinned to the commit `v6` pointed at on 5 September 2026, which CodeQL
+      # asks of any third-party action: a tag can be moved to run other code in
+      # a job that holds the Cloudflare token. `actions/*` are GitHub's own and
+      # exempt. ci.yml still says `v6`; it holds no secrets.
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,73 @@
+# Every merge to main that touches the app becomes the web build on
+# app.langx.io — the same trigger and the same paths as the OTA update in
+# apps/mobile/.eas/workflows/update.yml. That one runs on expo.dev and hands
+# the JS to installed apps; this one runs here and hands it to the browser.
+# Until 5 September 2026 the web half was `pnpm deploy:web` from a laptop, by
+# hand, and app.langx.io routinely sat a few merges behind the phones.
+#
+# `EXPO_PUBLIC_*` values are inlined when the bundle is exported, and this
+# checkout has no `.env`, so they come from repository secrets. They are the
+# values the EAS `production` environment holds for update.yml, plus the
+# RevenueCat web key, which only the web build needs and EAS does not have.
+# The API URL is written here in the open, as eas.json writes it for the
+# production build profile. A missing secret does not fail the export: the
+# bundle simply ships without that integration, exactly as a local build does
+# — so a blank Plans screen or silent analytics after a run means a secret
+# went missing, not that the code broke.
+#
+# `deploy:web` is reused rather than re-spelt so there is one definition of a
+# web deploy, by hand or from here. It uploads to the Pages project and then
+# runs scripts/verify-web-deploy.mjs against app.langx.io, which is what turns
+# an upload that "succeeded" into a stale edge into a red run.
+name: Deploy web
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - apps/mobile/**
+      - packages/shared/**
+      - pnpm-lock.yaml
+      - .github/workflows/deploy-web.yml
+      - '!**/*.md'
+  workflow_dispatch:
+
+# One deploy at a time, in order. Cancelling a run mid-upload buys nothing; a
+# second merge while one is running waits its turn and ships the newer tree,
+# and GitHub drops any runs queued between the two.
+concurrency:
+  group: deploy-web
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Export the web build
+        working-directory: apps/mobile
+        env:
+          EXPO_PUBLIC_API_URL: https://api.langx.io
+          EXPO_PUBLIC_REVENUECAT_WEB_KEY: ${{ secrets.EXPO_PUBLIC_REVENUECAT_WEB_KEY }}
+          EXPO_PUBLIC_POSTHOG_KEY: ${{ secrets.EXPO_PUBLIC_POSTHOG_KEY }}
+        run: pnpm build:web
+
+      - name: Upload to Cloudflare Pages and check the live host
+        working-directory: apps/mobile
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm deploy:web

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -2,9 +2,9 @@
 # the pull requests merged since the previous tag.
 #
 # The tag is the trigger and `pnpm release` is what makes one: it bumps the
-# version, commits and tags, and the person pushes. So this is the only
-# workflow here besides CI, and it builds nothing — shipping still lives on
-# expo.dev (`apps/mobile/.eas/workflows/`), and a store build is still a
+# version, commits and tags, and the person pushes. It builds nothing —
+# `deploy-web.yml` ships the web on merge, store builds and OTA updates live
+# on expo.dev (`apps/mobile/.eas/workflows/`), and a store build is still a
 # decision someone makes there.
 #
 # The guard is the tag having to match the version in package.json. A tag

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -302,13 +302,23 @@ pnpm --filter @langx/api exec tsx scripts/send-campaign.ts \
 ## Shipping runs on expo.dev
 
 Builds, store submissions and over-the-air updates are all EAS jobs, defined
-in `apps/mobile/.eas/workflows/`. GitHub Actions tests, and turns a version tag
-into a Release page (see below). The two workflows, and what each costs:
+in `apps/mobile/.eas/workflows/`. GitHub Actions tests, deploys the web and
+turns a version tag into a Release page (see below). The workflows that ship
+something, and what each costs:
 
-| Workflow      | Trigger                  | Cost                              |
-| ------------- | ------------------------ | --------------------------------- |
-| `update.yml`  | every merge to `main`    | nothing — an OTA update, no build |
-| `release.yml` | by hand, pick a platform | one build, then `eas submit`      |
+| Workflow         | Where          | Trigger                  | Cost                               |
+| ---------------- | -------------- | ------------------------ | ---------------------------------- |
+| `update.yml`     | expo.dev       | every merge to `main`    | nothing — an OTA update, no build  |
+| `deploy-web.yml` | GitHub Actions | every merge to `main`    | nothing — a static export to Pages |
+| `release.yml`    | expo.dev       | by hand, pick a platform | one build, then `eas submit`       |
+
+`update.yml` and `deploy-web.yml` watch the same paths on purpose: a merge
+that changes the app reaches installed phones and `app.langx.io` from the
+same commit, and neither waits for the other. Until 5 September 2026 the web
+half was `pnpm deploy:web` from a laptop and lagged the phones by however
+long nobody remembered it. The GitHub workflow reuses that same script, so
+the hand-run path still exists and still ends with the live-host check;
+the secrets it needs are named in the workflow file.
 
 **The version number is `major.minor` and lives in the root `package.json`.**
 `app.config.ts` imports it, so the binaries and the web build carry whatever
@@ -320,11 +330,12 @@ git push -u origin <branch>   # the release commit goes through a PR like any ot
 git push origin v2.1          # once it is on main; the tag creates the GitHub Release
 ```
 
-The tag is the only GitHub-side automation: `github-release.yml` checks it
-against `package.json` and writes a Release with notes from the merged pull
-requests. It builds nothing. A new number reaches the stores with the next
-`release.yml` run on expo.dev and the web with the next `pnpm deploy:web`;
-installed apps keep showing the binary's own number until a store build ships.
+The tag's only effect is on GitHub: `github-release.yml` checks it against
+`package.json` and writes a Release with notes from the merged pull requests.
+It builds nothing. A new number reaches the stores with the next `release.yml`
+run on expo.dev, and the web with the merge of the release commit itself,
+since `deploy-web.yml` runs on it; installed apps keep showing the binary's
+own number until a store build ships.
 
 **There is one channel, `production`, and merging to `main` publishes to it.**
 A JS-only change reaches every installed app on its next launch without a

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -45,7 +45,7 @@ the repos themselves.
 
 | Host             | Hosting                                                       | How a change gets there                                                    |
 | ---------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `app.langx.io`   | Cloudflare Pages project `langx-web` (direct upload)          | `pnpm --filter @langx/mobile deploy:web` from this repo, by hand           |
+| `app.langx.io`   | Cloudflare Pages project `langx-web` (direct upload)          | push to `main` of this repo; `deploy-web.yml` exports, uploads and checks  |
 | `api.langx.io`   | Fly.io app `langx-api`, behind Cloudflare                     | `fly deploy -a langx-api` from this repo, by hand                          |
 | `langx.io`       | Cloudflare Pages project `website` (direct upload)            | push to `main` of `langx/website`; its workflow builds, uploads and purges |
 | `token.langx.io` | Cloudflare Pages project `token-website` (**Git-integrated**) | push to `main` of `langx/token-website`; Pages builds it                   |

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -155,6 +155,9 @@ EXPO_PUBLIC_API_URL=https://<your-api-host> pnpm run build:web
 pnpm run deploy:web
 ```
 
+This repo runs those two commands on every merge to `main`, in
+`.github/workflows/deploy-web.yml`; the file names the secrets it expects.
+
 Two details in that setup are not decoration. `apple-app-site-association` is
 sent as `application/json` by `public/_headers` — it is checked in without a
 file extension, so a host that sniffs the type breaks iOS deep links while


### PR DESCRIPTION
`update.yml` on expo.dev has shipped the OTA update on every merge since 5 September; `app.langx.io` was still `pnpm deploy:web` by hand. This adds `.github/workflows/deploy-web.yml`, which runs on the same paths, exports the web build with the production `EXPO_PUBLIC_*` values, and reuses the existing `deploy:web` script — upload to the Pages project `langx-web`, then `verify-web-deploy.mjs` against the live host. `workflow_dispatch` is there for a re-run after a cache purge.

**Before merging, set four repository secrets** (Settings → Secrets and variables → Actions):

| Secret | Value |
| --- | --- |
| `CLOUDFLARE_API_TOKEN` | a **new** token scoped to Account → Cloudflare Pages → Edit — not the all-permissions one in `.env` |
| `CLOUDFLARE_ACCOUNT_ID` | as in `.env` |
| `EXPO_PUBLIC_REVENUECAT_WEB_KEY` | as in `apps/mobile/.env`; EAS does not hold it |
| `EXPO_PUBLIC_POSTHOG_KEY` | as in `apps/mobile/.env` / the EAS `production` environment |

Without them the export still succeeds and the upload step fails, so a merge before the secrets exist gives a red run and changes nothing live.

Docs: `repo-map.md` (how `app.langx.io` gets a change), `release-runbook.md` (the shipping table), `self-host.md`, and the header comment in `github-release.yml`.

Verified locally: `EXPO_NO_DOTENV=1 EXPO_PUBLIC_API_URL=https://api.langx.io pnpm build:web` exports cleanly with no `.env`, and the bundle carries `api.langx.io`; the `.env` token can read the Pages project from a clean HOME through `CLOUDFLARE_API_TOKEN` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)