### PR TITLE
Add the Karpathy guidelines to CLAUDE.md and as a project skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,14 +1,5 @@
 {
-  "extraKnownMarketplaces": {
-    "karpathy-skills": {
-      "source": {
-        "source": "github",
-        "repo": "multica-ai/andrej-karpathy-skills"
-      }
-    }
-  },
   "enabledPlugins": {
-    "claude-code-setup@claude-plugins-official": true,
-    "andrej-karpathy-skills@karpathy-skills": true
+    "claude-code-setup@claude-plugins-official": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,14 @@
 {
+  "extraKnownMarketplaces": {
+    "karpathy-skills": {
+      "source": {
+        "source": "github",
+        "repo": "multica-ai/andrej-karpathy-skills"
+      }
+    }
+  },
   "enabledPlugins": {
-    "claude-code-setup@claude-plugins-official": true
+    "claude-code-setup@claude-plugins-official": true,
+    "andrej-karpathy-skills@karpathy-skills": true
   }
 }

--- a/.claude/skills/karpathy-guidelines/SKILL.md
+++ b/.claude/skills/karpathy-guidelines/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: karpathy-guidelines
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+license: MIT
+---
+
+# Karpathy Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,3 +121,33 @@ without waiting to be asked again — this rule is why it is written down rather
 than repeated. It does not soften the paragraph above: what lands on disk is
 still English, all of it. The two cover different things, the artefact and the
 conversation, and only the artefact is what other people read.
+
+## How to work
+
+Four rules adapted from Andrej Karpathy's notes on how coding agents go wrong
+([source](https://github.com/multica-ai/andrej-karpathy-skills), MIT). They
+bias toward caution over speed; for trivial fixes use judgment.
+
+**Think before coding.** State assumptions explicitly. If several readings of
+the request exist, present them instead of picking one silently. If a simpler
+approach exists, say so and push back. If something is unclear, stop, name
+what is confusing, and ask.
+
+**Simplicity first.** Write the minimum code that solves the problem. No
+features beyond what was asked, no abstractions for single-use code, no
+"flexibility" nobody requested, no error handling for impossible cases. If 200
+lines could be 50, rewrite. The test: would a senior engineer call this
+overcomplicated?
+
+**Surgical changes.** Touch only what you must. Do not "improve" adjacent
+code, comments or formatting; do not refactor what is not broken; match the
+existing style even where you would do it differently. Unrelated dead code
+gets mentioned, not deleted. Remove only the imports, variables and functions
+that _your_ change made unused. Every changed line should trace back to the
+request.
+
+**Goal-driven execution.** Turn tasks into verifiable goals: "add validation"
+becomes "write tests for invalid inputs, then make them pass"; "fix the bug"
+becomes "write a test that reproduces it, then make it pass"; "refactor X"
+becomes "tests pass before and after". For multi-step work, state a short
+plan where each step names its check, then loop until every check holds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,74 @@
+# CLAUDE.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
 # Working in this repo
 
 LangX v2 — a language-exchange app. Expo (iOS/Android/web) + Fastify + MongoDB,
@@ -121,33 +192,3 @@ without waiting to be asked again — this rule is why it is written down rather
 than repeated. It does not soften the paragraph above: what lands on disk is
 still English, all of it. The two cover different things, the artefact and the
 conversation, and only the artefact is what other people read.
-
-## How to work
-
-Four rules adapted from Andrej Karpathy's notes on how coding agents go wrong
-([source](https://github.com/multica-ai/andrej-karpathy-skills), MIT). They
-bias toward caution over speed; for trivial fixes use judgment.
-
-**Think before coding.** State assumptions explicitly. If several readings of
-the request exist, present them instead of picking one silently. If a simpler
-approach exists, say so and push back. If something is unclear, stop, name
-what is confusing, and ask.
-
-**Simplicity first.** Write the minimum code that solves the problem. No
-features beyond what was asked, no abstractions for single-use code, no
-"flexibility" nobody requested, no error handling for impossible cases. If 200
-lines could be 50, rewrite. The test: would a senior engineer call this
-overcomplicated?
-
-**Surgical changes.** Touch only what you must. Do not "improve" adjacent
-code, comments or formatting; do not refactor what is not broken; match the
-existing style even where you would do it differently. Unrelated dead code
-gets mentioned, not deleted. Remove only the imports, variables and functions
-that _your_ change made unused. Every changed line should trace back to the
-request.
-
-**Goal-driven execution.** Turn tasks into verifiable goals: "add validation"
-becomes "write tests for invalid inputs, then make them pass"; "fix the bug"
-becomes "write a test that reproduces it, then make it pass"; "refactor X"
-becomes "tests pass before and after". For multi-step work, state a short
-plan where each step names its check, then loop until every check holds.


### PR DESCRIPTION
Brings [multica-ai/andrej-karpathy-skills](https://github.com/multica-ai/andrej-karpathy-skills) (MIT) into the repo in two forms:

- Its `CLAUDE.md` goes at the top of this repo's `CLAUDE.md`, verbatim apart from prettier's blank lines before lists, with the existing repo instructions following it. This is the always-on copy.
- Its `SKILL.md` lands at `.claude/skills/karpathy-guidelines/SKILL.md`, also verbatim, so it can be invoked on demand as `/karpathy-guidelines`.

Earlier commits on this branch tried a project-scope plugin and then a paraphrased section; both are superseded. `.claude/settings.json` ends up unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)