### PR TITLE
Add the Terms of Use link App Review requires to the store description

### DIFF
--- a/docs/store/listing.md
+++ b/docs/store/listing.md
@@ -12,6 +12,15 @@ The listing may advertise them.
 
 The listings must also declare in-app purchases. v1 had none.
 
+**The App Store description must end with a working Terms of Use link.**
+App Review rejected 2.0.0 on 6 September 2026 under Guideline 3.1.2
+(Business: Payments – Subscriptions): an app that sells auto-renewable
+subscriptions has to link the Terms of Use (EULA) from the metadata on its
+product page, and the app description is the only place Apple reads it from
+when the standard Apple EULA is used. The footer below is that link, plus the
+privacy policy so both documents are one tap away. Keep it when the description
+is next rewritten.
+
 ---
 
 ## English
@@ -50,6 +59,10 @@ The listings must also declare in-app purchases. v1 had none.
 > browsing.
 >
 > LangX is open source (BSD-3) and can be self-hosted.
+>
+> Terms of Use (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+> Terms & Conditions: https://langx.io/terms-conditions
+> Privacy Policy: https://langx.io/privacy-policy
 
 **Keywords (iOS, 100 chars)**
 `language,exchange,learn,practice,speaking,tandem,partner,english,spanish,chat`
@@ -89,6 +102,10 @@ The listings must also declare in-app purchases. v1 had none.
 > sınırsız çeviri, profilini kimin görüntülediği ve gizli gezinme ekler.
 >
 > LangX açık kaynaktır (BSD-3) ve kendi sunucunda barındırılabilir.
+>
+> Kullanım Koşulları (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+> Şartlar ve Koşullar: https://langx.io/terms-conditions
+> Gizlilik Politikası: https://langx.io/privacy-policy
 
 ---
 


### PR DESCRIPTION
## Why

App Review rejected iOS 2.0.0 (submission `7e129e40…`, build 132) on 6 September 2026 under **Guideline 3.1.2 – Business: Payments – Subscriptions**:

> The submission offers auto-renewable subscriptions … but does not include a functional link to the Terms of Use (EULA) in the app metadata that appears on the app's App Store product page.

The in-app paywall already links the terms and the privacy policy; what was missing was the link in the **App Store description**, which is where Apple reads it from when the standard Apple EULA is used.

## What

- `docs/store/listing.md`: the English and Turkish descriptions now end with a legal footer — the standard Apple EULA, `langx.io/terms-conditions` and `langx.io/privacy-policy` — and the intro says why the footer has to survive the next rewrite.
- The same footer has been saved on the 2.0.0 version page in App Store Connect (English (U.S.) description, 1,309 characters).

## Not in this PR

Resubmitting the 6-item submission to App Review is a click in App Store Connect, done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)