### PR TITLE
feat(mobile): design follow-ups, part 1

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/feed.tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed.tsx
@@ -1,5 +1,5 @@
 import Feather from '@expo/vector-icons/Feather'
-import { MAX_POST_LENGTH, POST_KINDS, type PostKind } from '@langx/shared'
+import { FEED_TOP_CORRECTIONS, MAX_POST_LENGTH, POST_KINDS, type PostKind } from '@langx/shared'
 import { router, useFocusEffect } from 'expo-router'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from 'react-native'
@@ -346,6 +346,10 @@ export default function FeedScreen() {
                       {relativeTime(item.createdAt, { t, locale })}
                     </Text>
                   </View>
+                  {/* The prototype's ink pill; the threshold is shared with the post screen. */}
+                  {item.correctionCount >= FEED_TOP_CORRECTIONS ? (
+                    <Text style={styles.topPill}>{t('feed.top')}</Text>
+                  ) : null}
                 </Pressable>
 
                 {/* The sentence opens its thread; it is the one affordance every row has. */}
@@ -537,6 +541,15 @@ const useStyles = makeStyles(({ colors, font, radius, spacing }) => ({
   who: { alignItems: 'center', flexDirection: 'row', gap: spacing.md },
   whoText: { flex: 1, minWidth: 0 },
   name: { ...font.heading, color: colors.text, fontSize: 15 },
+  topPill: {
+    backgroundColor: colors.ink,
+    borderRadius: radius.pill,
+    color: colors.bg,
+    fontSize: 12,
+    fontWeight: '700',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
   meta: { color: colors.textFaint, fontSize: 13, fontWeight: '400' },
   body: { color: colors.text, fontSize: 18, fontWeight: '400', lineHeight: 27 },
   // The word somebody wants to hear said, set like a heading.

--- a/apps/mobile/app/(app)/(tabs)/me.tsx
+++ b/apps/mobile/app/(app)/(tabs)/me.tsx
@@ -2,6 +2,7 @@ import { LoadFailed } from '../../../src/components/LoadFailed'
 import { wornCosmetic, TIER_BADGES, TIER_NAMES, tierUnlocking } from '@langx/shared'
 import Feather from '@expo/vector-icons/Feather'
 import { router } from 'expo-router'
+import { useState } from 'react'
 import { placeLabel } from '../../../src/lib/placeLabel'
 import { ActivityIndicator, Platform, Pressable, Text, View } from 'react-native'
 import {
@@ -17,6 +18,7 @@ import {
 } from '../../../src/api/queries'
 import { DebugQuotaPanel } from '../../../src/components/DebugQuotaPanel'
 import { PhotoGallery } from '../../../src/components/PhotoGallery'
+import { PhotoViewer } from '../../../src/components/PhotoViewer'
 import { WeeklyChart } from '../../../src/components/WeeklyChart'
 import { Avatar } from '../../../src/components/ui/Avatar'
 import { CosmeticTitle } from '../../../src/components/CosmeticTitle'
@@ -36,6 +38,8 @@ import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 export default function MeScreen() {
   useScreenInteractive()
   const { colors } = useTheme()
+  // Above the early return, where hooks have to be.
+  const [avatarOpen, setAvatarOpen] = useState(false)
   const styles = useStyles()
   const t = useT()
   const { locale } = useLocale()
@@ -124,13 +128,41 @@ export default function MeScreen() {
   return (
     <Screen scroll {...pull}>
       <View style={styles.hero}>
-        <Avatar
-          url={profile.avatarUrl}
-          name={profile.displayName}
-          seed={profile._id}
-          size={80}
-          frame={wornFrame?.tone}
-        />
+        {/*
+          A photo opens full screen, as on the public profile; a generated face
+          or initials is a stand-in and stays a plain avatar — no button, and a
+          screen reader is not told there is one.
+        */}
+        {profile.avatarUrl ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t('photo.open')}
+            onPress={() => setAvatarOpen(true)}
+          >
+            <Avatar
+              url={profile.avatarUrl}
+              name={profile.displayName}
+              seed={profile._id}
+              size={80}
+              frame={wornFrame?.tone}
+            />
+          </Pressable>
+        ) : (
+          <Avatar
+            url={profile.avatarUrl}
+            name={profile.displayName}
+            seed={profile._id}
+            size={80}
+            frame={wornFrame?.tone}
+          />
+        )}
+        {profile.avatarUrl ? (
+          <PhotoViewer
+            photos={[{ url: profile.avatarUrl }]}
+            index={avatarOpen ? 0 : null}
+            onClose={() => setAvatarOpen(false)}
+          />
+        ) : null}
         <View style={styles.heroText}>
           <View style={styles.nameRow}>
             <Text style={styles.name} numberOfLines={1}>

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -49,8 +49,9 @@ import {
 } from '../../../src/components/AttachmentPreview'
 import { MessageBubbleSkeleton } from '../../../src/components/skeletons/MessageBubbleSkeleton'
 import { Avatar } from '../../../src/components/ui/Avatar'
+import { Skeleton } from '../../../src/components/ui/Skeleton'
 import { Screen } from '../../../src/components/ui/Screen'
-import { useProfileCache } from '../../../src/hooks/useProfileCache'
+import { useProfileCache, useProfileCacheStatus } from '../../../src/hooks/useProfileCache'
 import { useVoiceRecorder } from '../../../src/hooks/useVoiceRecorder'
 import { chooseAlert, confirmAlert, showAlert } from '../../../src/lib/alert'
 import { emitWithAck, getSocket } from '../../../src/lib/socket'
@@ -238,6 +239,10 @@ export default function ChatScreen() {
   const mediaLockedFor = messages.data?.pages[0]?.mediaLockedFor ?? 0
   const partners = useProfileCache(partnerId ? [partnerId] : [])
   const partner = partners[partnerId]
+  // "Not yet" and "never" draw differently: a placeholder while the profile
+  // loads, the generic title only for an account that is really gone.
+  const partnerLoading =
+    useProfileCacheStatus(partnerId ? [partnerId] : [])[partnerId] === 'pending'
 
   /**
    * Opening the thread is the read receipt — and *focusing* it, not mounting
@@ -908,24 +913,35 @@ export default function ChatScreen() {
             style={styles.headerUser}
             onPress={() => partner && openProfile(partner.handle, `/(app)/chat/${conversationId}`)}
           >
-            <Avatar
-              url={partner?.avatarUrl}
-              name={partner?.displayName ?? '?'}
-              seed={partner?._id}
-              size={40}
-              online={partner?.isOnline ?? false}
-            />
+            {partnerLoading ? (
+              <Skeleton width={40} height={40} radius={20} />
+            ) : (
+              <Avatar
+                url={partner?.avatarUrl}
+                name={partner?.displayName ?? '?'}
+                seed={partner?._id}
+                size={40}
+                online={partner?.isOnline ?? false}
+              />
+            )}
             <View style={styles.headerText}>
-              <Text style={styles.headerName} numberOfLines={1}>
-                {partner?.displayName ?? t('chat.title')}
-              </Text>
+              {partnerLoading ? (
+                <>
+                  <Skeleton width={120} height={14} />
+                  <Skeleton width={80} height={12} style={styles.headerSkeletonGap} />
+                </>
+              ) : (
+                <Text style={styles.headerName} numberOfLines={1}>
+                  {partner?.displayName ?? t('chat.title')}
+                </Text>
+              )}
               {/*
               One line that is either presence or typing, never both stacked —
               the header is 40px tall and a third line pushes the avatar out of
               alignment with the name. `PresenceLine` keeps that true: online
               and last-seen are mutually exclusive states of one line, not two.
             */}
-              {partnerTyping ? (
+              {partnerLoading ? null : partnerTyping ? (
                 <Text style={styles.typing}>{t('chat.typing')}</Text>
               ) : (
                 <PresenceLine lastActiveAt={partner?.lastActiveAt} />
@@ -1371,6 +1387,7 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
   },
   headerText: { flex: 1, minWidth: 0 },
   headerName: { ...font.heading, color: colors.text, fontSize: 17 },
+  headerSkeletonGap: { marginTop: 6 },
   // The accent, like Online: somebody typing is as live as the status line gets.
   typing: { ...font.caption, color: colors.accent, fontSize: 13 },
   more: { alignItems: 'center', height: 36, justifyContent: 'center', width: 36 },

--- a/apps/mobile/app/(app)/post/[id].tsx
+++ b/apps/mobile/app/(app)/post/[id].tsx
@@ -2,7 +2,12 @@ import Feather from '@expo/vector-icons/Feather'
 import { useFocusEffect, useLocalSearchParams } from 'expo-router'
 import { useCallback, useMemo, useState } from 'react'
 import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from 'react-native'
-import { MAX_COMMENT_LENGTH, MAX_POST_LENGTH, TOKEN_RULES } from '@langx/shared'
+import {
+  FEED_TOP_CORRECTIONS,
+  MAX_COMMENT_LENGTH,
+  MAX_POST_LENGTH,
+  TOKEN_RULES,
+} from '@langx/shared'
 import {
   uploadPostMedia,
   useAddComment,
@@ -383,6 +388,10 @@ export default function PostScreen() {
                     {names.language(post.language)} · {relativeTime(post.createdAt, { t, locale })}
                   </Text>
                 </View>
+                {/* The prototype's ink pill on the post itself; the threshold is shared with the feed. */}
+                {post.correctionCount >= FEED_TOP_CORRECTIONS ? (
+                  <Text style={styles.topPost}>{t('feed.top')}</Text>
+                ) : null}
               </Pressable>
               <Text style={styles.body}>{post.body}</Text>
               {attachmentsOf(post).length > 0 ? (
@@ -745,6 +754,16 @@ const useStyles = makeStyles(({ colors, font, radius, spacing }) => ({
   },
   whoText: { flex: 1, minWidth: 0 },
   name: { ...font.heading, color: colors.text, fontSize: 15 },
+  // The post's own Top badge; `topPill` below is the TOP tag on a correction row.
+  topPost: {
+    backgroundColor: colors.ink,
+    borderRadius: radius.pill,
+    color: colors.bg,
+    fontSize: 12,
+    fontWeight: '700',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
   meta: { color: colors.textFaint, fontSize: 13, fontWeight: '400' },
   body: { color: colors.text, fontSize: 22, lineHeight: 32, paddingBottom: 18 },
   media: { paddingBottom: 18 },

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -22,7 +22,6 @@ import { placeLabel } from '../../../src/lib/placeLabel'
 import { Button } from '../../../src/components/ui/Button'
 import { Callout } from '../../../src/components/ui/Callout'
 import { FormField } from '../../../src/components/ui/FormField'
-import { CosmeticTitle } from '../../../src/components/CosmeticTitle'
 import { LanguageColumns } from '../../../src/components/LanguageColumns'
 import { PhotoGallery } from '../../../src/components/PhotoGallery'
 import { PhotoViewer } from '../../../src/components/PhotoViewer'
@@ -258,13 +257,6 @@ export default function ProfileScreen() {
         <View style={styles.heroText}>
           <View style={styles.nameRow}>
             <Text style={styles.name}>{user.displayName}</Text>
-            {/*
-              Kept although the prototype's sample profiles wear none: a title
-              is bought to be seen by other people, and this is the one screen
-              where other people look. The frame on the avatar is the same
-              purchase shown the same way.
-            */}
-            <CosmeticTitle cosmetic={wornCosmetic(user.equipped, user.cosmetics ?? [], 'title')} />
             <Text style={styles.age}>{user.age}</Text>
           </View>
           <Text style={styles.handle} numberOfLines={1}>

--- a/apps/mobile/app/(auth)/sign-up.tsx
+++ b/apps/mobile/app/(auth)/sign-up.tsx
@@ -18,6 +18,7 @@ import { authClient } from '../../src/lib/auth-client'
 import { authErrorKey } from '../../src/lib/errors'
 import { goBackTo } from '../../src/lib/navigation'
 import { PASSWORD_MIN_LENGTH, passwordIssueKey } from '../../src/lib/passwordForm'
+import { nameFromEmail } from '../../src/lib/seedDisplayName'
 import { useT } from '../../src/i18n'
 import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
@@ -34,7 +35,6 @@ export default function SignUp() {
   const styles = useStyles()
   const t = useT()
   const { start: browse } = useGuestBrowse()
-  const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
@@ -57,7 +57,9 @@ export default function SignUp() {
      */
     if (shouldGateGuest(session?.user)) await authClient.signOut()
     const { error: signUpError } = await authClient.signUp.email({
-      name,
+      // v3 asks for no name at sign-up; Better Auth still wants one, so it is
+      // guessed from the address and offered back on the about-you step.
+      name: nameFromEmail(email),
       email,
       password,
       // Resolves to langx://verify-email-success on native and the
@@ -84,7 +86,7 @@ export default function SignUp() {
 
   // The same condition the button uses, so Enter can never submit a
   // form the button refuses — nor fire twice while one is in flight.
-  const canSubmit = !loading && !!name && !!email && !passwordTooShort(password) && accepted
+  const canSubmit = !loading && !!email && !passwordTooShort(password) && accepted
 
   return (
     <Screen scroll style={styles.form}>
@@ -97,14 +99,6 @@ export default function SignUp() {
       </View>
 
       <View style={styles.fields}>
-        <FormField
-          placeholder={t('auth.name')}
-          value={name}
-          onChangeText={setName}
-          autoComplete="name"
-          returnKeyType="go"
-          onSubmitEditing={() => canSubmit && void onSubmit()}
-        />
         <FormField
           returnKeyType="go"
           onSubmitEditing={() => canSubmit && void onSubmit()}

--- a/apps/mobile/app/[username].tsx
+++ b/apps/mobile/app/[username].tsx
@@ -9,14 +9,15 @@ import {
 } from '@langx/shared'
 import { useQuery } from '@tanstack/react-query'
 import { Redirect, useLocalSearchParams } from 'expo-router'
-import { useEffect } from 'react'
-import { ActivityIndicator, Text, View } from 'react-native'
+import { useEffect, useState } from 'react'
+import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { api } from '../src/api/client'
 import { authClient } from '../src/lib/auth-client'
 import { Avatar } from '../src/components/ui/Avatar'
 import { Button } from '../src/components/ui/Button'
 import { EmptyState } from '../src/components/ui/EmptyState'
 import { LanguageColumns } from '../src/components/LanguageColumns'
+import { PhotoViewer } from '../src/components/PhotoViewer'
 import { Screen } from '../src/components/ui/Screen'
 import { FLAG_KEYS, writeFlag } from '../src/lib/localFlags'
 import { openExternal } from '../src/lib/openExternal'
@@ -44,6 +45,8 @@ import { useScreenInteractive } from '../src/hooks/useScreenInteractive'
  */
 export default function SharedProfileScreen() {
   useScreenInteractive()
+  // Above the early returns, where hooks have to be.
+  const [avatarOpen, setAvatarOpen] = useState(false)
   const params = useLocalSearchParams<{ username: string; invite?: string }>()
   const handle = (params.username ?? '').toLowerCase()
   /*
@@ -120,7 +123,24 @@ export default function SharedProfileScreen() {
           takes an id and nothing else, so this page keeps the initials rather
           than reopening a decision made for the open internet.
         */}
-        <Avatar url={user.avatarUrl} name={user.displayName} size={96} />
+        {user.avatarUrl ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t('photo.open')}
+            onPress={() => setAvatarOpen(true)}
+          >
+            <Avatar url={user.avatarUrl} name={user.displayName} size={96} />
+          </Pressable>
+        ) : (
+          <Avatar url={user.avatarUrl} name={user.displayName} size={96} />
+        )}
+        {user.avatarUrl ? (
+          <PhotoViewer
+            photos={[{ url: user.avatarUrl }]}
+            index={avatarOpen ? 0 : null}
+            onClose={() => setAvatarOpen(false)}
+          />
+        ) : null}
         <View style={styles.heroText}>
           <Text style={styles.name}>{user.displayName}</Text>
           <Text style={styles.handle} numberOfLines={1}>

--- a/apps/mobile/src/components/PhotoViewer.tsx
+++ b/apps/mobile/src/components/PhotoViewer.tsx
@@ -4,6 +4,7 @@ import { useVideoPlayer, VideoView } from 'expo-video'
 import { useCallback, useEffect, useRef } from 'react'
 import {
   Animated,
+  I18nManager,
   Modal,
   PanResponder,
   Platform,
@@ -139,6 +140,31 @@ export function PhotoViewer({ photos, index, onClose, onIndexChange }: PhotoView
   const latest = useRef({ index, photos, onIndexChange })
   latest.current = { index, photos, onIndexChange }
 
+  /**
+   * Where the close disc sits, in the same window coordinates the gesture
+   * reads. Kept in a ref for the reason `latest` is: the responder is built
+   * once and would otherwise hold the first render's inset. The gesture
+   * layer refuses a touch that starts here, so the disc gets it even on a
+   * platform that paints the transformed picture over an absolutely
+   * positioned sibling — which is what made the ✕ unreachable once a photo
+   * filled the screen.
+   */
+  const closeZone = useRef({ top: 0, bottom: 0, start: 0, end: 0 })
+  closeZone.current = {
+    top: insets.top + spacing.sm - CLOSE_HIT_SLOP,
+    bottom: insets.top + spacing.sm + CLOSE_SIZE + CLOSE_HIT_SLOP,
+    start: spacing.lg - CLOSE_HIT_SLOP,
+    end: spacing.lg + CLOSE_SIZE + CLOSE_HIT_SLOP,
+  }
+  function overClose(x: number, y: number): boolean {
+    const zone = closeZone.current
+    if (y < zone.top || y > zone.bottom) return false
+    const width = frame.current.width
+    // `end` is the right edge in a left-to-right layout and the left in Arabic.
+    const fromEdge = I18nManager.isRTL ? x : width - x
+    return fromEdge >= zone.start && fromEdge <= zone.end
+  }
+
   function page(step: number): void {
     const { index: at, photos: album, onIndexChange: change } = latest.current
     if (at === null) return
@@ -197,8 +223,10 @@ export function PhotoViewer({ photos, index, onClose, onIndexChange }: PhotoView
     PanResponder.create({
       // Claimed on touch-down, unlike the list rows: this view is the whole
       // modal, so there is no tap of anyone else's to swallow.
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: () => true,
+      onStartShouldSetPanResponder: (event) =>
+        !overClose(event.nativeEvent.pageX, event.nativeEvent.pageY),
+      onMoveShouldSetPanResponder: (event) =>
+        !overClose(event.nativeEvent.pageX, event.nativeEvent.pageY),
       onPanResponderGrant: (event) => {
         const touches = event.nativeEvent.touches
         start.current = {
@@ -368,54 +396,75 @@ export function PhotoViewer({ photos, index, onClose, onIndexChange }: PhotoView
           </Animated.View>
         )}
 
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={t('photo.close')}
-          style={({ pressed }) => [
-            styles.close,
-            { top: insets.top + spacing.sm },
-            pressed && styles.closePressed,
-          ]}
-          onPress={onClose}
-          hitSlop={12}
-        >
-          <Text style={styles.closeText}>✕</Text>
-        </Pressable>
+        {/*
+          The chrome sits on a layer of its own above the stage. `zIndex` on
+          the disc alone was not enough everywhere: react-native-web paints a
+          transformed sibling over it, and Android wants `elevation` before it
+          reorders touch targets. `box-none` keeps the layer itself out of the
+          way, so a tap between the controls still reaches the picture.
+        */}
+        <View style={styles.chrome} pointerEvents="box-none">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t('photo.close')}
+            style={({ pressed }) => [
+              styles.close,
+              { top: insets.top + spacing.sm },
+              pressed && styles.closePressed,
+            ]}
+            onPress={onClose}
+            hitSlop={CLOSE_HIT_SLOP}
+          >
+            <Text style={styles.closeText}>✕</Text>
+          </Pressable>
 
-        {photos.length > 1 ? (
-          <View style={[styles.pager, { paddingBottom: insets.bottom + spacing.lg }]}>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t('photo.previous')}
-              onPress={() => page(-1)}
-              hitSlop={12}
-            >
-              <Text style={styles.pagerArrow}>‹</Text>
-            </Pressable>
-            <Text style={styles.pagerCount}>
-              {t('photo.counter', { index: index + 1, total: photos.length })}
-            </Text>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t('photo.next')}
-              onPress={() => page(1)}
-              hitSlop={12}
-            >
-              <Text style={styles.pagerArrow}>›</Text>
-            </Pressable>
-          </View>
-        ) : null}
+          {photos.length > 1 ? (
+            <View style={[styles.pager, { paddingBottom: insets.bottom + spacing.lg }]}>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t('photo.previous')}
+                onPress={() => page(-1)}
+                hitSlop={12}
+              >
+                <Text style={styles.pagerArrow}>‹</Text>
+              </Pressable>
+              <Text style={styles.pagerCount}>
+                {t('photo.counter', { index: index + 1, total: photos.length })}
+              </Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t('photo.next')}
+                onPress={() => page(1)}
+                hitSlop={12}
+              >
+                <Text style={styles.pagerArrow}>›</Text>
+              </Pressable>
+            </View>
+          ) : null}
+        </View>
       </View>
     </Modal>
   )
 }
+
+/** The disc's diameter and the slop around it; 36 + 12 + 12 is the platform's 44pt target and then some. */
+const CLOSE_SIZE = 36
+const CLOSE_HIT_SLOP = 12
 
 function pointOf(touch: { pageX: number; pageY: number } | undefined): Point {
   return { x: touch?.pageX ?? 0, y: touch?.pageY ?? 0 }
 }
 
 const useStyles = makeStyles(({ colors, font, spacing }) => ({
-  backdrop: { backgroundColor: colors.scrimStrong, flex: 1, justifyContent: 'center' },
+  // `relative`, so the chrome's z-order is decided against this and not
+  // against whatever stacking context the transformed stage creates on web.
+  backdrop: {
+    backgroundColor: colors.scrimStrong,
+    flex: 1,
+    justifyContent: 'center',
+    position: 'relative',
+  },
+  chrome: { bottom: 0, elevation: 2, left: 0, position: 'absolute', right: 0, top: 0, zIndex: 2 },
   stage: { flex: 1, width: '100%' },
   full: { flex: 1, width: '100%' },
   /*
@@ -427,11 +476,10 @@ const useStyles = makeStyles(({ colors, font, spacing }) => ({
     backgroundColor: colors.scrim,
     borderRadius: 18,
     end: spacing.lg,
-    height: 36,
+    height: CLOSE_SIZE,
     justifyContent: 'center',
     position: 'absolute',
-    width: 36,
-    zIndex: 1,
+    width: CLOSE_SIZE,
   },
   closePressed: { opacity: 0.7 },
   closeText: { color: colors.onScrim, fontSize: 18, fontWeight: '600' },

--- a/apps/mobile/src/hooks/useProfileCache.ts
+++ b/apps/mobile/src/hooks/useProfileCache.ts
@@ -30,3 +30,32 @@ export function useProfileCache(userIds: string[]): Record<string, PublicProfile
   })
   return map
 }
+
+export type ProfileCacheStatus = 'pending' | 'ready' | 'missing'
+
+/**
+ * Whether each id's profile is still on its way, here, or not coming.
+ *
+ * A screen that draws a placeholder while a name loads needs to tell "not yet"
+ * from "never": the chat header used to show the same "?" for both, which read
+ * as a real header with the wrong content. Same queries, same keys as
+ * `useProfileCache`, so TanStack answers both hooks from one request.
+ */
+export function useProfileCacheStatus(userIds: string[]): Record<string, ProfileCacheStatus> {
+  const unique = [...new Set(userIds.filter(Boolean))]
+
+  const results = useQueries({
+    queries: unique.map((id) => ({
+      queryKey: keys.profile(id),
+      queryFn: () => api.get<PublicProfileDto>(`/profiles/${id}`),
+      staleTime: 5 * 60_000,
+    })),
+  })
+
+  const map: Record<string, ProfileCacheStatus> = {}
+  unique.forEach((id, index) => {
+    const result = results[index]
+    map[id] = result?.data ? 'ready' : result?.isError ? 'missing' : 'pending'
+  })
+  return map
+}

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -885,6 +885,7 @@ export const ar: Localized<EnMessages> = {
     },
     composeHint: 'سيصححها متحدث أصلي — عادةً خلال ساعة. التصحيحات بلا حدود في كل الخطط.',
     voiceNote: 'مقطع صوتي',
+    top: 'الأبرز',
   },
 
   profile: {

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -329,7 +329,6 @@ export const ar: Localized<EnMessages> = {
     welcomeBack: 'أهلًا بعودتك',
     email: 'البريد الإلكتروني',
     password: 'كلمة المرور',
-    name: 'الاسم',
     forgotPassword: 'نسيت كلمة المرور؟',
     signIn: 'تسجيل الدخول',
     signingIn: 'جارٍ تسجيل الدخول…',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -767,6 +767,7 @@ export const de: Localized<EnMessages> = {
     composeHint:
       'Jemand mit Muttersprache korrigiert es – meist innerhalb einer Stunde. Korrekturen sind in jedem Tarif unbegrenzt.',
     voiceNote: 'Sprachnotiz',
+    top: 'Top',
   },
 
   profile: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -284,7 +284,6 @@ export const de: Localized<EnMessages> = {
     welcomeBack: 'Willkommen zurück',
     email: 'E-Mail',
     password: 'Passwort',
-    name: 'Name',
     forgotPassword: 'Passwort vergessen?',
     signIn: 'Anmelden',
     signingIn: 'Anmeldung läuft…',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -789,6 +789,7 @@ export const en = {
     composeHint:
       'Somebody native will fix it — usually within the hour. Corrections are unlimited on every plan.',
     voiceNote: 'Voice note',
+    top: 'Top',
   },
 
   profile: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -318,7 +318,6 @@ export const en = {
     welcomeBack: 'Welcome back',
     email: 'Email',
     password: 'Password',
-    name: 'Name',
     forgotPassword: 'Forgot password?',
     signIn: 'Sign in',
     signingIn: 'Signing you in…',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -747,6 +747,7 @@ export const es: Localized<EnMessages> = {
     composeHint:
       'Alguien nativo la corregirá, normalmente en menos de una hora. Las correcciones son ilimitadas en todos los planes.',
     voiceNote: 'Nota de voz',
+    top: 'Destacado',
   },
 
   profile: {

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -281,7 +281,6 @@ export const es: Localized<EnMessages> = {
     welcomeBack: 'Bienvenido de nuevo',
     email: 'Correo',
     password: 'Contraseña',
-    name: 'Nombre',
     forgotPassword: '¿Olvidaste tu contraseña?',
     signIn: 'Iniciar sesión',
     signingIn: 'Iniciando sesión…',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -751,6 +751,7 @@ export const fr: Localized<EnMessages> = {
     composeHint:
       'Quelqu’un de natif la corrigera, en général dans l’heure. Les corrections sont illimitées sur tous les forfaits.',
     voiceNote: 'Note vocale',
+    top: 'Top',
   },
 
   profile: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -285,7 +285,6 @@ export const fr: Localized<EnMessages> = {
     welcomeBack: 'Content de te revoir',
     email: 'E-mail',
     password: 'Mot de passe',
-    name: 'Nom',
     forgotPassword: 'Mot de passe oublié ?',
     signIn: 'Se connecter',
     signingIn: 'Connexion en cours…',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -277,7 +277,6 @@ export const ptBR: Localized<EnMessages> = {
     welcomeBack: 'Que bom te ver de novo',
     email: 'E-mail',
     password: 'Senha',
-    name: 'Nome',
     forgotPassword: 'Esqueceu a senha?',
     signIn: 'Entrar',
     signingIn: 'Entrando…',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -739,6 +739,7 @@ export const ptBR: Localized<EnMessages> = {
     composeHint:
       'Alguém nativo vai corrigir, geralmente em menos de uma hora. As correções são ilimitadas em todos os planos.',
     voiceNote: 'Áudio',
+    top: 'Destaque',
   },
 
   profile: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -846,6 +846,7 @@ export const ru: Localized<EnMessages> = {
     composeHint:
       'Носитель языка исправит — обычно в течение часа. Исправления без ограничений на любом тарифе.',
     voiceNote: 'Голосовая заметка',
+    top: 'Топ',
   },
 
   profile: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -318,7 +318,6 @@ export const ru: Localized<EnMessages> = {
     welcomeBack: 'С возвращением',
     email: 'Почта',
     password: 'Пароль',
-    name: 'Имя',
     forgotPassword: 'Забыл пароль?',
     signIn: 'Войти',
     signingIn: 'Выполняется вход…',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -750,6 +750,7 @@ export const tr: Localized<EnMessages> = {
     composeHint:
       'Anadili olan biri düzeltir — genellikle bir saat içinde. Düzeltmeler her planda sınırsız.',
     voiceNote: 'Ses kaydı',
+    top: 'Öne çıkan',
   },
 
   profile: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -291,7 +291,6 @@ export const tr: Localized<EnMessages> = {
     welcomeBack: 'Tekrar hoş geldin',
     email: 'E-posta',
     password: 'Parola',
-    name: 'Ad',
     forgotPassword: 'Parolanı mı unuttun?',
     signIn: 'Giriş yap',
     signingIn: 'Giriş yapılıyor…',

--- a/apps/mobile/src/lib/seedDisplayName.test.ts
+++ b/apps/mobile/src/lib/seedDisplayName.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { displayNameToSeed } from './seedDisplayName'
+import { displayNameToSeed, nameFromEmail } from './seedDisplayName'
 
 const base = { current: '', accountName: 'Emily', hydrated: true, alreadySeeded: false }
 
@@ -30,5 +30,27 @@ describe('displayNameToSeed', () => {
 
   it('trims what it offers', () => {
     expect(displayNameToSeed({ ...base, accountName: '  Emily  ' })).toBe('Emily')
+  })
+})
+
+describe('nameFromEmail', () => {
+  it('capitalises the words of the local part', () => {
+    expect(nameFromEmail('alex.m94@example.com')).toBe('Alex M')
+  })
+
+  it('treats underscores, pluses and hyphens as word breaks', () => {
+    expect(nameFromEmail('emily_rose+langx@example.com')).toBe('Emily Rose Langx')
+  })
+
+  it('drops digits', () => {
+    expect(nameFromEmail('yuki2026@example.com')).toBe('Yuki')
+  })
+
+  it('falls back to the bare local part when only digits are left', () => {
+    expect(nameFromEmail('12345@example.com')).toBe('12345')
+  })
+
+  it('ignores surrounding whitespace', () => {
+    expect(nameFromEmail('  sam@example.com ')).toBe('Sam')
   })
 })

--- a/apps/mobile/src/lib/seedDisplayName.ts
+++ b/apps/mobile/src/lib/seedDisplayName.ts
@@ -30,3 +30,25 @@ export function displayNameToSeed(input: {
   if (input.current.trim().length > 0) return null
   return account
 }
+
+/**
+ * A first guess at a display name from an email address, for a sign-up form
+ * that no longer asks for one — v3 signs up with an email and a password only,
+ * but Better Auth's `signUp.email` still requires a `name`, and about-you
+ * offers whatever is sent here back to the person to change.
+ *
+ * The local part, with the separators people put between words turned into
+ * spaces, digits dropped and each word capitalised: "alex.m94@…" → "Alex M".
+ * Falls back to the bare local part when that leaves nothing, so the account
+ * never gets an empty name.
+ */
+export function nameFromEmail(email: string): string {
+  const local = email.trim().split('@')[0] ?? ''
+  const words = local
+    .replace(/\d+/g, ' ')
+    .split(/[._+\-\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+  const guess = words.join(' ')
+  return guess.length > 0 ? guess : local
+}

--- a/packages/shared/src/feed.ts
+++ b/packages/shared/src/feed.ts
@@ -29,6 +29,15 @@ function withLegacyMedia(value: unknown): unknown {
 export const MAX_POST_LENGTH = 300
 export const MAX_POST_NOTE_LENGTH = 500
 
+/**
+ * How many corrections make a post "Top" in the feed and on its own screen.
+ *
+ * There is no ranking to derive the badge from — nothing may sort by likes or
+ * comments — so it is a threshold on the one count the card already shows.
+ * Here rather than in the app so the card and the post screen read one number.
+ */
+export const FEED_TOP_CORRECTIONS = 5
+
 export const postBodySchema = z.string().trim().min(1).max(MAX_POST_LENGTH)
 
 /**


### PR DESCRIPTION
## What

The first batch of follow-ups from `docs/plans/design-handoff-follow-ups.md`, all mobile-only and matching the prototype:

- **Sign-up** asks for an email and a password only; the account name Better Auth requires is guessed from the address and offered back on the about-you step.
- **Public profile** no longer shows the worn title in the hero (it stays on the Me tab).
- **Me tab and shared card** avatars open full screen, like the public profile's.
- **Photo viewer**: the close disc is reachable again when a picture fills the screen (chrome on its own layer, gesture refuses the disc's rectangle).
- **Chat header** draws a skeleton while the partner profile loads instead of a "?" avatar and the generic title.
- **Feed / post**: posts with five or more corrections carry the prototype's "Top" pill (`FEED_TOP_CORRECTIONS` in `packages/shared`).

## Verification

`pnpm typecheck`, eslint on the changed files, `vitest` (mobile 703 · shared 302), `prettier --check .` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
