### PR TITLE
feat(chat): optimistic sends — the field clears at once and rows read Sending until acked

### DIFF
--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -62,6 +62,14 @@ import {
   retireDelivered,
   type UnsentMessage,
 } from '../../../src/lib/unsentMessages'
+import {
+  addOutgoing,
+  isOutgoingId,
+  outgoingId,
+  removeOutgoing,
+  retireArrived,
+  type OutgoingMessage,
+} from '../../../src/lib/outgoingMessages'
 import { errorCodeOf } from '../../../src/lib/errors'
 import { listState } from '../../../src/lib/listState'
 import { shouldSubmitOnEnter } from '../../../src/lib/submitOnEnter'
@@ -112,7 +120,8 @@ export default function ChatScreen() {
   const messages = useMessages(conversationId)
 
   const [draft, setDraft] = useState('')
-  const [sending, setSending] = useState(false)
+  /** Sends in flight, drawn in the thread before the server has answered. */
+  const [outgoing, setOutgoing] = useState<OutgoingMessage[]>([])
   const [unsent, setUnsent] = useState<UnsentMessage[]>([])
   const [correcting, setCorrecting] = useState<MessageDto | null>(null)
   const [partnerTyping, setPartnerTyping] = useState(false)
@@ -194,7 +203,29 @@ export default function ChatScreen() {
   const thread = jumpAnchor ? windowed : messages
 
   const items = useMemo(() => messagesNewestFirst(thread.data), [thread.data])
-  const rows = useMemo(() => messageRows(items), [items])
+  /*
+   * Your own sends, drawn before the server has answered. Newest first like
+   * `items`, and ahead of them: the inverted list puts index 0 nearest the
+   * composer, which is where a sentence just typed belongs. `senderId` is the
+   * viewer, so `isMine` and the tail rule treat the row as one of theirs, and
+   * the id carries a prefix so the row's actions know to wait for the echo.
+   */
+  const viewerId = me.data?._id
+  const threadItems = useMemo<MessageDto[]>(() => {
+    if (!viewerId || outgoing.length === 0) return items
+    const standIns: MessageDto[] = outgoing.map((message) => ({
+      _id: outgoingId(message.clientId),
+      conversationId,
+      senderId: viewerId,
+      type: 'text',
+      body: message.body,
+      clientId: message.clientId,
+      createdAt: message.sentAt,
+      ...(message.replyTo ? { replyTo: message.replyTo } : {}),
+    }))
+    return [...standIns, ...items]
+  }, [items, outgoing, viewerId, conversationId])
+  const rows = useMemo(() => messageRows(threadItems), [threadItems])
 
   /**
    * A send whose ack was lost still left an unsent row, and the message may
@@ -204,6 +235,16 @@ export default function ChatScreen() {
   useEffect(() => {
     setUnsent((list) =>
       retireDelivered(
+        list,
+        items.map((message) => message.clientId),
+      ),
+    )
+  }, [items])
+  // The same retirement for the stand-ins: the echo carries the `clientId`,
+  // and whichever of ack and echo arrives first removes the row.
+  useEffect(() => {
+    setOutgoing((list) =>
+      retireArrived(
         list,
         items.map((message) => message.clientId),
       ),
@@ -476,18 +517,20 @@ export default function ChatScreen() {
    * `clientId` is passed in on a retry so the row updates itself instead of
    * stacking a second copy of the same sentence.
    */
-  async function deliver(body: string, clientId: string): Promise<void> {
+  async function deliver(body: string, clientId: string, replyToMessageId?: string): Promise<void> {
     try {
       const socket = await getSocket()
       await emitWithAck(socket, 'message:send', {
         conversationId,
         body,
         clientId,
-        ...(replyingTo ? { replyToMessageId: replyingTo._id } : {}),
+        ...(replyToMessageId ? { replyToMessageId } : {}),
       })
       setUnsent((list) => removeUnsent(list, clientId))
-      track({ name: 'message_sent', properties: { kind: 'text', reply: replyingTo !== null } })
-      setReplyingTo(null)
+      track({
+        name: 'message_sent',
+        properties: { kind: 'text', reply: replyToMessageId !== undefined },
+      })
     } catch {
       /*
        * Swallowed on purpose, and this is the whole change: it used to be
@@ -500,15 +543,19 @@ export default function ChatScreen() {
         addUnsent(list, {
           clientId,
           body,
-          ...(replyingTo ? { replyToMessageId: replyingTo._id } : {}),
+          ...(replyToMessageId ? { replyToMessageId } : {}),
           failedAt: new Date().toISOString(),
         }),
       )
+    } finally {
+      // Landed or failed, the stand-in has somewhere better to be: the echo
+      // has usually retired it already, the unsent row takes over otherwise.
+      setOutgoing((list) => removeOutgoing(list, clientId))
     }
   }
 
   async function retry(message: UnsentMessage): Promise<void> {
-    await deliver(message.body, message.clientId)
+    await deliver(message.body, message.clientId, message.replyToMessageId)
   }
 
   async function send(): Promise<void> {
@@ -516,7 +563,7 @@ export default function ChatScreen() {
     // The attachments are the message when there are any; the draft becomes
     // their caption, which is why this runs before the empty-body guard.
     if (pendingMedia.length > 0) {
-      if (sending || sendingMedia) return
+      if (sendingMedia) return
       const items = pendingMedia
       setPendingMedia([])
       setDraft('')
@@ -525,44 +572,85 @@ export default function ChatScreen() {
       listRef.current?.scrollToOffset({ offset: 0, animated: true })
       return
     }
-    if (!body || sending) return
-    setSending(true)
+    if (!body) return
+    /*
+     * The field clears on the press and never locks. What was typed is already
+     * on its way into the thread as its own row, so the composer has nothing
+     * to hold on to — and the next sentence can be typed while the first is
+     * still travelling. Two or three "Sending" rows at once is the normal case
+     * for somebody who types the way people talk.
+     */
+    setDraft('')
+    notifyTyping(false)
+    if (editing) {
+      const target = editing
+      setEditing(null)
+      void commitEdit(target, body)
+      return
+    }
+    if (correcting) {
+      const target = correcting
+      setCorrecting(null)
+      void commitCorrection(target, body)
+    } else {
+      const reply = replyingTo
+      setReplyingTo(null)
+      const clientId = newClientId(Date.now(), Math.random())
+      setOutgoing((list) =>
+        addOutgoing(list, {
+          clientId,
+          body,
+          sentAt: new Date().toISOString(),
+          ...(reply
+            ? { replyTo: { messageId: reply._id, senderId: reply.senderId, preview: reply.body } }
+            : {}),
+        }),
+      )
+      // `deliver` never rejects — a failure becomes an unsent row.
+      void deliver(body, clientId, reply?._id)
+    }
+    // Sending is a statement about the live conversation, so it ends a
+    // detour into the history rather than posting into the middle of it.
+    setJumpAnchor(null)
+    // Inverted, so the newest message is offset 0.
+    listRef.current?.scrollToOffset({ offset: 0, animated: true })
+    setAwayFrom(null)
+  }
+
+  /**
+   * An edit changes a row that exists, so it has nothing to draw ahead of the
+   * ack; it waits quietly, and a refusal puts the text back where it was typed
+   * so nothing is lost.
+   */
+  async function commitEdit(target: MessageDto, body: string): Promise<void> {
     try {
       const socket = await getSocket()
-      if (editing) {
-        await emitWithAck(socket, 'message:edit', {
-          conversationId,
-          messageId: editing._id,
-          body,
-        })
-        setEditing(null)
-        setDraft('')
-        return
-      }
-      if (correcting) {
-        await emitWithAck(socket, 'message:correct', {
-          conversationId,
-          targetMessageId: correcting._id,
-          corrected: body,
-        })
-        setCorrecting(null)
-        track({ name: 'message_sent', properties: { kind: 'correction', reply: false } })
-      } else {
-        // `deliver` never rejects — a failure becomes an unsent row — so the
-        // composer clears either way. The text is not lost, it has moved into
-        // the thread where the reader can see it did not go.
-        await deliver(body, newClientId(Date.now(), Math.random()))
-      }
-      setDraft('')
-      notifyTyping(false)
-      // Sending is a statement about the live conversation, so it ends a
-      // detour into the history rather than posting into the middle of it.
-      setJumpAnchor(null)
-      // Inverted, so the newest message is offset 0.
-      listRef.current?.scrollToOffset({ offset: 0, animated: true })
-      setAwayFrom(null)
-    } finally {
-      setSending(false)
+      await emitWithAck(socket, 'message:edit', {
+        conversationId,
+        messageId: target._id,
+        body,
+      })
+    } catch {
+      setEditing(target)
+      setDraft(body)
+      void showAlert(t('chat.actionFailed'), t('common.retry'))
+    }
+  }
+
+  /** The same rule for a correction: the card appears when the server echoes it. */
+  async function commitCorrection(target: MessageDto, corrected: string): Promise<void> {
+    try {
+      const socket = await getSocket()
+      await emitWithAck(socket, 'message:correct', {
+        conversationId,
+        targetMessageId: target._id,
+        corrected,
+      })
+      track({ name: 'message_sent', properties: { kind: 'correction', reply: false } })
+    } catch {
+      setCorrecting(target)
+      setDraft(corrected)
+      void showAlert(t('chat.actionFailed'), t('common.retry'))
     }
   }
 
@@ -1128,6 +1216,8 @@ export default function ChatScreen() {
                     <Text style={styles.dayLabel}>{dayLabel(row.day, { t, locale })}</Text>
                   </View>
                 ) : (
+                  // A stand-in has no server id yet, so a menu or a reply on it
+                  // would have nothing to act on until the echo lands.
                   <MessageBubble
                     message={row.message}
                     mine={isMine(row.message)}
@@ -1136,8 +1226,9 @@ export default function ChatScreen() {
                     translation={translations[row.message._id]}
                     translating={translating === row.message._id}
                     highlighted={highlighted === row.message._id}
-                    onLongPress={onLongPress}
-                    onReply={onReply}
+                    pending={isOutgoingId(row.message._id)}
+                    onLongPress={isOutgoingId(row.message._id) ? ignore : onLongPress}
+                    onReply={isOutgoingId(row.message._id) ? ignore : onReply}
                     onJumpTo={onJumpTo}
                     onOpenMedia={onOpenMedia}
                   />
@@ -1296,19 +1387,19 @@ export default function ChatScreen() {
               attachment with no caption is something to send, so a picked
               photo turns it back into the send button. */}
             {draft.trim() || pendingMedia.length > 0 ? (
-              <View style={[styles.sendShell, (sending || sendingMedia) && styles.sendDisabled]}>
+              <View style={[styles.sendShell, sendingMedia && styles.sendDisabled]}>
                 <Pressable
                   accessibilityRole="button"
                   accessibilityLabel={t('common.send')}
                   onPress={() => void send()}
-                  disabled={sending || sendingMedia}
+                  disabled={sendingMedia}
                   style={({ pressed }) => [
                     styles.send,
-                    pressed && !(sending || sendingMedia) && styles.sendPressed,
+                    pressed && !sendingMedia && styles.sendPressed,
                   ]}
                 >
                   <Feather
-                    name={sending || sendingMedia ? 'more-horizontal' : 'send'}
+                    name={sendingMedia ? 'more-horizontal' : 'send'}
                     size={20}
                     color={colors.primaryText}
                   />
@@ -1612,6 +1703,9 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
 
 /** A thread's worth; the composer sits below them either way. */
 const SKELETON_BUBBLES = ['a', 'b', 'c', 'd', 'e', 'f']
+
+/** For a stand-in row: the server has not named it yet, so its actions wait. */
+const ignore = () => undefined
 
 /**
  * Below this many messages the thread still shows its opening tip. Three is

--- a/apps/mobile/src/components/MessageBubble.tsx
+++ b/apps/mobile/src/components/MessageBubble.tsx
@@ -45,6 +45,8 @@ export interface MessageBubbleProps {
   translating: boolean
   /** Briefly ringed after a jump, so the reader sees where they landed. */
   highlighted: boolean
+  /** An optimistic stand-in for a send in flight; the meta says "Sending". */
+  pending?: boolean
   onLongPress: (message: MessageDto, alreadyTranslated: boolean, anchor?: AnchorRect) => void
   onReply: (message: MessageDto) => void
   onJumpTo: (messageId: string) => void
@@ -71,6 +73,7 @@ export const MessageBubble = memo(function MessageBubble({
   translation,
   translating,
   highlighted,
+  pending = false,
   onLongPress,
   onReply,
   onJumpTo,
@@ -246,7 +249,7 @@ export const MessageBubble = memo(function MessageBubble({
    * rounded shape, and the side is the only thing that says whose it is.
    */
   const column = [styles.column, mine ? styles.columnMine : styles.columnTheirs]
-  const meta = <MessageMeta message={message} mine={mine} />
+  const meta = <MessageMeta message={message} mine={mine} pending={pending} />
 
   /**
    * A withdrawal keeps its place in the thread rather than closing the gap.

--- a/apps/mobile/src/components/MessageMeta.tsx
+++ b/apps/mobile/src/components/MessageMeta.tsx
@@ -16,7 +16,10 @@ function clockTime(iso: string, locale: Locale): string {
 }
 
 /** The word for each state, drawn beside the clock. */
-const LABEL_KEYS: Record<DeliveryState, MessageKey> = {
+const LABEL_KEYS: Record<DeliveryState | 'sending', MessageKey> = {
+  // Not a server state: the row is the sender's own stand-in, drawn before
+  // the ack, and it says so until the echo replaces it.
+  sending: 'messageMeta.sending',
   sent: 'messageMeta.sent',
   delivered: 'messageMeta.delivered',
   read: 'messageMeta.read',
@@ -31,12 +34,21 @@ const LABEL_KEYS: Record<DeliveryState, MessageKey> = {
  * out over a socket the recipient is holding, or when they next connect;
  * `readAt` when they open the thread. Neither is inferred from the other.
  */
-export function MessageMeta({ message, mine }: { message: MessageDto; mine: boolean }) {
+export function MessageMeta({
+  message,
+  mine,
+  pending = false,
+}: {
+  message: MessageDto
+  mine: boolean
+  /** The row is an optimistic stand-in; see `lib/outgoingMessages`. */
+  pending?: boolean
+}) {
   const { colors } = useTheme()
   const styles = useStyles()
   const t = useT()
   const { locale } = useLocale()
-  const state = deliveryStateOf(message)
+  const state = pending ? 'sending' : deliveryStateOf(message)
 
   return (
     <View style={styles.row}>

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -128,6 +128,7 @@ export const ar: Localized<EnMessages> = {
     attachment: 'مرفق',
     photo: 'صورة',
     message: 'رسالة',
+    sending: 'جارٍ الإرسال',
   },
 
   interests: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -120,6 +120,7 @@ export const de: Localized<EnMessages> = {
     attachment: 'Anhang',
     photo: 'Foto',
     message: 'Nachricht',
+    sending: 'Wird gesendet',
   },
 
   interests: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -147,6 +147,7 @@ export const en = {
     attachment: 'Attachment',
     photo: 'Photo',
     message: 'Message',
+    sending: 'Sending',
   },
 
   /**

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -119,6 +119,7 @@ export const es: Localized<EnMessages> = {
     attachment: 'Adjunto',
     photo: 'Foto',
     message: 'Mensaje',
+    sending: 'Enviando',
   },
 
   interests: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -121,6 +121,7 @@ export const fr: Localized<EnMessages> = {
     attachment: 'Pièce jointe',
     photo: 'Photo',
     message: 'Message',
+    sending: 'Envoi en cours',
   },
 
   interests: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -115,6 +115,7 @@ export const ptBR: Localized<EnMessages> = {
     attachment: 'Anexo',
     photo: 'Foto',
     message: 'Mensagem',
+    sending: 'Enviando',
   },
 
   interests: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -127,6 +127,7 @@ export const ru: Localized<EnMessages> = {
     attachment: 'Вложение',
     photo: 'Фото',
     message: 'Сообщение',
+    sending: 'Отправляется',
   },
 
   interests: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -130,6 +130,7 @@ export const tr: Localized<EnMessages> = {
     attachment: 'Ek',
     photo: 'Fotoğraf',
     message: 'Mesaj',
+    sending: 'Gönderiliyor',
   },
 
   interests: {

--- a/apps/mobile/src/lib/outgoingMessages.test.ts
+++ b/apps/mobile/src/lib/outgoingMessages.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+  addOutgoing,
+  isOutgoingId,
+  MAX_OUTGOING,
+  outgoingId,
+  removeOutgoing,
+  retireArrived,
+  type OutgoingMessage,
+} from './outgoingMessages'
+
+const at = '2026-09-07T10:00:00.000Z'
+const row = (clientId: string, body = clientId): OutgoingMessage => ({ clientId, body, sentAt: at })
+
+describe('addOutgoing', () => {
+  it('puts the newest first, like the inverted thread', () => {
+    const list = addOutgoing(addOutgoing([], row('a')), row('b'))
+    expect(list.map((m) => m.clientId)).toEqual(['b', 'a'])
+  })
+
+  it('replaces a row with the same clientId instead of stacking it', () => {
+    const list = addOutgoing([row('a', 'first')], row('a', 'second'))
+    expect(list).toHaveLength(1)
+    expect(list[0]?.body).toBe('second')
+  })
+
+  it('keeps the list bounded', () => {
+    let list: OutgoingMessage[] = []
+    for (let i = 0; i < MAX_OUTGOING + 5; i++) list = addOutgoing(list, row(String(i)))
+    expect(list).toHaveLength(MAX_OUTGOING)
+    expect(list[0]?.clientId).toBe(String(MAX_OUTGOING + 4))
+  })
+})
+
+describe('removeOutgoing', () => {
+  it('removes by clientId and leaves the rest', () => {
+    expect(removeOutgoing([row('a'), row('b')], 'a').map((m) => m.clientId)).toEqual(['b'])
+  })
+})
+
+describe('retireArrived', () => {
+  it('drops the rows the thread now holds', () => {
+    const list = [row('a'), row('b'), row('c')]
+    expect(retireArrived(list, ['b', undefined, 'zzz']).map((m) => m.clientId)).toEqual(['a', 'c'])
+  })
+
+  it('returns the list untouched when nothing has arrived', () => {
+    const list = [row('a')]
+    expect(retireArrived(list, [undefined])).toBe(list)
+  })
+})
+
+describe('outgoing ids', () => {
+  it('round-trips through the prefix', () => {
+    expect(isOutgoingId(outgoingId('abc'))).toBe(true)
+    expect(isOutgoingId('66f1a2c9d3e84b7a1c2d3e4f')).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/outgoingMessages.ts
+++ b/apps/mobile/src/lib/outgoingMessages.ts
@@ -1,0 +1,78 @@
+/**
+ * Messages the composer has handed off and the server has not yet echoed.
+ *
+ * Pressing Send used to lock the composer and wait for the socket's ack: the
+ * text stayed in the field, the button turned into a spinner, and a second
+ * sentence could not be typed until the first had landed. Now the field clears
+ * on the press and the sentence moves into the thread at once, drawn as your
+ * own bubble with "Sending" under it, and gives way to the real message when
+ * the server echoes it back with the same `clientId`. Two or three can be in
+ * the air at a time; each is its own row with its own id.
+ *
+ * A pure module for the reason `unsentMessages` is: vitest only sees
+ * `src/lib/**`, so the queue has to live where it can be tested. It is that
+ * queue's sibling in shape — a message goes from here to there when its send
+ * fails, and to nowhere when it succeeds.
+ */
+export interface OutgoingMessage {
+  /** Client-minted, the same id the send carries; the echo brings it back. */
+  clientId: string
+  body: string
+  /** The quote the row draws, in the shape the server would snapshot it. */
+  replyTo?: { messageId: string; senderId: string; preview: string }
+  /** When Send was pressed — the row's clock until the server's own arrives. */
+  sentAt: string
+}
+
+/**
+ * Well above the two or three a fast typist has in the air at once. A guard,
+ * not a quota: nothing here is refused, the oldest stand-in is dropped.
+ */
+export const MAX_OUTGOING = 20
+
+/** Newest first, like the inverted thread. Replaces by `clientId` rather than stacking. */
+export function addOutgoing(
+  list: readonly OutgoingMessage[],
+  message: OutgoingMessage,
+): OutgoingMessage[] {
+  const withoutSelf = list.filter((entry) => entry.clientId !== message.clientId)
+  return [message, ...withoutSelf].slice(0, MAX_OUTGOING)
+}
+
+export function removeOutgoing(
+  list: readonly OutgoingMessage[],
+  clientId: string,
+): OutgoingMessage[] {
+  return list.filter((entry) => entry.clientId !== clientId)
+}
+
+/**
+ * Drops the rows whose message the thread now holds.
+ *
+ * The ack and the echo race, and either may arrive first; whichever the
+ * screen sees first retires the stand-in, so the sentence is never on screen
+ * twice.
+ */
+export function retireArrived(
+  list: readonly OutgoingMessage[],
+  arrivedClientIds: readonly (string | undefined)[],
+): OutgoingMessage[] {
+  const arrived = new Set(arrivedClientIds.filter((id): id is string => Boolean(id)))
+  if (arrived.size === 0) return list as OutgoingMessage[]
+  return list.filter((entry) => !arrived.has(entry.clientId))
+}
+
+/**
+ * The id a stand-in row carries until the server names the message. Prefixed
+ * so the thread can tell it apart: a long-press or a reply on a row the server
+ * does not know yet has nothing to act on.
+ */
+export const OUTGOING_ID_PREFIX = 'outgoing:'
+
+export function outgoingId(clientId: string): string {
+  return `${OUTGOING_ID_PREFIX}${clientId}`
+}
+
+export function isOutgoingId(id: string): boolean {
+  return id.startsWith(OUTGOING_ID_PREFIX)
+}


### PR DESCRIPTION
## What

D4 from `docs/plans/design-handoff-follow-ups.md`.

- Pressing **Send** clears the field immediately and never locks the input or the button; two or three messages can be in flight at once.
- Each send appears in the thread right away as the sender's own bubble with **"Sending"** under it (`src/lib/outgoingMessages.ts`, a sibling of the unsent queue, with tests). The server's echo carries the same `clientId` and replaces the stand-in with the real message, which reads **"Sent"** and then Delivered/Read.
- A failed send moves the row to the existing retry list. Edits and corrections wait for the ack quietly and put the text back in the field if refused (they used to surface nothing).
- `MessageMeta` gains a `sending` state; `messageMeta.sending` added to all eight locales.

## Verification

`pnpm typecheck`, eslint on the changed files, `vitest` (mobile 709), `prettier --check .` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
