### PR TITLE
feat(onboarding): claim the username before the photo

### DIFF
--- a/apps/mobile/app/(onboarding)/_layout.tsx
+++ b/apps/mobile/app/(onboarding)/_layout.tsx
@@ -24,6 +24,8 @@ export default function OnboardingLayout() {
         reached by `replace` and are not a place to go back from.
       */}
       <Stack.Screen name="languages" options={{ gestureEnabled: false }} />
+      {/* The claim behind it cannot be undone, so the photo step has no back. */}
+      <Stack.Screen name="photo" options={{ gestureEnabled: false }} />
       <Stack.Screen name="welcome-back" options={{ gestureEnabled: false }} />
       <Stack.Screen name="done" options={{ gestureEnabled: false }} />
     </Stack>

--- a/apps/mobile/app/(onboarding)/about-you.tsx
+++ b/apps/mobile/app/(onboarding)/about-you.tsx
@@ -139,7 +139,7 @@ export default function AboutYouStep() {
         <Button
           label={t('common.continue')}
           disabled={!canContinue}
-          onPress={() => router.push('/(onboarding)/photo')}
+          onPress={() => router.push('/(onboarding)/handle')}
         />
       </ScrollView>
     </Screen>

--- a/apps/mobile/app/(onboarding)/handle.tsx
+++ b/apps/mobile/app/(onboarding)/handle.tsx
@@ -33,7 +33,9 @@ function useDebounced<T>(value: T, delay = 400): T {
 }
 
 /**
- * The last step: pick a handle, then create the profile.
+ * The step that creates the profile: pick a handle, claim it, and the photo
+ * follows. v3 puts the username before the picture — the account exists once
+ * this screen is done, and what comes after is written onto it.
  *
  * v1 ran on Appwrite and its users had handles; a returning user's handle is
  * reserved for them and this is where they claim it. The reservation lookup is
@@ -114,9 +116,8 @@ export default function HandleStep() {
         // Every level is set by the time this screen is reachable — the
         // wizard's third step will not continue without them.
         learning: current.learning.map((l, index) => ({ ...l, priority: index + 1 })),
-        ...(current.bio.trim() ? { bio: current.bio.trim() } : {}),
-        ...(current.interests.length > 0 ? { interests: current.interests } : {}),
-        ...(current.avatarUrl ? { avatarUrl: current.avatarUrl } : {}),
+        // No photo and no bio here: both are asked on the step after this one
+        // and written onto the profile this request creates.
         // Silently ignored by the server if it resolves to nobody — see
         // `attachReferral`. Nothing here should be able to fail a sign-up.
         ...(current.referredByHandle
@@ -142,10 +143,10 @@ export default function HandleStep() {
         },
       })
       await queryClient.invalidateQueries({ queryKey: keys.me })
-      // To the finish screen, not straight into discovery: a list of strangers
-      // with no instruction is a poor first thing to hand someone who has just
-      // finished four forms.
-      router.replace('/(onboarding)/done')
+      // On to the photo, which writes onto the profile that now exists; the
+      // finish screen comes after it. `replace`, because the claim cannot be
+      // undone by going back.
+      router.replace('/(onboarding)/photo')
     } catch (error) {
       // The API's own message is English and written for a developer; the
       // person filling in this form gets ours instead.
@@ -201,7 +202,7 @@ export default function HandleStep() {
         keyboardShouldPersistTaps="handled"
         automaticallyAdjustKeyboardInsets
       >
-        <StepProgress step="handle" onBack={() => goBackTo('/(onboarding)/photo')} />
+        <StepProgress step="handle" onBack={() => goBackTo('/(onboarding)/about-you')} />
         <Text style={styles.title}>{t('onboarding.handleTitle')}</Text>
 
         {reserved ? (
@@ -284,7 +285,7 @@ export default function HandleStep() {
         )}
 
         <Button
-          label={t('onboarding.startUsing')}
+          label={t('common.continue')}
           disabled={!canSubmit}
           loading={submitting}
           onPress={submit}

--- a/apps/mobile/app/(onboarding)/photo.tsx
+++ b/apps/mobile/app/(onboarding)/photo.tsx
@@ -4,33 +4,31 @@ import { router } from 'expo-router'
 import { useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
 import { Image } from 'expo-image'
-import { uploadAvatarBytes } from '../../src/api/queries'
+import { useMe, useUpdateProfile, useUploadAvatar } from '../../src/api/queries'
 import { StepProgress } from '../../src/components/StepProgress'
 import { Button } from '../../src/components/ui/Button'
 import { FormField } from '../../src/components/ui/FormField'
 import { Screen } from '../../src/components/ui/Screen'
-import { updateDraft, useOnboardingDraft } from '../../src/hooks/useOnboardingDraft'
 import { showAlert } from '../../src/lib/alert'
-import { goBackTo } from '../../src/lib/navigation'
 import { pickImageAsset } from '../../src/lib/pickMediaAsset'
 import { makeStyles, useTheme } from '../../src/lib/theme'
 import { useT } from '../../src/i18n'
 import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
- * Step 4 of 5, and both halves of it are skippable.
+ * The last step, and both halves of it are skippable.
  *
- * `docs/architecture.md` has described the wizard as "languages + levels →
- * gender/bio/avatar/interests → username claim" from the beginning; the avatar
- * and the bio are the two that make a first impression. Without them a new
- * account arrives in discovery as a letter on a grey circle with nothing to
- * open with, which is the worst possible first impression in a product whose
- * whole mechanic is strangers choosing each other. Interests wait for the
- * profile editor — v3 keeps this step to the two.
+ * The avatar and the bio are the two things that make a first impression.
+ * Without them a new account arrives in discovery as a letter on a grey circle
+ * with nothing to open with, which is the worst possible first impression in a
+ * product whose whole mechanic is strangers choosing each other. Interests
+ * wait for the profile editor — v3 keeps this step to the two.
  *
- * The picture is uploaded here but **not** confirmed: `confirm` writes onto a
- * profile and there is no profile until the last step. The URL rides in the
- * draft and `POST /profiles` writes it, running the same bucket check.
+ * v3 claims the username *before* this screen, so the profile already exists
+ * when it opens. The picture therefore goes through the same upload-and-confirm
+ * the profile editor uses, and the bio is a plain `PATCH /profiles/me` — nothing
+ * rides in the draft any more, which is also why there is no way back: the
+ * claim behind this screen cannot be undone.
  */
 export default function PhotoStep() {
   useScreenInteractive()
@@ -38,8 +36,12 @@ export default function PhotoStep() {
   const { colors } = useTheme()
   const t = useT()
 
-  const draft = useOnboardingDraft()
-  const [uploading, setUploading] = useState(false)
+  const me = useMe()
+  const uploadAvatar = useUploadAvatar()
+  const updateProfile = useUpdateProfile()
+  const [bio, setBio] = useState('')
+  const [saving, setSaving] = useState(false)
+  const uploading = uploadAvatar.isPending
 
   async function pickPhoto(): Promise<void> {
     const picked = await pickImageAsset({ allowsEditing: true, aspect: [1, 1] })
@@ -56,22 +58,40 @@ export default function PhotoStep() {
     }
     if (picked.status === 'cancelled') return
 
-    setUploading(true)
     try {
-      const url = await uploadAvatarBytes(picked.image.uri, picked.image.contentType)
-      updateDraft({ avatarUrl: url })
+      await uploadAvatar.mutateAsync(picked.image)
     } catch {
       void showAlert(t('errors.uploadFailed'), t('onboarding.photoUploadFailed'))
-    } finally {
-      setUploading(false)
     }
   }
 
-  // The name is required two steps back, so there is always a letter to show.
-  const initial = draft.displayName.trim().charAt(0).toUpperCase()
+  /**
+   * Saves the bio if there is one, then on to the finish screen. Skipping is
+   * the same navigation without the save; the picture, if any, is already on
+   * the profile.
+   */
+  async function finish(save: boolean): Promise<void> {
+    const text = bio.trim()
+    if (save && text.length > 0) {
+      setSaving(true)
+      try {
+        await updateProfile.mutateAsync({ bio: text })
+      } catch {
+        setSaving(false)
+        void showAlert(t('editProfile.saveFailed'), t('common.retry'))
+        return
+      }
+      setSaving(false)
+    }
+    router.replace('/(onboarding)/done')
+  }
+
+  const avatarUrl = me.data?.avatarUrl
+  // The name was required two steps back, so there is always a letter to show.
+  const initial = (me.data?.displayName ?? '').trim().charAt(0).toUpperCase()
   const photoLabel = uploading
     ? t('onboarding.uploading')
-    : draft.avatarUrl
+    : avatarUrl
       ? t('onboarding.changePhoto')
       : t('onboarding.addPhoto')
 
@@ -89,7 +109,8 @@ export default function PhotoStep() {
         keyboardShouldPersistTaps="handled"
         automaticallyAdjustKeyboardInsets
       >
-        <StepProgress step="photo" onBack={() => goBackTo('/(onboarding)/about-you')} />
+        {/* No back arrow: the username behind this screen is claimed and the profile exists. */}
+        <StepProgress step="photo" />
         <Text style={styles.title}>{t('onboarding.photoTitle')}</Text>
         <Text style={styles.subtitle}>{t('onboarding.photoBody')}</Text>
 
@@ -102,8 +123,8 @@ export default function PhotoStep() {
             onPress={() => void pickPhoto()}
             style={({ pressed }) => [styles.avatar, pressed && styles.pressed]}
           >
-            {draft.avatarUrl ? (
-              <Image source={{ uri: draft.avatarUrl }} style={styles.photo} contentFit="cover" />
+            {avatarUrl ? (
+              <Image source={{ uri: avatarUrl }} style={styles.photo} contentFit="cover" />
             ) : (
               <Text style={styles.initial}>{initial}</Text>
             )}
@@ -126,8 +147,8 @@ export default function PhotoStep() {
         <View style={styles.bio}>
           <FormField
             label={t('onboarding.aboutYouOptional')}
-            value={draft.bio}
-            onChangeText={(bio) => updateDraft({ bio })}
+            value={bio}
+            onChangeText={setBio}
             placeholder={t('onboarding.bioPrompt')}
             multiline
             maxLength={BIO_MAX_LENGTH}
@@ -141,11 +162,16 @@ export default function PhotoStep() {
           wants to correct it grants location permission in Settings.
         */}
 
-        <Button label={t('common.continue')} onPress={() => router.push('/(onboarding)/handle')} />
+        <Button
+          label={t('onboarding.startUsing')}
+          loading={saving}
+          disabled={uploading}
+          onPress={() => finish(true)}
+        />
         <Pressable
           accessibilityRole="button"
           hitSlop={8}
-          onPress={() => router.push('/(onboarding)/handle')}
+          onPress={() => void finish(false)}
           style={({ pressed }) => [styles.skip, pressed && styles.pressed]}
         >
           <Text style={styles.skipText}>{t('common.skip')}</Text>

--- a/apps/mobile/src/hooks/useOnboardingDraft.ts
+++ b/apps/mobile/src/hooks/useOnboardingDraft.ts
@@ -15,8 +15,6 @@ export interface OnboardingDraft {
   displayName: string
   birthDate: string
   gender: Gender
-  bio: string
-  interests: string[]
   /**
    * Whoever's invite link brought them here, or what they typed in. Kept on
    * the draft so it survives a relaunch mid-onboarding, exactly like the
@@ -31,8 +29,6 @@ export interface OnboardingDraft {
    */
   referredBySource: ReferralSource
   country: string
-  /** Uploaded during the wizard; written by `POST /profiles`, not by `confirm`. */
-  avatarUrl: string
 }
 
 const EMPTY: OnboardingDraft = {
@@ -42,12 +38,9 @@ const EMPTY: OnboardingDraft = {
   displayName: '',
   birthDate: '',
   gender: 'undisclosed',
-  bio: '',
-  interests: [],
   referredByHandle: '',
   referredBySource: 'manual',
   country: '',
-  avatarUrl: '',
 }
 
 /**

--- a/apps/mobile/src/lib/onboardingStep.test.ts
+++ b/apps/mobile/src/lib/onboardingStep.test.ts
@@ -9,12 +9,9 @@ const EMPTY: OnboardingDraft = {
   displayName: '',
   birthDate: '',
   gender: 'undisclosed',
-  bio: '',
-  interests: [],
   referredByHandle: '',
   referredBySource: 'manual' as const,
   country: '',
-  avatarUrl: '',
 }
 
 const draft = (patch: Partial<OnboardingDraft>): OnboardingDraft => ({ ...EMPTY, ...patch })
@@ -75,24 +72,25 @@ describe('furthestOnboardingStep', () => {
     )
   })
 
-  it('reaches the photo step with the required fields in place', () => {
+  it('reaches the handle step with the required fields in place', () => {
     expect(
       furthestOnboardingStep(
         draft({ ...withLanguages, displayName: 'Ada', birthDate: '1994-03-07' }),
       ),
-    ).toBe('photo')
+    ).toBe('handle')
   })
 
   /**
-   * `handle` is the submit step. Landing there directly would skip the avatar
-   * and interests without the user ever seeing that they were offered.
+   * `photo` comes after the profile exists, and a profile is what keeps the
+   * gate from sending anyone back into the wizard — so a draft can never earn
+   * it, however far it got.
    */
-  it('never resumes on the handle step, even with a handle already typed', () => {
+  it('never resumes on the photo step, even with a handle already typed', () => {
     expect(
       furthestOnboardingStep(
         draft({ ...withLanguages, displayName: 'Ada', birthDate: '1994-03-07', handle: 'ada' }),
       ),
-    ).toBe('photo')
+    ).toBe('handle')
   })
 
   it('treats whitespace as unfilled', () => {

--- a/apps/mobile/src/lib/onboardingStep.ts
+++ b/apps/mobile/src/lib/onboardingStep.ts
@@ -5,7 +5,7 @@ import type { OnboardingDraft } from '../hooks/useOnboardingDraft'
  * `languages` screen, behind two tabs — v3 merged them back, with Continue
  * driving the tab change so the sequence survives the merge.
  */
-export const ONBOARDING_STEPS = ['languages', 'levels', 'about-you', 'photo', 'handle'] as const
+export const ONBOARDING_STEPS = ['languages', 'levels', 'about-you', 'handle', 'photo'] as const
 export type OnboardingStep = (typeof ONBOARDING_STEPS)[number]
 
 /**
@@ -17,9 +17,9 @@ export type OnboardingStep = (typeof ONBOARDING_STEPS)[number]
  *
  * It reads what a step *requires*, not what the user last looked at — a draft
  * with languages but no name belongs on `about-you` whichever screen was open
- * when the app died. `handle` is never returned: it is the submit step, and
- * dropping someone straight onto "claim your username" skips the two optional
- * fields before it without them ever seeing that they existed.
+ * when the app died. `photo` is never returned: it is the step after the
+ * profile exists (v3 claims the username first, then asks for a picture), and
+ * a profile is exactly what stops the gate from sending anyone here at all.
  */
 /**
  * What a guest fills in: the two language questions and nothing else.
@@ -42,7 +42,7 @@ export function furthestOnboardingStep(draft: OnboardingDraft): OnboardingStep {
   // fit between what you speak and how well you speak it.
   if (draft.learning.some((entry) => entry.level === null)) return 'levels'
   if (!draft.displayName.trim() || !draft.birthDate.trim()) return 'about-you'
-  return 'photo'
+  return 'handle'
 }
 
 export function onboardingHref(step: OnboardingStep): `/(onboarding)/${OnboardingStep}` {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1076,8 +1076,9 @@ only thing that matters is preserving store identity.
 
 1. Sign-up/sign-in (email + Google + Apple), verification, password reset,
    **16+ age gate** (18+ at launch)
-2. Onboarding: languages + levels → gender/bio/avatar/interests → **username
-   claim**
+2. Onboarding: languages + levels → gender/birth date → **username claim** →
+   avatar/bio (v3, 7 September 2026: the username moved ahead of the photo, so
+   the picture and the bio are written onto a profile that already exists)
 3. Profile view/edit, presigned avatar upload + **multi-photo gallery**
 4. Discovery: ranked list + free filters + **two sort presets**, infinite
    scroll, **direct message start** from a profile or the list

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -606,6 +606,15 @@ would be lost on "back", and serialising a growing draft through route params
 turns the URL into a form encoding. A small store outside React matches the
 real lifetime: the draft outlives any one screen and is thrown away on submit.
 
+**7 September 2026 — the username moved ahead of the photo.** The v3 design
+claims the handle right after the about-you step, and the picture and bio come
+last. That changes what the draft carries: the profile exists by the time the
+photo screen opens, so the avatar goes through the same upload-and-confirm the
+profile editor uses and the bio is a plain `PATCH /profiles/me`. Neither rides
+in the draft any more, and `furthestOnboardingStep` can now land on `handle`
+(the step that submits) but never on `photo` — a profile is exactly what keeps
+the gate from sending anyone back into the wizard.
+
 ## Client — `expo-notifications` must be imported lazily
 
 Expo Go dropped remote push on Android in SDK 53, and `expo-notifications`


### PR DESCRIPTION
## Summary

Design follow-up **A1** from `docs/plans/design-handoff-follow-ups.md`: the v3 prototype orders the wizard as languages → levels → about you → **username** → **photo**, and the app now does the same.

- `handle` creates the profile (no `bio`/`avatarUrl` in the body any more) and continues to `photo`; its CTA is "Continue", back goes to about-you.
- `photo` is the last step and works on the profile that now exists: avatar through the profile editor's upload + confirm, bio through `PATCH /profiles/me`. "Start using LangX" saves and finishes, "Skip for now" finishes. No back arrow and no back gesture, since the claim behind it cannot be undone.
- `furthestOnboardingStep` resumes on `handle` at most, never on `photo`; tests updated. The draft drops `bio`, `interests`, `avatarUrl`.
- `docs/architecture.md` and `docs/decisions.md` get a dated addendum.

## Test plan

- [x] `tsc --noEmit`, eslint, prettier, vitest (all mobile tests green)
- [ ] Simulator: about-you → Continue lands on the handle step; claiming lands on the photo step with the letter avatar; Skip → Discover
- [ ] Kill the app between handle and photo → reopens on Discover (profile exists), not in the wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)