### PR TITLE
fix(wallet): keep the hero number below its kicker

### DIFF
--- a/apps/mobile/app/(app)/wallet/index.tsx
+++ b/apps/mobile/app/(app)/wallet/index.tsx
@@ -166,13 +166,14 @@ const useStyles = makeStyles(({ colors, font, spacing }) => ({
   },
   pressed: { opacity: 0.7 },
   kicker: { color: colors.textFaint, fontSize: 13, fontWeight: '600' },
-  // Set solid: digits have no descenders, and the number is the whole block.
+  // Not set solid: Nunito's ascender is taller than the em box, so a line
+  // height equal to the size let the digits climb into the kicker above.
   balanceValue: {
     ...font.heading,
     color: colors.text,
     fontSize: 56,
     fontVariant: ['tabular-nums'],
-    lineHeight: 56,
+    lineHeight: 64,
   },
   balanceHint: { alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between' },
   body: { color: colors.textMuted, fontSize: 15 },

--- a/apps/mobile/app/(app)/wallet/pool.tsx
+++ b/apps/mobile/app/(app)/wallet/pool.tsx
@@ -139,8 +139,9 @@ const useStyles = makeStyles(({ colors, font, spacing }) => ({
     paddingTop: spacing.lg,
   },
   kicker: { color: colors.textFaint, fontSize: 13, fontWeight: '600' },
-  // Set solid, like the wallet's balance: a signed integer has no descenders.
-  shareValue: { ...font.heading, color: colors.success, fontSize: 48, lineHeight: 48 },
+  // Not set solid, like the wallet's balance: Nunito's ascender is taller than
+  // the em box, so a line height equal to the size overlapped the kicker.
+  shareValue: { ...font.heading, color: colors.success, fontSize: 48, lineHeight: 56 },
   meta: { color: colors.textMuted, fontSize: 14 },
   today: { gap: 10, marginTop: 18 },
   todayHead: { flexDirection: 'row', justifyContent: 'space-between' },


### PR DESCRIPTION
## Summary

On **Wallet** and **Daily pool** the big number overlapped the small label above it. Both were set solid (line height equal to the font size); Nunito ascends above the em box, so the digits climbed into the kicker. The line box now has the height the glyphs need (56 → 64, 48 → 56).

## Test plan

- [x] prettier
- [ ] Simulator: Wallet balance and Daily pool share sit clear of their labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)