### PR TITLE
feat(chat): "Send a message" opens the thread's composer on a new-chat screen

### DIFF
--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -7,23 +7,11 @@ import {
   MAX_VIDEO_SECONDS,
   type Media,
   MESSAGE_REACTIONS,
-  TOKEN_RULES,
 } from '@langx/shared'
 import { useQueryClient } from '@tanstack/react-query'
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import {
-  ActivityIndicator,
-  Animated,
-  FlatList,
-  Platform,
-  Pressable,
-  Text,
-  TextInput,
-  View,
-  type NativeSyntheticEvent,
-  type TextInputKeyPressEventData,
-} from 'react-native'
+import { ActivityIndicator, Animated, FlatList, Pressable, Text, View } from 'react-native'
 import {
   markConversationRead,
   uploadMessageMedia,
@@ -40,6 +28,7 @@ import { track } from '../../../src/lib/analytics'
 import { setActiveConversation } from '../../../src/lib/activeConversation'
 import { useKeyboardInset } from '../../../src/hooks/useKeyboardInset'
 import { PresenceLine } from '../../../src/components/PresenceLine'
+import { ChatComposer } from '../../../src/components/ChatComposer'
 import { ComposerHint } from '../../../src/components/ComposerHint'
 import { MessageBubble } from '../../../src/components/MessageBubble'
 import { PhotoViewer } from '../../../src/components/PhotoViewer'
@@ -72,7 +61,6 @@ import {
 } from '../../../src/lib/outgoingMessages'
 import { errorCodeOf } from '../../../src/lib/errors'
 import { listState } from '../../../src/lib/listState'
-import { shouldSubmitOnEnter } from '../../../src/lib/submitOnEnter'
 import { messageActionsFor } from '../../../src/lib/messageActions'
 import { openMessageMenu, type AnchorRect } from '../../../src/lib/messageMenu'
 import { goBackTo, openProfile } from '../../../src/lib/navigation'
@@ -153,7 +141,6 @@ export default function ChatScreen() {
   const block = useBlockUser()
   const recorder = useVoiceRecorder()
   /** Only for the pill's dress: white ground and accent ring while it has focus. */
-  const [focused, setFocused] = useState(false)
   const [sendingMedia, setSendingMedia] = useState(false)
   /**
    * Picked, and waiting for the send button.
@@ -1271,44 +1258,65 @@ export default function ChatScreen() {
         </View>
 
         {/*
-          One block under a hairline: the mode banner when there is one, the
-          picked attachments, the row itself, and the hint under it.
+          The block under the hairline is `ChatComposer`, shared with the
+          screen that starts a conversation. What needs a conversation — the
+          attach control, the recorder, the microphone — is passed in from
+          here, and the mode banner and picked attachments ride above the row.
         */}
-        <View style={styles.composer}>
-          {/*
-            One shape for all three modes — reply, edit, correct. The label says
-            which; the line under it is the message it is about, cut to one line
-            because the composer below already holds the text being written.
-          */}
-          {mode ? (
-            <View style={styles.modeBanner}>
-              <View style={styles.modeText}>
-                <Text style={styles.modeLabel} numberOfLines={1}>
-                  {mode.label}
-                </Text>
-                <Text style={styles.modePreview} numberOfLines={1}>
-                  {mode.preview}
-                </Text>
-              </View>
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={t('common.cancel')}
-                hitSlop={8}
-                onPress={mode.clear}
-              >
-                <Feather name="x" size={18} color={colors.textMuted} />
-              </Pressable>
-            </View>
-          ) : null}
-          {/* Above the row rather than inside it: the row holds the send
-            button, and anything that grows in there competes for width with
-            the only control that sends the message. */}
-          <AttachmentPreviewRow
-            pending={pendingMedia}
-            onRemove={(index) => setPendingMedia((items) => items.filter((_, at) => at !== index))}
-          />
-          <View style={styles.composerRow}>
-            {recorder.isRecording ? (
+        <ChatComposer
+          value={draft}
+          onChangeText={onChangeDraft}
+          placeholder={
+            correcting
+              ? t('chat.writeCorrection')
+              : items.length === 0 && partner
+                ? t('chat.sayHello', { name: partner.displayName })
+                : t('chat.writeMessage')
+          }
+          onSend={() => void send()}
+          hasAttachment={pendingMedia.length > 0}
+          busy={sendingMedia}
+          above={
+            <>
+              {/*
+                One shape for all three modes — reply, edit, correct. The label
+                says which; the line under it is the message it is about, cut
+                to one line because the field below already holds the text
+                being written.
+              */}
+              {mode ? (
+                <View style={styles.modeBanner}>
+                  <View style={styles.modeText}>
+                    <Text style={styles.modeLabel} numberOfLines={1}>
+                      {mode.label}
+                    </Text>
+                    <Text style={styles.modePreview} numberOfLines={1}>
+                      {mode.preview}
+                    </Text>
+                  </View>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={t('common.cancel')}
+                    hitSlop={8}
+                    onPress={mode.clear}
+                  >
+                    <Feather name="x" size={18} color={colors.textMuted} />
+                  </Pressable>
+                </View>
+              ) : null}
+              {/* Above the row rather than inside it: the row holds the send
+                button, and anything that grows in there competes for width with
+                the only control that sends the message. */}
+              <AttachmentPreviewRow
+                pending={pendingMedia}
+                onRemove={(index) =>
+                  setPendingMedia((items) => items.filter((_, at) => at !== index))
+                }
+              />
+            </>
+          }
+          leading={
+            recorder.isRecording ? (
               <View style={styles.recording}>
                 <Text style={styles.recordingDot}>●</Text>
                 <Text style={styles.recordingTime}>
@@ -1345,98 +1353,30 @@ export default function ChatScreen() {
                   color={mediaLockedFor > 0 ? colors.textFaint : colors.textMuted}
                 />
               </Pressable>
-            )}
-            <TextInput
-              value={draft}
-              onChangeText={onChangeDraft}
-              placeholder={
-                correcting
-                  ? t('chat.writeCorrection')
-                  : items.length === 0 && partner
-                    ? t('chat.sayHello', { name: partner.displayName })
-                    : t('chat.writeMessage')
-              }
-              placeholderTextColor={colors.textFaint}
-              style={[styles.input, focused && styles.inputFocused]}
-              onFocus={() => setFocused(true)}
-              onBlur={() => setFocused(false)}
-              multiline
-              /**
-               * Web only, and it has to be a key handler: `multiline` is a
-               * `<textarea>` in the browser, where `onSubmitEditing` never
-               * fires — the handler that used to be here had never run. On
-               * native the return key inserts a newline and the send button is
-               * the way to send, which is what people expect there.
-               */
-              {...(Platform.OS === 'web'
-                ? {
-                    onKeyPress: (event: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
-                      const { key, shiftKey } = event.nativeEvent as TextInputKeyPressEventData & {
-                        shiftKey?: boolean
-                      }
-                      if (!shouldSubmitOnEnter(key, shiftKey === true)) return
-                      // Otherwise the newline lands in the box behind the send.
-                      event.preventDefault()
-                      void send()
-                    },
-                  }
-                : {})}
-            />
-            {/* The button becomes a microphone when there is nothing to send,
-              which is the gesture people already expect from a chat app. An
-              attachment with no caption is something to send, so a picked
-              photo turns it back into the send button. */}
-            {draft.trim() || pendingMedia.length > 0 ? (
-              <View style={[styles.sendShell, sendingMedia && styles.sendDisabled]}>
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel={t('common.send')}
-                  onPress={() => void send()}
-                  disabled={sendingMedia}
-                  style={({ pressed }) => [
-                    styles.send,
-                    pressed && !sendingMedia && styles.sendPressed,
-                  ]}
-                >
-                  <Feather
-                    name={sendingMedia ? 'more-horizontal' : 'send'}
-                    size={20}
-                    color={colors.primaryText}
-                  />
-                </Pressable>
-              </View>
-            ) : (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={t('chat.voiceMessage')}
-                onPress={() => void toggleRecording()}
-                disabled={sendingMedia}
-                style={[
-                  styles.mic,
-                  recorder.isRecording && styles.recordButtonActive,
-                  sendingMedia && styles.sendDisabled,
-                ]}
-              >
-                <Feather
-                  name={recorder.isRecording ? 'square' : 'mic'}
-                  size={20}
-                  color={recorder.isRecording ? colors.textInverse : colors.text}
-                />
-              </Pressable>
-            )}
-          </View>
-          {/*
-          The two facts a first-time user cannot discover: that a long press
-          corrects, and that a message pays. Both come from `TOKEN_RULES`
-          rather than being written into the copy.
-        */}
-          <View style={styles.composerHint}>
-            <ComposerHint style={styles.hintLeft} />
-            <Text style={styles.hintRight}>
-              {t('chat.tokensPerMessage', { count: TOKEN_RULES.award.message })}
-            </Text>
-          </View>
-        </View>
+            )
+          }
+          idleAction={
+            /* A microphone when there is nothing to send, which is the gesture
+              people already expect from a chat app. */
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t('chat.voiceMessage')}
+              onPress={() => void toggleRecording()}
+              disabled={sendingMedia}
+              style={[
+                styles.mic,
+                recorder.isRecording && styles.recordButtonActive,
+                sendingMedia && styles.micDisabled,
+              ]}
+            >
+              <Feather
+                name={recorder.isRecording ? 'square' : 'mic'}
+                size={20}
+                color={recorder.isRecording ? colors.textInverse : colors.text}
+              />
+            </Pressable>
+          }
+        />
         <PhotoViewer
           photos={viewing?.items ?? []}
           index={viewing?.index ?? null}
@@ -1611,68 +1551,6 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
   },
   pinText: { ...font.caption, color: colors.text, flex: 1 },
   older: { paddingVertical: spacing.md },
-  /**
-   * Everything under the hairline: banner, attachments, the row, the hint.
-   * The bottom is `spacing.md` on top of the safe-area inset `Screen` already
-   * adds — the prototype's 28 is that inset, drawn in a frame that has none.
-   */
-  composer: {
-    backgroundColor: colors.surface,
-    borderTopColor: colors.border,
-    borderTopWidth: 1,
-    gap: 10,
-    paddingBottom: spacing.md,
-    paddingHorizontal: spacing.lg,
-    paddingTop: 10,
-  },
-  composerRow: { alignItems: 'flex-end', flexDirection: 'row', gap: spacing.sm },
-  composerHint: { alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between' },
-  hintLeft: { ...font.caption, color: colors.textFaint },
-  // The green pair marks earning, same as "Earned" rows elsewhere.
-  hintRight: { ...font.caption, color: colors.success, fontWeight: '600' },
-  /**
-   * A fill pill — v3's one grey allowed to be a shape. The border is there
-   * only to say something: transparent at rest, accent while focused, so the
-   * box does not grow by a pixel when it takes focus.
-   */
-  input: {
-    ...font.body,
-    backgroundColor: colors.fill,
-    borderColor: 'transparent',
-    borderRadius: radius.xl,
-    borderWidth: 1,
-    color: colors.text,
-    flex: 1,
-    fontSize: 16,
-    lineHeight: 22,
-    maxHeight: 120,
-    minHeight: 48,
-    paddingHorizontal: 18,
-    paddingVertical: 13,
-  },
-  inputFocused: { backgroundColor: colors.bg, borderColor: colors.accent },
-  /**
-   * The one yellow on the screen, standing on the same hard shadow `ui/Button`
-   * does: a shell in the shade, a face on it that drops on press. The negative
-   * margin lets the shade hang below the row the way `box-shadow` does, so it
-   * is the face — not the shade — that lines up with the input's bottom.
-   */
-  sendShell: {
-    backgroundColor: colors.primaryShade,
-    borderRadius: 14,
-    marginBottom: -3,
-    paddingBottom: 3,
-  },
-  send: {
-    alignItems: 'center',
-    backgroundColor: colors.primary,
-    borderRadius: 14,
-    height: 48,
-    justifyContent: 'center',
-    width: 48,
-  },
-  sendPressed: { transform: [{ translateY: 3 }] },
-  sendDisabled: { opacity: 0.35 },
   // A fill circle: the microphone is the resting state, not the committing one.
   mic: {
     alignItems: 'center',
@@ -1683,6 +1561,7 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
     width: 48,
   },
   recordButtonActive: { backgroundColor: colors.danger },
+  micDisabled: { opacity: 0.35 },
   // A bare muted glyph, sized to line up with the pill beside it.
   attach: {
     alignItems: 'center',

--- a/apps/mobile/app/(app)/chat/new.tsx
+++ b/apps/mobile/app/(app)/chat/new.tsx
@@ -1,0 +1,207 @@
+import Feather from '@expo/vector-icons/Feather'
+import { router, useLocalSearchParams } from 'expo-router'
+import { useState } from 'react'
+import { Animated, Pressable, Text, View } from 'react-native'
+import { ApiRequestError } from '../../../src/api/client'
+import { useStartConversation } from '../../../src/api/queries'
+import { ChatComposer } from '../../../src/components/ChatComposer'
+import { ComposerHint } from '../../../src/components/ComposerHint'
+import { PresenceLine } from '../../../src/components/PresenceLine'
+import { Avatar } from '../../../src/components/ui/Avatar'
+import { Screen } from '../../../src/components/ui/Screen'
+import { Skeleton } from '../../../src/components/ui/Skeleton'
+import { useKeyboardInset } from '../../../src/hooks/useKeyboardInset'
+import { useProfileCache, useProfileCacheStatus } from '../../../src/hooks/useProfileCache'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
+import { useT } from '../../../src/i18n'
+import { authClient } from '../../../src/lib/auth-client'
+import { goBackTo, openProfile } from '../../../src/lib/navigation'
+import { openPaywall } from '../../../src/lib/paywall'
+import { requireAccount } from '../../../src/lib/requireAccount'
+import { makeStyles, useTheme } from '../../../src/lib/theme'
+import { showToast } from '../../../src/lib/toast'
+
+/**
+ * A conversation that does not exist yet, drawn as the one it is about to be.
+ *
+ * "Send a message" on a profile used to unfold a form on the profile itself.
+ * v3 opens this instead: the thread's own header and composer over an empty
+ * thread, so the first sentence is written where the reply will arrive. The
+ * first send is what creates the conversation (`POST /conversations`), and the
+ * screen is then replaced by the real thread — there is nothing to come back
+ * to here.
+ *
+ * Everything that needs a conversation id — attachments, voice, the ⋯ menu —
+ * is absent rather than disabled: the thread has them the moment it exists.
+ */
+export default function NewChatScreen() {
+  useScreenInteractive()
+  const styles = useStyles()
+  const { colors } = useTheme()
+  const t = useT()
+  const { to, from } = useLocalSearchParams<{ to: string; from?: string }>()
+  const partnerId = to ?? ''
+  const here = `/(app)/chat/new?to=${partnerId}`
+  const { data: session } = authClient.useSession()
+  const keyboardInset = useKeyboardInset()
+  const startConversation = useStartConversation()
+  // The cache the profile that pushed here has already filled, so the header
+  // is drawn at once; the skeleton is for a deep link that arrives cold.
+  const partner = useProfileCache(partnerId ? [partnerId] : [])[partnerId]
+  const partnerLoading =
+    useProfileCacheStatus(partnerId ? [partnerId] : [])[partnerId] === 'pending'
+  const [draft, setDraft] = useState('')
+
+  async function send(): Promise<void> {
+    const body = draft.trim()
+    if (!body || !partnerId || startConversation.isPending) return
+    // The gate at the call site, where the screen knows what was being tried;
+    // the transport catches a forgotten one only as a duller version of this.
+    if (!requireAccount(session?.user)) return
+    // Cleared at once, like a send in a thread. Put back if the send fails,
+    // so nothing typed is lost to a cap or a dropped connection.
+    setDraft('')
+    try {
+      const conversation = await startConversation.mutateAsync({ toUserId: partnerId, body })
+      router.replace(`/(app)/chat/${conversation._id}`)
+    } catch (caught) {
+      setDraft(body)
+      if (caught instanceof ApiRequestError) {
+        // The free tier's daily cap is the single most important thing this
+        // screen has to explain well — a generic failure here reads as a bug.
+        // `openPaywall` rather than the raw route: it is the one place that
+        // knows how the paywall is reached.
+        if (caught.code === 'QUOTA_EXCEEDED') {
+          openPaywall(undefined, here)
+          return
+        }
+        // Somebody else got there first — from another device, or the other
+        // person wrote. The list has the thread; this screen has nothing.
+        if (caught.code === 'CONVERSATION_EXISTS') {
+          router.replace('/(app)/(tabs)/chats')
+          return
+        }
+        showToast(caught.message)
+        return
+      }
+      showToast(t('profile.sendFailed'))
+    }
+  }
+
+  return (
+    <Screen fluid style={styles.screen}>
+      {/* Padded for the keyboard the same way the thread is — see `useKeyboardInset`. */}
+      <Animated.View style={[styles.avoid, { paddingBottom: keyboardInset }]}>
+        <View style={styles.header}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t('common.backPlain')}
+            onPress={() => goBackTo('/(app)/(tabs)/discover', from)}
+            hitSlop={12}
+            style={styles.back}
+          >
+            <Feather name="arrow-left" size={22} color={colors.text} />
+          </Pressable>
+          <Pressable
+            style={styles.headerUser}
+            onPress={() => partner && openProfile(partner.handle, here)}
+          >
+            {partnerLoading ? (
+              <Skeleton width={40} height={40} radius={20} />
+            ) : (
+              <Avatar
+                url={partner?.avatarUrl}
+                name={partner?.displayName ?? '?'}
+                seed={partner?._id}
+                size={40}
+                online={partner?.isOnline ?? false}
+              />
+            )}
+            <View style={styles.headerText}>
+              {partnerLoading ? (
+                <>
+                  <Skeleton width={120} height={14} />
+                  <Skeleton width={80} height={12} style={styles.headerSkeletonGap} />
+                </>
+              ) : (
+                <>
+                  <Text style={styles.headerName} numberOfLines={1}>
+                    {partner?.displayName ?? t('chat.title')}
+                  </Text>
+                  <PresenceLine lastActiveAt={partner?.lastActiveAt} />
+                </>
+              )}
+            </View>
+          </Pressable>
+        </View>
+
+        {/*
+          The empty thread. The opening tip sits where the thread draws it on
+          a short conversation — at the top of the column, under the header —
+          so the screen already looks like the thread it is about to become.
+        */}
+        <View style={styles.thread}>
+          <ComposerHint slot="chat" style={styles.threadTip} />
+        </View>
+
+        <ChatComposer
+          value={draft}
+          onChangeText={setDraft}
+          placeholder={
+            partner ? t('chat.sayHello', { name: partner.displayName }) : t('chat.writeMessage')
+          }
+          onSend={() => void send()}
+          busy={startConversation.isPending}
+          autoFocus
+        />
+      </Animated.View>
+    </Screen>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
+  screen: { paddingHorizontal: 0 },
+  avoid: { flex: 1 },
+  // The thread's header, without the ⋯ — every entry in that menu needs a conversation.
+  header: {
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    borderBottomColor: colors.border,
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    gap: spacing.md,
+    paddingBottom: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingTop: 6,
+  },
+  back: {
+    alignItems: 'center',
+    height: 34,
+    justifyContent: 'center',
+    width: 34,
+  },
+  headerUser: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    gap: spacing.md,
+    minWidth: 0,
+  },
+  headerText: { flex: 1, minWidth: 0 },
+  headerName: { ...font.heading, color: colors.text, fontSize: 17 },
+  headerSkeletonGap: { marginTop: 6 },
+  thread: { flex: 1, paddingHorizontal: spacing.lg, paddingTop: spacing.lg },
+  threadTip: {
+    ...font.caption,
+    alignSelf: 'center',
+    backgroundColor: colors.accentBg,
+    borderRadius: radius.lg,
+    color: colors.text,
+    fontSize: 13,
+    lineHeight: 18,
+    maxWidth: 300,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: 10,
+    textAlign: 'center',
+  },
+}))

--- a/apps/mobile/app/(app)/profile/[handle].tsx
+++ b/apps/mobile/app/(app)/profile/[handle].tsx
@@ -5,23 +5,19 @@ import { useState } from 'react'
 import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { authClient } from '../../../src/lib/auth-client'
 import { requireAccount } from '../../../src/lib/requireAccount'
-import { ApiRequestError } from '../../../src/api/client'
 import {
   useBlockUser,
   useMe,
   useProfile,
   usePublicSummary,
-  useQuota,
   useReportUser,
   useSetFollow,
-  useStartConversation,
 } from '../../../src/api/queries'
 import { ActivityMap } from '../../../src/components/ActivityMap'
 import { Avatar } from '../../../src/components/ui/Avatar'
 import { placeLabel } from '../../../src/lib/placeLabel'
 import { Button } from '../../../src/components/ui/Button'
 import { Callout } from '../../../src/components/ui/Callout'
-import { FormField } from '../../../src/components/ui/FormField'
 import { LanguageColumns } from '../../../src/components/LanguageColumns'
 import { PhotoGallery } from '../../../src/components/PhotoGallery'
 import { PhotoViewer } from '../../../src/components/PhotoViewer'
@@ -32,7 +28,6 @@ import { chooseAlert, confirmAlert } from '../../../src/lib/alert'
 import { goBackTo, openFollows } from '../../../src/lib/navigation'
 import { shareLink } from '../../../src/lib/share'
 import { profileShareText } from '../../../src/lib/shareText'
-import { openPaywall } from '../../../src/lib/paywall'
 import { showToast } from '../../../src/lib/toast'
 import { makeStyles, useTheme } from '../../../src/lib/theme'
 import { accountAgeLabel, interestLabel, useDisplayNames, useT } from '../../../src/i18n'
@@ -53,23 +48,12 @@ export default function ProfileScreen() {
   const me = useMe()
   const setFollow = useSetFollow(handle ?? '')
   const here = `/(app)/profile/${handle}`
-  const startConversation = useStartConversation()
   const { data: session } = authClient.useSession()
   const summary = usePublicSummary(handle ?? '')
-  const quota = useQuota()
   const block = useBlockUser()
   const report = useReportUser()
 
-  const [message, setMessage] = useState('')
-  /*
-   * The composer is behind the button, not beside it. A conversation here has
-   * to open with a first message, but a text field at the foot of every
-   * profile read as a form to fill in; "Send a message" is the decision, and
-   * the field appears once it has been made.
-   */
-  const [composing, setComposing] = useState(false)
   const [avatarOpen, setAvatarOpen] = useState(false)
-  const [error, setError] = useState<string | undefined>()
 
   if (profile.isPending) {
     return (
@@ -93,7 +77,6 @@ export default function ProfileScreen() {
 
   const user = profile.data
   const isSelf = user?._id === me.data?._id
-  const canSend = message.trim().length > 0
   const following = user.follow.viewerFollows
   const age = accountAgeLabel(t, new Date(user.createdAt))
 
@@ -103,41 +86,6 @@ export default function ProfileScreen() {
   const handleLine = [`@${user.handle}`, placeLabel(user, names.country) ?? null]
     .filter(Boolean)
     .join(' · ')
-
-  async function send(): Promise<void> {
-    // The gate at the call site, where the screen knows what was being tried.
-    // The transport catches a forgotten one, but only as a duller version of
-    // this — see `requireAccount`.
-    if (!requireAccount(session?.user)) return
-    setError(undefined)
-    try {
-      const conversation = await startConversation.mutateAsync({
-        toUserId: user._id,
-        body: message.trim(),
-      })
-      setMessage('')
-      router.replace(`/(app)/chat/${conversation._id}`)
-    } catch (caught) {
-      if (caught instanceof ApiRequestError) {
-        // The free tier's 5-a-day cap is the single most important thing this
-        // screen has to explain well — a generic failure here reads as a bug.
-        if (caught.code === 'QUOTA_EXCEEDED') {
-          // `openPaywall` rather than the raw route: it is the one place that
-          // knows how the paywall is reached, and pushing the path directly
-          // meant this call site quietly missed whatever it does.
-          openPaywall(undefined, `/(app)/profile/${handle}`)
-          return
-        }
-        if (caught.code === 'CONVERSATION_EXISTS') {
-          router.replace('/(app)/(tabs)/chats')
-          return
-        }
-        setError(caught.message)
-      } else {
-        setError(t('profile.sendFailed'))
-      }
-    }
-  }
 
   async function confirmBlock(): Promise<void> {
     const yes = await confirmAlert({
@@ -367,44 +315,29 @@ export default function ProfileScreen() {
       ) : (
         <View style={styles.actions}>
           {/*
-            A conversation that already exists is a link, not a form. The
-            composer below cannot start a second one — `startConversation`
-            refuses, which used to surface as "a conversation with this user
-            already exists" after typing a message out.
+            A conversation that already exists is a link to it; one that does
+            not is a link to the screen that starts it — v3 opens the thread's
+            own composer rather than unfolding a form here, so the first
+            sentence is written where the reply will arrive. `chat/new` cannot
+            start a second conversation — `startConversation` refuses — which
+            is why the existing one is offered first.
           */}
           {user.conversationId ? (
             <Button
               label={t('profile.openChat')}
               onPress={() => router.push(`/(app)/chat/${user.conversationId}`)}
             />
-          ) : composing ? (
-            <>
-              <FormField
-                value={message}
-                onChangeText={setMessage}
-                placeholder={t('chat.sayHello', { name: user.displayName })}
-                autoCapitalize="sentences"
-                autoCorrect
-                autoFocus
-              />
-              <Button
-                label={t('common.send')}
-                disabled={!canSend}
-                loading={startConversation.isPending}
-                onPress={() => void send()}
-              />
-              {/* The cap the free plan is about to hit, said before it is hit. */}
-              {quota.data ? (
-                <Text style={styles.quotaHint}>
-                  {t('me.newChatsLeft')} {quota.data.initiations.remaining ?? '—'} /{' '}
-                  {quota.data.initiations.limit ?? '∞'}
-                </Text>
-              ) : null}
-            </>
           ) : (
-            <Button label={t('profile.sendMessage')} onPress={() => setComposing(true)} />
+            <Button
+              label={t('profile.sendMessage')}
+              // Gated here as well as at the send: a guest should hear about
+              // the account before typing a message out, not after.
+              onPress={() => {
+                if (!requireAccount(session?.user)) return
+                router.push(`/(app)/chat/new?to=${user._id}&from=${encodeURIComponent(here)}`)
+              }}
+            />
           )}
-          {error ? <Text style={styles.error}>{error}</Text> : null}
           <Button
             label={following ? t('profile.following') : t('profile.follow')}
             variant="secondary"
@@ -495,6 +428,4 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   tagLabel: { color: colors.accent, fontSize: 13, fontWeight: '700' },
   actions: { gap: spacing.md, paddingTop: spacing.xl },
   editProfile: { marginTop: spacing.xl },
-  quotaHint: { color: colors.textFaint, fontSize: 13 },
-  error: { ...font.caption, color: colors.danger },
 }))

--- a/apps/mobile/src/components/ChatComposer.tsx
+++ b/apps/mobile/src/components/ChatComposer.tsx
@@ -1,0 +1,206 @@
+import Feather from '@expo/vector-icons/Feather'
+import { TOKEN_RULES } from '@langx/shared'
+import { useState, type ReactNode } from 'react'
+import {
+  Platform,
+  Pressable,
+  Text,
+  TextInput,
+  View,
+  type NativeSyntheticEvent,
+  type TextInputKeyPressEventData,
+} from 'react-native'
+import { useT } from '../i18n'
+import { shouldSubmitOnEnter } from '../lib/submitOnEnter'
+import { makeStyles, useTheme } from '../lib/theme'
+import { ComposerHint } from './ComposerHint'
+
+interface ChatComposerProps {
+  value: string
+  onChangeText: (text: string) => void
+  placeholder: string
+  onSend: () => void
+  /**
+   * Something other than the text is ready to go — a picked photo — so the
+   * send button stays up with an empty field.
+   */
+  hasAttachment?: boolean
+  /**
+   * A send the next one has to wait for: media uploading, or the conversation
+   * itself being created. Text sends never set this; they go optimistically.
+   */
+  busy?: boolean
+  autoFocus?: boolean
+  /** Left of the field — the attach control, or the recording readout in its place. */
+  leading?: ReactNode
+  /** Right of the field when there is nothing to send — the microphone. Nothing when omitted. */
+  idleAction?: ReactNode
+  /** Above the row, under the hairline — the mode banner and the picked attachments. */
+  above?: ReactNode
+}
+
+/**
+ * The block under the hairline at the foot of a thread: whatever sits above
+ * the row, the row itself — leading control, fill-pill field, yellow send —
+ * and the two-part hint under it.
+ *
+ * Shared by the thread and by the screen that starts one, so "Send a message"
+ * on a profile lands on the same composer the conversation will have. Only
+ * the field and the send button live here; the attach, record and microphone
+ * controls need a conversation and are passed in by the thread.
+ */
+export function ChatComposer({
+  value,
+  onChangeText,
+  placeholder,
+  onSend,
+  hasAttachment = false,
+  busy = false,
+  autoFocus = false,
+  leading,
+  idleAction,
+  above,
+}: ChatComposerProps) {
+  const styles = useStyles()
+  const { colors } = useTheme()
+  const t = useT()
+  const [focused, setFocused] = useState(false)
+  const canSend = value.trim().length > 0 || hasAttachment
+
+  return (
+    <View style={styles.composer}>
+      {above}
+      <View style={styles.row}>
+        {leading}
+        <TextInput
+          value={value}
+          onChangeText={onChangeText}
+          placeholder={placeholder}
+          placeholderTextColor={colors.textFaint}
+          style={[styles.input, focused && styles.inputFocused]}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          autoFocus={autoFocus}
+          multiline
+          /**
+           * Web only, and it has to be a key handler: `multiline` is a
+           * `<textarea>` in the browser, where `onSubmitEditing` never fires.
+           * On native the return key inserts a newline and the send button is
+           * the way to send, which is what people expect there.
+           */
+          {...(Platform.OS === 'web'
+            ? {
+                onKeyPress: (event: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+                  const { key, shiftKey } = event.nativeEvent as TextInputKeyPressEventData & {
+                    shiftKey?: boolean
+                  }
+                  if (!shouldSubmitOnEnter(key, shiftKey === true)) return
+                  // Otherwise the newline lands in the box behind the send.
+                  event.preventDefault()
+                  onSend()
+                },
+              }
+            : {})}
+        />
+        {/* The send button appears only when there is something to send; the
+          resting state to its right (a microphone, in a thread) is the
+          caller's. An attachment with no caption is something to send. */}
+        {canSend ? (
+          <View style={[styles.sendShell, busy && styles.sendDisabled]}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t('common.send')}
+              onPress={onSend}
+              disabled={busy}
+              style={({ pressed }) => [styles.send, pressed && !busy && styles.sendPressed]}
+            >
+              <Feather
+                name={busy ? 'more-horizontal' : 'send'}
+                size={20}
+                color={colors.primaryText}
+              />
+            </Pressable>
+          </View>
+        ) : (
+          idleAction
+        )}
+      </View>
+      {/*
+        The two facts a first-time user cannot discover: that a long press
+        corrects, and that a message pays. Both come from `TOKEN_RULES`
+        rather than being written into the copy.
+      */}
+      <View style={styles.hint}>
+        <ComposerHint style={styles.hintLeft} />
+        <Text style={styles.hintRight}>
+          {t('chat.tokensPerMessage', { count: TOKEN_RULES.award.message })}
+        </Text>
+      </View>
+    </View>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
+  /**
+   * Everything under the hairline: banner, attachments, the row, the hint.
+   * The bottom is `spacing.md` on top of the safe-area inset `Screen` already
+   * adds — the prototype's 28 is that inset, drawn in a frame that has none.
+   */
+  composer: {
+    backgroundColor: colors.surface,
+    borderTopColor: colors.border,
+    borderTopWidth: 1,
+    gap: 10,
+    paddingBottom: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingTop: 10,
+  },
+  row: { alignItems: 'flex-end', flexDirection: 'row', gap: spacing.sm },
+  hint: { alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between' },
+  hintLeft: { ...font.caption, color: colors.textFaint },
+  // The green pair marks earning, same as "Earned" rows elsewhere.
+  hintRight: { ...font.caption, color: colors.success, fontWeight: '600' },
+  /**
+   * A fill pill — v3's one grey allowed to be a shape. The border is there
+   * only to say something: transparent at rest, accent while focused, so the
+   * box does not grow by a pixel when it takes focus.
+   */
+  input: {
+    ...font.body,
+    backgroundColor: colors.fill,
+    borderColor: 'transparent',
+    borderRadius: radius.xl,
+    borderWidth: 1,
+    color: colors.text,
+    flex: 1,
+    fontSize: 16,
+    lineHeight: 22,
+    maxHeight: 120,
+    minHeight: 48,
+    paddingHorizontal: 18,
+    paddingVertical: 13,
+  },
+  inputFocused: { backgroundColor: colors.bg, borderColor: colors.accent },
+  /**
+   * The one yellow on the screen, standing on the same hard shadow `ui/Button`
+   * does: a shell in the shade, a face on it that drops on press. The negative
+   * margin lets the shade hang below the row the way `box-shadow` does, so it
+   * is the face — not the shade — that lines up with the input's bottom.
+   */
+  sendShell: {
+    backgroundColor: colors.primaryShade,
+    borderRadius: 14,
+    marginBottom: -3,
+    paddingBottom: 3,
+  },
+  send: {
+    alignItems: 'center',
+    backgroundColor: colors.primary,
+    borderRadius: 14,
+    height: 48,
+    justifyContent: 'center',
+    width: 48,
+  },
+  sendPressed: { transform: [{ translateY: 3 }] },
+  sendDisabled: { opacity: 0.35 },
+}))


### PR DESCRIPTION
## Summary

Design follow-up **A5** from `docs/plans/design-handoff-follow-ups.md`.

- New `app/(app)/chat/new.tsx` (`?to=<userId>`): the thread's header (avatar, name, presence — skeleton while the profile loads) over an empty thread with the opening tip, and the composer. The first send calls `POST /conversations` and replaces the screen with the real thread. `QUOTA_EXCEEDED` → paywall, `CONVERSATION_EXISTS` → chat list, other failures → toast with the draft restored. Guests are gated at the button and at the send.
- New `src/components/ChatComposer.tsx`: the field, the send button (with the web Enter handling) and the hint row, extracted from the thread. The thread passes in its attach/recording control, microphone and the mode banner + attachments.
- Profile: "Send a message" pushes to `chat/new`; the inline field, quota hint and error line are gone.

No new i18n keys.

## Test plan

- [x] `tsc --noEmit`, eslint, prettier, vitest (86 files, 710 tests)
- [ ] Simulator: profile → Send a message → new-chat screen with the person's name; type → send → lands in the thread with the message
- [ ] Existing thread: composer unchanged (attach, mic, reply/edit/correct banners, Sending → Sent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)