### PR TITLE
feat(api): carry the four numbers the v3 screens name

### DIFF
--- a/apps/api/src/modules/chat/corrections.ts
+++ b/apps/api/src/modules/chat/corrections.ts
@@ -1,10 +1,20 @@
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import { decodeDateIdCursor, encodeDateIdCursor } from '../../lib/dateIdCursor'
-import type { Message } from './conversations'
+import type { Conversation, Message } from './conversations'
+
+export interface CorrectionWritten {
+  message: Message
+  /**
+   * The other side of the conversation — who the correction was for. Absent
+   * only if the conversation is gone, which the row tolerates by showing the
+   * date alone.
+   */
+  recipientId?: string
+}
 
 export interface CorrectionsPage {
-  items: Message[]
+  items: CorrectionWritten[]
   nextCursor: string | null
 }
 
@@ -25,6 +35,12 @@ export interface CorrectionsPage {
  *
  * Rides `sender_type_created`. `sender_type` gives the same filter with no
  * `createdAt`, which sorts every correction the user ever wrote in memory.
+ *
+ * Each row names who it was for. A message carries only a `conversationId`,
+ * so the page's conversations are read once (`_id` lookup, `participants`
+ * only) and the other participant is attached — the design leads every row
+ * with "For {name}", and the client has no endpoint that resolves a
+ * conversation to its partner without fetching the thread.
  */
 export async function listCorrectionsWritten(
   db: Db,
@@ -54,11 +70,25 @@ export async function listCorrectionsWritten(
     .toArray()
 
   const hasMore = rows.length > limit
-  const items = hasMore ? rows.slice(0, limit) : rows
-  const last = items.at(-1)
+  const messages = hasMore ? rows.slice(0, limit) : rows
+  const last = messages.at(-1)
+
+  const conversations = await db
+    .collection<Conversation>(COLLECTIONS.conversations)
+    .find(
+      { _id: { $in: [...new Set(messages.map((m) => m.conversationId))] } },
+      { projection: { participants: 1 } },
+    )
+    .toArray()
+  const partnerByConversation = new Map(
+    conversations.map((c) => [String(c._id), c.participants.find((p) => p !== userId)]),
+  )
 
   return {
-    items,
+    items: messages.map((message) => {
+      const recipientId = partnerByConversation.get(String(message.conversationId))
+      return recipientId ? { message, recipientId } : { message }
+    }),
     nextCursor: hasMore && last ? encodeDateIdCursor(last.createdAt, last._id) : null,
   }
 }

--- a/apps/api/src/modules/moderation/blocks.ts
+++ b/apps/api/src/modules/moderation/blocks.ts
@@ -84,12 +84,17 @@ export async function unblockUser(db: Db, blockerId: string, blockedId: string):
 
 export interface BlockedPage {
   items: Block[]
+  /** Everyone blocked, not the page: the number the settings row shows. */
+  total: number
   nextCursor: string | null
 }
 
 /**
  * Paged. This used to have no limit at all — one query and one response body
  * sized by however many people someone had blocked.
+ *
+ * `total` rides along on every page rather than only the first, because it is
+ * one indexed count and the row that shows it reads whichever page is cached.
  */
 export async function listBlocked(
   db: Db,
@@ -102,19 +107,23 @@ export async function listBlocked(
     filter.$or = [{ createdAt: { $lt: date } }, { createdAt: date, _id: { $lt: id } }]
   }
 
+  const blocks = db.collection<Block>(COLLECTIONS.blocks)
   // One extra to know whether a next page exists without a second round trip.
-  const page = await db
-    .collection<Block>(COLLECTIONS.blocks)
-    .find(filter)
-    .sort({ createdAt: -1, _id: -1 })
-    .limit(query.limit + 1)
-    .toArray()
+  const [page, total] = await Promise.all([
+    blocks
+      .find(filter)
+      .sort({ createdAt: -1, _id: -1 })
+      .limit(query.limit + 1)
+      .toArray(),
+    blocks.countDocuments({ blockerId }),
+  ])
 
   const hasMore = page.length > query.limit
   const items = hasMore ? page.slice(0, query.limit) : page
   const last = items.at(-1)
   return {
     items,
+    total,
     nextCursor: hasMore && last ? encodeDateIdCursor(last.createdAt, last._id) : null,
   }
 }

--- a/apps/api/src/modules/moderation/profileViews.test.ts
+++ b/apps/api/src/modules/moderation/profileViews.test.ts
@@ -131,6 +131,8 @@ describe('profile views, a row per day', () => {
     const first = await getViewers(handle.db, 'me', { limit: 2 }, at(10 * MIN))
     expect(first.week?.map((day) => day.visits)).toEqual([0, 0, 0, 1, 0, 4, 2])
     expect(first.week?.at(-1)?.day).toBe('2026-09-05')
+    // People over the window, not visits: xue twice is one person.
+    expect(first.weekPeople).toBe(3)
     expect(first.nextCursor).not.toBeNull()
 
     const second = await getViewers(
@@ -140,6 +142,7 @@ describe('profile views, a row per day', () => {
       at(10 * MIN),
     )
     expect(second.week).toBeUndefined()
+    expect(second.weekPeople).toBeUndefined()
   })
 
   it('reports people, not rows, to the digest — and never names a guest', async () => {

--- a/apps/api/src/modules/moderation/profileViews.ts
+++ b/apps/api/src/modules/moderation/profileViews.ts
@@ -86,6 +86,11 @@ export interface ViewerSummary {
    * paid part.
    */
   week?: { day: string; visits: number }[]
+  /**
+   * Distinct people over the same seven days — the sentence above the chart.
+   * First page only, like `week`; a count, so free like `week`.
+   */
+  weekPeople?: number
   /** `null` on the last page. */
   nextCursor: string | null
 }
@@ -217,11 +222,7 @@ async function visitsByDay(
   hidden: string[],
   now: Date,
 ): Promise<{ day: string; visits: number }[]> {
-  const days: string[] = []
-  for (let back = VIEWS_WEEK_DAYS - 1; back >= 0; back--) {
-    days.push(utcDayKey(new Date(now.getTime() - back * 24 * 60 * 60 * 1000)))
-  }
-  const from = new Date(`${days[0]}T00:00:00Z`)
+  const { days, from } = weekWindow(now)
 
   const rows = await db
     .collection<ProfileView>(COLLECTIONS.profileViews)
@@ -243,6 +244,33 @@ async function visitsByDay(
     .toArray()
   const byDay = new Map(rows.map((row) => [row._id, row.visits]))
   return days.map((day) => ({ day, visits: byDay.get(day) ?? 0 }))
+}
+
+/** The seven day keys the chart draws, oldest first, and the instant the first one starts. */
+function weekWindow(now: Date): { days: string[]; from: Date } {
+  const days: string[] = []
+  for (let back = VIEWS_WEEK_DAYS - 1; back >= 0; back--) {
+    days.push(utcDayKey(new Date(now.getTime() - back * 24 * 60 * 60 * 1000)))
+  }
+  return { days, from: new Date(`${days[0]}T00:00:00Z`) }
+}
+
+/**
+ * Distinct visitors over the chart's window — people, not visits, because
+ * "6 people in the last week" is the sentence the design puts over the chart
+ * and one person over three days is one person.
+ */
+async function peopleInWeek(
+  db: Db,
+  viewedId: string,
+  hidden: string[],
+  now: Date,
+): Promise<number> {
+  const { from } = weekWindow(now)
+  const people = await db
+    .collection<ProfileView>(COLLECTIONS.profileViews)
+    .distinct('viewerId', { viewedId, viewerId: { $nin: hidden }, lastViewedAt: { $gte: from } })
+  return people.length
 }
 
 /**
@@ -366,6 +394,13 @@ export async function getViewers(
     nextCursor:
       hasMore && lastView ? encodeDateIdCursor(lastView.lastViewedAt, lastView._id) : null,
   }
-  if (!query.cursor) summary.week = await visitsByDay(db, userId, hidden, now)
+  if (!query.cursor) {
+    const [week, weekPeople] = await Promise.all([
+      visitsByDay(db, userId, hidden, now),
+      peopleInWeek(db, userId, hidden, now),
+    ])
+    summary.week = week
+    summary.weekPeople = weekPeople
+  }
   return summary
 }

--- a/apps/api/src/modules/tokens/pool.ts
+++ b/apps/api/src/modules/tokens/pool.ts
@@ -227,16 +227,29 @@ export async function runDailyPool(
  * that guards double payment, so sorting on its third key makes this a walk of
  * one index rather than a scan and a sort. Day keys are `YYYY-MM-DD`, so
  * lexicographic descending is chronological descending.
+ *
+ * `participants` is how many people that day's run paid — the run record
+ * already keeps it as `result.paid`, so "1,284 active that day" under the
+ * share costs one keyed read and no new write. Absent if the run record is
+ * gone (it is operational, not ledger), which the screen tolerates.
  */
 export async function readLastPoolPayout(
   db: Db,
   userId: string,
-): Promise<{ day: string; amount: number } | null> {
+): Promise<{ day: string; amount: number; participants?: number } | null> {
   const row = await db
     .collection<TokenLedgerEntry>(COLLECTIONS.tokenLedger)
     .findOne({ userId, kind: 'dailyPool' }, { sort: { refId: -1 } })
 
   // `refId` is always written for a pool award, but the type allows its
   // absence and a row without one has no day to be shown against.
-  return row?.refId ? { day: row.refId, amount: row.amount } : null
+  if (!row?.refId) return null
+
+  const run = await db
+    .collection<JobRun>(COLLECTIONS.jobRuns)
+    .findOne({ job: DAILY_POOL_JOB, periodKey: row.refId }, { projection: { 'result.paid': 1 } })
+  const participants = run?.result?.paid
+  return participants === undefined
+    ? { day: row.refId, amount: row.amount }
+    : { day: row.refId, amount: row.amount, participants }
 }

--- a/apps/api/src/routes/leaderboard.test.ts
+++ b/apps/api/src/routes/leaderboard.test.ts
@@ -272,6 +272,10 @@ describe('Faz 9 — daily pool, leaderboards and token sinks', () => {
         .collection<TokenLedgerEntry>(COLLECTIONS.tokenLedger)
         .findOne({ userId: user.userId, kind: 'dailyPool', refId: day })
       expect(summary.pool.lastPayout?.amount).toBe(row?.amount)
+      // How many that run paid, read off the run record — the "N active that
+      // day" line under the share.
+      if (outcome.ran) expect(summary.pool.lastPayout?.participants).toBe(outcome.result.paid)
+      expect(summary.pool.lastPayout?.participants).toBeGreaterThanOrEqual(1)
     })
 
     it('splits the pool in proportion to activity, and pays nothing twice on a re-run', async () => {

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -152,19 +152,26 @@ describe('Faz 5 — conversation/message history REST', () => {
       }
 
       const seen: string[] = []
+      const recipients = new Set<string | undefined>()
       let cursor: string | null | undefined
       for (let guard = 0; guard < 5; guard++) {
         const url = `/me/corrections?limit=2${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`
         const response = await app.inject({ method: 'GET', url, headers: { cookie: a.cookie } })
         expect(response.statusCode, response.body).toBe(200)
-        const body = response.json<{ items: { _id: string }[]; nextCursor: string | null }>()
+        const body = response.json<{
+          items: { _id: string; recipientId?: string }[]
+          nextCursor: string | null
+        }>()
         seen.push(...body.items.map((m) => m._id))
+        for (const m of body.items) recipients.add(m.recipientId)
         cursor = body.nextCursor
         if (!cursor) break
       }
 
       expect(seen).toHaveLength(5)
       expect(new Set(seen).size).toBe(5)
+      // Every row says who it was for: the other side of its conversation.
+      expect([...recipients]).toEqual([b.userId])
     })
 
     /** The other side's corrections are theirs, not yours. */

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -168,7 +168,10 @@ export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
         request.query.cursor,
       )
       return reply.send({
-        items: page.items.map((m) => toMessageView(m, request.userId)),
+        items: page.items.map(({ message, recipientId }) => ({
+          ...toMessageView(message, request.userId),
+          ...(recipientId ? { recipientId } : {}),
+        })),
         nextCursor: page.nextCursor,
       })
     },

--- a/apps/api/src/routes/moderation.test.ts
+++ b/apps/api/src/routes/moderation.test.ts
@@ -197,7 +197,10 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
       const b = await newUser()
       expect((await post(a, '/blocks', { userId: b.userId })).statusCode).toBe(201)
       expect((await post(a, '/blocks', { userId: b.userId })).statusCode).toBe(201) // no duplicate-key 500
-      expect((await get(a, '/blocks')).json<{ items: unknown[] }>().items).toHaveLength(1)
+      const listed = (await get(a, '/blocks')).json<{ items: unknown[]; total: number }>()
+      expect(listed.items).toHaveLength(1)
+      // The whole list's count, for the settings row — not the page's.
+      expect(listed.total).toBe(1)
 
       const removed = await app.inject({
         method: 'DELETE',
@@ -205,7 +208,9 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
         headers: { cookie: a.cookie },
       })
       expect(removed.statusCode).toBe(204)
-      expect((await get(a, '/blocks')).json<{ items: unknown[] }>().items).toHaveLength(0)
+      const after = (await get(a, '/blocks')).json<{ items: unknown[]; total: number }>()
+      expect(after.items).toHaveLength(0)
+      expect(after.total).toBe(0)
     })
 
     /** Had no limit at all: one query and one response body sized by the list. */

--- a/apps/mobile/app/(app)/corrections.tsx
+++ b/apps/mobile/app/(app)/corrections.tsx
@@ -15,6 +15,7 @@ import { dayLabel } from '../../src/lib/messageGroups'
 import { goBackTo, openPost } from '../../src/lib/navigation'
 import { listState } from '../../src/lib/listState'
 import { makeStyles } from '../../src/lib/theme'
+import { useProfileCache } from '../../src/hooks/useProfileCache'
 import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
@@ -55,6 +56,10 @@ export default function WritingScreen() {
   const myPosts = useMemo(
     () => dedupeById(posts.data?.pages.flatMap((p) => p.items) ?? []),
     [posts.data],
+  )
+  // The rows carry who each correction was for as an id; these are the names.
+  const recipients = useProfileCache(
+    corrections.flatMap((c) => (c.recipientId ? [c.recipientId] : [])),
   )
 
   const active = tab === 'corrections' ? page : posts
@@ -101,7 +106,15 @@ export default function WritingScreen() {
           ListFooterComponent={
             page.isFetchingNextPage ? <ActivityIndicator style={styles.loading} /> : null
           }
-          renderItem={({ item }) => <Row message={item} t={t} locale={locale} styles={styles} />}
+          renderItem={({ item }) => (
+            <Row
+              message={item}
+              recipient={item.recipientId ? recipients[item.recipientId]?.displayName : undefined}
+              t={t}
+              locale={locale}
+              styles={styles}
+            />
+          )}
         />
       ) : (
         <FlatList
@@ -167,23 +180,26 @@ function PostRow({ post, styles }: { post: FeedPost; styles: ReturnType<typeof u
  * height for both, and reading the whole original is what tells you which
  * correction this was.
  *
- * The top line is the date alone. The design leads with who the correction
- * was for, but the row carries only a `conversationId` and there is no
- * endpoint that resolves one conversation to its partner without fetching the
- * thread, so the name waits on the API.
+ * The top line leads with who the correction was for, as the design does,
+ * with the date at the far end. The name comes from the profile cache off
+ * the `recipientId` the API attaches; while it loads — or against an API that
+ * does not send it — the line is the date alone.
  */
 function Row({
   message,
+  recipient,
   t,
   locale,
   styles,
 }: {
   message: MessageDto
+  recipient: string | undefined
   t: ReturnType<typeof useT>
   locale: Locale
   styles: ReturnType<typeof useStyles>
 }) {
   const correction = message.correction
+  const when = dayLabel(message.createdAt.slice(0, 10), { t, locale })
 
   return (
     <Pressable
@@ -195,9 +211,16 @@ function Row({
       }
       style={({ pressed }) => [styles.row, pressed && styles.pressed]}
     >
-      <Text style={[styles.when, styles.whenAlone]}>
-        {dayLabel(message.createdAt.slice(0, 10), { t, locale })}
-      </Text>
+      {recipient ? (
+        <View style={styles.top}>
+          <Text style={styles.forName} numberOfLines={1}>
+            {t('corrections.forName', { name: recipient })}
+          </Text>
+          <Text style={styles.when}>{when}</Text>
+        </View>
+      ) : (
+        <Text style={[styles.when, styles.whenAlone]}>{when}</Text>
+      )}
       {correction ? <Text style={styles.original}>{correction.original}</Text> : null}
       <Text style={styles.corrected}>{message.body}</Text>
     </Pressable>
@@ -213,6 +236,8 @@ const useStyles = makeStyles(({ colors, spacing }) => ({
     gap: spacing.sm,
     paddingVertical: 18,
   },
+  // Green, like the corrections count: a correction is something given.
+  forName: { color: colors.success, flex: 1, fontSize: 13, fontWeight: '700' },
   pressed: { opacity: 0.6 },
   top: { alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between' },
   when: { color: colors.textFaint, fontSize: 13 },

--- a/apps/mobile/app/(app)/viewers.tsx
+++ b/apps/mobile/app/(app)/viewers.tsx
@@ -104,7 +104,13 @@ export default function ViewersScreen() {
           }}
           ListHeaderComponent={
             <>
-              {week.length > 0 ? (
+              {/* People when the API says how many, as the design words it;
+                visits from an API that only counts those. */}
+              {summary?.weekPeople !== undefined ? (
+                <Text style={styles.summary}>
+                  {t('viewers.weekPeople', { count: summary.weekPeople })}
+                </Text>
+              ) : week.length > 0 ? (
                 <Text style={styles.summary}>
                   {t('viewers.weekSummary', { count: weekVisits })}
                 </Text>

--- a/apps/mobile/app/(app)/wallet/pool.tsx
+++ b/apps/mobile/app/(app)/wallet/pool.tsx
@@ -77,6 +77,15 @@ export default function PoolScreen() {
               <Text style={styles.shareValue}>
                 {t('tokens.shareAmount', { count: lastPayout.amount })}
               </Text>
+              {/* Who the share was split with; absent from an API that does not say. */}
+              {lastPayout.participants !== undefined ? (
+                <Text style={styles.meta}>
+                  {t('tokens.poolParticipants', {
+                    count: lastPayout.participants,
+                    n: lastPayout.participants.toLocaleString(locale),
+                  })}
+                </Text>
+              ) : null}
             </>
           ) : (
             <Text style={styles.meta}>

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -477,6 +477,11 @@ export interface MessageDto {
    * have arrived.
    */
   clientId?: string
+  /**
+   * Who a correction was for — the other side of its conversation. Only on
+   * `/me/corrections`, and only from an API that attaches it.
+   */
+  recipientId?: string
   /** Somebody corrected this sentence, so it can no longer be edited. */
   corrected?: boolean
   deliveredAt?: string
@@ -1210,6 +1215,8 @@ export interface ViewerPageDto {
   }[]
   /** Visits per day, oldest first, ending today. First page only. */
   week?: { day: string; visits: number }[]
+  /** Distinct people over the same week. First page only; absent from an older API. */
+  weekPeople?: number
   nextCursor: string | null
 }
 
@@ -1564,6 +1571,8 @@ export interface BlockDto {
 
 export interface BlockPageDto {
   items: BlockDto[]
+  /** Everyone blocked, not the page. Absent from an older API. */
+  total?: number
   nextCursor: string | null
 }
 

--- a/apps/mobile/src/components/settings/SettingsRow.tsx
+++ b/apps/mobile/src/components/settings/SettingsRow.tsx
@@ -15,8 +15,9 @@ import { router } from 'expo-router'
 import { Image, Platform, Pressable, Text, View } from 'react-native'
 import darkIcon from '../../../assets/icons/dark.png'
 import defaultIcon from '../../../assets/icons/default.png'
+import { useBlocks } from '../../api/queries'
 import type { SettingsModel } from '../../hooks/useSettingsModel'
-import { type MessageKey, useDisplayNames } from '../../i18n'
+import { type MessageKey, useDisplayNames, useLocale, useT } from '../../i18n'
 import { relativeTime } from '../../lib/format'
 import { openExternal } from '../../lib/openExternal'
 import { openPaywall } from '../../lib/paywall'
@@ -486,13 +487,7 @@ export function SettingsRow({ id, model, last = false }: SettingsRowProps) {
         />
       )
     case 'account.blocked':
-      return (
-        <ListRow
-          title={t('settings.blockedPeople')}
-          last={last}
-          onPress={() => router.push('/(app)/blocked')}
-        />
-      )
+      return <BlockedPeopleRow last={last} />
     case 'account.export':
       return (
         <ListRow
@@ -667,6 +662,26 @@ function ExternalRow({
       <Text style={[styles.rowTitle, styles.rowGrow]}>{title}</Text>
       <Feather name="share" size={18} color={colors.textFaint} />
     </Pressable>
+  )
+}
+
+/**
+ * Its own component because the count is a query, and a hook cannot live in
+ * one arm of the switch above. The number is the whole list's `total` off
+ * whichever page is cached — none while it loads, or against an older API,
+ * and the row is then the title alone.
+ */
+function BlockedPeopleRow({ last }: { last: boolean }) {
+  const t = useT()
+  const { locale } = useLocale()
+  const total = useBlocks().data?.pages[0]?.total
+  return (
+    <ListRow
+      title={t('settings.blockedPeople')}
+      value={total === undefined ? undefined : total.toLocaleString(locale)}
+      last={last}
+      onPress={() => router.push('/(app)/blocked')}
+    />
   )
 }
 

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -520,6 +520,7 @@ export const ar: Localized<EnMessages> = {
     combinedTitle: 'ما كتبته',
     tabCorrections: 'التصحيحات',
     tabPosts: 'المنشورات',
+    forName: 'لـ {name}',
   },
   myPosts: {
     emptyTitle: 'لم تسأل عن شيء بعد',
@@ -1291,6 +1292,14 @@ export const ar: Localized<EnMessages> = {
       other: '{count} نشاط',
     },
     todayBreakdown: '{messages} رسالة، {corrections} تصحيح، {partners} أشخاص.',
+    poolParticipants: {
+      zero: 'لا أحد كان نشطًا ذلك اليوم',
+      one: 'شخص واحد كان نشطًا ذلك اليوم',
+      two: 'شخصان كانا نشطين ذلك اليوم',
+      few: '{n} أشخاص كانوا نشطين ذلك اليوم',
+      many: '{n} شخصًا كانوا نشطين ذلك اليوم',
+      other: '{n} شخص كانوا نشطين ذلك اليوم',
+    },
   },
 
   invite: {
@@ -1566,6 +1575,14 @@ export const ar: Localized<EnMessages> = {
     },
     seeWhoWith: 'اعرف من هم مع {plan}',
     unlockBody: 'الأسماء والملفات الشخصية، بالإضافة إلى التصفح المتخفي لك.',
+    weekPeople: {
+      zero: 'لا أحد في الأسبوع الأخير.',
+      one: 'شخص واحد في الأسبوع الأخير.',
+      two: 'شخصان في الأسبوع الأخير.',
+      few: '{count} أشخاص في الأسبوع الأخير.',
+      many: '{count} شخصًا في الأسبوع الأخير.',
+      other: '{count} شخص في الأسبوع الأخير.',
+    },
   },
 
   blocked: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -462,6 +462,7 @@ export const de: Localized<EnMessages> = {
     combinedTitle: 'Was du geschrieben hast',
     tabCorrections: 'Korrekturen',
     tabPosts: 'Beiträge',
+    forName: 'Für {name}',
   },
   myPosts: {
     emptyTitle: 'Noch nichts gefragt',
@@ -1116,6 +1117,7 @@ export const de: Localized<EnMessages> = {
     todaySoFar: 'Heute bisher',
     activityScore: { one: '{count} Aktivität', other: '{count} Aktivität' },
     todayBreakdown: '{messages} Nachrichten, {corrections} Korrekturen, {partners} Personen.',
+    poolParticipants: { one: '{n} aktiv an dem Tag', other: '{n} aktiv an dem Tag' },
   },
 
   invite: {
@@ -1338,6 +1340,10 @@ export const de: Localized<EnMessages> = {
     },
     seeWhoWith: 'Mit {plan} siehst du, wer',
     unlockBody: 'Namen und Profile, dazu Inkognito-Surfen für dich.',
+    weekPeople: {
+      one: '{count} Person in der letzten Woche.',
+      other: '{count} Personen in der letzten Woche.',
+    },
   },
 
   blocked: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -492,6 +492,7 @@ export const en = {
     combinedTitle: 'Your writing',
     tabCorrections: 'Corrections',
     tabPosts: 'Posts',
+    forName: 'For {name}',
   },
   myPosts: {
     emptyTitle: 'Nothing asked yet',
@@ -1134,6 +1135,7 @@ export const en = {
     todaySoFar: 'Today so far',
     activityScore: { one: '{count} activity', other: '{count} activity' },
     todayBreakdown: '{messages} messages, {corrections} corrections, {partners} people.',
+    poolParticipants: { one: '{n} active that day', other: '{n} active that day' },
   },
 
   /** One per `TOKEN_KINDS`; `kindKey()` builds the key from the kind itself. */
@@ -1356,6 +1358,10 @@ export const en = {
     },
     seeWhoWith: 'See who with {plan}',
     unlockBody: 'Names and profiles, plus incognito browsing for you.',
+    weekPeople: {
+      one: '{count} person in the last week.',
+      other: '{count} people in the last week.',
+    },
   },
 
   blocked: {

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -454,6 +454,7 @@ export const es: Localized<EnMessages> = {
     combinedTitle: 'Lo que has escrito',
     tabCorrections: 'Correcciones',
     tabPosts: 'Publicaciones',
+    forName: 'Para {name}',
   },
   myPosts: {
     emptyTitle: 'Todavía no has preguntado nada',
@@ -1092,6 +1093,7 @@ export const es: Localized<EnMessages> = {
     todaySoFar: 'Hoy hasta ahora',
     activityScore: { one: '{count} de actividad', other: '{count} de actividad' },
     todayBreakdown: '{messages} mensajes, {corrections} correcciones, {partners} personas.',
+    poolParticipants: { one: '{n} activo ese día', other: '{n} activos ese día' },
   },
 
   invite: {
@@ -1311,6 +1313,10 @@ export const es: Localized<EnMessages> = {
     },
     seeWhoWith: 'Descubre quién con {plan}',
     unlockBody: 'Nombres y perfiles, además de navegación de incógnito para ti.',
+    weekPeople: {
+      one: '{count} persona en la última semana.',
+      other: '{count} personas en la última semana.',
+    },
   },
 
   blocked: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -460,6 +460,7 @@ export const fr: Localized<EnMessages> = {
     combinedTitle: 'Ce que tu as écrit',
     tabCorrections: 'Corrections',
     tabPosts: 'Publications',
+    forName: 'Pour {name}',
   },
   myPosts: {
     emptyTitle: 'Tu n’as encore rien demandé',
@@ -1098,6 +1099,7 @@ export const fr: Localized<EnMessages> = {
     todaySoFar: 'Aujourd’hui',
     activityScore: { one: '{count} d’activité', other: '{count} d’activité' },
     todayBreakdown: '{messages} messages, {corrections} corrections, {partners} personnes.',
+    poolParticipants: { one: '{n} actif ce jour-là', other: '{n} actifs ce jour-là' },
   },
 
   invite: {
@@ -1319,6 +1321,10 @@ export const fr: Localized<EnMessages> = {
     },
     seeWhoWith: 'Voir qui avec {plan}',
     unlockBody: 'Les noms et les profils, plus la navigation incognito pour toi.',
+    weekPeople: {
+      one: '{count} personne la semaine dernière.',
+      other: '{count} personnes la semaine dernière.',
+    },
   },
 
   blocked: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -450,6 +450,7 @@ export const ptBR: Localized<EnMessages> = {
     combinedTitle: 'O que você escreveu',
     tabCorrections: 'Correções',
     tabPosts: 'Publicações',
+    forName: 'Para {name}',
   },
   myPosts: {
     emptyTitle: 'Você ainda não perguntou nada',
@@ -1086,6 +1087,7 @@ export const ptBR: Localized<EnMessages> = {
     todaySoFar: 'Hoje até agora',
     activityScore: { one: '{count} de atividade', other: '{count} de atividade' },
     todayBreakdown: '{messages} mensagens, {corrections} correções, {partners} pessoas.',
+    poolParticipants: { one: '{n} ativo naquele dia', other: '{n} ativos naquele dia' },
   },
 
   invite: {
@@ -1307,6 +1309,10 @@ export const ptBR: Localized<EnMessages> = {
     },
     seeWhoWith: 'Veja quem com {plan}',
     unlockBody: 'Nomes e perfis, e ainda navegação anônima para você.',
+    weekPeople: {
+      one: '{count} pessoa na última semana.',
+      other: '{count} pessoas na última semana.',
+    },
   },
 
   blocked: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -503,6 +503,7 @@ export const ru: Localized<EnMessages> = {
     combinedTitle: 'Написанное тобой',
     tabCorrections: 'Исправления',
     tabPosts: 'Публикации',
+    forName: 'Для {name}',
   },
   myPosts: {
     emptyTitle: 'Ты ещё ничего не спросил',
@@ -1226,6 +1227,12 @@ export const ru: Localized<EnMessages> = {
       other: '{count} активности',
     },
     todayBreakdown: '{messages} сообщений, {corrections} исправлений, {partners} собеседников.',
+    poolParticipants: {
+      one: '{n} активный в тот день',
+      few: '{n} активных в тот день',
+      many: '{n} активных в тот день',
+      other: '{n} активных в тот день',
+    },
   },
 
   invite: {
@@ -1485,6 +1492,12 @@ export const ru: Localized<EnMessages> = {
     },
     seeWhoWith: 'Узнай, кто — с {plan}',
     unlockBody: 'Имена и профили, а ещё режим инкогнито для тебя.',
+    weekPeople: {
+      one: '{count} человек за последнюю неделю.',
+      few: '{count} человека за последнюю неделю.',
+      many: '{count} человек за последнюю неделю.',
+      other: '{count} человека за последнюю неделю.',
+    },
   },
 
   blocked: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -457,6 +457,7 @@ export const tr: Localized<EnMessages> = {
     combinedTitle: 'Yazdıkların',
     tabCorrections: 'Düzeltmeler',
     tabPosts: 'Gönderiler',
+    forName: '{name} için',
   },
   myPosts: {
     emptyTitle: 'Henüz bir şey sormadın',
@@ -1096,6 +1097,7 @@ export const tr: Localized<EnMessages> = {
     todaySoFar: 'Bugün şu ana kadar',
     activityScore: { one: '{count} aktivite', other: '{count} aktivite' },
     todayBreakdown: '{messages} mesaj, {corrections} düzeltme, {partners} kişi.',
+    poolParticipants: { one: 'O gün {n} kişi aktifti', other: 'O gün {n} kişi aktifti' },
   },
 
   invite: {
@@ -1314,6 +1316,7 @@ export const tr: Localized<EnMessages> = {
     },
     seeWhoWith: '{plan} ile kim olduğunu gör',
     unlockBody: 'İsimler ve profiller, ayrıca senin için gizli gezinme.',
+    weekPeople: { one: 'Son bir haftada {count} kişi.', other: 'Son bir haftada {count} kişi.' },
   },
 
   blocked: {

--- a/packages/shared/src/token.ts
+++ b/packages/shared/src/token.ts
@@ -572,7 +572,14 @@ export const tokenSummarySchema = z.object({
      * earned for — not the day it was paid. Null until the first payout lands,
      * which for a new account is the morning after their first active day.
      */
-    lastPayout: z.object({ day: z.string(), amount: z.number().int() }).nullable(),
+    lastPayout: z
+      .object({
+        day: z.string(),
+        amount: z.number().int(),
+        /** How many people that day's run paid. Absent when the run record is gone. */
+        participants: z.number().int().optional(),
+      })
+      .nullable(),
   }),
   /**
    * All-time counts that are not token totals.


### PR DESCRIPTION
## Summary

Design follow-ups **B4, B1, B6, B7** from `docs/plans/design-handoff-follow-ups.md`. Every new field is optional for the client, so the API can deploy before or after the app update.

| Endpoint | New field | Shown as |
|---|---|---|
| `GET /blocks` | `total` | value on Settings → Account → Blocked people |
| `GET /me/corrections` | `recipientId` per row | "For {name}" leading each correction row |
| `GET /me/viewers` | `weekPeople` (first page) | "{n} people in the last week." above the chart |
| `GET /me/tokens` | `pool.lastPayout.participants` | "{n} active that day" under the share |

- The recipient lookup lives in `listCorrectionsWritten` (one `_id` query per page, `participants` projection); the handler only maps.
- `participants` is read off the pool run record (`result.paid`), so no new write.
- Three new i18n keys in all eight locales.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
- [x] API: moderation, messages, profileViews, leaderboard test files extended and green (171 tests)
- [x] Mobile (710) and shared (302) suites green
- [ ] After `fly deploy`: the four screens show the numbers against production

🤖 Generated with [Claude Code](https://claude.com/claude-code)