### PR TITLE
feat(chat): pin from the thread header, and report a post from its menu

### DIFF
--- a/apps/api/src/modules/moderation/blocks.ts
+++ b/apps/api/src/modules/moderation/blocks.ts
@@ -26,6 +26,8 @@ export interface Report {
   conversationId?: ObjectId
   /** The specific message, when the report was raised from one. */
   messageId?: ObjectId
+  /** The post, when the report was raised from the feed. */
+  postId?: ObjectId
   status: 'open' | 'reviewing' | 'actioned' | 'dismissed'
   createdAt: Date
 }
@@ -174,6 +176,13 @@ export async function reportUser(
       report.messageId = new ObjectId(input.messageId)
     } catch {
       throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Malformed message id')
+    }
+  }
+  if (input.postId !== undefined) {
+    try {
+      report.postId = new ObjectId(input.postId)
+    } catch {
+      throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Malformed post id')
     }
   }
   await reports.insertOne(report)

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -530,6 +530,46 @@ describe('Faz 5 — conversation/message history REST', () => {
     expect(new Set(seen).size).toBe(3)
   })
 
+  it('returns one conversation with the viewer own flags, and 404s a stranger', async () => {
+    const a = await newUser('one-a@example.com')
+    const b = await newUser('one-b@example.com')
+    const outsider = await newUser('one-outsider@example.com')
+    const conversation = await startConversation(a, b.userId, 'just us')
+
+    await app.inject({
+      method: 'PATCH',
+      url: `/conversations/${conversation._id}/flags`,
+      headers: { cookie: a.cookie },
+      payload: { pinned: true },
+    })
+
+    const mine = await app.inject({
+      method: 'GET',
+      url: `/conversations/${conversation._id}`,
+      headers: { cookie: a.cookie },
+    })
+    expect(mine.statusCode, mine.body).toBe(200)
+    expect(mine.json<{ _id: string; pinned: boolean }>()).toMatchObject({
+      _id: conversation._id,
+      pinned: true,
+    })
+
+    // The pin is per person: the other side sees the same thread unpinned.
+    const theirs = await app.inject({
+      method: 'GET',
+      url: `/conversations/${conversation._id}`,
+      headers: { cookie: b.cookie },
+    })
+    expect(theirs.json<{ pinned: boolean }>().pinned).toBe(false)
+
+    const stranger = await app.inject({
+      method: 'GET',
+      url: `/conversations/${conversation._id}`,
+      headers: { cookie: outsider.cookie },
+    })
+    expect(stranger.statusCode).toBe(404)
+  })
+
   it('404s the message history of a conversation you are not part of', async () => {
     const a = await newUser('history-a@example.com')
     const b = await newUser('history-b@example.com')

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -17,6 +17,8 @@ import {
   listMessagesAround,
   markConversationRead,
 } from '../modules/chat/messages'
+import { assertConversationAccess } from '../modules/chat/access'
+import { toConversationView } from '../modules/chat/conversationView'
 import { toMessageView } from '../modules/chat/messageView'
 import { listCorrectionsWritten } from '../modules/chat/corrections'
 import {
@@ -82,6 +84,30 @@ export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request, reply) => {
       await deleteConversationForUser(app.mongo.db, request.params.id, request.userId)
       return reply.code(204).send()
+    },
+  )
+
+  /*
+   * One thread as the list would draw it — the viewer's own pin and archive
+   * state above all. The thread screen needs it for the header's menu and
+   * used to have no way to ask short of paging the whole list; the message
+   * window carries `participants` and the media lock but not the flags.
+   * `assertConversationAccess` is the same gate the messages take: a stranger
+   * gets the 404 that says nothing.
+   */
+  app.get(
+    '/conversations/:id',
+    {
+      preHandler: requireAuth,
+      schema: { params: z.object({ id: z.string().trim().min(1) }) },
+    },
+    async (request, reply) => {
+      const conversation = await assertConversationAccess(
+        app.mongo.db,
+        request.params.id,
+        request.userId,
+      )
+      return reply.send(toConversationView(conversation, request.userId))
     },
   )
 

--- a/apps/api/src/routes/moderation.test.ts
+++ b/apps/api/src/routes/moderation.test.ts
@@ -338,6 +338,27 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
       expect(stored?.conversationId?.toString()).toBe(conversationId)
     })
 
+    it('keeps the post a report was raised from', async () => {
+      const reporter = await newUser()
+      const target = await newUser()
+      // Existence is not checked, as it is not for a message: a post deleted
+      // between reading and reporting is still worth the reviewer's look.
+      const postId = new ObjectId().toString()
+
+      const response = await post(reporter, '/reports', {
+        userId: target.userId,
+        reason: 'inappropriate_content',
+        postId,
+      })
+      expect(response.statusCode, response.body).toBe(201)
+
+      const stored = await handle.db
+        .collection<Report>(COLLECTIONS.reports)
+        .findOne({ reporterId: reporter.userId, reportedId: target.userId })
+      expect(stored?.postId?.toString()).toBe(postId)
+      expect(stored?.conversationId).toBeUndefined()
+    })
+
     it('still accepts a report raised from a profile, with neither pointer', async () => {
       const reporter = await newUser()
       const target = await newUser()

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -16,6 +16,8 @@ import {
   markConversationRead,
   uploadMessageMedia,
   useBlockUser,
+  useConversation,
+  useConversationFlags,
   useMe,
   useMessages,
   useMessageWindow,
@@ -139,6 +141,9 @@ export default function ChatScreen() {
   const keyboardInset = useKeyboardInset()
   const report = useReportUser()
   const block = useBlockUser()
+  // For the header menu's pin — the message window does not carry the flags.
+  const conversation = useConversation(conversationId)
+  const flags = useConversationFlags()
   const recorder = useVoiceRecorder()
   /** Only for the pill's dress: white ground and accent ring while it has focus. */
   const [sendingMedia, setSendingMedia] = useState(false)
@@ -906,15 +911,20 @@ export default function ChatScreen() {
    */
   async function openThreadMenu(): Promise<void> {
     if (!partner) return
+    const pinned = conversation.data?.pinned ?? false
     const choice = await chooseAlert(partner.displayName, undefined, [
       { label: t('chat.viewProfile'), value: 'profile' },
       { label: t('chats.starredMessages'), value: 'starred' },
+      // The same toggle the list offers, where the design puts it as well.
+      { label: pinned ? t('chats.unpin') : t('chats.pin'), value: 'pin' },
       { label: t('common.block'), value: 'block', destructive: true },
     ])
     if (choice === 'profile') {
       openProfile(partner.handle, `/(app)/chat/${conversationId}`)
     } else if (choice === 'starred') {
       router.push('/(app)/starred')
+    } else if (choice === 'pin') {
+      flags.mutate({ conversationId, pinned: !pinned })
     } else if (choice === 'block') {
       // The same question the profile asks, so the two places agree.
       const yes = await confirmAlert({

--- a/apps/mobile/app/(app)/post/[id].tsx
+++ b/apps/mobile/app/(app)/post/[id].tsx
@@ -21,6 +21,7 @@ import {
   usePostAnswers,
   usePostComments,
   usePostCorrections,
+  useReportUser,
 } from '../../../src/api/queries'
 import type { Media, PostCorrection, PronunciationAnswer } from '../../../src/api/types'
 import { AudioBubble, MediaGallery } from '../../../src/components/MediaBubble'
@@ -186,6 +187,7 @@ export default function PostScreen() {
   })
 
   const mine = post ? post.author._id === me.data?._id : false
+  const report = useReportUser()
 
   function share(): void {
     if (!post) return
@@ -200,8 +202,9 @@ export default function PostScreen() {
   const replyCount = post ? (pronouncing ? post.answerCount : post.correctionCount) : 0
 
   /**
-   * The header's "more" sheet. Share on somebody else's post, delete on your
-   * own — the two things that used to sit as text actions under the sentence.
+   * The header's "more" sheet. Share and Report on somebody else's post,
+   * delete on your own — the things that used to sit as text actions under
+   * the sentence.
    */
   async function openMore(): Promise<void> {
     if (!post) return
@@ -211,9 +214,29 @@ export default function PostScreen() {
         ])
       : await chooseAlert(t('feed.post'), undefined, [
           { label: t('share.action'), value: 'share' as const },
+          { label: t('common.report'), value: 'report' as const, destructive: true },
         ])
     if (choice === 'share') share()
+    if (choice === 'report') void confirmReport()
     if (choice === 'delete') void confirmDeletePost()
+  }
+
+  /** The same three reasons a profile offers, pointed at the post. */
+  async function confirmReport(): Promise<void> {
+    if (!post) return
+    const reason = await chooseAlert(t('common.report'), t('report.postQuestion'), [
+      { label: t('report.spam'), value: 'spam' },
+      { label: t('report.harassment'), value: 'harassment' },
+      { label: t('report.inappropriate'), value: 'inappropriate_content' },
+    ])
+    if (!reason) return
+    report.mutate(
+      { userId: post.author._id, reason, postId: post._id },
+      {
+        onSuccess: () => showToast(t('report.messageSent')),
+        onError: () => showToast(t('report.failed')),
+      },
+    )
   }
 
   function submitCorrection(): void {

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -95,6 +95,8 @@ export const keys = {
    * `messages`.
    */
   conversations: (filter: string) => ['conversations', filter] as const,
+  /** Under the `['conversations']` prefix on purpose: every flag write invalidates it. */
+  conversation: (id: string) => ['conversations', 'one', id] as const,
   messages: (id: string) => ['messages', id] as const,
   /**
    * Deliberately a child of `messages(id)`: a socket patch written with
@@ -790,6 +792,31 @@ export function useDeleteConversation() {
   })
 }
 
+/**
+ * One thread's row — for the header menu's pin, which the message window does
+ * not carry. Seeded from whichever list page already holds the thread so the
+ * menu is right on first open, then confirmed by the server.
+ */
+export function useConversation(conversationId: string) {
+  const client = useQueryClient()
+  return useQuery({
+    queryKey: keys.conversation(conversationId),
+    queryFn: () => api.get<ConversationDto>(`/conversations/${conversationId}`),
+    enabled: conversationId.length > 0,
+    placeholderData: () => {
+      for (const [, data] of client.getQueriesData<InfiniteData<ConversationPageDto>>({
+        queryKey: ['conversations'],
+      })) {
+        for (const page of data?.pages ?? []) {
+          const hit = [...page.pinned, ...page.items].find((c) => c._id === conversationId)
+          if (hit) return hit
+        }
+      }
+      return undefined
+    },
+  })
+}
+
 export function useConversationFlags() {
   const client = useQueryClient()
   return useMutation({
@@ -1266,6 +1293,7 @@ export function useReportUser() {
       details?: string
       conversationId?: string
       messageId?: string
+      postId?: string
     }) => api.post('/reports', input),
   })
 }

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -771,6 +771,7 @@ export const ar: Localized<EnMessages> = {
     messageSent: 'تم الإبلاغ. شكرًا — نطّلع على كل بلاغ.',
     profileSent: 'أُرسل البلاغ. سننظر في الأمر.',
     failed: 'تعذّر الإبلاغ',
+    postQuestion: 'لماذا تبلّغ عن هذه المشاركة؟',
   },
 
   feed: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -680,6 +680,7 @@ export const de: Localized<EnMessages> = {
     messageSent: 'Gemeldet. Danke — wir sehen uns jede Meldung an.',
     profileSent: 'Meldung gesendet. Wir sehen es uns an.',
     failed: 'Melden fehlgeschlagen',
+    postQuestion: 'Warum meldest du diesen Beitrag?',
   },
 
   feed: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -702,6 +702,7 @@ export const en = {
     messageSent: 'Reported. Thank you — we look at every one.',
     profileSent: 'Report sent. We will look into it.',
     failed: 'Could not report',
+    postQuestion: 'Why are you reporting this post?',
   },
 
   feed: {

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -660,6 +660,7 @@ export const es: Localized<EnMessages> = {
     messageSent: 'Denunciado. Gracias: revisamos todas.',
     profileSent: 'Denuncia enviada. Lo revisaremos.',
     failed: 'No se pudo denunciar',
+    postQuestion: '¿Por qué denuncias esta publicación?',
   },
 
   feed: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -663,6 +663,7 @@ export const fr: Localized<EnMessages> = {
     messageSent: 'Signalé. Merci — nous regardons chaque signalement.',
     profileSent: 'Signalement envoyé. Nous allons regarder.',
     failed: 'Signalement impossible',
+    postQuestion: 'Pourquoi signalez-vous cette publication ?',
   },
 
   feed: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -652,6 +652,7 @@ export const ptBR: Localized<EnMessages> = {
     messageSent: 'Denunciado. Obrigado — olhamos todas.',
     profileSent: 'Denúncia enviada. Vamos analisar.',
     failed: 'Não deu para denunciar',
+    postQuestion: 'Por que você está denunciando esta publicação?',
   },
 
   feed: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -740,6 +740,7 @@ export const ru: Localized<EnMessages> = {
     messageSent: 'Жалоба отправлена. Спасибо — мы смотрим каждую.',
     profileSent: 'Жалоба отправлена. Мы разберёмся.',
     failed: 'Не удалось отправить жалобу',
+    postQuestion: 'Почему вы жалуетесь на эту публикацию?',
   },
 
   feed: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -663,6 +663,7 @@ export const tr: Localized<EnMessages> = {
     messageSent: 'Bildirildi. Teşekkürler — hepsine bakıyoruz.',
     profileSent: 'Bildirim gönderildi. İnceleyeceğiz.',
     failed: 'Bildirilemedi',
+    postQuestion: 'Bu gönderiyi neden şikâyet ediyorsun?',
   },
 
   feed: {

--- a/packages/shared/src/moderation.ts
+++ b/packages/shared/src/moderation.ts
@@ -35,6 +35,12 @@ export const reportSchema = z.object({
    * profile has neither, and one raised from a thread has both.
    */
   messageId: z.string().trim().min(1).optional(),
+  /**
+   * Optional pointer to the post the report is about. A post is public and
+   * has no conversation, so it is a third place a report can be raised from,
+   * alongside a profile and a message.
+   */
+  postId: z.string().trim().min(1).optional(),
 })
 export type ReportInput = z.infer<typeof reportSchema>
 


### PR DESCRIPTION
## Summary

Design follow-ups **B3** and **B2** from `docs/plans/design-handoff-follow-ups.md`.

- **API** `GET /conversations/:id` → the viewer's `ConversationView` (own `pinned`/`archived`), 404 for a non-participant via `assertConversationAccess`.
- **Mobile** `useConversation(id)` (placeholder from the cached list pages, under the `['conversations']` key prefix so flag writes invalidate it); the chat header ⋯ menu gains **Pin chat / Unpin chat** between Starred and Block, as the prototype orders it.
- **Shared/API** `reportSchema` accepts `postId`; the report stores it.
- **Mobile** post screen ⋯ menu offers **Report** (destructive) beside Share on somebody else's post; reasons as on a profile, `postId` attached. One new i18n key in eight locales.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
- [x] API messages + moderation test files extended and green (115 tests); mobile (710) and shared suites green
- [ ] After `fly deploy`: chat header menu pins a thread and the list reflects it; post report lands in `reports` with `postId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)