### PR TITLE
feat(paywall): lead the yearly plan with the store's own per-month price

### DIFF
--- a/apps/mobile/app/(app)/paywall.tsx
+++ b/apps/mobile/app/(app)/paywall.tsx
@@ -481,9 +481,25 @@ export default function PaywallScreen() {
           <ActivityIndicator style={styles.priceLoading} />
         ) : offer ? (
           <View style={styles.priceBlock}>
+            {/*
+              A yearly plan leads with what it costs a month, as the design
+              does — the store's own per-month string, never a division done
+              here — and says how it is billed. Without one from the store the
+              row falls back to the charge and its period. The trial terms
+              below always quote the charge itself.
+            */}
             <View style={styles.priceRow}>
-              <Text style={styles.price}>{offer.priceString}</Text>
-              <Text style={styles.per}>{t(PERIOD_PHRASE[offer.period])}</Text>
+              {offer.period === 'yearly' && offer.perMonthPriceString ? (
+                <>
+                  <Text style={styles.price}>{offer.perMonthPriceString}</Text>
+                  <Text style={styles.per}>{t('paywall.perMonthBilledYearly')}</Text>
+                </>
+              ) : (
+                <>
+                  <Text style={styles.price}>{offer.priceString}</Text>
+                  <Text style={styles.per}>{t(PERIOD_PHRASE[offer.period])}</Text>
+                </>
+              )}
             </View>
             {/*
               The whole sequence — how long the trial runs and what it renews

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -1659,6 +1659,7 @@ export const ar: Localized<EnMessages> = {
     yearlySaving: 'سنوي · وفّر {percent}%',
     billingPeriod: 'فترة الفوترة',
     start: 'ابدأ مع {plan}',
+    perMonthBilledYearly: 'شهريًا · تُحصَّل سنويًا',
   },
 
   pickers: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -1423,6 +1423,7 @@ export const de: Localized<EnMessages> = {
     yearlySaving: 'Jährlich · {percent}% sparen',
     billingPeriod: 'Abrechnungszeitraum',
     start: 'Mit {plan} starten',
+    perMonthBilledYearly: 'pro Monat · jährlich abgerechnet',
   },
 
   pickers: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -1439,6 +1439,7 @@ export const en = {
     yearlySaving: 'Yearly · save {percent}%',
     billingPeriod: 'Billing period',
     start: 'Start {plan}',
+    perMonthBilledYearly: 'a month · billed yearly',
   },
 
   pickers: {

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -1396,6 +1396,7 @@ export const es: Localized<EnMessages> = {
     yearlySaving: 'Anual · ahorra un {percent}%',
     billingPeriod: 'Periodo de facturación',
     start: 'Empieza con {plan}',
+    perMonthBilledYearly: 'al mes · facturado anualmente',
   },
 
   pickers: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -1404,6 +1404,7 @@ export const fr: Localized<EnMessages> = {
     yearlySaving: 'Annuel · {percent}% d’économie',
     billingPeriod: 'Période de facturation',
     start: 'Commencer avec {plan}',
+    perMonthBilledYearly: 'par mois · facturé à l’année',
   },
 
   pickers: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -1391,6 +1391,7 @@ export const ptBR: Localized<EnMessages> = {
     yearlySaving: 'Anual · economize {percent}%',
     billingPeriod: 'Período de cobrança',
     start: 'Começar com {plan}',
+    perMonthBilledYearly: 'por mês · cobrado anualmente',
   },
 
   pickers: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -1578,6 +1578,7 @@ export const ru: Localized<EnMessages> = {
     yearlySaving: 'Ежегодно · экономия {percent}%',
     billingPeriod: 'Период оплаты',
     start: 'Начать с {plan}',
+    perMonthBilledYearly: 'в месяц · оплата раз в год',
   },
 
   pickers: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -1395,6 +1395,7 @@ export const tr: Localized<EnMessages> = {
     yearlySaving: 'Yıllık · %{percent} indirim',
     billingPeriod: 'Ödeme dönemi',
     start: '{plan} ile başla',
+    perMonthBilledYearly: 'aylık · yıllık faturalandırılır',
   },
 
   pickers: {

--- a/apps/mobile/src/lib/fakePurchases.test.ts
+++ b/apps/mobile/src/lib/fakePurchases.test.ts
@@ -33,6 +33,16 @@ describe('fakeOffers', () => {
   it('labels every price as a test price', () => {
     for (const offer of fakeOffers()) {
       expect(offer.priceString).toMatch(/^TEST /)
+      if (offer.perMonthPriceString !== undefined) {
+        expect(offer.perMonthPriceString).toMatch(/^TEST /)
+      }
+    }
+  })
+
+  /** The yearly row leads with the store's monthly figure, so the harness has to supply one. */
+  it('gives every yearly offer a per-month price, and no other', () => {
+    for (const offer of fakeOffers()) {
+      expect(offer.perMonthPriceString !== undefined).toBe(offer.period === 'yearly')
     }
   })
 })

--- a/apps/mobile/src/lib/fakePurchases.ts
+++ b/apps/mobile/src/lib/fakePurchases.ts
@@ -76,6 +76,11 @@ export function fakeOffers(): PurchaseOffer[] {
     id,
     tier: PACKAGES[id].tier,
     priceString: `TEST $${TEST_AMOUNTS[id].toFixed(2)}`,
+    // The harness stands in for the store, so the division the app itself
+    // never does is done here — labelled TEST like everything else it says.
+    ...(PACKAGES[id].period === 'yearly'
+      ? { perMonthPriceString: `TEST $${(TEST_AMOUNTS[id] / 12).toFixed(2)}` }
+      : {}),
     period: PACKAGES[id].period,
     price: TEST_AMOUNTS[id],
     freeTrialDays: PACKAGES[id].period === 'yearly' ? TEST_FREE_TRIAL_DAYS : null,

--- a/apps/mobile/src/lib/purchases.ts
+++ b/apps/mobile/src/lib/purchases.ts
@@ -103,6 +103,13 @@ export interface PurchaseOffer {
   tier: PaidPlanTier
   /** Localised and currency-correct, straight from the store. Never formatted here: store compliance requires the real price, not one we compute. */
   priceString: string
+  /**
+   * The same price as the store states it per month — "€4.99" on a yearly
+   * plan billed at €59.88. The store's own text again, not a division done
+   * here, for the same compliance reason; absent when the store does not
+   * provide one (a monthly plan, a lifetime purchase, an older SDK).
+   */
+  perMonthPriceString?: string
   period: BillingPeriod
   /**
    * The same amount as a number, in the storefront's currency.
@@ -237,10 +244,12 @@ export async function getOffers(): Promise<PurchaseOffer[]> {
       const definition = packageDefinition(pkg.identifier)
       if (definition === null || definition.tier === 'free') continue
       packagesById.set(pkg.identifier, pkg)
+      const perMonth = pkg.product.pricePerMonthString
       offers.push({
         id: pkg.identifier,
         tier: definition.tier,
         priceString: pkg.product.priceString,
+        ...(perMonth ? { perMonthPriceString: perMonth } : {}),
         period: definition.period,
         price: pkg.product.price,
         freeTrialDays: freeTrialDays(pkg.product.introPrice),

--- a/apps/mobile/src/lib/webBilling.web.ts
+++ b/apps/mobile/src/lib/webBilling.web.ts
@@ -213,12 +213,16 @@ export async function getWebBillingOffers(): Promise<PurchaseOffer[]> {
       if (definition === null || definition.tier === 'free') continue
       packagesById.set(pkg.identifier, pkg)
       const product = pkg.webBillingProduct
+      // RevenueCat's own monthly conversion of the base phase, formatted by
+      // it — the one number this file may show that is not the charge itself.
+      const perMonth = product.defaultSubscriptionOption?.base.pricePerMonth?.formattedPrice
       offers.push({
         id: pkg.identifier,
         tier: definition.tier,
         // The store's own text, in the buyer's currency. Never formatted here:
         // the price a person reads has to be the one the checkout charges.
         priceString: product.price.formattedPrice,
+        ...(perMonth ? { perMonthPriceString: perMonth } : {}),
         period: definition.period,
         price: product.price.amountMicros / MICROS_PER_UNIT,
         freeTrialDays: freeTrialDays(product.freeTrialPhase),


### PR DESCRIPTION
## Summary

Design follow-up **B9** from `docs/plans/design-handoff-follow-ups.md`.

- `PurchaseOffer.perMonthPriceString?` — native: `pkg.product.pricePerMonthString`; web billing: `defaultSubscriptionOption.base.pricePerMonth.formattedPrice`; fake store: a `TEST $…` figure for yearly packages only.
- Paywall price row: yearly → **per-month string** + "a month · billed yearly"; otherwise unchanged. Trial terms and the change notice still quote the actual charge (`priceString`), so the "no computed prices" rule holds.
- One new i18n key in eight locales; fake-store tests extended.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, mobile suite (711 tests)
- [ ] Paywall with the fake store: yearly shows the TEST per-month figure with "billed yearly"; monthly unchanged
- [ ] Real offering on iOS/Android: per-month figure matches the store's

🤖 Generated with [Claude Code](https://claude.com/claude-code)