### PR TITLE
feat(kitchen): the contributor strip, sourced from GitHub and cached

### DIFF
--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -115,6 +115,12 @@ export const COLLECTIONS = {
   appConfig: 'appConfig',
   jobRuns: 'jobRuns',
   /**
+   * A single document (`_id: 'langx/langx'`): the last contributor list GitHub
+   * returned and when. Served stale when GitHub refuses — see
+   * `modules/kitchen/contributors.ts`.
+   */
+  githubContributors: 'githubContributors',
+  /**
    * One row per share card ever rendered. The `_id` is the whole of the public
    * `app.langx.io/s/<id>` address, so it is a random 22 characters rather than
    * anything derived — a guessable id would let a stranger walk the list.

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -47,6 +47,9 @@ const envSchema = z.object({
   // link instead of sending it — the app still boots and is testable, but
   // nothing is delivered until a real key is set.
   RESEND_API_KEY: emptyToUndefined(z.string().optional()),
+  // Raises GitHub's rate limit for the contributor strip on Our Kitchen.
+  // Never required: without it the list is simply refreshed less often.
+  GITHUB_TOKEN: emptyToUndefined(z.string().optional()),
   // resend.dev requires no domain verification, so this works immediately;
   // point it at a verified langx.io sender before Faz 13's launch.
   EMAIL_FROM: z.string().min(1).default('LangX <onboarding@resend.dev>'),

--- a/apps/api/src/modules/kitchen/contributors.ts
+++ b/apps/api/src/modules/kitchen/contributors.ts
@@ -1,0 +1,142 @@
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+
+/** One person on the repository's contributor list. */
+export interface Contributor {
+  login: string
+  avatarUrl: string
+  /** Their GitHub profile. */
+  url: string
+}
+
+export interface ContributorsView {
+  /** Everyone, bots excluded — the "+N" the strip ends with is this minus `top`. */
+  total: number
+  /** The most active, most first, as many as the strip draws. */
+  top: Contributor[]
+}
+
+/** The repository whose contributors Our Kitchen shows. */
+export const CONTRIBUTORS_REPO = 'langx/langx'
+/** Six faces and a "+N" is what the design draws. */
+export const CONTRIBUTORS_TOP = 6
+/**
+ * How long a good answer is reused before GitHub is asked again. The list
+ * moves by a name or two a week; six hours keeps the unauthenticated rate
+ * limit (60 requests an hour, shared across everything this process does)
+ * from ever being the thing that decides whether the strip is drawn.
+ */
+export const CONTRIBUTORS_TTL_MS = 6 * 60 * 60 * 1000
+/** Contributors come 100 to a page; the repository is nowhere near three pages. */
+const MAX_PAGES = 3
+
+interface CachedContributors {
+  _id: string
+  fetchedAt: Date
+  view: ContributorsView
+}
+
+const EMPTY: ContributorsView = { total: 0, top: [] }
+
+/**
+ * The last good answer, per process. Mongo holds the same thing across
+ * processes and restarts; this saves the round trip for the common case.
+ */
+let memory: CachedContributors | null = null
+
+/** Test only: forget the in-process answer, so a test starts from Mongo or GitHub. */
+export function resetContributorsCache(): void {
+  memory = null
+}
+
+/**
+ * One row of GitHub's answer, read defensively: the body is whatever came
+ * back, and a shape this code did not expect is skipped rather than trusted.
+ * Dependabot and friends are on the list too; they did not contribute in the
+ * sense the strip means.
+ */
+function asContributor(row: unknown): Contributor | null {
+  if (typeof row !== 'object' || row === null) return null
+  const record = row as Record<string, unknown>
+  if (record.type === 'Bot') return null
+  const { login, avatar_url: avatarUrl, html_url: url } = record
+  if (typeof login !== 'string' || typeof avatarUrl !== 'string' || typeof url !== 'string') {
+    return null
+  }
+  return { login, avatarUrl, url }
+}
+
+/**
+ * Who has contributed to the repository, for the strip on Our Kitchen.
+ *
+ * GitHub is the only source there is, and it is neither fast nor always
+ * willing (an hour of rate limit is routine without a token). So the answer is
+ * kept — in this process and in a single Mongo document — and GitHub is asked
+ * only when what is kept is older than `CONTRIBUTORS_TTL_MS`. When GitHub
+ * refuses, the stale answer is served rather than nothing; only with no
+ * answer ever is the strip empty, and the app draws nothing for that.
+ *
+ * `GITHUB_TOKEN` raises the rate limit and is never required: a self-hosted
+ * instance without one still works, it simply asks less often.
+ */
+export async function readContributors(
+  db: Db,
+  options: { token?: string | undefined; fetchImpl?: typeof fetch; now?: Date } = {},
+): Promise<ContributorsView> {
+  const now = options.now ?? new Date()
+  const isFresh = (fetchedAt: Date) => now.getTime() - fetchedAt.getTime() < CONTRIBUTORS_TTL_MS
+
+  if (memory && isFresh(memory.fetchedAt)) return memory.view
+
+  const cache = db.collection<CachedContributors>(COLLECTIONS.githubContributors)
+  const stored = await cache.findOne({ _id: CONTRIBUTORS_REPO })
+  if (stored && isFresh(stored.fetchedAt)) {
+    memory = stored
+    return stored.view
+  }
+
+  const view = await fetchFromGitHub(options.token, options.fetchImpl ?? fetch)
+  if (view) {
+    const entry: CachedContributors = { _id: CONTRIBUTORS_REPO, fetchedAt: now, view }
+    await cache.replaceOne({ _id: CONTRIBUTORS_REPO }, entry, { upsert: true })
+    memory = entry
+    return view
+  }
+  // Stale beats empty: yesterday's list is still the list of people who built this.
+  return stored?.view ?? memory?.view ?? EMPTY
+}
+
+/** `null` on any failure — a refusal, a network error, an unexpected body. */
+async function fetchFromGitHub(
+  token: string | undefined,
+  fetchImpl: typeof fetch,
+): Promise<ContributorsView | null> {
+  const headers: Record<string, string> = {
+    accept: 'application/vnd.github+json',
+    'user-agent': 'langx-api',
+  }
+  if (token) headers.authorization = `Bearer ${token}`
+
+  const people: Contributor[] = []
+  try {
+    for (let page = 1; page <= MAX_PAGES; page++) {
+      const response = await fetchImpl(
+        `https://api.github.com/repos/${CONTRIBUTORS_REPO}/contributors?per_page=100&page=${page}`,
+        { headers },
+      )
+      if (!response.ok) return null
+      const body: unknown = await response.json()
+      if (!Array.isArray(body)) return null
+      const rows: unknown[] = body
+      for (const row of rows) {
+        const person = asContributor(row)
+        if (person) people.push(person)
+      }
+      if (rows.length < 100) break
+    }
+  } catch {
+    return null
+  }
+  // GitHub already orders by contribution count, most first.
+  return { total: people.length, top: people.slice(0, CONTRIBUTORS_TOP) }
+}

--- a/apps/api/src/routes/public.test.ts
+++ b/apps/api/src/routes/public.test.ts
@@ -1,7 +1,7 @@
 import { aggregateId } from '@langx/shared'
 import type { FastifyInstance } from 'fastify'
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildApp } from '../app'
 import { createAuth } from '../auth'
 import { connectToDatabase, type DbHandle } from '../db/client'
@@ -9,6 +9,7 @@ import { COLLECTIONS } from '../db/collections'
 import { ensureIndexes } from '../db/indexes'
 import { loadEnv } from '../env'
 import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
+import { CONTRIBUTORS_TOP, resetContributorsCache } from '../modules/kitchen/contributors'
 import { createStorageProvider } from '../storage/createStorageProvider'
 import { createTranslationProvider } from '../translation/createTranslationProvider'
 import { CapturingEmailSender } from '../testSupport/authFlow'
@@ -196,6 +197,74 @@ describe('the public routes v1 used to serve', () => {
       })
       expect(trusted.headers['access-control-allow-origin']).toBe(TRUSTED_ORIGIN)
       expect(trusted.headers['access-control-allow-credentials']).toBe('true')
+    })
+  })
+
+  describe('the contributor strip on Our Kitchen', () => {
+    const gitHubRow = (login: string, type = 'User') => ({
+      login,
+      avatar_url: `https://avatars.example/${login}`,
+      html_url: `https://github.com/${login}`,
+      type,
+    })
+
+    beforeEach(async () => {
+      resetContributorsCache()
+      await handle.db.collection(COLLECTIONS.githubContributors).deleteMany({})
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('lists the most active first, drops bots, and caches the answer', async () => {
+      const rows = [
+        ...Array.from({ length: 8 }, (_, i) => gitHubRow(`dev${i}`)),
+        gitHubRow('dependabot[bot]', 'Bot'),
+      ]
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify(rows), { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const first = await app.inject({ method: 'GET', url: '/public/contributors' })
+      expect(first.statusCode, first.body).toBe(200)
+      expect(first.headers['cache-control']).toContain('max-age=')
+      const body = first.json<{
+        total: number
+        top: { login: string; avatarUrl: string; url: string }[]
+      }>()
+      // Eight people; the bot is not one of them.
+      expect(body.total).toBe(8)
+      expect(body.top).toHaveLength(CONTRIBUTORS_TOP)
+      expect(body.top[0]).toEqual({
+        login: 'dev0',
+        avatarUrl: 'https://avatars.example/dev0',
+        url: 'https://github.com/dev0',
+      })
+
+      // The second read is served from the cache: GitHub is not asked again.
+      await app.inject({ method: 'GET', url: '/public/contributors' })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('serves the last good list when GitHub refuses, and nothing when it never answered', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(new Response('rate limited', { status: 403 })),
+      )
+      const cold = await app.inject({ method: 'GET', url: '/public/contributors' })
+      expect(cold.statusCode).toBe(200)
+      expect(cold.json()).toEqual({ total: 0, top: [] })
+
+      // An old answer in Mongo, older than the TTL, from another process.
+      await handle.db.collection(COLLECTIONS.githubContributors).insertOne({
+        _id: 'langx/langx' as never,
+        fetchedAt: new Date(0),
+        view: { total: 3, top: [{ login: 'old', avatarUrl: 'a', url: 'u' }] },
+      })
+      const stale = await app.inject({ method: 'GET', url: '/public/contributors' })
+      expect(stale.json<{ total: number }>().total).toBe(3)
     })
   })
 })

--- a/apps/api/src/routes/public.ts
+++ b/apps/api/src/routes/public.ts
@@ -3,12 +3,15 @@ import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { Resend } from 'resend'
 import { z } from 'zod'
 import { ApiError } from '../lib/ApiError'
+import { readContributors } from '../modules/kitchen/contributors'
 import { getLeaderboard } from '../modules/tokens/leaderboard'
 
 /** token.langx.io shows ten rows and nothing else. */
 const PUBLIC_BOARD_SIZE = 10
 /** A public table that changes at most once a day; a minute of caching is plenty. */
 const BOARD_CACHE_SECONDS = 60
+/** The contributor list moves by a name a week; an hour at the edge is nothing lost. */
+const CONTRIBUTORS_CACHE_SECONDS = 60 * 60
 
 /**
  * The two things v1's Express API served to callers outside the app, moved
@@ -88,6 +91,23 @@ export const publicRoutes: FastifyPluginAsyncZod = async (app) => {
           tokens,
         })),
       })
+    },
+  )
+
+  /**
+   * Who built this, for the strip on Our Kitchen. Public because the
+   * repository is; served from a cache because GitHub is the only source and
+   * is rate-limited. `{ total: 0, top: [] }` when nothing was ever fetched, and
+   * the app draws nothing for that.
+   */
+  app.get(
+    '/public/contributors',
+    { config: { rateLimit: { max: 60, timeWindow: '1 minute' } } },
+    async (_request, reply) => {
+      const view = await readContributors(app.mongo.db, { token: app.env.GITHUB_TOKEN })
+      return reply
+        .header('cache-control', `public, max-age=${CONTRIBUTORS_CACHE_SECONDS}`)
+        .send(view)
     },
   )
 }

--- a/apps/mobile/app/(app)/kitchen.tsx
+++ b/apps/mobile/app/(app)/kitchen.tsx
@@ -1,5 +1,7 @@
 import Feather from '@expo/vector-icons/Feather'
 import { Pressable, Text, View } from 'react-native'
+import { useContributors } from '../../src/api/queries'
+import { Avatar } from '../../src/components/ui/Avatar'
 import { Screen } from '../../src/components/ui/Screen'
 import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
 import { KITCHEN_SECTIONS } from '../../src/lib/externalLinks'
@@ -23,11 +25,47 @@ export default function KitchenScreen() {
   const styles = useStyles()
   const { colors } = useTheme()
   const t = useT()
+  const contributors = useContributors().data
+  // The contributors page is already a row in `KITCHEN_SECTIONS`; the strip
+  // opens the same address rather than carrying a second copy of it.
+  const contributorsUrl = KITCHEN_SECTIONS.flatMap((section) => section.rows).find(
+    (row) => row.labelKey === 'kitchen.fundamentals',
+  )?.url
 
   return (
     <Screen scroll>
       <ScreenHeader title={t('kitchen.title')} onBack={() => goBackTo('/(app)/settings')} />
       <Text style={styles.intro}>{t('kitchen.intro')}</Text>
+
+      {/*
+        The people, before the links: a row of faces, a "+N" for the rest, and
+        the caption. Drawn only when the API has a list — an empty strip would
+        say nobody built this.
+      */}
+      {contributors && contributors.total > 0 ? (
+        <Pressable
+          accessibilityRole="link"
+          accessibilityLabel={t('kitchen.fundamentals')}
+          onPress={() => contributorsUrl && void openExternal(contributorsUrl)}
+          style={({ pressed }) => [styles.people, pressed && styles.pressed]}
+        >
+          <View style={styles.faces}>
+            {contributors.top.map((person) => (
+              <Avatar key={person.login} url={person.avatarUrl} name={person.login} size={32} />
+            ))}
+            {contributors.total > contributors.top.length ? (
+              <View style={styles.more}>
+                <Text style={styles.moreText}>
+                  {t('kitchen.moreContributors', {
+                    count: contributors.total - contributors.top.length,
+                  })}
+                </Text>
+              </View>
+            ) : null}
+          </View>
+          <Text style={styles.caption}>{t('kitchen.fundamentals')}</Text>
+        </Pressable>
+      ) : null}
 
       {KITCHEN_SECTIONS.map((section) => (
         <View key={section.titleKey} style={styles.group}>
@@ -59,8 +97,21 @@ export default function KitchenScreen() {
   )
 }
 
-const useStyles = makeStyles(({ colors, spacing }) => ({
+const useStyles = makeStyles(({ colors, spacing, radius }) => ({
   intro: { color: colors.textMuted, fontSize: 16, lineHeight: 24, marginTop: spacing.xs },
+  people: { gap: spacing.sm, paddingBottom: 4, paddingTop: spacing.lg },
+  faces: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
+  // The fill circle at the end of the row, sized like a face.
+  more: {
+    alignItems: 'center',
+    backgroundColor: colors.fill,
+    borderRadius: radius.pill,
+    height: 32,
+    justifyContent: 'center',
+    width: 32,
+  },
+  moreText: { color: colors.textMuted, fontSize: 12, fontWeight: '700' },
+  caption: { color: colors.textFaint, fontSize: 13 },
   group: { marginTop: spacing.xl },
   kicker: {
     color: colors.textFaint,

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -140,6 +140,7 @@ export const keys = {
   unread: ['unread'] as const,
   viewers: ['viewers'] as const,
   leaderboard: (period: PeriodType) => ['leaderboard', period] as const,
+  contributors: ['contributors'] as const,
   streakLeaderboard: (metric: string) => ['leaderboard', 'streak', metric] as const,
   blocks: ['blocks'] as const,
 }
@@ -1256,6 +1257,24 @@ export function useViewers() {
       ),
     initialPageParam: '',
     getNextPageParam: (last) => last.nextCursor ?? undefined,
+  })
+}
+
+export interface ContributorsDto {
+  /** Everyone who has contributed to the repository; `top` is the first few. */
+  total: number
+  top: { login: string; avatarUrl: string; url: string }[]
+}
+
+/**
+ * The strip on Our Kitchen. Public, cached for hours on the server and for an
+ * hour here: the list moves by a name a week.
+ */
+export function useContributors() {
+  return useQuery({
+    queryKey: keys.contributors,
+    queryFn: () => api.get<ContributorsDto>('/public/contributors'),
+    staleTime: 60 * 60 * 1000,
   })
 }
 

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -1045,6 +1045,7 @@ export const ar: Localized<EnMessages> = {
     blog: 'المدونة',
     licenses: 'التراخيص',
     codeOfConduct: 'مدونة السلوك',
+    moreContributors: '+{count}',
   },
   streak: {
     title: 'سلسلتك',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -897,6 +897,7 @@ export const de: Localized<EnMessages> = {
     blog: 'Blog',
     licenses: 'Lizenzen',
     codeOfConduct: 'Verhaltenskodex',
+    moreContributors: '+{count}',
   },
   streak: {
     title: 'Deine Serie',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -918,6 +918,7 @@ export const en = {
     blog: 'Blog',
     licenses: 'Licenses',
     codeOfConduct: 'Code of conduct',
+    moreContributors: '+{count}',
   },
   streak: {
     title: 'Your streak',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -875,6 +875,7 @@ export const es: Localized<EnMessages> = {
     blog: 'Blog',
     licenses: 'Licencias',
     codeOfConduct: 'Código de conducta',
+    moreContributors: '+{count}',
   },
   streak: {
     title: 'Tu racha',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -881,6 +881,7 @@ export const fr: Localized<EnMessages> = {
     blog: 'Blog',
     licenses: 'Licences',
     codeOfConduct: 'Code de conduite',
+    moreContributors: '+{count}',
   },
   streak: {
     title: 'Ta série',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -868,6 +868,7 @@ export const ptBR: Localized<EnMessages> = {
     blog: 'Blog',
     licenses: 'Licenças',
     codeOfConduct: 'Código de conduta',
+    moreContributors: '+{count}',
   },
   streak: {
     title: 'Sua sequência',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -996,6 +996,7 @@ export const ru: Localized<EnMessages> = {
     blog: 'Блог',
     licenses: 'Лицензии',
     codeOfConduct: 'Кодекс поведения',
+    moreContributors: '+{count}',
   },
   streak: {
     title: 'Твоя серия',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -879,6 +879,7 @@ export const tr: Localized<EnMessages> = {
     blog: 'Blog',
     licenses: 'Lisanslar',
     codeOfConduct: 'Davranış kuralları',
+    moreContributors: '+{count}',
   },
   streak: {
     title: 'Serin',


### PR DESCRIPTION
## Summary

Design follow-up **B8** from `docs/plans/design-handoff-follow-ups.md`.

- **API** `modules/kitchen/contributors.ts`: `readContributors` — in-process cache → Mongo document (`githubContributors`, single row) → GitHub `repos/langx/langx/contributors` (bots dropped, up to 3 pages). Six-hour TTL; stale served on refusal; `{ total: 0, top: [] }` only when nothing was ever fetched. Optional `GITHUB_TOKEN` env.
- **API** `GET /public/contributors` (rate-limited like the public board, `cache-control` one hour).
- **Mobile** `useContributors()` and the strip on Our Kitchen: six 32px avatars, a fill "+N" pill, caption; tapping opens the contributors page already in `KITCHEN_SECTIONS`. Nothing drawn while empty.
- One new i18n key ("+{count}") in eight locales.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
- [x] API `public.test.ts`: fetch stubbed — ordering, bot filter, cache hit, stale-on-refusal, empty-when-never (10 tests green); mobile suite green
- [ ] After `fly deploy`: `curl https://api.langx.io/public/contributors` returns the real list; Kitchen shows the strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)