### PR TITLE
feat(account): connect and disconnect Google and Apple from Sign-in methods

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -318,6 +318,35 @@ export async function createAuth({ env, db, client, emailSender, revenueCat }: C
 
     socialProviders,
 
+    /**
+     * Connecting and disconnecting Google and Apple from Settings → Sign-in
+     * methods. Both providers are trusted — they verify the address they hand
+     * over — and a different address is allowed on an *explicit* link, because
+     * Apple's private relay is a different address by design and "connect
+     * Apple" would otherwise fail for exactly the people it is for. Implicit
+     * linking at sign-in keeps Better Auth's own same-address rule.
+     *
+     * `allowUnlinkingAll` stays off: the last way into an account cannot be
+     * removed, which is the rule that made offering Disconnect safe at all.
+     */
+    account: {
+      accountLinking: {
+        enabled: true,
+        trustedProviders: ['google', 'apple'],
+        allowDifferentEmails: true,
+        allowUnlinkingAll: false,
+      },
+    },
+
+    // The two account-linking calls are the only Better Auth routes a signed-in
+    // person can hit in a loop from a settings screen; ten a minute is plenty.
+    rateLimit: {
+      customRules: {
+        '/link-social': { window: 60, max: 10 },
+        '/unlink-account': { window: 60, max: 10 },
+      },
+    },
+
     plugins: [
       expo(),
       /*

--- a/apps/api/src/modules/account/signInMethods.ts
+++ b/apps/api/src/modules/account/signInMethods.ts
@@ -1,5 +1,5 @@
 import { LINKED_PROVIDERS, type LinkedProvider, type SignInMethods } from '@langx/shared'
-import type { Db } from 'mongodb'
+import type { Db, ObjectId } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import { authId } from '../../lib/authId'
 import { emailFor } from '../profiles/emailFor'
@@ -17,6 +17,7 @@ function isLinkedProvider(providerId: string): providerId is LinkedProvider {
 }
 
 interface AccountRow {
+  _id: ObjectId | string
   providerId?: string
   password?: string | null
   createdAt?: Date
@@ -46,13 +47,19 @@ export async function getSignInMethods(
 ): Promise<SignInMethods> {
   const rows = await db
     .collection<AccountRow>(COLLECTIONS.account)
-    .find({ userId: authId(userId) }, { projection: { providerId: 1, password: 1, createdAt: 1 } })
+    .find(
+      { userId: authId(userId) },
+      { projection: { _id: 1, providerId: 1, password: 1, createdAt: 1 } },
+    )
     .toArray()
 
   const linked = rows
     .filter((row) => typeof row.providerId === 'string' && isLinkedProvider(row.providerId))
     .map((row) => ({
       provider: row.providerId as LinkedProvider,
+      // The row's id, as Better Auth reads it back: `unlink-account` compares
+      // against `account.id`, which the Mongo adapter maps from `_id`.
+      id: String(row._id),
       linkedAt: (row.createdAt ?? new Date(0)).toISOString(),
     }))
     // Oldest first, so the list does not reshuffle when a second provider is

--- a/apps/api/src/routes/signInMethods.test.ts
+++ b/apps/api/src/routes/signInMethods.test.ts
@@ -148,6 +148,49 @@ describe('sign-in methods', () => {
 
     expect(body.linked.map((row) => row.provider)).toEqual(['google', 'apple'])
     expect(body.linked[0]?.linkedAt).toBe('2026-01-05T00:00:00.000Z')
+    // Each row carries the id `unlink-account` takes.
+    for (const row of body.linked) expect(row.id).toMatch(/^[0-9a-f]{24}$/)
+  })
+
+  describe('disconnecting a provider', () => {
+    function unlink(user: SignedUpUser, accountId: string) {
+      return app.inject({
+        method: 'POST',
+        url: '/api/auth/unlink-account',
+        headers: { cookie: user.cookie },
+        payload: { accountId },
+      })
+    }
+
+    it('removes a provider while a password remains', async () => {
+      const { user } = await newUser('unlink-ok@example.com')
+      await linkProvider(user.userId, 'google', new Date('2026-04-01T00:00:00.000Z'))
+      const before = (await methods(user)).json<SignInMethods>()
+      const google = before.linked.find((row) => row.provider === 'google')
+      expect(google).toBeDefined()
+
+      const response = await unlink(user, google!.id)
+      expect(response.statusCode, response.body).toBe(200)
+
+      const after = (await methods(user)).json<SignInMethods>()
+      expect(after.linked).toEqual([])
+      expect(after.hasPassword).toBe(true)
+    })
+
+    /** The rule that made offering Disconnect safe: the last way in stays. */
+    it('refuses to remove the only way in', async () => {
+      const { user } = await newUser('unlink-last@example.com')
+      await linkProvider(user.userId, 'apple', new Date('2026-04-01T00:00:00.000Z'))
+      await dropPassword(user.userId)
+      const only = (await methods(user)).json<SignInMethods>().linked[0]
+      expect(only).toBeDefined()
+
+      const response = await unlink(user, only!.id)
+      expect(response.statusCode, response.body).toBe(400)
+
+      const after = (await methods(user)).json<SignInMethods>()
+      expect(after.linked.map((row) => row.provider)).toEqual(['apple'])
+    })
   })
 
   /**

--- a/apps/mobile/app/(app)/settings/sign-in-methods.tsx
+++ b/apps/mobile/app/(app)/settings/sign-in-methods.tsx
@@ -1,18 +1,26 @@
 import { Ionicons } from '@expo/vector-icons'
 import Feather from '@expo/vector-icons/Feather'
-import type { LinkedProvider } from '@langx/shared'
-import { router } from 'expo-router'
-import { Text, View } from 'react-native'
+import { LINKED_PROVIDERS, type LinkedProvider } from '@langx/shared'
+import { router, useFocusEffect } from 'expo-router'
+import { useCallback } from 'react'
+import { Pressable, Text, View } from 'react-native'
 import { Button } from '../../../src/components/ui/Button'
 import { ListRow } from '../../../src/components/ui/ListRow'
 import { Screen } from '../../../src/components/ui/Screen'
 import { ScreenHeader } from '../../../src/components/ui/ScreenHeader'
 import { Skeleton } from '../../../src/components/ui/Skeleton'
-import { useSignInMethods } from '../../../src/hooks/useSignInMethods'
+import { useAppConfig } from '../../../src/hooks/useAppConfig'
+import {
+  useLinkProvider,
+  useSignInMethods,
+  useUnlinkProvider,
+} from '../../../src/hooks/useSignInMethods'
 import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
 import { useT } from '../../../src/i18n'
+import { confirmAlert } from '../../../src/lib/alert'
 import { goBackTo } from '../../../src/lib/navigation'
 import { makeStyles, useTheme } from '../../../src/lib/theme'
+import { showToast } from '../../../src/lib/toast'
 
 /** Providers keep their own names — neither Google's nor Apple's is translated. */
 const PROVIDER_NAMES: Record<LinkedProvider, string> = { google: 'Google', apple: 'Apple' }
@@ -33,9 +41,10 @@ const PROVIDER_NAMES: Record<LinkedProvider, string> = { google: 'Google', apple
  * a while it answered that tap with nothing, which read as broken on both
  * sides of `hasPassword`.
  *
- * Linking and unlinking are deliberately not here. Unlinking needs a rule
- * about the last remaining method before it can be offered safely, and a row
- * that can lock somebody out is worse than a row that is missing.
+ * Connect and Disconnect sit on each provider's row, as the design draws
+ * them. Disconnect is withheld — not merely refused — when the link is the only
+ * way in: the server would say no (`allowUnlinkingAll` is off), but a button
+ * that can only fail is worse than a line that says why it is not there.
  */
 export default function SignInMethodsScreen() {
   useScreenInteractive()
@@ -44,6 +53,44 @@ export default function SignInMethodsScreen() {
   const t = useT()
   const methods = useSignInMethods()
   const data = methods.data
+  const offered = useAppConfig().data?.authProviders
+  const link = useLinkProvider()
+  const unlink = useUnlinkProvider()
+
+  // A browser-based link comes back to this screen; the list is stale then.
+  // `refetch` is the stable reference, not the query object, which is new on
+  // every render and would refetch in a loop.
+  const refetch = methods.refetch
+  useFocusEffect(
+    useCallback(() => {
+      void refetch()
+    }, [refetch]),
+  )
+
+  async function connect(provider: LinkedProvider): Promise<void> {
+    try {
+      const outcome = await link.mutateAsync(provider)
+      if (outcome === 'linked') showToast(t('settings.signInLinked'))
+    } catch {
+      showToast(t('settings.signInLinkFailed'))
+    }
+  }
+
+  async function disconnect(provider: LinkedProvider, accountId: string): Promise<void> {
+    const yes = await confirmAlert({
+      title: t('settings.signInDisconnect'),
+      message: t('settings.signInDisconnectConfirm', { provider: PROVIDER_NAMES[provider] }),
+      confirmLabel: t('settings.signInDisconnect'),
+      destructive: true,
+    })
+    if (!yes) return
+    try {
+      await unlink.mutateAsync(accountId)
+      showToast(t('settings.signInUnlinked'))
+    } catch {
+      showToast(t('settings.signInUnlinkFailed'))
+    }
+  }
 
   return (
     <Screen scroll>
@@ -75,30 +122,68 @@ export default function SignInMethodsScreen() {
           ) : null}
 
           <Text style={styles.kicker}>{t('settings.signInConnected')}</Text>
-          {data.linked.length === 0 ? (
-            <ListRow title={t('settings.signInNoneConnected')} last />
-          ) : (
-            data.linked.map((account, index) => (
+          {/*
+            One row per provider this build offers, connected or not, so the
+            way to connect is where the connection will be shown. A provider
+            linked before the build stopped offering it still gets its row:
+            it can be disconnected, and hiding it would hide a way in.
+          */}
+          {LINKED_PROVIDERS.filter(
+            (provider) =>
+              offered?.[provider] || data.linked.some((account) => account.provider === provider),
+          ).map((provider, index, rows) => {
+            const account = data.linked.find((row) => row.provider === provider)
+            // The only way in: no password and nothing else linked.
+            const lastWayIn = account !== undefined && !data.hasPassword && data.linked.length === 1
+            const busy = link.isPending || unlink.isPending
+            return (
               /*
                * Local rather than a `ListRow`: the provider's mark leads the
                * row, and `ListRow` has no slot before the title. Same metrics.
                */
               <View
-                key={account.provider}
-                style={[styles.provider, index < data.linked.length - 1 && styles.divided]}
+                key={provider}
+                style={[styles.provider, index < rows.length - 1 && styles.divided]}
               >
-                <ProviderMark provider={account.provider} />
+                <ProviderMark provider={provider} />
                 <View style={styles.providerText}>
-                  <Text style={styles.providerName}>{PROVIDER_NAMES[account.provider]}</Text>
+                  <Text style={styles.providerName}>{PROVIDER_NAMES[provider]}</Text>
                   <Text style={styles.providerMeta}>
-                    {t('settings.signInConnectedSince', {
-                      date: new Date(account.linkedAt).toLocaleDateString(),
-                    })}
+                    {account
+                      ? lastWayIn
+                        ? t('settings.signInLastMethod')
+                        : t('settings.signInConnectedSince', {
+                            date: new Date(account.linkedAt).toLocaleDateString(),
+                          })
+                      : t('settings.signInNoneConnected')}
                   </Text>
                 </View>
+                {account ? (
+                  lastWayIn ? null : (
+                    <Pressable
+                      accessibilityRole="button"
+                      disabled={busy}
+                      hitSlop={8}
+                      onPress={() => void disconnect(provider, account.id)}
+                      style={({ pressed }) => pressed && styles.pressed}
+                    >
+                      <Text style={styles.disconnect}>{t('settings.signInDisconnect')}</Text>
+                    </Pressable>
+                  )
+                ) : (
+                  <Pressable
+                    accessibilityRole="button"
+                    disabled={busy}
+                    hitSlop={8}
+                    onPress={() => void connect(provider)}
+                    style={({ pressed }) => pressed && styles.pressed}
+                  >
+                    <Text style={styles.connect}>{t('settings.signInConnect')}</Text>
+                  </Pressable>
+                )}
               </View>
-            ))
-          )}
+            )
+          })}
         </>
       ) : methods.isError ? (
         /*
@@ -170,6 +255,10 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   providerText: { flex: 1, gap: 2 },
   providerName: { color: colors.text, fontSize: 17, fontWeight: '600' },
   providerMeta: { color: colors.textMuted, fontSize: 14 },
+  // Text actions, as the design draws them: the accent to add, the danger to remove.
+  connect: { color: colors.accent, fontSize: 14, fontWeight: '600' },
+  disconnect: { color: colors.danger, fontSize: 14, fontWeight: '600' },
+  pressed: { opacity: 0.6 },
   googleMark: { borderRadius: radius.pill, height: 20, overflow: 'hidden', width: 20 },
   quadrant: { height: 10, position: 'absolute', width: 10 },
   quadrantBlue: { backgroundColor: '#4285f4', left: 0, top: 0 },

--- a/apps/mobile/src/hooks/useSignInMethods.ts
+++ b/apps/mobile/src/hooks/useSignInMethods.ts
@@ -1,6 +1,8 @@
-import type { SetPasswordInput, SignInMethods } from '@langx/shared'
+import type { LinkedProvider, SetPasswordInput, SignInMethods } from '@langx/shared'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import * as Linking from 'expo-linking'
 import { api } from '../api/client'
+import { isNativeAppleSignInAvailable, requestAppleIdentity } from '../lib/appleSignIn'
 import { authClient } from '../lib/auth-client'
 
 export const SIGN_IN_METHODS_KEY = ['sign-in-methods'] as const
@@ -61,6 +63,58 @@ export function useChangePassword() {
         revokeOtherSessions: false,
       })
       if (error) throw new Error(error.code ?? error.message ?? 'could not change the password')
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: SIGN_IN_METHODS_KEY }),
+  })
+}
+
+/** Where a browser-based link returns to: this screen, either way. */
+function linkRedirects() {
+  const here = Linking.createURL('/settings/sign-in-methods')
+  return { callbackURL: here, errorCallbackURL: here }
+}
+
+/**
+ * Connects Google or Apple to the signed-in account.
+ *
+ * The same two roads sign-in takes: Apple on a device goes through the native
+ * sheet and hands Better Auth the identity token, so nothing leaves the app;
+ * everything else opens the provider in a browser and comes back to this
+ * screen, where the list is refetched on focus. Resolves `'cancelled'` when
+ * the person closed the Apple sheet — that is not a failure to report.
+ */
+export function useLinkProvider() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (
+      provider: LinkedProvider,
+    ): Promise<'linked' | 'redirected' | 'cancelled'> => {
+      if (provider === 'apple' && (await isNativeAppleSignInAvailable())) {
+        const identity = await requestAppleIdentity()
+        if (!identity) return 'cancelled'
+        const { error } = await authClient.linkSocial({ provider: 'apple', idToken: identity })
+        if (error) throw new Error(error.code ?? error.message ?? 'could not link the account')
+        return 'linked'
+      }
+      const { error } = await authClient.linkSocial({ provider, ...linkRedirects() })
+      if (error) throw new Error(error.code ?? error.message ?? 'could not link the account')
+      return 'redirected'
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: SIGN_IN_METHODS_KEY }),
+  })
+}
+
+/**
+ * Disconnects one link. The server refuses to remove the last way in
+ * (`allowUnlinkingAll` is off), and the screen does not offer the button in
+ * that state — this is the guard behind the guard.
+ */
+export function useUnlinkProvider() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (accountId: string) => {
+      const { error } = await authClient.unlinkAccount({ accountId })
+      if (error) throw new Error(error.code ?? error.message ?? 'could not unlink the account')
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: SIGN_IN_METHODS_KEY }),
   })

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -1184,6 +1184,14 @@ export const ar: Localized<EnMessages> = {
       other: 'بقيت لديك {count} ترجمة مجانية اليوم',
     },
     whatYouHave: 'ما لديك',
+    signInConnect: 'ربط',
+    signInDisconnect: 'إلغاء الربط',
+    signInDisconnectConfirm: 'إلغاء ربط {provider}؟ لن تتمكن من تسجيل الدخول به بعد الآن.',
+    signInLastMethod: 'طريقتك الوحيدة للدخول — عيّن كلمة مرور قبل إلغاء الربط.',
+    signInLinked: 'تم الربط.',
+    signInUnlinked: 'تم إلغاء الربط.',
+    signInLinkFailed: 'تعذّر الربط. حاول مرة أخرى.',
+    signInUnlinkFailed: 'تعذّر إلغاء الربط. حاول مرة أخرى.',
   },
 
   deletion: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -1033,6 +1033,14 @@ export const de: Localized<EnMessages> = {
       other: 'Heute hast du noch {count} kostenlose Übersetzungen',
     },
     whatYouHave: 'Was du hast',
+    signInConnect: 'Verbinden',
+    signInDisconnect: 'Trennen',
+    signInDisconnectConfirm: '{provider} trennen? Du kannst dich damit dann nicht mehr anmelden.',
+    signInLastMethod: 'Dein einziger Weg hinein – lege erst ein Passwort fest.',
+    signInLinked: 'Verbunden.',
+    signInUnlinked: 'Getrennt.',
+    signInLinkFailed: 'Verbinden fehlgeschlagen. Versuch es noch einmal.',
+    signInUnlinkFailed: 'Trennen fehlgeschlagen. Versuch es noch einmal.',
   },
 
   deletion: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -1051,6 +1051,15 @@ export const en = {
       other: '{count} free translations left today',
     },
     whatYouHave: 'What you have',
+    signInConnect: 'Connect',
+    signInDisconnect: 'Disconnect',
+    signInDisconnectConfirm:
+      'Disconnect {provider}? You will no longer be able to sign in with it.',
+    signInLastMethod: 'Your only way in — set a password before disconnecting it.',
+    signInLinked: 'Connected.',
+    signInUnlinked: 'Disconnected.',
+    signInLinkFailed: 'Could not connect. Try again.',
+    signInUnlinkFailed: 'Could not disconnect. Try again.',
   },
 
   deletion: {

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -1009,6 +1009,14 @@ export const es: Localized<EnMessages> = {
       other: 'Te quedan {count} traducciones gratis hoy',
     },
     whatYouHave: 'Lo que tienes',
+    signInConnect: 'Conectar',
+    signInDisconnect: 'Desconectar',
+    signInDisconnectConfirm: '¿Desconectar {provider}? Ya no podrás iniciar sesión con esa cuenta.',
+    signInLastMethod: 'Tu única forma de entrar: pon una contraseña antes de desconectarla.',
+    signInLinked: 'Conectado.',
+    signInUnlinked: 'Desconectado.',
+    signInLinkFailed: 'No se pudo conectar. Inténtalo de nuevo.',
+    signInUnlinkFailed: 'No se pudo desconectar. Inténtalo de nuevo.',
   },
 
   deletion: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -1016,6 +1016,15 @@ export const fr: Localized<EnMessages> = {
       other: 'Il te reste {count} traductions gratuites aujourd’hui',
     },
     whatYouHave: 'Ce que tu as',
+    signInConnect: 'Connecter',
+    signInDisconnect: 'Déconnecter',
+    signInDisconnectConfirm: 'Déconnecter {provider} ? Vous ne pourrez plus vous connecter avec.',
+    signInLastMethod:
+      'Votre seul moyen de connexion : définissez un mot de passe avant de le déconnecter.',
+    signInLinked: 'Connecté.',
+    signInUnlinked: 'Déconnecté.',
+    signInLinkFailed: 'Connexion impossible. Réessayez.',
+    signInUnlinkFailed: 'Déconnexion impossible. Réessayez.',
   },
 
   deletion: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -1003,6 +1003,14 @@ export const ptBR: Localized<EnMessages> = {
       other: 'Você ainda tem {count} traduções grátis hoje',
     },
     whatYouHave: 'O que você tem',
+    signInConnect: 'Conectar',
+    signInDisconnect: 'Desconectar',
+    signInDisconnectConfirm: 'Desconectar {provider}? Você não poderá mais entrar com essa conta.',
+    signInLastMethod: 'Sua única forma de entrar — defina uma senha antes de desconectar.',
+    signInLinked: 'Conectado.',
+    signInUnlinked: 'Desconectado.',
+    signInLinkFailed: 'Não foi possível conectar. Tente de novo.',
+    signInUnlinkFailed: 'Não foi possível desconectar. Tente de novo.',
   },
 
   deletion: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -1132,6 +1132,14 @@ export const ru: Localized<EnMessages> = {
       other: 'Сегодня осталось {count} бесплатного перевода',
     },
     whatYouHave: 'Что у тебя есть',
+    signInConnect: 'Подключить',
+    signInDisconnect: 'Отключить',
+    signInDisconnectConfirm: 'Отключить {provider}? Вы больше не сможете входить с его помощью.',
+    signInLastMethod: 'Единственный способ входа — сначала задайте пароль.',
+    signInLinked: 'Подключено.',
+    signInUnlinked: 'Отключено.',
+    signInLinkFailed: 'Не удалось подключить. Попробуйте ещё раз.',
+    signInUnlinkFailed: 'Не удалось отключить. Попробуйте ещё раз.',
   },
 
   deletion: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -1013,6 +1013,15 @@ export const tr: Localized<EnMessages> = {
       other: 'Bugün {count} ücretsiz çeviri hakkın kaldı',
     },
     whatYouHave: 'Sende olanlar',
+    signInConnect: 'Bağla',
+    signInDisconnect: 'Bağlantıyı kes',
+    signInDisconnectConfirm:
+      '{provider} bağlantısı kesilsin mi? Artık onunla giriş yapamayacaksın.',
+    signInLastMethod: 'Tek giriş yolun — kesmeden önce bir şifre belirle.',
+    signInLinked: 'Bağlandı.',
+    signInUnlinked: 'Bağlantı kesildi.',
+    signInLinkFailed: 'Bağlanamadı. Tekrar dene.',
+    signInUnlinkFailed: 'Bağlantı kesilemedi. Tekrar dene.',
   },
 
   deletion: {

--- a/docs/plans/design-handoff-follow-ups.md
+++ b/docs/plans/design-handoff-follow-ups.md
@@ -10,12 +10,37 @@ design.** This plan says how.
 
 ## Status on 7 September 2026
 
-Not started. The screen pass itself is on the branch above, uncommitted, with
-typecheck, lint, tests and prettier green. Part A below is mobile-only and can
-land on the same branch; Part B changes `packages/shared` and `apps/api` and
-needs an API deploy before the app can read the new fields — every new field is
-therefore optional on the wire, and the app draws nothing for it until the API
-answers.
+**Done.** Every item below has landed on `main`, in this order:
+
+| PR    | Items                                                                                         |
+| ----- | --------------------------------------------------------------------------------------------- |
+| #1168 | the screen pass itself (64 routes) and Part C                                                 |
+| #1169 | D1, D3, A4, A3, B10, D2                                                                       |
+| #1170 | D4 — optimistic send, "Sending → Sent"                                                        |
+| #1171 | A1 — username before photo                                                                    |
+| #1172 | Wallet and Daily pool hero numbers no longer climb into their labels (reported while testing) |
+| #1173 | A5 — `chat/new` and `ChatComposer`                                                            |
+| #1174 | B4, B1, B6, B7                                                                                |
+| #1175 | B3 (pin from the header; the prototype's menu has no archive), B2                             |
+| #1176 | B9                                                                                            |
+| #1177 | B8                                                                                            |
+| #1178 | B5                                                                                            |
+
+The API was deployed after #1174 and #1175, and again after #1177 and #1178;
+the web app and the OTA update go out on every merge. Two things the text below
+still says in the future tense turned out differently once the code was read:
+
+- **B3** adds only Pin/Unpin to the chat header, because that is what the
+  prototype's menu holds — archive stays a list gesture.
+- **B5**: Better Auth 1.7.1's `unlink-account` takes the link row's own `id`
+  (it compares against `account.id`), not the provider's `accountId`, so the
+  shared schema carries `id`. `allowDifferentEmails` is on for the explicit
+  link, because Apple's private relay is a different address by design.
+  Implicit linking at sign-in keeps Better Auth's own same-address rule.
+
+Part A was mobile-only; Part B changed `packages/shared` and `apps/api` and
+every new field is optional on the wire, so the app drew nothing for it until
+the API answered.
 
 ## Part A — the five judgement calls, resolved towards the prototype
 

--- a/packages/shared/src/account.ts
+++ b/packages/shared/src/account.ts
@@ -105,6 +105,11 @@ export type LinkedProvider = (typeof LINKED_PROVIDERS)[number]
 
 export const linkedAccountSchema = z.object({
   provider: z.enum(LINKED_PROVIDERS),
+  /**
+   * Better Auth's own id for the link row — what its `unlink-account` takes.
+   * Not the provider's id for the person; that one never leaves the server.
+   */
+  id: z.string(),
   /** When the link was made, so the row can say "connected in March". */
   linkedAt: z.string(),
 })


### PR DESCRIPTION
## Summary

Design follow-up **B5** — the last item in `docs/plans/design-handoff-follow-ups.md`, whose status section this PR closes out.

- **API** `auth.ts`: `account.accountLinking = { enabled, trustedProviders: ['google','apple'], allowDifferentEmails: true, allowUnlinkingAll: false }`; `rateLimit.customRules` for `/link-social` and `/unlink-account` (10/min).
- **Shared/API** each linked account on `/me/sign-in-methods` carries `id` — Better Auth 1.7.1's `unlink-account` compares against the link row's `account.id`, not the provider's account id.
- **Mobile** `useLinkProvider` (native Apple → `linkSocial({ idToken })`; otherwise browser round trip back to the screen, refetched on focus) and `useUnlinkProvider`. The screen shows one row per offered provider: **Connect** (accent) when unlinked, **Disconnect** (danger, confirmed) when linked — withheld with an explanation when it is the only way in and there is no password.
- Eight new i18n keys in eight locales.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
- [x] API `signInMethods.test.ts`: `id` on linked rows; unlink succeeds while a password remains; unlink of the only way in is refused with 400 (16 tests green). Mobile and shared suites green.
- [ ] Device: Settings → Account → Sign-in methods → Connect Apple (native sheet) → row shows "Connected {date}"; Disconnect asks, then removes; with no password and one provider the button is absent and the line explains

🤖 Generated with [Claude Code](https://claude.com/claude-code)