### PR TITLE
fix(security): close the code-scanning alerts that point at something real

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+# Nothing here writes back to GitHub, so the token needs nothing but read.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -15,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - uses: actions/setup-node@v7
         with:

--- a/apps/api/scripts/maintenance.ts
+++ b/apps/api/scripts/maintenance.ts
@@ -11,6 +11,7 @@
  *   pnpm --filter @langx/api exec tsx scripts/maintenance.ts min-version ios 2.1.0
  *   pnpm --filter @langx/api exec tsx scripts/maintenance.ts flag translationEnabled false
  */
+import { appConfigSchema, minVersionSchema } from '@langx/shared'
 import { connectToDatabase } from '../src/db/client'
 import { loadEnv } from '../src/env'
 import { getAppConfig, setMaintenance, updateAppConfig } from '../src/modules/appConfig/appConfig'
@@ -42,9 +43,14 @@ async function main(): Promise<void> {
       }
       case 'min-version': {
         const [platform, version] = args
-        if (!platform || !version) throw new Error('usage: min-version <ios|android|web> <x.y.z>')
+        // The argument becomes a property name, so it is checked against the
+        // schema's own keys first: a typo gets a usage line, not a new field.
+        const platformKey = minVersionSchema.keyof().safeParse(platform)
+        if (!platformKey.success || !version) {
+          throw new Error('usage: min-version <ios|android|web> <x.y.z>')
+        }
         const current = await getAppConfig(db, Number.POSITIVE_INFINITY)
-        const next = { ...current.minVersion, [platform]: version }
+        const next = { ...current.minVersion, [platformKey.data]: version }
         await updateAppConfig(db, { minVersion: next })
         console.log(`Minimum ${platform} version is now ${version}`)
         console.log('Clients below it get 426 UPDATE_REQUIRED and a forced-update screen.')
@@ -52,12 +58,14 @@ async function main(): Promise<void> {
       }
       case 'flag': {
         const [name, value] = args
-        if (!name || (value !== 'true' && value !== 'false')) {
+        // Same rule as `min-version`: only a flag the schema knows can be set.
+        const flagKey = appConfigSchema.shape.flags.keyof().safeParse(name)
+        if (!flagKey.success || (value !== 'true' && value !== 'false')) {
           throw new Error('usage: flag <name> <true|false>')
         }
         const current = await getAppConfig(db, Number.POSITIVE_INFINITY)
         await updateAppConfig(db, {
-          flags: { ...current.flags, [name]: value === 'true' },
+          flags: { ...current.flags, [flagKey.data]: value === 'true' },
         })
         console.log(`Flag ${name} is now ${value}`)
         break

--- a/apps/mobile/src/api/apiFetch.ts
+++ b/apps/mobile/src/api/apiFetch.ts
@@ -13,7 +13,10 @@ import { authClient } from '../lib/auth-client'
  * handles this without help.
  */
 export async function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
-  const url = path.startsWith('http') ? path : `${API_URL}${path}`
+  // Always our own host. Paths carry request-derived pieces (a handle, an id,
+  // a cursor), and a path that could also be a whole URL would let one of
+  // those pick the host — which is the shape CodeQL flags as request forgery.
+  const url = `${API_URL}${path}`
 
   if (Platform.OS === 'web') {
     /*


### PR DESCRIPTION
## Summary

Six of the eight open CodeQL alerts have a real change behind them:

- **#25, #24** `ci.yml`: explicit `permissions: contents: read`, and `pnpm/action-setup` pinned to the same commit `deploy-web.yml` uses.
- **#30, #9** `apiFetch.ts`: the `path.startsWith('http')` escape hatch is gone, so the URL is always our host plus a path. No caller passed a full URL.
- **#11, #10** `scripts/maintenance.ts`: `min-version` and `flag` validate their argument against the schema's keys (`minVersionSchema.keyof()`, `appConfigSchema.shape.flags.keyof()`) before it becomes a property name.

The remaining two (#21 conversation `unread` keys read off the database record, #29 a constant export URL) are dismissed as false positives with the reason on each alert.

## Test plan

- [x] `tsc --noEmit` for `apps/api` and `apps/mobile`, eslint, prettier
- [ ] CodeQL on this PR closes the six alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)