### PR TITLE
fix(android): drop ACTIVITY_RECOGNITION so Play stops asking for a health declaration

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -105,7 +105,27 @@ const config: ExpoConfig = {
      * and below cannot save its capture without it, and the policy does not
      * cover it.
      */
-    blockedPermissions: ['android.permission.READ_EXTERNAL_STORAGE'],
+    /*
+     * `ACTIVITY_RECOGNITION` comes from expo-sensors' own manifest, which
+     * declares it once for the whole module because `Pedometer` — the step
+     * counter — cannot read its sensor without it. The only sensor this app
+     * touches is the accelerometer, in `useShake`, and that one is unrestricted
+     * on every Android version. So the permission was never requested at
+     * runtime and was never needed; it arrived at manifest-merge time and sat
+     * in the bundle.
+     *
+     * Play reads it as a health signal. Bundle 136 was refused with "Your app
+     * uses the android.permission.ACTIVITY_RECOGNITION permission and must meet
+     * Health apps policy requirements", which is also what made every submit
+     * die in `fastlane supply` on the health declaration: the declaration said
+     * "no health features" while the manifest said otherwise, and Play believes
+     * the manifest. Removing it is the fix Google's own message asks for; the
+     * alternative is claiming a health feature the app does not have.
+     */
+    blockedPermissions: [
+      'android.permission.READ_EXTERNAL_STORAGE',
+      'android.permission.ACTIVITY_RECOGNITION',
+    ],
     intentFilters: [
       {
         action: 'VIEW',

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -361,20 +361,25 @@ every install loses the API on its next launch.
       Store Connect (app 6474187141) with no hand on it, so the distribution
       certificate, the provisioning profile and the App Store Connect API key
       are all in EAS. Review itself still happens in App Store Connect.
-- [ ] **Play submit — the health declaration.** The service account
-      `eas-submit@langx-48eb0.iam.gserviceaccount.com` is _not_ the problem: on
-      7 September 2026 it was already a Play Console user with "Release to
-      production" on the app. Every failed submit — 5 September and the
-      `release.yml` run of 7 September — died in `fastlane supply` on
-      `You must let us know whether your app includes any health features`,
-      and uploading the same bundle (2.0, version code 136) by hand showed the
-      same error on the release page. App content → Health apps read "no
-      health features" since 5 September but had never been _sent for review_;
-      re-saving it put it into Publishing overview → Changes in review. Once
-      that publishes, roll out the saved Production draft (release "2.0",
-      bundle 136) from the console, and `release.yml` for Android should pass
-      its submit step from then on. If it fails again with the same message,
-      the declaration is the place to look, not credentials.
+- [ ] **Play submit — `ACTIVITY_RECOGNITION` in the bundle.** The service
+      account `eas-submit@langx-48eb0.iam.gserviceaccount.com` is _not_ the
+      problem: on 7 September 2026 it was already a Play Console user with
+      "Release to production" on the app. Every failed submit — 5 September and
+      the `release.yml` run of 7 September — died in `fastlane supply` on
+      `You must let us know whether your app includes any health features`, and
+      uploading the same bundle (2.0, version code 136) by hand showed the same
+      error on the release page. Re-saving App content → Health apps did not
+      clear it, and the release page then said why: "Your app uses the
+      android.permission.ACTIVITY_RECOGNITION permission and must meet Health
+      apps policy requirements." The permission is expo-sensors', declared for
+      `Pedometer`, and it reached the bundle at manifest-merge time — `useShake`
+      only ever reads the accelerometer, which needs no permission. A
+      declaration cannot win an argument with the manifest, so the manifest
+      changed: the permission is in `blockedPermissions` in `app.config.ts`,
+      verified gone from `processReleaseMainManifest`'s merged output. That is a
+      native change — bundle 136 still contains the permission, so it needs a
+      new Android build with a new version code, not an OTA. Roll that one out
+      and the submit step should pass from then on.
 
 What is already in EAS: the Android application identifier with the real
 upload keystore (alias `key0`, the v1 key Play trusts), the FCM V1 service


### PR DESCRIPTION
## What

`android.permission.ACTIVITY_RECOGNITION` goes into `blockedPermissions` in `apps/mobile/app.config.ts`.

## Why

Play refuses the Android release with:

> Your app uses the android.permission.ACTIVITY_RECOGNITION permission and must meet Health apps policy requirements. If you don't have any health features in your app, remove this permission from your app's manifest.

That is the same blocker every submit has hit since 5 September, one layer down: `fastlane supply` died on `You must let us know whether your app includes any health features`, and re-saving App content → Health apps as "no health features" could not clear it, because the manifest said otherwise and Play believes the manifest.

The permission is expo-sensors', declared once for the whole module because `Pedometer` cannot read the step-counter sensor without it. The only sensor this app touches is the accelerometer, in `useShake` (shake to open the hourly gift), and that one is unrestricted on every Android version — the permission was never requested at runtime and was never needed. It arrived at manifest-merge time.

Removing it is what Google's own message asks for; the alternative is claiming a health feature the app does not have.

## Verification

`npx expo prebuild --platform android --clean` then `./gradlew :app:processReleaseMainManifest`. The merged release manifest before and after:

```
- android.permission.ACTIVITY_RECOGNITION
  android.permission.CAMERA
  android.permission.INTERNET
  …
```

`ACTIVITY_RECOGNITION` is gone from `merged_manifest/release/processReleaseMainManifest/AndroidManifest.xml`; nothing else changed. Shake still works — `useShake` only calls `Accelerometer`, which needs no permission.

typecheck, lint, format:check and tests all pass.

## Note for whoever ships this

**Native change, not an OTA.** Bundle 136 in the Production draft still contains the permission, so it needs a fresh Android build with a new version code before the submit will pass. `docs/release-runbook.md` is updated to say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)