### PR TITLE
test(paywall): the fake store's yearly prices divide as cleanly as the real ones

### DIFF
--- a/apps/mobile/src/lib/fakePurchases.test.ts
+++ b/apps/mobile/src/lib/fakePurchases.test.ts
@@ -45,4 +45,17 @@ describe('fakeOffers', () => {
       expect(offer.perMonthPriceString !== undefined).toBe(offer.period === 'yearly')
     }
   })
+
+  /**
+   * Real yearly prices are picked so that dividing them by twelve reads as a
+   * price rather than a remainder — `planSaving.test.ts` says why, and the
+   * paywall's largest number is the one it produces. The harness has to render
+   * the same shape or it is exercising a screen that no longer exists.
+   */
+  it('divides every yearly price into a clean monthly one', () => {
+    for (const offer of fakeOffers()) {
+      if (offer.period !== 'yearly') continue
+      expect(offer.perMonthPriceString).toMatch(/\.99$/)
+    }
+  })
 })


### PR DESCRIPTION
Follow-on to the price change that landed inside #1185 — the yearly prices were moved so the store's per-month string reads as a price rather than a remainder ($59.90 a year prints $4.99 a month), and `planSaving.test.ts` asserts that for the real pair.

The fake store's amounts were moved onto the same rule in the same change, but nothing held them there, and the harness is the only place the per-month string is *built* rather than supplied by a store. A yearly amount edited back to something that divides to `$3.33` would leave the fake store rendering a shape the paywall can no longer produce — silently, in the one configuration used to look at the screen without a store.

Thirteen lines of test, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)