### PR TITLE
chore(deps): group the weekly Dependabot pull requests, except Expo's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,40 @@ updates:
       interval: 'weekly'
     open-pull-requests-limit: 5
 
+    # One pull request a week instead of one per package, for two reasons
+    # beyond tidiness. `deploy-web.yml` triggers on `pnpm-lock.yaml`, so every
+    # separate bump used to push its own bundle to app.langx.io; and five open
+    # PRs is the limit above, so a full queue meant Dependabot could not raise
+    # a *security* update until somebody drained it by hand.
+    #
+    # Expo owns the excluded names. `pnpm-workspace.yaml` and CONTRIBUTING.md
+    # both say they move only via `npx expo install --check`, and grouping them
+    # would hide such a bump inside a pull request titled after something else
+    # — which matters because these are the packages that are autolinked native
+    # code, so their version is part of the `fingerprint` runtime version. A
+    # bump that silently shifts it publishes OTA updates under a runtime
+    # version no released binary has. They stay ungrouped and individually
+    # reviewable.
+    groups:
+      npm:
+        patterns:
+          - '*'
+        exclude-patterns:
+          - 'expo'
+          - 'expo-*'
+          - 'react-native*'
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+        update-types:
+          - 'minor'
+          - 'patch'
+
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -312,9 +312,16 @@ something, and what each costs:
 | `deploy-web.yml` | GitHub Actions | every merge to `main`    | nothing — a static export to Pages |
 | `release.yml`    | expo.dev       | by hand, pick a platform | one build, then `eas submit`       |
 
-`update.yml` and `deploy-web.yml` watch the same paths on purpose: a merge
-that changes the app reaches installed phones and `app.langx.io` from the
-same commit, and neither waits for the other. Until 5 September 2026 the web
+`update.yml` and `deploy-web.yml` watch nearly the same paths on purpose: a
+merge that changes the app reaches installed phones and `app.langx.io` from
+the same commit, and neither waits for the other. **Nearly**, and the gap has
+a direction: `deploy-web.yml` also fires on `pnpm-lock.yaml`, which
+`update.yml` does not watch. A dependency bump that touches only the lockfile
+— every Dependabot catalog bump — therefore reaches the browser and not the
+phones, and the two run different versions of that package until the next
+merge that does touch `apps/mobile/**`. Harmless for a patch release, but it
+means the web is where such a bump is first observable, and the only place to
+check it. Until 5 September 2026 the web
 half was `pnpm deploy:web` from a laptop and lagged the phones by however
 long nobody remembered it. The GitHub workflow reuses that same script, so
 the hand-run path still exists and still ends with the live-host check;
@@ -344,6 +351,17 @@ change, so what merges is what ships: there is no staging channel left to
 catch a mistake, and `release.yml` is the only thing that still needs a
 decision. Only a native change — a new module, a permission, an SDK bump, an
 icon — needs a build.
+
+Which is why a native-module version bump is never only a dependency bump.
+`runtimeVersion` is a fingerprint and `@expo/fingerprint` hashes the source
+directory of every autolinked module, so changing one changes the runtime
+version, and every later JS-only merge then publishes to a runtime version no
+released binary has: `update.yml` keeps going green while reaching nobody.
+**Deferred on 7 September 2026 for exactly this reason:**
+`react-native-safe-area-context` `~5.7.0 → ~5.9.1` (langx/langx#1043), left
+open rather than merged. Expo SDK 57 bundles `~5.7.0` and
+`bundledNativeModules.json` is the authority; revisit after this store round,
+with a build, and only if `npx expo install --check` asks for it.
 
 An update job builds the bundle on EAS from a fresh checkout, and
 `EXPO_PUBLIC_*` values are inlined at that moment. `eas.json`'s `env` blocks


### PR DESCRIPTION
Falls out of reviewing the five open Dependabot PRs. Two of them are the reason
this exists.

## What changes

`.github/dependabot.yml` gets a group for npm and one for github-actions, so the
weekly run raises one pull request per ecosystem instead of one per package —
with Expo's packages deliberately **excluded** from the npm group.

## Why group

- `deploy-web.yml` triggers on `pnpm-lock.yaml`. Every separate catalog bump was
  its own bundle push to app.langx.io.
- `open-pull-requests-limit` is 5 and four npm PRs were open. One more and
  Dependabot could not have raised a **security** update until somebody drained
  the queue by hand.

## Why Expo is excluded

`react-native*`, `expo*` and the React pins are autolinked native code, so their
versions are part of the `fingerprint` runtime version (`app.config.ts` sets
`runtimeVersion: { policy: 'fingerprint' }`, and `@expo/fingerprint` hashes each
autolinked module's source directory). A bump folded into a grouped PR titled
after something else changes the runtime version quietly — after which every
JS-only merge publishes an OTA under a runtime version no released binary has,
and `update.yml` keeps going green while reaching nobody.

`pnpm-workspace.yaml` and `CONTRIBUTING.md` already say these move only via
`npx expo install --check`. Keeping them ungrouped is what gives that rule
somewhere to apply. #1043 is the live example and stays open, unaffected by this
change — `exclude-patterns` keeps it out of the group rather than superseding it.

## Runbook

Two corrections, both found while checking the above:

- It said `update.yml` and `deploy-web.yml` watch the same paths. They do not —
  `deploy-web.yml` also watches `pnpm-lock.yaml`, so a lockfile-only bump reaches
  the browser and not the phones, and the two run different versions of that
  package until the next merge touching `apps/mobile/**`.
- The deferred `react-native-safe-area-context` bump is recorded next to the
  paragraph on what needs a native build, so the reminder outlives the PR.

## Verification

`prettier --check` passes on both files. Nothing here runs at build or test
time; GitHub validates `dependabot.yml` on merge, and the next weekly run is
what actually proves the grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)