### PR TITLE
chore(deps): keep the scoped Expo packages out of the Dependabot group too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,12 +30,25 @@ updates:
         patterns:
           - '*'
         exclude-patterns:
+          # Unscoped names first. `react-native*` catches reanimated,
+          # safe-area-context, purchases, screens, worklets and the rest.
           - 'expo'
           - 'expo-*'
           - 'react-native*'
           - 'react'
           - 'react-dom'
           - '@types/react'
+          # And the scoped ones, which `react-native*` does NOT match — the
+          # leading `@` is part of the name. Leaving these out is what let
+          # `@react-native/metro-config` and
+          # `@react-native-community/datetimepicker` into the first grouped
+          # pull request (#1189), the former to 0.87.1, which is the exact
+          # version `pnpm-workspace.yaml`'s override exists to keep out.
+          - '@react-native/*'
+          - '@react-native-community/*'
+          - '@expo/*'
+          - '@expo-google-fonts/*'
+          - 'babel-preset-expo'
         update-types:
           - 'minor'
           - 'patch'

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@eslint/js": "catalog:",
-    "@types/node": "^24.3.0",
+    "@types/node": "catalog:",
     "eslint": "catalog:",
     "prettier": "catalog:",
     "typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,7 +125,7 @@ importers:
         specifier: 'catalog:'
         version: 10.0.1(eslint@10.9.1)
       '@types/node':
-        specifier: ^24.3.0
+        specifier: 'catalog:'
         version: 24.13.3
       eslint:
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,5 +66,12 @@ onlyBuiltDependencies:
 # peer resolved to whatever the registry offered, which was 0.87.1 from the next
 # minor. It is listed as a devDependency of apps/mobile as well, which is what
 # actually puts a 0.86 copy in the tree for the override to hold at.
+#
+# Dependabot pushes on this. It offered 0.87.1 — the same next-minor that
+# leaked in before — inside the first grouped pull request (#1189, closed),
+# where the version would have moved under a title naming thirteen other
+# packages. `.github/dependabot.yml` now excludes `@react-native/*` from the
+# group for that reason. The devDependency and this override have to move
+# together, and only when Expo's SDK does.
 overrides:
   '@react-native/metro-config': 0.86.3


### PR DESCRIPTION
Follow-up to #1188, prompted by the first grouped pull request it produced.

## The gap

`react-native*` does not match `@react-native/metro-config`. The leading `@` is
part of the package name, so the exclusion list in #1188 covered the unscoped
half of the Expo/RN family and silently missed the scoped half. #1189 arrived
carrying three of them:

| Package | In the group | Should be |
|---|---|---|
| `@react-native/metro-config` | 0.86.3 → **0.87.1** | pinned 0.86.3 by `overrides` |
| `@react-native-community/datetimepicker` | 9.1.0 → 9.2.0 | SDK 57 bundles **9.1.0** |
| `babel-preset-expo` | ~57.0.8 → ~57.0.10 | Expo's, reviewed on its own |

The first one is the one that matters. `pnpm-workspace.yaml`'s override exists
because 0.87.1 leaked in once before and nothing errored — and here it was
again, inside a pull request titled after thirteen other packages. Exactly the
failure mode #1188 said grouping must not create.

Now excluded: `@react-native/*`, `@react-native-community/*`, `@expo/*`,
`@expo-google-fonts/*`, `babel-preset-expo`. The override's own comment now
says that Dependabot pushes on this pin and that the devDependency and the
override move together, and only when Expo's SDK does.

## `@types/node` joins the catalog

`@types/node` was the only devDependency in the root manifest still written as
a literal `^24.3.0` while `pnpm-workspace.yaml`'s catalog also defined it. With
the same package declared two ways, Dependabot could not tell which to move:
#1191 raised the manifest to `^26.4.1` and left the lockfile on `^24.3.0`, and
`pnpm install --frozen-lockfile` rejected the pair:

    ERR_PNPM_OUTDATED_LOCKFILE
      - @types/node (lockfile: ^24.3.0, manifest: ^26.4.1)

It now reads `catalog:` like `@eslint/js`, `eslint`, `prettier`, `typescript`
and `typescript-eslint`. The resolved version is unchanged — 24.13.3 before and
after — so the lockfile change is the one line that records the new specifier.

## Verification

- `pnpm install --frozen-lockfile --lockfile-only` passes and rewrites nothing.
- The lockfile diff is one line. `pnpm install --lockfile-only` wanted to strip
  the `libc: [glibc]` / `libc: [musl]` fields from fourteen platform packages —
  an artefact of regenerating on macOS — so the specifier was edited by hand
  instead. Those fourteen fields are still there; CI runs on Ubuntu and they
  decide which binary it gets.
- `prettier --check` passes on all three edited files.

#1189 and #1191 are closed as superseded; #1190 and #1192 stay open, since they
are native modules and get the same individual review as #1043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)