### PR TITLE
docs(runbook): the deferred native bumps are a list of five, not one

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -357,11 +357,20 @@ Which is why a native-module version bump is never only a dependency bump.
 directory of every autolinked module, so changing one changes the runtime
 version, and every later JS-only merge then publishes to a runtime version no
 released binary has: `update.yml` keeps going green while reaching nobody.
-**Deferred on 7 September 2026 for exactly this reason:**
-`react-native-safe-area-context` `~5.7.0 → ~5.9.1` (langx/langx#1043), left
-open rather than merged. Expo SDK 57 bundles `~5.7.0` and
-`bundledNativeModules.json` is the authority; revisit after this store round,
-with a build, and only if `npx expo install --check` asks for it.
+**Every open Dependabot pull request against a `react-native*` package is
+deferred for this reason**, and they are deliberately left open rather than
+closed so the versions stay visible. There were five by the evening of
+7 September 2026 — safe-area-context, reanimated, worklets, screens and
+purchases — and the weekly run adds more. Do not merge them one at a time.
+`.github/dependabot.yml` keeps the whole Expo/RN family out of the grouped pull
+request precisely so each one lands where it can be seen.
+
+They come off the list together, and not by reading the list:
+`bundledNativeModules.json` is the authority for what SDK 57 wants, so after
+this store round run `npx expo install --check` and take what it asks for, with
+a build behind it. A bump nobody asked for is one nobody has to take —
+`react-native-purchases` is the exception worth naming, since Expo does not
+bundle it and only the fingerprint argument applies.
 
 An update job builds the bundle on EAS from a fresh checkout, and
 `EXPO_PUBLIC_*` values are inlined at that moment. `eas.json`'s `env` blocks


### PR DESCRIPTION
Follow-up to #1188 and #1194.

The paragraph was written when `react-native-safe-area-context` (#1043) was the
only native bump being held back. By the end of the same evening the corrected
grouping had surfaced four more, each as its own pull request — which is exactly
what excluding the Expo/RN family from the group is for:

| PR | Package | SDK 57 bundles |
|---|---|---|
| #1043 | `react-native-safe-area-context` `~5.7.0 → ~5.9.1` | `~5.7.0` |
| #1190 | `react-native-reanimated` `4.5.1 → 4.6.0` | `4.5.1` |
| #1195 | `react-native-worklets` `0.10.1 → 0.12.1` | `0.10.1` |
| #1196 | `react-native-screens` `4.26.2 → 4.27.0` | `~4.26.0` |
| #1192 | `react-native-purchases` `10.8.1 → 10.9.0` | not bundled |

Enumerating them in the runbook would go stale within the week, so the paragraph
now names the class instead and says how they come off the list: together, after
a store round, from whatever `npx expo install --check` asks for — not from
whatever Dependabot happened to offer.

`react-native-purchases` is called out as the exception. Expo does not bundle
it, so there is no pin to violate; only the fingerprint argument applies, plus
the fact that it is the purchase path on a build currently in review.

They stay open on purpose, so the versions remain visible rather than being
rediscovered later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)