### PR TITLE
docs: branding is a repo to work in now

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -490,8 +490,12 @@ a rank, so gold has to read as something bought rather than as the product.
       in `Logo.svelte`, and the feature screenshots under
       `website/static/images/features/`, which still show v1's UI
 - [ ] Re-shoot the store screenshots in the new identity. They live in
-      `branding/`, which is out of scope for work — the shots are needed, the
-      repo is still not one to work in
+      `branding/`, which is now a repo to work in: `branding/BRAND.md` is the
+      v3 identity written down, `branding/app-resources/v2/` carries the icons
+      and splash badges the app ships, and `branding/2.0.x/` holds the
+      composition — the shot list, the numbers, and the template rendered empty
+      at each store size. What is missing is the captures themselves, which
+      need the app signed in against a local replica set
 
 ## The paywall sells the trial and the saving
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -489,13 +489,15 @@ a rank, so gold has to read as something bought rather than as the product.
       `website/src/app.html`, `website/static/favicons/*`, the inline fills
       in `Logo.svelte`, and the feature screenshots under
       `website/static/images/features/`, which still show v1's UI
-- [ ] Re-shoot the store screenshots in the new identity. They live in
-      `branding/`, which is now a repo to work in: `branding/BRAND.md` is the
-      v3 identity written down, `branding/app-resources/v2/` carries the icons
-      and splash badges the app ships, and `branding/2.0.x/` holds the
-      composition — the shot list, the numbers, and the template rendered empty
-      at each store size. What is missing is the captures themselves, which
-      need the app signed in against a local replica set
+- [ ] Re-shoot the store screenshots in the new identity. `branding/` is now a
+      repo to work in and most of this is done there: `BRAND.md` is the v3
+      identity written down, `app-resources/v2/` carries the icons and splash
+      badges this app ships, and `2.0.x/` holds a full uploadable set — six
+      shots at every App Store and Play slot, in all eight languages, plus the
+      feature graphics. What is still open is that the screen inside each shot
+      is rendered from the site's phone components rather than captured from a
+      build. Replacing them shot for shot needs the app signed in against a
+      local replica set; the composition does not change when they are
 
 ## The paywall sells the trial and the saving
 

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -68,6 +68,7 @@ that repo means reconnecting the Pages project in the dashboard first.
 | `packages/shared/src/token.ts`, `cosmetics.ts` | the numbers on token.langx.io and the token pages in `docs/` |
 | `apps/mobile/assets/`                          | `branding/app-resources/v2/` — the same bytes, copied        |
 | `apps/mobile/src/lib/theme/tokens.ts`          | `branding/BRAND.md` — the palette, the type and the scales   |
+| `apps/mobile/src/lib/theme/tokens.ts`          | `website/DESIGN.md` and `website/src/lib/scss/_themes.scss`  |
 
 One more runs the other way: the app's link table
 `apps/mobile/src/lib/externalLinks.ts` (Settings → Legal, and the "Our Kitchen"

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -14,6 +14,7 @@ The working assumption in these docs is that the sibling repos are checked out
   website/        langx.io
   token-website/  token.langx.io
   docs/           docs.langx.io (GitBook source)
+  branding/       logos, app icons, store screenshots
 ```
 
 Paths such as `website/src/lib/data/plans.ts` in this repo's docs mean that
@@ -29,6 +30,7 @@ mean this folder.
 | [`langx/website`](https://github.com/langx/website)             | langx.io — SvelteKit, deployed by its own GitHub Actions workflow |
 | [`langx/token-website`](https://github.com/langx/token-website) | token.langx.io — plain HTML/CSS/JS, no build step                 |
 | [`langx/docs`](https://github.com/langx/docs)                   | GitBook source for docs.langx.io; `SUMMARY.md` is the entry point |
+| [`langx/branding`](https://github.com/langx/branding)           | Logos, app icons, store screenshots, press kit. No code           |
 
 ### `langx/api` — retired
 
@@ -64,6 +66,8 @@ that repo means reconnecting the Pages project in the dashboard first.
 | `packages/shared/src/cosmetics.ts`             | `website/src/lib/data/token.ts`                              |
 | `docs/store/listing.md`                        | `website/src/lib/data/meta.ts`                               |
 | `packages/shared/src/token.ts`, `cosmetics.ts` | the numbers on token.langx.io and the token pages in `docs/` |
+| `apps/mobile/assets/`                          | `branding/app-resources/v2/` — the same bytes, copied        |
+| `apps/mobile/src/lib/theme/tokens.ts`          | `branding/BRAND.md` — the palette, the type and the scales   |
 
 One more runs the other way: the app's link table
 `apps/mobile/src/lib/externalLinks.ts` (Settings → Legal, and the "Our Kitchen"
@@ -94,10 +98,9 @@ was built from it), `langx-flutter`, `db-bulk-update`,
 `rss-to-medium-autopublish`, `insight`, `insight-counterscale`,
 `capacitor-voice-recorder`, `db`, `sdk`, `cepix`.
 
-Live on GitHub but out of scope: `copilot` (OpenAI-backed Discord assistant),
-`branding` (logos, store screenshots, press kit — no code), `.github` (the
-organisation profile). `langx-react-native`, the first RN sketch of v2, moved
-into this repo; its remote no longer resolves.
+Live on GitHub but out of scope: `copilot` (OpenAI-backed Discord assistant)
+and `.github` (the organisation profile). `langx-react-native`, the first RN
+sketch of v2, moved into this repo; its remote no longer resolves.
 
 To understand how v1 worked, read `langx-angular`, `api`, and
 [`v1-reference.md`](v1-reference.md).


### PR DESCRIPTION
Docs only — two files, no code, no assets.

`repo-map.md` listed `branding` under "live on GitHub but out of scope", and the design-pass item in `release-runbook.md` said the store screenshots were needed but the repo was "still not one to work in". It has been brought onto the v3 identity ([langx/branding#1](https://github.com/langx/branding/pull/1)), so both of those sentences send the next reader in the wrong direction.

## What changes

- `branding` moves into the in-scope table and into the sibling-checkout layout at the top of `repo-map.md`.
- Three rows join the hand-kept links table, which exists for exactly this and is checked by nothing:
  - `apps/mobile/assets/` → `branding/app-resources/v2/` (the same bytes, copied)
  - `apps/mobile/src/lib/theme/tokens.ts` → `branding/BRAND.md`
  - `apps/mobile/src/lib/theme/tokens.ts` → `website/DESIGN.md` and `website/src/lib/scss/_themes.scss`

  The last one is not new — the website already carries the v3 palette under its own token names. It just was not written down.
- The runbook's screenshot item now says what is actually still open: a full uploadable set exists in eight languages, but the screen inside each shot is rendered from the site's phone components rather than captured from a build. Replacing them needs the app signed in against a local replica set.

`pnpm format:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZpebuvTporra5HKY2Kr9y


---
_Generated by [Claude Code](https://claude.ai/code/session_012ZpebuvTporra5HKY2Kr9y)_