### PR TITLE
chore(deps): take the root-only tooling packages off the catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     "release": "node scripts/release.mjs"
   },
   "devDependencies": {
-    "@eslint/js": "catalog:",
+    "@eslint/js": "^10.0.1",
     "@types/node": "catalog:",
-    "eslint": "catalog:",
-    "prettier": "catalog:",
+    "eslint": "^10.9.1",
+    "prettier": "^3.6.2",
     "typescript": "catalog:",
-    "typescript-eslint": "catalog:"
+    "typescript-eslint": "^8.68.0"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ catalogs:
     '@better-auth/expo':
       specifier: ^1.7.1
       version: 1.7.1
-    '@eslint/js':
-      specifier: ^10.0.1
-      version: 10.0.1
     '@fastify/cors':
       specifier: ^11.3.0
       version: 11.3.0
@@ -45,9 +42,6 @@ catalogs:
     esbuild:
       specifier: ^0.28.2
       version: 0.28.2
-    eslint:
-      specifier: ^10.9.1
-      version: 10.9.1
     fastify:
       specifier: ^5.12.1
       version: 5.12.1
@@ -72,9 +66,6 @@ catalogs:
     pino-pretty:
       specifier: ^13.1.2
       version: 13.1.3
-    prettier:
-      specifier: ^3.6.2
-      version: 3.9.6
     react:
       specifier: 19.2.3
       version: 19.2.3
@@ -102,9 +93,6 @@ catalogs:
     typescript:
       specifier: ~6.0.3
       version: 6.0.3
-    typescript-eslint:
-      specifier: ^8.68.0
-      version: 8.68.0
     vitest:
       specifier: ^4.1.11
       version: 4.1.11
@@ -122,22 +110,22 @@ importers:
   .:
     devDependencies:
       '@eslint/js':
-        specifier: 'catalog:'
+        specifier: ^10.0.1
         version: 10.0.1(eslint@10.9.1)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
       eslint:
-        specifier: 'catalog:'
+        specifier: ^10.9.1
         version: 10.9.1
       prettier:
-        specifier: 'catalog:'
+        specifier: ^3.6.2
         version: 3.9.6
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       typescript-eslint:
-        specifier: 'catalog:'
+        specifier: ^8.68.0
         version: 8.68.0(eslint@10.9.1)(typescript@6.0.3)
 
   apps/api:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,17 +2,28 @@ packages:
   - apps/*
   - packages/*
 
-# Single source of truth for versions shared across workspaces.
+# Single source of truth for versions shared across workspaces — and only
+# those. `eslint`, `@eslint/js`, `prettier` and `typescript-eslint` are declared
+# in the root manifest and nowhere else, so a catalog entry for them shared
+# nothing; it only added a second place to write the version down. It also
+# broke them. Dependabot rewrites the *root* importer's `specifier: 'catalog:'`
+# to a concrete version when it bumps a catalog entry, and `--frozen-lockfile`
+# then rejects the pair — which is how #1189 and #1197 both died on
+# `typescript-eslint`, before a single test ran. The same bump against
+# `apps/*` passes, so it is the root importer specifically. Those four now
+# carry literal versions in the root `package.json`; do not move them back.
+#
+# What is left here is genuinely shared: `typescript` by the root and all three
+# workspaces, `@types/node` by the root and `apps/api`, `vitest` by the three
+# workspaces. `tsx` has one consumer and stays anyway — it is not declared at
+# the root, so it never hits the bug above.
+#
 # Expo-owned versions (expo-*, react-native*, react*) are pinned per the SDK 57
 # template and must only be changed via `npx expo install --check`.
 catalog:
   # language + tooling
   '@types/node': ^24.3.0
   typescript: ~6.0.3
-  eslint: ^10.9.1
-  '@eslint/js': ^10.0.1
-  typescript-eslint: ^8.68.0
-  prettier: ^3.6.2
   vitest: ^4.1.11
   tsx: ^4.23.12
 


### PR DESCRIPTION
Fixes the failure that killed both #1189 and #1197 at the install step, twelve
seconds in, before a single test ran:

    ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile"
      - typescript-eslint (lockfile: 8.69.0, manifest: catalog:)

## What is actually wrong

When Dependabot bumps a catalog entry it rewrites the **root** importer's
`specifier: 'catalog:'` to the concrete version, while `package.json` still
says `catalog:`. The pair no longer agrees and `--frozen-lockfile` refuses it.

The same thing against a workspace package is fine — `zod` (#1046), `resend`
(#1047) and `@tanstack/react-query` (#1042) were all catalog bumps this week
and all passed. The difference is the root importer.

## The fix, and why it is a fix rather than a workaround

Four of the six root catalog entries were declared **in the root manifest and
nowhere else**:

| Package | Declared in |
|---|---|
| `eslint` | root only |
| `@eslint/js` | root only |
| `prettier` | root only |
| `typescript-eslint` | root only |
| `typescript` | root + `apps/api` + `apps/mobile` + `packages/shared` |
| `@types/node` | root + `apps/api` |

`pnpm-workspace.yaml` describes the catalog as the single source of truth for
versions *shared across workspaces*. The first four share nothing — the entry
only added a second place to write the version down, and a bug. They now carry
literal versions in the root `package.json`, where Dependabot updates them the
ordinary way. The last two are genuinely shared and stay, as do `vitest` and
`tsx` (one consumer, but not declared at the root, so it never meets the bug).

No updates are lost — this is not an `ignore`. The comment at the top of
`pnpm-workspace.yaml` now records the reasoning so nobody moves them back.

## Verification

- `pnpm install --frozen-lockfile --lockfile-only` passes and rewrites nothing.
- **Every resolved `version:` in the lockfile is unchanged.** The diff is the
  four catalog blocks and the four root importer specifiers, nothing else.
- `pnpm install --lockfile-only` additionally wanted to strip `libc: [glibc]` /
  `libc: [musl]` from fourteen platform packages, and `bufferutil` /
  `utf-8-validate` from one metro snapshot's transitive peers. Both are
  artefacts of regenerating on macOS rather than Linux; CI runs on Ubuntu and
  those `libc` fields decide which binary it gets. They were restored and the
  count re-checked (14).
- `prettier --check` passes.

#1197 should be rebased after this lands; the `typescript-eslint` half of it is
what this unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)