### PR TITLE
Release 2.1

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/api",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 API — Better Auth + REST + Socket.io in one Fastify process",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/mobile",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 client — iOS, Android and web from one Expo codebase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langx",
-  "version": "2.0",
+  "version": "2.1",
   "private": true,
   "description": "LangX v2 \u2014 language exchange app (Expo mobile/web + Fastify API + MongoDB Atlas)",
   "license": "BSD-3-Clause",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/shared",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "Contract shared by @langx/api and @langx/mobile: zod schemas, language and level tables, plan limits, token rules, error codes",


### PR DESCRIPTION
Bumps the version to 2.1, so everything merged from here on ships as 2.1 rather than as more 2.0.

v2.0 is done: iOS and Android are both live on build 136, and the `v2.0` tag and its release notes now say so.

`pnpm release minor` wrote this — the root `package.json` carries `2.1` and the three workspace packages carry `2.1.0`, because `pnpm deploy` matches `@langx/shared@workspace:*` by semver and `2.1` is not one.

The `v2.1` tag is **not** pushed. It exists locally only; pushing it is what creates the GitHub Release, and that waits until 2.1 actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)