### PR TITLE
docs(store): the six listings the screenshots cannot go up without

### DIFF
--- a/docs/store/listing.md
+++ b/docs/store/listing.md
@@ -107,9 +107,297 @@ is next rewritten.
 > Şartlar ve Koşullar: https://langx.io/terms-conditions
 > Gizlilik Politikası: https://langx.io/privacy-policy
 
+**Anahtar kelimeler (iOS, 100 karakter)**
+`dil,değişim,öğren,pratik,konuşma,tandem,partner,ingilizce,ispanyolca,sohbet`
+
+---
+
+## Español (es-ES)
+
+**Título (30)**
+`LangX: Intercambio de idiomas`
+
+**Subtítulo (80)**
+`Practica un idioma hablando con quien aprende el tuyo.`
+
+**Descripción**
+
+> LangX te empareja con personas que hablan el idioma que aprendes y están
+> aprendiendo el tuyo. Sin clases, sin deberes: solo conversaciones reales con
+> alguien que necesita exactamente lo que tú puedes ofrecer.
+>
+> **Emparejamiento en ambos sentidos.** Solo ves a personas cuyos idiomas
+> encajan con los tuyos en las dos direcciones, así que cada conversación
+> aporta algo a los dos.
+>
+> **Corrección mutua.** Toca cualquier mensaje para sugerir una forma mejor de
+> decirlo. Las correcciones son ilimitadas para todo el mundo y en todos los
+> planes: enseñar es lo esencial.
+>
+> **Traducción cuando te atascas.** Integrada, sin salir del chat.
+>
+> **Un motivo para volver.** Mantén tu racha diaria, gana tokens por hablar y
+> enseñar, y mira dónde quedas en las clasificaciones semanal, mensual, anual y
+> de siempre.
+>
+> **Gratis siempre.** Responde sin límite a todos los mensajes que recibas y
+> corrige tantos como quieras. En el plan gratuito puedes iniciar 5
+> conversaciones nuevas al día.
+>
+> **LangX Pro** añade conversaciones nuevas ilimitadas, filtros por género,
+> país, edad y nivel, traducción ilimitada, quién ha visto tu perfil y
+> navegación de incógnito.
+>
+> LangX es de código abierto (BSD-3) y se puede autoalojar.
+>
+> Términos de uso (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+> Términos y condiciones: https://langx.io/terms-conditions
+> Política de privacidad: https://langx.io/privacy-policy
+
+**Palabras clave (iOS, 100 caracteres)**
+`idioma,intercambio,aprender,practicar,hablar,tándem,compañero,inglés,español,chat`
+
+---
+
+## Русский (ru)
+
+**Название (30)**
+`LangX: языковой обмен`
+
+**Подзаголовок (80)**
+`Практикуй язык с теми, кто учит твой.`
+
+**Описание**
+
+> LangX подбирает тебе собеседников, которые говорят на языке, который ты
+> учишь, и учат твой язык. Никаких уроков и домашних заданий — просто живые
+> разговоры с человеком, которому нужно именно то, что ты можешь дать.
+>
+> **Совпадение в обе стороны.** Ты видишь только тех, чьи языки подходят твоим
+> в обоих направлениях, поэтому каждый разговор что-то даёт обоим.
+>
+> **Исправляйте друг друга.** Нажми на любое сообщение, чтобы предложить, как
+> сказать лучше. Исправления безлимитны для всех и на любом тарифе — учить друг
+> друга и есть смысл приложения.
+>
+> **Перевод, когда застрял.** Встроенный, не выходя из чата.
+>
+> **Повод возвращаться.** Держи ежедневную серию, зарабатывай токены за
+> общение и помощь другим и смотри своё место в таблицах за неделю, месяц, год
+> и всё время.
+>
+> **Всегда бесплатно.** Отвечай без ограничений на все полученные сообщения и
+> исправляй сколько хочешь. На бесплатном тарифе можно начинать 5 новых
+> разговоров в день.
+>
+> **LangX Pro** добавляет безлимитные новые разговоры, фильтры по полу, стране,
+> возрасту и уровню, безлимитный перевод, просмотр тех, кто заходил в твой
+> профиль, и невидимый режим.
+>
+> LangX — открытый исходный код (BSD-3), можно развернуть на своём сервере.
+>
+> Условия использования (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+> Условия и положения: https://langx.io/terms-conditions
+> Политика конфиденциальности: https://langx.io/privacy-policy
+
+**Ключевые слова (iOS, 100 символов)**
+`язык,обмен,учить,практика,разговор,тандем,партнёр,английский,испанский,чат`
+
+---
+
+## العربية (ar-SA)
+
+**الاسم (30)**
+`LangX: تبادل اللغات`
+
+**العنوان الفرعي (80)**
+`تدرّب على لغة بالحديث مع من يتعلّم لغتك.`
+
+**الوصف**
+
+> يجمعك LangX مع أشخاص يتحدثون اللغة التي تتعلّمها ويتعلّمون لغتك. لا دروس ولا
+> واجبات — فقط محادثات حقيقية مع شخص يحتاج تمامًا إلى ما تستطيع تقديمه.
+>
+> **تطابق في الاتجاهين.** لا ترى إلا من تتوافق لغاتهم مع لغاتك في الاتجاهين،
+> فيكون في كل محادثة ما يفيد الطرفين.
+>
+> **صحّحوا لبعضكم.** اضغط على أي رسالة لتقترح صياغة أفضل. التصحيحات غير محدودة
+> للجميع وفي كل الخطط — فالتعليم هو جوهر التطبيق.
+>
+> **ترجمة عند التوقف.** مدمجة، دون مغادرة المحادثة.
+>
+> **سبب للعودة.** حافظ على سلسلتك اليومية، واكسب الرموز مقابل الحديث والتعليم،
+> وشاهد ترتيبك في لوحات الأسبوع والشهر والسنة وكل الأوقات.
+>
+> **مجاني دائمًا.** ردّ بلا حدود على كل رسالة تصلك، وصحّح ما شئت. في الخطة
+> المجانية يمكنك بدء 5 محادثات جديدة يوميًا.
+>
+> **LangX Pro** يضيف محادثات جديدة بلا حدود، وفلاتر حسب الجنس والبلد والعمر
+> والمستوى، وترجمة بلا حدود، ومعرفة من زار ملفك، والتصفّح المخفي.
+>
+> LangX مفتوح المصدر (BSD-3) ويمكن استضافته ذاتيًا.
+>
+> شروط الاستخدام (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+> الشروط والأحكام: https://langx.io/terms-conditions
+> سياسة الخصوصية: https://langx.io/privacy-policy
+
+**الكلمات المفتاحية (iOS، 100 حرف)**
+`لغة,تبادل,تعلم,تدريب,محادثة,تاندم,شريك,إنجليزي,إسباني,دردشة`
+
+---
+
+## Français (fr-FR)
+
+**Nom (30)**
+`LangX : échange linguistique`
+
+**Sous-titre (80)**
+`Pratiquez une langue avec ceux qui apprennent la vôtre.`
+
+**Description**
+
+> LangX vous met en relation avec des personnes qui parlent la langue que vous
+> apprenez et qui apprennent la vôtre. Pas de cours, pas de devoirs — juste de
+> vraies conversations avec quelqu'un à qui vous apportez exactement ce dont il
+> a besoin.
+>
+> **Une correspondance dans les deux sens.** Vous ne voyez que des personnes
+> dont les langues complètent les vôtres dans les deux sens : chaque
+> conversation a donc un intérêt pour les deux.
+>
+> **Corrigez-vous mutuellement.** Touchez un message pour proposer une
+> meilleure formulation. Les corrections sont illimitées pour tout le monde et
+> sur toutes les formules — s'apprendre les uns aux autres, c'est tout l'objet.
+>
+> **La traduction quand vous bloquez.** Intégrée, sans quitter la conversation.
+>
+> **Une raison de revenir.** Tenez une série quotidienne, gagnez des jetons en
+> parlant et en aidant, et voyez votre place aux classements de la semaine, du
+> mois, de l'année et de tous les temps.
+>
+> **Gratuit, toujours.** Répondez sans limite à tous les messages que vous
+> recevez et corrigez-en autant que vous voulez. La formule gratuite permet de
+> démarrer 5 nouvelles conversations par jour.
+>
+> **LangX Pro** ajoute les nouvelles conversations illimitées, les filtres par
+> genre, pays, âge et niveau, la traduction illimitée, les visiteurs de votre
+> profil et la navigation en incognito.
+>
+> LangX est open source (BSD-3) et peut être auto-hébergé.
+>
+> Conditions d'utilisation (CLUF) : https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+> Conditions générales : https://langx.io/terms-conditions
+> Politique de confidentialité : https://langx.io/privacy-policy
+
+**Mots-clés (iOS, 100 caractères)**
+`langue,échange,apprendre,pratiquer,parler,tandem,partenaire,anglais,espagnol,chat`
+
+---
+
+## Deutsch (de-DE)
+
+**Name (30)**
+`LangX: Sprachaustausch`
+
+**Untertitel (80)**
+`Übe eine Sprache mit Menschen, die deine lernen.`
+
+**Beschreibung**
+
+> LangX bringt dich mit Menschen zusammen, die die Sprache sprechen, die du
+> lernst, und die deine Sprache lernen. Kein Unterricht, keine Hausaufgaben —
+> nur echte Gespräche mit jemandem, der genau das braucht, was du geben kannst.
+>
+> **Passend in beide Richtungen.** Du siehst nur Menschen, deren Sprachen in
+> beide Richtungen zu deinen passen. So hat jedes Gespräch für beide Seiten
+> etwas.
+>
+> **Korrigiert euch gegenseitig.** Tippe auf eine Nachricht und schlage vor,
+> wie man es besser sagt. Korrekturen sind für alle und in jedem Tarif
+> unbegrenzt — ums Beibringen geht es hier.
+>
+> **Übersetzung, wenn du hängst.** Eingebaut, ohne den Chat zu verlassen.
+>
+> **Ein Grund wiederzukommen.** Halte deine tägliche Serie, verdiene Tokens
+> fürs Reden und Helfen und sieh, wo du in den Ranglisten für Woche, Monat,
+> Jahr und alle Zeiten stehst.
+>
+> **Immer kostenlos.** Antworte unbegrenzt auf jede Nachricht, die du bekommst,
+> und korrigiere so viel du willst. Im kostenlosen Tarif kannst du 5 neue
+> Gespräche pro Tag beginnen.
+>
+> **LangX Pro** ergänzt unbegrenzte neue Gespräche, Filter nach Geschlecht,
+> Land, Alter und Niveau, unbegrenzte Übersetzung, wer dein Profil besucht hat,
+> und das Surfen im Inkognito-Modus.
+>
+> LangX ist Open Source (BSD-3) und lässt sich selbst hosten.
+>
+> Nutzungsbedingungen (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+> Allgemeine Geschäftsbedingungen: https://langx.io/terms-conditions
+> Datenschutzerklärung: https://langx.io/privacy-policy
+
+**Keywords (iOS, 100 Zeichen)**
+`Sprache,Austausch,lernen,üben,sprechen,Tandem,Partner,Englisch,Spanisch,Chat`
+
+---
+
+## Português do Brasil (pt-BR)
+
+**Nome (30)**
+`LangX: Intercâmbio de Idiomas`
+
+**Subtítulo (80)**
+`Pratique um idioma conversando com quem aprende o seu.`
+
+**Descrição**
+
+> O LangX conecta você a pessoas que falam o idioma que você aprende e que
+> estão aprendendo o seu. Sem aulas, sem lição de casa — só conversas de
+> verdade com alguém que precisa exatamente do que você tem a oferecer.
+>
+> **Combinação nos dois sentidos.** Você só vê pessoas cujos idiomas encaixam
+> com os seus nas duas direções, então toda conversa tem algo para os dois.
+>
+> **Corrijam um ao outro.** Toque em qualquer mensagem para sugerir um jeito
+> melhor de dizer. As correções são ilimitadas para todo mundo, em todos os
+> planos — ensinar é o ponto principal.
+>
+> **Tradução quando você trava.** Integrada, sem sair da conversa.
+>
+> **Um motivo para voltar.** Mantenha sua sequência diária, ganhe tokens por
+> conversar e ensinar e veja sua posição nos rankings da semana, do mês, do ano
+> e de todos os tempos.
+>
+> **Grátis, sempre.** Responda sem limite a todas as mensagens que receber e
+> corrija quantas quiser. No plano gratuito, você pode iniciar 5 conversas
+> novas por dia.
+>
+> **O LangX Pro** acrescenta conversas novas ilimitadas, filtros por gênero,
+> país, idade e nível, tradução ilimitada, quem visitou seu perfil e navegação
+> anônima.
+>
+> O LangX é de código aberto (BSD-3) e pode ser hospedado por você mesmo.
+>
+> Termos de uso (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+> Termos e condições: https://langx.io/terms-conditions
+> Política de privacidade: https://langx.io/privacy-policy
+
+**Palavras-chave (iOS, 100 caracteres)**
+`idioma,intercâmbio,aprender,praticar,falar,tandem,parceiro,inglês,espanhol,chat`
+
 ---
 
 ## What's new (release notes)
+
+A version update needs release notes in **every** localization, not just the
+primary one — App Store Connect will not let the version be submitted with one
+missing.
+
+The third line is not optional in any language. Every v1 user has to sign up
+again — the old password hashes could not be migrated — and without that
+sentence the first thing a returning user meets is a login that rejects them.
+
+**English**
 
 > LangX v2 is a rebuild. Faster matching, realtime chat, message corrections,
 > built-in translation, daily streaks and token leaderboards.
@@ -119,6 +407,77 @@ is next rewritten.
 >
 > Badges are coming back in the next release.
 
-The third line is not optional. Every v1 user has to sign up again — the old
-password hashes could not be migrated — and without that sentence the first
-thing a returning user meets is a login that rejects them.
+**Türkçe**
+
+> LangX v2 baştan yazıldı. Daha hızlı eşleşme, anlık sohbet, mesaj
+> düzeltmeleri, yerleşik çeviri, günlük seriler ve token sıralamaları.
+>
+> Kullanıcı adın seni bekliyor — daha önce kullandığın e-postayla kaydol ve
+> geri al.
+>
+> Rozetler bir sonraki sürümde geri geliyor.
+
+**Español**
+
+> LangX v2 está reconstruido desde cero. Emparejamiento más rápido, chat en
+> tiempo real, correcciones de mensajes, traducción integrada, rachas diarias y
+> clasificaciones por tokens.
+>
+> Tu nombre de usuario te está esperando: regístrate con el correo que usabas
+> antes y recupéralo.
+>
+> Las insignias vuelven en la próxima versión.
+
+**Русский**
+
+> LangX v2 переписан заново. Более быстрый подбор, чат в реальном времени,
+> исправления сообщений, встроенный перевод, ежедневные серии и таблицы по
+> токенам.
+>
+> Твоё имя пользователя ждёт тебя — зарегистрируйся с той же почтой, что и
+> раньше, и забери его.
+>
+> Значки вернутся в следующем обновлении.
+
+**العربية**
+
+> أُعيد بناء LangX v2 من الأساس. مطابقة أسرع، ومحادثة فورية، وتصحيح الرسائل،
+> وترجمة مدمجة، وسلاسل يومية، ولوحات ترتيب بالرموز.
+>
+> اسم المستخدم الخاص بك في انتظارك — سجّل بالبريد الإلكتروني الذي كنت تستخدمه
+> واسترجعه.
+>
+> الشارات تعود في الإصدار القادم.
+
+**Français**
+
+> LangX v2 a été reconstruit. Mise en relation plus rapide, chat en temps réel,
+> correction des messages, traduction intégrée, séries quotidiennes et
+> classements de jetons.
+>
+> Votre nom d'utilisateur vous attend : inscrivez-vous avec l'adresse e-mail
+> que vous utilisiez avant pour le récupérer.
+>
+> Les badges reviennent dans la prochaine version.
+
+**Deutsch**
+
+> LangX v2 ist neu gebaut. Schnelleres Matching, Chat in Echtzeit,
+> Nachrichtenkorrekturen, eingebaute Übersetzung, tägliche Serien und
+> Token-Ranglisten.
+>
+> Dein Benutzername wartet auf dich — melde dich mit der E-Mail-Adresse an, die
+> du vorher benutzt hast, und hol ihn dir zurück.
+>
+> Abzeichen kommen im nächsten Release zurück.
+
+**Português do Brasil**
+
+> O LangX v2 foi reconstruído. Combinação mais rápida, chat em tempo real,
+> correção de mensagens, tradução integrada, sequências diárias e rankings de
+> tokens.
+>
+> Seu nome de usuário está esperando por você — cadastre-se com o e-mail que
+> você usava antes e recupere-o.
+>
+> As medalhas voltam na próxima versão.

--- a/docs/store/listing.md
+++ b/docs/store/listing.md
@@ -21,6 +21,11 @@ when the standard Apple EULA is used. The footer below is that link, plus the
 privacy policy so both documents are one tap away. Keep it when the description
 is next rewritten.
 
+Apple's subtitle is **30 characters**; the 80-character line is Google Play's
+short description. They were the same field here until now, which made every
+subtitle in this file too long for the App Store — the English and the Turkish
+included. Both are written out below, per language.
+
 ---
 
 ## English
@@ -28,7 +33,10 @@ is next rewritten.
 **Title (30)**
 `LangX: Language Exchange`
 
-**Subtitle / short description (80)**
+**Apple subtitle (30)**
+`Practice with real people`
+
+**Play short description (80)**
 `Practice a language by talking with people learning yours.`
 
 **Description**
@@ -74,7 +82,10 @@ is next rewritten.
 **Başlık (30)**
 `LangX: Dil Değişimi`
 
-**Kısa açıklama (80)**
+**Apple altbaşlığı (30)**
+`Gerçek insanlarla pratik`
+
+**Play kısa açıklaması (80)**
 `Senin dilini öğrenen biriyle konuşarak dil öğren.`
 
 **Açıklama**
@@ -117,7 +128,10 @@ is next rewritten.
 **Título (30)**
 `LangX: Intercambio de idiomas`
 
-**Subtítulo (80)**
+**Subtítulo de Apple (30)**
+`Practica con gente real`
+
+**Descripción corta de Play (80)**
 `Practica un idioma hablando con quien aprende el tuyo.`
 
 **Descripción**
@@ -164,7 +178,10 @@ is next rewritten.
 **Название (30)**
 `LangX: языковой обмен`
 
-**Подзаголовок (80)**
+**Подзаголовок Apple (30)**
+`Практика с живыми людьми`
+
+**Краткое описание Play (80)**
 `Практикуй язык с теми, кто учит твой.`
 
 **Описание**
@@ -210,7 +227,10 @@ is next rewritten.
 **الاسم (30)**
 `LangX: تبادل اللغات`
 
-**العنوان الفرعي (80)**
+**العنوان الفرعي في Apple (30)**
+`تدرّب مع أشخاص حقيقيين`
+
+**الوصف المختصر في Play (80)**
 `تدرّب على لغة بالحديث مع من يتعلّم لغتك.`
 
 **الوصف**
@@ -251,7 +271,10 @@ is next rewritten.
 **Nom (30)**
 `LangX : échange linguistique`
 
-**Sous-titre (80)**
+**Sous-titre Apple (30)**
+`Pratiquez avec de vrais gens`
+
+**Description courte Play (80)**
 `Pratiquez une langue avec ceux qui apprennent la vôtre.`
 
 **Description**
@@ -299,7 +322,10 @@ is next rewritten.
 **Name (30)**
 `LangX: Sprachaustausch`
 
-**Untertitel (80)**
+**Apple-Untertitel (30)**
+`Üben mit echten Menschen`
+
+**Play-Kurzbeschreibung (80)**
 `Übe eine Sprache mit Menschen, die deine lernen.`
 
 **Beschreibung**
@@ -346,7 +372,10 @@ is next rewritten.
 **Nome (30)**
 `LangX: Intercâmbio de Idiomas`
 
-**Subtítulo (80)**
+**Subtítulo da Apple (30)**
+`Pratique com gente real`
+
+**Descrição curta da Play (80)**
 `Pratique um idioma conversando com quem aprende o seu.`
 
 **Descrição**
@@ -389,95 +418,145 @@ is next rewritten.
 
 ## What's new (release notes)
 
+These are **2.1's** notes, read back from App Store Connect on 8 September 2026
+— not 2.0's. The rebuild notes that used to sit here described the wrong
+release; 2.1 is a chat release.
+
 A version update needs release notes in **every** localization, not just the
 primary one — App Store Connect will not let the version be submitted with one
 missing.
 
-The third line is not optional in any language. Every v1 user has to sign up
+The last line is not optional in any language. Every v1 user has to sign up
 again — the old password hashes could not be migrated — and without that
 sentence the first thing a returning user meets is a login that rejects them.
 
-**English**
+"Polyglot" is a plan name and stays in English everywhere, the way "LangX Pro"
+does in the description.
 
-> LangX v2 is a rebuild. Faster matching, realtime chat, message corrections,
-> built-in translation, daily streaks and token leaderboards.
+**English** — the copy already live on the version, left as it is
+
+> Chat got most of the work in this one.
 >
-> Your username is waiting for you — sign up with the email you used before and
-> claim it.
+> Stickers, in two packs, for any conversation.
+> Save a phrase from a message and keep it as a card.
+> Ask your partner a quiz - your question, your options, one right answer.
+> Propose a meeting and see it in both clocks, yours and theirs, with a reminder an hour before.
+> A faster sheet for sending photos, video and voice notes.
 >
-> Badges are coming back in the next release.
+> Polyglot adds writing in your own language and sending in theirs, and exporting a conversation's saved phrases as a file that opens in Anki.
+>
+> Tokens are simpler to follow: one token a message, up to a daily cap.
+>
+> Coming back from the old app? Sign up with the email you used before - your username is waiting for you.
 
 **Türkçe**
 
-> LangX v2 baştan yazıldı. Daha hızlı eşleşme, anlık sohbet, mesaj
-> düzeltmeleri, yerleşik çeviri, günlük seriler ve token sıralamaları.
+> Bu sürümde en çok sohbet üzerinde çalışıldı.
 >
-> Kullanıcı adın seni bekliyor — daha önce kullandığın e-postayla kaydol ve
-> geri al.
+> İki pakette çıkartmalar, her sohbet için.
+> Bir mesajdaki ifadeyi kaydet, kart olarak sakla.
+> Partnerine soru sor - kendi sorun, kendi şıkların, tek doğru cevap.
+> Buluşma öner, iki saatte birden gör, seninkinde ve onunkinde, bir saat önce hatırlatmayla.
+> Fotoğraf, video ve sesli not göndermek için daha hızlı bir ekran.
 >
-> Rozetler bir sonraki sürümde geri geliyor.
+> Polyglot, kendi dilinde yazıp onun dilinde göndermeyi ve bir sohbette kaydettiğin ifadeleri Anki'de açılan bir dosya olarak dışa aktarmayı ekler.
+>
+> Token'ları takip etmek artık daha basit: mesaj başına bir token, günlük sınıra kadar.
+>
+> Eski uygulamadan mı dönüyorsun? Daha önce kullandığın e-postayla kaydol - kullanıcı adın seni bekliyor.
 
 **Español**
 
-> LangX v2 está reconstruido desde cero. Emparejamiento más rápido, chat en
-> tiempo real, correcciones de mensajes, traducción integrada, rachas diarias y
-> clasificaciones por tokens.
+> En esta versión el trabajo se centró en el chat.
 >
-> Tu nombre de usuario te está esperando: regístrate con el correo que usabas
-> antes y recupéralo.
+> Stickers, en dos paquetes, para cualquier conversación.
+> Guarda una frase de un mensaje y consérvala como tarjeta.
+> Propón un cuestionario a tu compañero: tu pregunta, tus opciones, una respuesta correcta.
+> Propón una quedada y velá en los dos relojes, el tuyo y el suyo, con un recordatorio una hora antes.
+> Un panel más rápido para enviar fotos, vídeo y notas de voz.
 >
-> Las insignias vuelven en la próxima versión.
+> Polyglot añade escribir en tu idioma y enviar en el suyo, y exportar las frases guardadas de una conversación como archivo que se abre en Anki.
+>
+> Los tokens son más fáciles de seguir: un token por mensaje, hasta un límite diario.
+>
+> ¿Vuelves de la app anterior? Regístrate con el correo que usabas antes: tu nombre de usuario te está esperando.
 
 **Русский**
 
-> LangX v2 переписан заново. Более быстрый подбор, чат в реальном времени,
-> исправления сообщений, встроенный перевод, ежедневные серии и таблицы по
-> токенам.
+> В этом обновлении больше всего работы досталось чату.
 >
-> Твоё имя пользователя ждёт тебя — зарегистрируйся с той же почтой, что и
-> раньше, и забери его.
+> Стикеры, в двух наборах, для любого разговора.
+> Сохрани фразу из сообщения и оставь её карточкой.
+> Задай собеседнику вопрос с вариантами - твой вопрос, твои варианты, один правильный ответ.
+> Предложи встречу и увидь её на обоих часах, твоих и его, с напоминанием за час.
+> Более быстрое окно для отправки фото, видео и голосовых.
 >
-> Значки вернутся в следующем обновлении.
+> Polyglot добавляет письмо на своём языке с отправкой на его языке и экспорт сохранённых фраз разговора файлом, который открывается в Anki.
+>
+> За токенами стало проще следить: один токен за сообщение, до дневного предела.
+>
+> Возвращаешься из старого приложения? Зарегистрируйся с той же почтой - твоё имя пользователя ждёт тебя.
 
 **العربية**
 
-> أُعيد بناء LangX v2 من الأساس. مطابقة أسرع، ومحادثة فورية، وتصحيح الرسائل،
-> وترجمة مدمجة، وسلاسل يومية، ولوحات ترتيب بالرموز.
+> نال الدردشة النصيب الأكبر من العمل في هذا الإصدار.
 >
-> اسم المستخدم الخاص بك في انتظارك — سجّل بالبريد الإلكتروني الذي كنت تستخدمه
-> واسترجعه.
+> ملصقات، في حزمتين، لأي محادثة.
+> احفظ عبارة من رسالة واحتفظ بها كبطاقة.
+> اطرح على شريكك سؤالًا - سؤالك، وخياراتك، وإجابة صحيحة واحدة.
+> اقترح موعدًا وشاهده بالتوقيتين، توقيتك وتوقيته، مع تذكير قبل ساعة.
+> واجهة أسرع لإرسال الصور والفيديو والرسائل الصوتية.
 >
-> الشارات تعود في الإصدار القادم.
+> يضيف Polyglot الكتابة بلغتك والإرسال بلغته، وتصدير العبارات المحفوظة من محادثة كملف يُفتح في Anki.
+>
+> صار تتبّع الرموز أبسط: رمز واحد لكل رسالة، حتى حد يومي.
+>
+> عائد من التطبيق القديم؟ سجّل بالبريد الإلكتروني الذي كنت تستخدمه - اسم المستخدم بانتظارك.
 
 **Français**
 
-> LangX v2 a été reconstruit. Mise en relation plus rapide, chat en temps réel,
-> correction des messages, traduction intégrée, séries quotidiennes et
-> classements de jetons.
+> Cette version a surtout fait avancer la conversation.
 >
-> Votre nom d'utilisateur vous attend : inscrivez-vous avec l'adresse e-mail
-> que vous utilisiez avant pour le récupérer.
+> Des stickers, en deux packs, pour n'importe quelle conversation.
+> Enregistrez une expression d'un message et gardez-la sous forme de carte.
+> Posez un quiz à votre partenaire : votre question, vos options, une seule bonne réponse.
+> Proposez un rendez-vous et voyez-le sur les deux horloges, la vôtre et la sienne, avec un rappel une heure avant.
+> Un panneau plus rapide pour envoyer photos, vidéos et notes vocales.
 >
-> Les badges reviennent dans la prochaine version.
+> Polyglot ajoute l'écriture dans votre langue et l'envoi dans la sienne, ainsi que l'export des expressions enregistrées d'une conversation dans un fichier qui s'ouvre dans Anki.
+>
+> Les jetons sont plus simples à suivre : un jeton par message, jusqu'à un plafond quotidien.
+>
+> Vous revenez de l'ancienne app ? Inscrivez-vous avec l'adresse e-mail que vous utilisiez avant - votre nom d'utilisateur vous attend.
 
 **Deutsch**
 
-> LangX v2 ist neu gebaut. Schnelleres Matching, Chat in Echtzeit,
-> Nachrichtenkorrekturen, eingebaute Übersetzung, tägliche Serien und
-> Token-Ranglisten.
+> In dieser Version ging die meiste Arbeit in den Chat.
 >
-> Dein Benutzername wartet auf dich — melde dich mit der E-Mail-Adresse an, die
-> du vorher benutzt hast, und hol ihn dir zurück.
+> Sticker, in zwei Paketen, für jede Unterhaltung.
+> Speichere eine Wendung aus einer Nachricht und behalte sie als Karte.
+> Stell deinem Partner eine Quizfrage - deine Frage, deine Optionen, eine richtige Antwort.
+> Schlage ein Treffen vor und sieh es in beiden Uhrzeiten, deiner und seiner, mit einer Erinnerung eine Stunde vorher.
+> Ein schnelleres Fenster zum Senden von Fotos, Videos und Sprachnachrichten.
 >
-> Abzeichen kommen im nächsten Release zurück.
+> Polyglot ergänzt das Schreiben in deiner Sprache und das Senden in seiner sowie den Export der gespeicherten Wendungen einer Unterhaltung als Datei, die sich in Anki öffnet.
+>
+> Tokens lassen sich einfacher verfolgen: ein Token pro Nachricht, bis zu einem Tageslimit.
+>
+> Kommst du aus der alten App zurück? Melde dich mit der E-Mail-Adresse an, die du vorher benutzt hast - dein Benutzername wartet auf dich.
 
 **Português do Brasil**
 
-> O LangX v2 foi reconstruído. Combinação mais rápida, chat em tempo real,
-> correção de mensagens, tradução integrada, sequências diárias e rankings de
-> tokens.
+> Nesta versão o trabalho ficou quase todo no chat.
 >
-> Seu nome de usuário está esperando por você — cadastre-se com o e-mail que
-> você usava antes e recupere-o.
+> Figurinhas, em dois pacotes, para qualquer conversa.
+> Salve uma expressão de uma mensagem e guarde como cartão.
+> Faça um quiz para seu parceiro: sua pergunta, suas opções, uma resposta certa.
+> Proponha um encontro e veja nos dois relógios, o seu e o dele, com um lembrete uma hora antes.
+> Uma tela mais rápida para enviar fotos, vídeos e áudios.
 >
-> As medalhas voltam na próxima versão.
+> O Polyglot acrescenta escrever no seu idioma e enviar no dele, e exportar as expressões salvas de uma conversa como arquivo que abre no Anki.
+>
+> Os tokens ficaram mais fáceis de acompanhar: um token por mensagem, até um limite diário.
+>
+> Voltando do app antigo? Cadastre-se com o e-mail que você usava antes - seu nome de usuário está esperando por você.


### PR DESCRIPTION
## Why

The store set in `langx/branding` is 448 screenshots in eight languages. App Store Connect currently has **one** localization — English (U.S.), primary — and every other language sits under "Not Localized".

A localization cannot be created without a description and keywords. So seven eighths of the screenshot set had nowhere to be uploaded to, by hand or by `fastlane deliver`. That, not the upload script, was the real blocker.

## What

`docs/store/listing.md` gains the six missing languages — Spanish, Russian, Arabic, French, German, Brazilian Portuguese. Turkish was already written and only needed its keyword line.

Each follows the English structure: the both-ways match first, then corrections, translation, the reason to come back, what "free" actually covers, then Pro. Every title is inside 30 characters, every subtitle inside 80, every keyword line inside 100 — checked, not estimated.

Release notes are now present for all eight, because a version update cannot be submitted with any localization's notes missing. The sentence telling v1 users to sign up again with their old email is in every one.

### The Terms of Use footer

Every description ends with the EULA link. App Review rejected 2.0.0 on 6 September 2026 under Guideline 3.1.2, and the requirement applies **per localization** — a translated description that drops the footer reintroduces the rejection in that language.

## What this does not do

**Only the Turkish has been read by a native speaker.** A headline is the most-read sentence in a listing. Have each language checked before the version is submitted — this is a shippable draft, not a signed-off translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)