### PR TITLE
fix(ci): let the web deploy check outlast Cloudflare's rollout window

### DIFF
--- a/apps/mobile/scripts/verify-web-deploy.mjs
+++ b/apps/mobile/scripts/verify-web-deploy.mjs
@@ -1,4 +1,6 @@
 /* global fetch, console */
+import { setTimeout as sleep } from 'node:timers/promises'
+
 /**
  * Proves a web deploy is actually serving: fetches the live index, finds the
  * entry bundle it references, and fetches that too.
@@ -11,29 +13,80 @@
  *
  * Runs against the custom domain, because that is what people open; the
  * `*.pages.dev` preview URL was fine that day and proved nothing.
+ *
+ * It retries, because the check runs about a second after `wrangler pages
+ * deploy` prints "Deployment complete" and Cloudflare has not finished moving
+ * the domain onto the new deployment by then. In that window the edge answers
+ * with the *previous* index.html, whose bundle the new deployment has already
+ * replaced — which looks exactly like the 5 September incident and is not it.
+ * That cost two red runs on 7 September, both on a deploy that was fine; the
+ * third attempt, minutes later, passed against the same commit.
+ *
+ * The distinction the retries have to preserve: a stale index that clears
+ * within seconds of a deploy is propagation, and a stale index that is still
+ * there half a minute later is the incident. So the window is bounded and the
+ * failure at the end of it is the original one, unsoftened.
  */
 // The custom domain, fixed: it is the address people open, and the one the
 // edge cache sits in front of. Not an argument — a URL from the command line
 // is a request-forgery finding, and there is no second host worth checking.
 const host = 'https://app.langx.io'
-const bust = `?verify=${Date.now()}`
 
-const index = await fetch(`${host}/${bust}`, { headers: { 'cache-control': 'no-cache' } })
-if (!index.ok) fail(`index answered ${index.status}`)
-const html = await index.text()
-const match = /_expo\/static\/js\/web\/entry-[a-z0-9]+\.js/.exec(html)
-if (!match) fail('index does not reference an entry bundle')
+// Five attempts over ~30s. Long enough for a rollout, short enough that a
+// genuinely stale edge is not left sitting behind a green check.
+const backoffMs = [3000, 6000, 9000, 12000]
 
-const bundle = await fetch(`${host}/${match[0]}`)
-const type = bundle.headers.get('content-type') ?? ''
-if (!bundle.ok || !/javascript/.test(type)) {
-  fail(
-    `bundle ${match[0]} answered ${bundle.status} (${type}) — the edge is serving a stale index.html; purge app.langx.io in Cloudflare`,
-  )
+let attempts = 0
+let outcome
+for (let attempt = 0; ; attempt++) {
+  outcome = await check()
+  if (outcome.ok || attempt === backoffMs.length) break
+  console.log(`web deploy check: ${outcome.reason} — retrying in ${backoffMs[attempt] / 1000}s`)
+  await sleep(backoffMs[attempt])
 }
+
+if (!outcome.ok) fail(outcome.reason)
+
 console.log(
-  `ok: ${host} serves ${match[0]} (${bundle.status}, cf-cache-status ${index.headers.get('cf-cache-status') ?? 'n/a'})`,
+  `ok: ${host} serves ${outcome.bundle} (200, cf-cache-status ${outcome.cacheStatus})` +
+    (outcome.attempts > 1 ? ` after ${outcome.attempts} attempts` : ''),
 )
+
+/**
+ * One full index→bundle round trip. Returns `{ ok: true, … }` or a `reason`
+ * worded for the final failure, since that is where it ends up if the window
+ * runs out.
+ */
+async function check() {
+  attempts++
+  // A fresh buster per attempt: reusing one URL would let a retry be answered
+  // from whatever the first attempt just put in a cache, which is the one
+  // thing these retries must not do.
+  const index = await fetch(`${host}/?verify=${Date.now()}`, {
+    headers: { 'cache-control': 'no-cache' },
+  })
+  if (!index.ok) return { ok: false, reason: `index answered ${index.status}` }
+
+  const html = await index.text()
+  const match = /_expo\/static\/js\/web\/entry-[a-z0-9]+\.js/.exec(html)
+  if (!match) return { ok: false, reason: 'index does not reference an entry bundle' }
+
+  const bundle = await fetch(`${host}/${match[0]}`)
+  const type = bundle.headers.get('content-type') ?? ''
+  if (!bundle.ok || !/javascript/.test(type)) {
+    return {
+      ok: false,
+      reason: `bundle ${match[0]} answered ${bundle.status} (${type}) — the edge is serving a stale index.html; purge app.langx.io in Cloudflare`,
+    }
+  }
+
+  return {
+    ok: true,
+    attempts,
+    bundle: match[0],
+    cacheStatus: index.headers.get('cf-cache-status') ?? 'n/a',
+  }
+}
 
 function fail(message) {
   console.error(`web deploy check FAILED: ${message}`)


### PR DESCRIPTION
`verify-web-deploy.mjs` failed two `Deploy web` runs on 7 September on a deploy
that was fine.

## What happens

The check runs about a second after `wrangler pages deploy` prints
"Deployment complete". Cloudflare has not finished moving the custom domain
onto the new deployment by then, so the edge still answers with the *previous*
`index.html` — whose fingerprinted bundle the new deployment has already
replaced. The bundle 404s:

    web deploy check FAILED: bundle _expo/static/js/web/entry-5e76a8b6….js
    answered 404 (text/html; charset=utf-8) — the edge is serving a stale
    index.html; purge app.langx.io in Cloudflare

Which is exactly the 5 September symptom the script exists to catch, and is
not it. Re-running could not fix it either: every re-run redeploys and reopens
the same window. The third attempt passed against the same commit once the
edge had settled — and app.langx.io was serving correctly throughout, verified
in a browser with zero console errors while the run was red.

## The change

Five attempts over about thirty seconds, then the original failure, unchanged.

The distinction that had to survive: **a stale index that clears within seconds
of a deploy is propagation; one still there half a minute later is the
incident.** So the window is bounded and the failure at the end of it is as
loud as before — this makes the check correct, not lenient.

Two details worth naming:

- **A fresh cache-buster per attempt.** The old code computed one
  `?verify=<ts>` up front. Reused across retries, a later attempt could be
  answered from whatever the first one just put in a cache, which is the one
  thing these retries must not do.
- **A run that needed more than one attempt says so** (`after 2 attempts`), so
  a rollout that is getting slower stays visible rather than hiding behind a
  green check.

No `--host` argument was added; the comment explaining why that is deliberate
still stands.

## Verification

Run against the live host, all three paths:

| Path | Result |
|---|---|
| Passes first try | `ok: … serves entry-4a52c790….js (200, cf-cache-status DYNAMIC)`, exit 0 — message identical to before |
| Persistent failure | four retries at 3s/6s/9s/12s, then the original message, exit 1, 31.5s total |
| Recovers on retry | `ok: … after 2 attempts`, exit 0 |

`prettier --check` passes. ESLint runs in CI (the scratch worktree used for the
live runs has no `node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)