### PR TITLE
tweak(plans): sending a translation moves to Polyglot

### DIFF
--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -186,7 +186,7 @@ export async function sendTextMessage(
       .collection<Profile>(COLLECTIONS.profiles)
       .findOne({ _id: senderId }, { projection: { entitlement: 1 } })
     if (!sender || !hasFeature(effectiveTier(sender), 'sendTranslation')) {
-      throw new ApiError(ERROR_CODES.UPGRADE_REQUIRED, 'Sending a translation requires Pro', {
+      throw new ApiError(ERROR_CODES.UPGRADE_REQUIRED, 'Sending a translation requires Pro+', {
         feature: 'sendTranslation',
       })
     }

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -313,7 +313,7 @@ export default function ChatScreen() {
    * the other way — their first native language with a written form.
    * `undefined` means there is none, and the row is not offered.
    */
-  /** Reading a translation is free; sending one is Fluent. See `PLAN_LIMITS`. */
+  /** Reading a translation is free; sending one is Polyglot. See `PLAN_LIMITS`. */
   const canSendTranslation = hasFeature(useEffectiveTier(), 'sendTranslation')
   const translateInto = partner
     ? translateTargetFor({ nativeLanguages: partner.nativeLanguages })

--- a/apps/mobile/app/(app)/paywall.tsx
+++ b/apps/mobile/app/(app)/paywall.tsx
@@ -120,10 +120,6 @@ const BENEFIT_COPY: Record<ProBenefit, BenefitCopy> = {
     title: 'paywall.advancedFilters',
     body: 'paywall.advancedFiltersBody',
   },
-  sendTranslation: {
-    title: 'paywall.sendTranslation',
-    body: 'paywall.sendTranslationBody',
-  },
   /*
    * Both of these are the *paid tier's* number, not the free one — unlike the
    * chat allowance above, which sells by naming the limit you are hitting.
@@ -161,6 +157,11 @@ const PRO_PLUS_BENEFIT_COPY: Record<ProPlusBenefit, BenefitCopy & { shipped: boo
   profileViewerIdentities: {
     title: 'paywall.whoViewed',
     body: 'paywall.whoViewedBody',
+    shipped: true,
+  },
+  sendTranslation: {
+    title: 'paywall.sendTranslation',
+    body: 'paywall.sendTranslationBody',
     shipped: true,
   },
   deckExport: {
@@ -211,7 +212,7 @@ const PRO_PLUS_BENEFIT_COPY: Record<ProPlusBenefit, BenefitCopy & { shipped: boo
  */
 const FEATURE_TITLE: Record<PlanFeature, MessageKey> = {
   advancedFilters: BENEFIT_COPY.advancedFilters.title,
-  sendTranslation: BENEFIT_COPY.sendTranslation.title,
+  sendTranslation: PRO_PLUS_BENEFIT_COPY.sendTranslation.title,
   deckExport: PRO_PLUS_BENEFIT_COPY.deckExport.title,
   profileViewerIdentities: PRO_PLUS_BENEFIT_COPY.profileViewerIdentities.title,
   incognito: PRO_PLUS_BENEFIT_COPY.incognito.title,

--- a/packages/shared/src/limits.ts
+++ b/packages/shared/src/limits.ts
@@ -76,13 +76,14 @@ export interface PlanLimits {
    * Sending your own message with a translation under it, rather than tapping
    * one you received to read it.
    *
-   * Paid for the one reason this file accepts: a real per-request cost.
-   * Reading is occasional and metered at `translationsPer24h`; *sending*
-   * translated is per message, so somebody writing a hundred messages a day
-   * bills roughly a hundred translations a day. At Google's per-character
-   * price that is more per month than a subscription costs, which makes a
-   * generous free allowance a promise made against somebody else's meter —
-   * the same sentence `translationsPer24h` is here for.
+   * Polyglot, beside the copilot, because the two are the same kind of thing:
+   * the only capabilities in this file with a real per-request cost. Reading
+   * is occasional and metered at `translationsPer24h`; *sending* translated is
+   * per message, so somebody writing a hundred messages a day bills roughly a
+   * hundred translations a day. At Google's per-character price that is more
+   * per month than a subscription costs, which makes a generous free
+   * allowance a promise made against somebody else's meter — the same
+   * sentence `translationsPer24h` is here for.
    *
    * **Reading stays free.** The free tier loses nothing it had: tap-to-
    * translate is untouched at 20 a day. This gates the composer mode only,
@@ -211,7 +212,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     correctionsPer24h: null,
     mediaPer24h: null,
     advancedFilters: true,
-    sendTranslation: true,
+    sendTranslation: false,
     deckExport: false,
     profileViewerIdentities: false,
     incognito: false,
@@ -296,7 +297,7 @@ export function quotaLimit(tier: PlanTier, kind: QuotaKind): Limit {
  * `403 UPGRADE_REQUIRED` payload. `hasFeature` reads these directly off
  * `PLAN_LIMITS`, so this list cannot drift from what the server enforces.
  */
-export const PRO_FEATURES = ['advancedFilters', 'sendTranslation'] as const
+export const PRO_FEATURES = ['advancedFilters'] as const
 export type ProFeature = (typeof PRO_FEATURES)[number]
 
 /**
@@ -311,6 +312,7 @@ export const PRO_PLUS_FEATURES = [
   'incognito',
   'nearby',
   'copilot',
+  'sendTranslation',
   'deckExport',
 ] as const
 export type ProPlusFeature = (typeof PRO_PLUS_FEATURES)[number]
@@ -335,7 +337,6 @@ export type PlanFeature = ProFeature | ProPlusFeature
 export const PRO_BENEFITS = [
   'unlimitedInitiations',
   'advancedFilters',
-  'sendTranslation',
   'translationQuota',
   'learningLanguages',
   /**
@@ -371,6 +372,7 @@ export const PRO_PLUS_BENEFITS = [
   'incognito',
   'nearby',
   'copilot',
+  'sendTranslation',
   'deckExport',
   'translationQuota',
   'learningLanguages',


### PR DESCRIPTION
Sending a translation shipped as Fluent in #1209. It belongs one tier up, beside the copilot: those two are the only capabilities in `PLAN_LIMITS` with a real per-request cost, and pricing them apart made the tier boundary arbitrary.

Reading a translation is untouched — free, 20 a day.

- `PRO_FEATURES` → `PRO_PLUS_FEATURES`, same for the benefits list
- `pro.sendTranslation: false`
- paywall moves the benefit card into the Polyglot block

🤖 Generated with [Claude Code](https://claude.com/claude-code)