### PR TITLE
feat(chat): the long-press menu speaks v3

### DIFF
--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -1017,6 +1017,12 @@ export default function ChatScreen() {
     const picked = await openMessageMenu({
       preview: message.body || t(messageTypeKey(message.type)),
       mine: isMine(message),
+      // Looked up rather than passed down: `endsGroup` belongs to the row, and
+      // a fourth positional argument on `onLongPress` is how the anchor and
+      // the flag start arriving in the wrong order.
+      tail: rows.some(
+        (row) => row.kind === 'message' && row.message._id === message._id && row.endsGroup,
+      ),
       actions,
       ...(anchor ? { anchor } : {}),
       // A withdrawn message cannot carry a reaction, so it gets no strip.

--- a/apps/mobile/src/components/MessageMenuHost.tsx
+++ b/apps/mobile/src/components/MessageMenuHost.tsx
@@ -6,7 +6,6 @@ import {
   Platform,
   Pressable,
   ScrollView,
-  StyleSheet,
   Text,
   useWindowDimensions,
   View,
@@ -68,20 +67,24 @@ export function MessageMenuHost() {
   const { actions, hasMore } = paginateActions(request.actions, page)
 
   // The rows on *this* page, plus whichever navigation row it carries. The
-  // anchored layout derives its height from this, and the hairline dividers
-  // need to know which row is last — the last one goes undivided, v3's rule.
+  // anchored layout derives its height from this, and the dividers need to
+  // know which row is last — the last one goes undivided, v3's rule.
   const rowCount = actions.length + (hasMore ? 1 : 0) + (page === 'more' ? 1 : 0)
   const rowOffset = page === 'more' ? 1 : 0
 
   /**
-   * The rows are shared between the two shapes but not their dress. The
-   * anchored menu keeps its compact rows — `ROW_HEIGHT` is derived from them —
-   * and the sheet takes v3's taller ones: every row under its own rule, the
-   * icon muted whatever the label says.
+   * The rows are one v3 row at two scales: the anchored menu's compact one —
+   * `ROW_HEIGHT` is derived from it — and the sheet's taller one, every row
+   * under its own rule. Everything else they share, including the rule the
+   * rest of the app follows: the icon is muted whatever the label says, and
+   * only the label carries the danger.
    */
   const anchored = request.anchor !== undefined
   const rowStyle = anchored ? styles.action : styles.sheetRow
   const labelStyle = anchored ? styles.label : styles.sheetLabel
+  // A fill under the popover's rounded row, the sheet's own fade under a row
+  // that spans the sheet — the way `AlertHost` presses its rows.
+  const pressedStyle = anchored ? styles.actionPressed : styles.sheetPressed
 
   const rows = (
     <>
@@ -93,7 +96,7 @@ export function MessageMenuHost() {
           style={({ pressed }) => [
             rowStyle,
             anchored && rowCount > 1 && styles.rowDivider,
-            pressed && styles.actionPressed,
+            pressed && pressedStyle,
           ]}
         >
           <Ionicons name="chevron-back" size={20} color={colors.textMuted} />
@@ -110,7 +113,7 @@ export function MessageMenuHost() {
           style={({ pressed }) => [
             rowStyle,
             anchored && rowOffset + index < rowCount - 1 && styles.rowDivider,
-            pressed && !action.disabled && styles.actionPressed,
+            pressed && !action.disabled && pressedStyle,
             action.disabled === true && styles.actionDisabled,
           ]}
         >
@@ -119,9 +122,20 @@ export function MessageMenuHost() {
             // and does not import them.
             name={action.icon as never}
             size={20}
-            color={anchored ? (action.destructive ? colors.danger : colors.text) : colors.textMuted}
+            color={colors.textMuted}
           />
-          <Text style={[labelStyle, action.destructive && styles.destructive]}>{action.label}</Text>
+          {/*
+            One line in the popover: `ROW_HEIGHT` is derived rather than
+            measured, so a label that wrapped — "Corrected — can't be edited",
+            and its longer translations — would put every row below it in the
+            wrong place. The sheet has the width to let it wrap.
+          */}
+          <Text
+            numberOfLines={anchored ? 1 : undefined}
+            style={[labelStyle, action.destructive && styles.destructive]}
+          >
+            {action.label}
+          </Text>
         </Pressable>
       ))}
 
@@ -129,7 +143,7 @@ export function MessageMenuHost() {
         <Pressable
           accessibilityRole="button"
           onPress={() => setPage('more')}
-          style={({ pressed }) => [rowStyle, pressed && styles.actionPressed]}
+          style={({ pressed }) => [rowStyle, pressed && pressedStyle]}
         >
           <Ionicons name="ellipsis-horizontal" size={20} color={colors.textMuted} />
           <Text style={[labelStyle, styles.muted]}>{t('messageMenu.more')}</Text>
@@ -272,12 +286,13 @@ export function MessageMenuHost() {
   )
 }
 
-/** Matches `action`'s padding and icon size below; the layout needs it up front. */
+/** `action`'s padding plus its tallest content — the label's pinned 22. The layout needs it up front. */
 const ROW_HEIGHT = 46
-/** The menu's own padding, top and bottom. */
-const MENU_CHROME = 16
-const MENU_WIDTH = 232
-const STRIP_HEIGHT = 54
+/** The menu's own padding, top and bottom, plus the outline on each. */
+const MENU_CHROME = 18
+/** Fits the longest label at 15 — Russian's "remove from starred", German's. */
+const MENU_WIDTH = 264
+const STRIP_HEIGHT = 56
 const STRIP_MAX_WIDTH = 336
 
 const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => ({
@@ -290,16 +305,21 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
     paddingVertical: spacing.md,
   },
   actionPressed: { backgroundColor: colors.fill },
+  sheetPressed: { opacity: 0.6 },
   actionDisabled: { opacity: 0.45 },
   /** Between rows only — the last row of a page goes undivided. */
-  rowDivider: { borderBottomColor: colors.border, borderBottomWidth: StyleSheet.hairlineWidth },
+  rowDivider: { borderBottomColor: colors.border, borderBottomWidth: 1 },
   muted: { color: colors.textMuted },
   backdrop: { backgroundColor: colors.scrim, flex: 1 },
   backdropBottom: { justifyContent: 'flex-end' },
   backdropCentred: { alignItems: 'center', justifyContent: 'center' },
   anchoredBackdrop: { backgroundColor: colors.scrim, flex: 1 },
   destructive: { color: colors.danger },
-  label: { ...font.body, color: colors.text },
+  /**
+   * v3's row type at the popover's scale: the sheet's 17 leaves no air in a
+   * 46px row. `lineHeight` is pinned because `ROW_HEIGHT` is derived from it.
+   */
+  label: { color: colors.text, flex: 1, fontSize: 15, fontWeight: '600', lineHeight: 22 },
   copyHero: { fontSize: 48, lineHeight: 58 },
   title: { ...font.heading, color: colors.text, marginBottom: 6 },
   // v3's sheet, as `AlertHost` draws it: the roundest corners in the app,
@@ -339,10 +359,14 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
   sheetLabel: { color: colors.text, flex: 1, fontSize: 17, fontWeight: '600' },
   foot: { marginTop: 18 },
   stripHolder: { position: 'absolute' },
+  // The pill the thread already draws reactions in: hairline outline over the
+  // quiet shadow, because in v3 a floating surface is bounded rather than lifted.
   strip: {
     ...cardShadow,
     backgroundColor: colors.bg,
+    borderColor: colors.border,
     borderRadius: radius.pill,
+    borderWidth: 1,
     flexGrow: 0,
   },
   stripInner: { alignItems: 'center', gap: 2, paddingHorizontal: 6, paddingVertical: 6 },
@@ -353,7 +377,8 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
     justifyContent: 'center',
     width: 42,
   },
-  emojiChosen: { backgroundColor: colors.fill },
+  // Blue carries everything chosen in v3; a grey fill would read as disabled.
+  emojiChosen: { backgroundColor: colors.accentBg },
   emojiGlyph: { fontSize: 24, lineHeight: 30 },
   copy: {
     borderRadius: 20,
@@ -364,12 +389,17 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
   // The lifted copy matches the v3 bubbles it stands in for.
   copyMine: { backgroundColor: colors.accentBg },
   copyTheirs: { backgroundColor: colors.fill },
-  copyText: { ...font.body, color: colors.text, lineHeight: 22 },
+  // 16 on 23, exactly `MessageBubble`'s: a copy that shrinks the text is a
+  // second bubble, not the one that was pressed.
+  copyText: { ...font.body, color: colors.text, fontSize: 16, lineHeight: 23 },
   copyTextMine: { color: colors.text },
+  // Outlined at the app's card radius, the way `AlertHost`'s card is drawn.
   menu: {
     ...cardShadow,
     backgroundColor: colors.bg,
-    borderRadius: radius.lg,
+    borderColor: colors.border,
+    borderRadius: radius.xl,
+    borderWidth: 1,
     paddingVertical: spacing.sm,
     position: 'absolute',
   },

--- a/apps/mobile/src/components/MessageMenuHost.tsx
+++ b/apps/mobile/src/components/MessageMenuHost.tsx
@@ -214,6 +214,7 @@ export function MessageMenuHost() {
             style={[
               styles.copy,
               request.mine ? styles.copyMine : styles.copyTheirs,
+              request.tail === true && (request.mine ? styles.copyTailMine : styles.copyTailTheirs),
               {
                 top: layout.bubble.top,
                 left: layout.bubble.left,
@@ -389,6 +390,9 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
   // The lifted copy matches the v3 bubbles it stands in for.
   copyMine: { backgroundColor: colors.accentBg },
   copyTheirs: { backgroundColor: colors.fill },
+  // And its squared corner, when the bubble that was pressed had one.
+  copyTailMine: { borderBottomEndRadius: 6 },
+  copyTailTheirs: { borderBottomStartRadius: 6 },
   // 16 on 23, exactly `MessageBubble`'s: a copy that shrinks the text is a
   // second bubble, not the one that was pressed.
   copyText: { ...font.body, color: colors.text, fontSize: 16, lineHeight: 23 },

--- a/apps/mobile/src/components/MessageMenuHost.tsx
+++ b/apps/mobile/src/components/MessageMenuHost.tsx
@@ -180,13 +180,21 @@ export function MessageMenuHost() {
      * that has to feel immediate, so the flip is decided before first paint.
      */
     const menuHeight = rowCount * ROW_HEIGHT + MENU_CHROME
-    const stripWidth = Math.min(STRIP_MAX_WIDTH, screen.width - 24)
+    /**
+     * The strip is as wide as the emoji it holds and no wider — a fixed width
+     * left a tail of empty pill after the last one. The screen still caps it,
+     * and past that the strip scrolls. A message that carries no strip — a
+     * withdrawn one — reserves nothing, rather than a band of empty air.
+     */
+    const stripWidth = request.reactions
+      ? Math.min(stripWidthFor(request.reactions.length), screen.width - 24)
+      : 0
     const layout = messageMenuLayout({
       anchor: request.anchor,
       screen: { width: screen.width, height: screen.height },
       insets: { top: insets.top, bottom: insets.bottom },
       menu: { width: MENU_WIDTH, height: menuHeight },
-      strip: { width: stripWidth, height: STRIP_HEIGHT },
+      strip: { width: stripWidth, height: request.reactions ? STRIP_HEIGHT : 0 },
       mine: request.mine,
       rtl: isRtl,
     })
@@ -293,8 +301,14 @@ const ROW_HEIGHT = 46
 const MENU_CHROME = 18
 /** Fits the longest label at 15 — Russian's "remove from starred", German's. */
 const MENU_WIDTH = 264
-const STRIP_HEIGHT = 56
-const STRIP_MAX_WIDTH = 336
+/** `emoji` and `stripInner`'s own numbers: a 42 cell, 2 between, 6 of padding and an outline each side. */
+const EMOJI_CELL = 42
+const EMOJI_GAP = 2
+const STRIP_CHROME = 14
+const STRIP_HEIGHT = EMOJI_CELL + STRIP_CHROME
+
+const stripWidthFor = (count: number): number =>
+  count * EMOJI_CELL + (count - 1) * EMOJI_GAP + STRIP_CHROME
 
 const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => ({
   action: {
@@ -370,13 +384,15 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
     borderWidth: 1,
     flexGrow: 0,
   },
-  stripInner: { alignItems: 'center', gap: 2, paddingHorizontal: 6, paddingVertical: 6 },
+  // The three numbers `stripWidthFor` counts with, so the pill it sizes and the
+  // cells it holds cannot drift apart.
+  stripInner: { alignItems: 'center', gap: EMOJI_GAP, paddingHorizontal: 6, paddingVertical: 6 },
   emoji: {
     alignItems: 'center',
     borderRadius: radius.pill,
-    height: 42,
+    height: EMOJI_CELL,
     justifyContent: 'center',
-    width: 42,
+    width: EMOJI_CELL,
   },
   // Blue carries everything chosen in v3; a grey fill would read as disabled.
   emojiChosen: { backgroundColor: colors.accentBg },

--- a/apps/mobile/src/lib/messageMenu.ts
+++ b/apps/mobile/src/lib/messageMenu.ts
@@ -24,6 +24,12 @@ export interface MessageMenuRequest {
   preview: string
   /** Tints the copy of the bubble the anchored layout draws. */
   mine: boolean
+  /**
+   * Whether the pressed bubble carried the tail corner — the squared one a
+   * run of messages gets on its last bubble. The lifted copy keeps it, or it
+   * is a different bubble from the one under the finger.
+   */
+  tail?: boolean
   actions: MessageAction[]
   /**
    * The measured bubble. Present means the menu is drawn against it; absent

--- a/apps/mobile/src/lib/messageMenuLayout.ts
+++ b/apps/mobile/src/lib/messageMenuLayout.ts
@@ -38,7 +38,12 @@ export interface MenuLayout {
 }
 
 const GUTTER = 12
-const GAP = 8
+/**
+ * Between the strip, the bubble and the menu. The bubble is being *lifted* out
+ * of the thread, and at 8 the menu read as glued to its underside rather than
+ * as a second surface — the same 12 the screen keeps at its edges.
+ */
+const GAP = 12
 
 /**
  * Where the strip, the bubble and the menu go once a bubble has been pressed.

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -334,14 +334,6 @@ export const sendCorrectionSchema = z.object({
 export type SendCorrectionInput = z.infer<typeof sendCorrectionSchema>
 
 /**
- * The reaction strip.
- *
- * Seven, because the row has to fit beside a `+` on the narrowest phone we
- * support, and because a longer strip stops being a glance and starts being a
- * decision. Plain 🔥 rather than WhatsApp's ❤️‍🔥: the flame is already the
- * streak's symbol in this app and reusing it here keeps one meaning per glyph.
- */
-/**
  * How long to wait for a socket ack before treating a send as failed.
  *
  * Without one, socket.io registers the ack with **no timer at all** and only
@@ -356,7 +348,21 @@ export type SendCorrectionInput = z.infer<typeof sendCorrectionSchema>
  */
 export const SOCKET_ACK_TIMEOUT_MS = 12_000
 
-export const MESSAGE_REACTIONS = ['👍', '❤️', '😂', '😮', '😢', '🙏', '🔥'] as const
+/**
+ * The reaction strip.
+ *
+ * Eight, which is what fills the pill edge to edge on a 390pt screen — the
+ * menu sizes the strip to this list, so any shorter one leaves empty pill
+ * after the last emoji. It is still short enough to be a glance rather than a
+ * decision, and on a narrower phone the strip scrolls rather than shrinking
+ * cells that are already only just tappable.
+ *
+ * Plain 🔥 rather than WhatsApp's ❤️‍🔥: the flame is already the streak's
+ * symbol in this app and reusing it here keeps one meaning per glyph. 👏 is
+ * the eighth because half of what is worth reacting to here is somebody
+ * getting a sentence right.
+ */
+export const MESSAGE_REACTIONS = ['👍', '❤️', '😂', '😮', '😢', '🙏', '🔥', '👏'] as const
 export type MessageReaction = (typeof MESSAGE_REACTIONS)[number]
 
 /**


### PR DESCRIPTION
The anchored long-press menu was the one surface in the app drawn in somebody else's language — a borderless white card on a soft shadow, ink-black icons, body-weight labels, a grey chip for the reaction you had already left. Held next to a thread of outlined pills and hairline rows it read as a patch from another app rather than as part of this one.

## What changed

**The menu takes the app's own vocabulary.** Outlined at the card radius over the quiet shadow, the way `AlertHost`'s card is drawn. The emoji strip is bounded like the reaction pill the thread already draws under a bubble. Icons are muted whatever the label says — the rule the sheet and the alert both already followed — with the danger left to the label alone. Rows take v3's 15/600 type, and the chosen emoji takes the accent tint, since blue is what carries a choice everywhere else in v3.

**The lifted copy is the bubble that was pressed.** Its text stops shrinking (16 on 23, exactly `MessageBubble`'s), and it keeps the squared tail corner when the bubble it stands for had one — otherwise holding your most recent message lifted a visibly different bubble out of the thread. `endsGroup` belongs to the row rather than the message, so the thread looks it up when it opens the menu instead of `onLongPress` growing a fourth positional argument.

**The strip fills its pill.** It was a fixed 336 wide however many emoji it held, leaving a tail of empty pill after the last one. It is now sized from the list it draws, capped by the screen; `MESSAGE_REACTIONS` gains an eighth, 👏, which fills the pill edge to edge on a 390pt screen. On a narrower phone the strip scrolls rather than shrinking cells that are only just tappable. A message with no strip at all — a withdrawn one — now reserves nothing instead of a band of empty air above it.

**More air around the lifted bubble.** The gap either side goes from 8 to 12, the same 12 the screen keeps at its edges; at 8 the menu read as glued to the bubble's underside rather than as a second surface under it.

Two knock-ons, both because the popover's height is derived rather than measured: the row label's line height is pinned and the anchored row is held to one line, so a long label — "Corrected — can't be edited" and its translations — can no longer wrap and put every row below it in the wrong place. The menu is wider (232 → 264) to make that ellipsis rare, and `MENU_CHROME`/`STRIP_HEIGHT` grow by the outlines they now carry.

## Checks

`pnpm -r typecheck`, `pnpm lint`, `prettier --check`, and the mobile (724) and shared (303) suites all pass locally. Verified visually as well as by tests: the menu was rendered in the Expo web build through a throwaway preview route and screenshotted in both schemes, before and after.

## Note for review

The reaction count's own note used to say "seven, because the row has to fit beside a `+` on the narrowest phone we support". There is no `+` in the strip today, so that clause has been rewritten around what the eighth emoji actually costs — a scroll on the narrowest phones. If a `+` is still planned, the eighth is the one to drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cu6CJNQE6vvNT5wjr5bgky

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu6CJNQE6vvNT5wjr5bgky)_