### PR TITLE
fix(chat): the long-press menu lifts the picture, not the word "Photo"

### DIFF
--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -3,6 +3,7 @@ import {
   canDeleteForEveryone,
   canEditMessage,
   translateTargetFor,
+  attachmentsOf,
   MAX_ATTACHMENTS,
   MAX_VIDEO_SECONDS,
   type Media,
@@ -78,7 +79,11 @@ import {
 import { errorCodeOf } from '../../../src/lib/errors'
 import { listState } from '../../../src/lib/listState'
 import { messageActionsFor } from '../../../src/lib/messageActions'
-import { openMessageMenu, type AnchorRect } from '../../../src/lib/messageMenu'
+import {
+  openMessageMenu,
+  type AnchorRect,
+  type MessageMenuRequest,
+} from '../../../src/lib/messageMenu'
 import { goBackTo, openProfile } from '../../../src/lib/navigation'
 import { openPaywall } from '../../../src/lib/paywall'
 import { pickMediaAssets, type PickSource } from '../../../src/lib/pickMediaAsset'
@@ -1021,6 +1026,7 @@ export default function ChatScreen() {
     alreadyTranslated: boolean,
     anchor?: AnchorRect,
   ): Promise<void> {
+    const picture = pictureOf(message)
     // Nothing left to act on: a withdrawn message is a placeholder, and the
     // one thing anyone might want — hiding it — is offered through the same
     // row, so it is still worth opening.
@@ -1042,6 +1048,9 @@ export default function ChatScreen() {
     const picked = await openMessageMenu({
       preview: message.body || t(messageTypeKey(message.type)),
       mine: isMine(message),
+      // So the menu lifts the picture out of the thread rather than the word
+      // "Photo". Audio is left out on purpose: see `MessageMenuRequest`.
+      ...(picture ? { picture, caption: message.body } : {}),
       // Looked up rather than passed down: `endsGroup` belongs to the row, and
       // a fourth positional argument on `onLongPress` is how the anchor and
       // the flag start arriving in the wrong order.
@@ -2004,6 +2013,22 @@ function TypingIndicator() {
       ))}
     </View>
   )
+}
+
+/**
+ * What the menu's copy of the bubble should draw, for the messages that draw a
+ * picture rather than a sentence.
+ *
+ * Audio is not one of them even though it carries an attachment: its bubble is
+ * a player, and the copy would mount a second one.
+ */
+function pictureOf(message: MessageDto): MessageMenuRequest['picture'] {
+  if (message.type === 'sticker') {
+    return message.sticker ? { kind: 'sticker', ...message.sticker } : undefined
+  }
+  if (message.type !== 'image' && message.type !== 'video') return undefined
+  const items = attachmentsOf(message)
+  return items.length > 0 ? { kind: 'media', items } : undefined
 }
 
 /** What the sheet shows above the actions when a message has no text. */

--- a/apps/mobile/src/components/MessageMenuHost.tsx
+++ b/apps/mobile/src/components/MessageMenuHost.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from '@expo/vector-icons'
+import { Image } from 'expo-image'
 import { isBigEmoji } from '../lib/singleEmoji'
 import { useEffect, useState } from 'react'
 import {
@@ -18,7 +19,9 @@ import {
   type MessageMenuRequest,
 } from '../lib/messageMenu'
 import { messageMenuLayout } from '../lib/messageMenuLayout'
+import { stickerAsset } from '../lib/stickerAssets'
 import { makeStyles, useTheme } from '../lib/theme'
+import { MediaGallery } from './MediaBubble'
 import { Button } from './ui/Button'
 import { useLocale, useT } from '../i18n'
 
@@ -173,6 +176,57 @@ export function MessageMenuHost() {
     </ScrollView>
   ) : null
 
+  /**
+   * What the lifted copy draws.
+   *
+   * A picture when the bubble drew one, and the same components the thread
+   * drew it with — a photo copied as a grey box with the word "Photo" in it is
+   * a caption standing where the message was. `videoMode="preview"` is the
+   * feed's still, muted frame: a copy is something to look at, not a second
+   * set of transport controls under the first.
+   */
+  const bare = request.picture?.kind === 'sticker'
+  const sticker =
+    request.picture?.kind === 'sticker'
+      ? stickerAsset(request.picture.packId, request.picture.stickerId)
+      : undefined
+
+  const copyText = (
+    /*
+      A message the thread shows as a hero has to look like one here too —
+      otherwise holding an emoji shrinks it, which reads as the menu having
+      replaced the message rather than lifted it.
+    */
+    <Text
+      style={[
+        styles.copyText,
+        request.mine && styles.copyTextMine,
+        isBigEmoji(request.preview) && styles.copyHero,
+      ]}
+      numberOfLines={6}
+    >
+      {request.preview}
+    </Text>
+  )
+
+  const copy =
+    request.picture?.kind === 'media' ? (
+      <>
+        <MediaGallery items={request.picture.items} mine={request.mine} videoMode="preview" />
+        {request.caption ? (
+          <Text style={[styles.copyText, styles.copyCaption]} numberOfLines={4}>
+            {request.caption}
+          </Text>
+        ) : null}
+      </>
+    ) : sticker ? (
+      <Image source={sticker} style={styles.copySticker} contentFit="contain" />
+    ) : (
+      // A pack this build does not carry falls back to the label, which is the
+      // same answer `MessageBubble` gives it.
+      copyText
+    )
+
   if (request.anchor) {
     /**
      * Heights are derived, not measured. Measuring after mounting means one
@@ -217,12 +271,18 @@ export function MessageMenuHost() {
             A copy of the bubble rather than the bubble itself: the real one is
             still in the list under the scrim, and lifting it out would mean
             re-mounting a row that owns a pan responder and a measurement.
+
+            A sticker takes no bubble around it, exactly as the thread draws
+            one: chrome around a sticker is what makes it look like a picture
+            somebody attached rather than a thing they said.
           */}
           <View
             style={[
-              styles.copy,
-              request.mine ? styles.copyMine : styles.copyTheirs,
-              request.tail === true && (request.mine ? styles.copyTailMine : styles.copyTailTheirs),
+              bare ? styles.copyBare : styles.copy,
+              bare ? null : request.mine ? styles.copyMine : styles.copyTheirs,
+              !bare &&
+                request.tail === true &&
+                (request.mine ? styles.copyTailMine : styles.copyTailTheirs),
               {
                 top: layout.bubble.top,
                 left: layout.bubble.left,
@@ -230,22 +290,7 @@ export function MessageMenuHost() {
               },
             ]}
           >
-            {/*
-              The menu draws its own copy of the bubble, so a message the thread
-              shows as a hero has to look like one here too — otherwise holding
-              an emoji shrinks it, which reads as the menu having replaced the
-              message rather than lifted it.
-            */}
-            <Text
-              style={[
-                styles.copyText,
-                request.mine && styles.copyTextMine,
-                isBigEmoji(request.preview) && styles.copyHero,
-              ]}
-              numberOfLines={6}
-            >
-              {request.preview}
-            </Text>
+            {copy}
           </View>
 
           <View
@@ -413,6 +458,11 @@ const useStyles = makeStyles(({ colors, font, spacing, radius, cardShadow }) => 
   // second bubble, not the one that was pressed.
   copyText: { ...font.body, color: colors.text, fontSize: 16, lineHeight: 23 },
   copyTextMine: { color: colors.text },
+  /** Under the picture, at the thread's own distance from it. */
+  copyCaption: { marginTop: spacing.xs },
+  /** `MessageBubble`'s sticker, and its lack of a bubble. */
+  copyBare: { position: 'absolute' },
+  copySticker: { height: 112, width: 112 },
   // Outlined at the app's card radius, the way `AlertHost`'s card is drawn.
   menu: {
     ...cardShadow,

--- a/apps/mobile/src/lib/messageMenu.ts
+++ b/apps/mobile/src/lib/messageMenu.ts
@@ -1,3 +1,4 @@
+import type { Media } from '@langx/shared'
 import type { MessageAction, MessageActionId } from './messageActions'
 
 /**
@@ -37,6 +38,21 @@ export interface MessageMenuRequest {
    * or a platform where the measurement failed — still gets.
    */
   anchor?: AnchorRect
+  /**
+   * What the pressed bubble drew, when it drew a picture rather than a
+   * sentence. Without it a photo is lifted out of the thread as a grey box
+   * with the word "Photo" in it — a description of the message standing where
+   * the message was.
+   *
+   * A voice note is deliberately not here. Its bubble is a player, and a copy
+   * of a player is a second player: a second `useAudioPlayer` on the same
+   * file, with its own play button, inside a menu. It keeps the label.
+   */
+  picture?:
+    | { kind: 'media'; items: readonly Media[] }
+    | { kind: 'sticker'; packId: string; stickerId: string }
+  /** The sentence under a picture, when the message carried one. */
+  caption?: string
   /** The emoji strip, when the message can carry a reaction. */
   reactions?: readonly string[]
   /** Which of them is already the viewer's, drawn selected. */


### PR DESCRIPTION
Follow-up to #1213, which left one case standing: the copy the menu lifts out of the thread could only draw text.

Holding a photo lifted a grey bubble with "Photo" written in it, and holding a sticker lifted a grey bubble at all — the thread draws a sticker with no bubble behind it, because chrome around one makes it look like a picture somebody attached rather than a thing they said. Both are a caption standing where the message was.

## What changed

`MessageMenuRequest` can now carry what the bubble drew — a `media` list or a sticker id — and the copy draws it with the same components the thread used: `MediaGallery` for a photo or a video, the bundled asset for a sticker, and the caption under the picture where the thread puts it. `videoMode="preview"` is the feed's still, muted, non-interactive frame: a copy is something to look at, not a second set of transport controls under the first.

The thread looks the picture up when it opens the menu (`pictureOf`), so nothing is added to `onLongPress`'s signature.

## What deliberately did not change

A voice note keeps its label. Its bubble *is* a player, so a faithful copy would mount a second `useAudioPlayer` on the same file, with its own play button, inside a menu — two players for one note is a worse answer than a word. The cards (phrase, meeting, quiz) keep theirs for the same reason in a smaller way: they are controls, not pictures.

## Checks

`pnpm -r typecheck`, `pnpm lint`, `prettier --check` and the mobile suite (728) pass. Verified visually as well: a photo message with a caption and a sticker message were rendered through the real host in the Expo web build and screenshotted — the photo lands inside the tinted bubble with its caption beneath it, the sticker lands bare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cu6CJNQE6vvNT5wjr5bgky

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu6CJNQE6vvNT5wjr5bgky)_