### PR TITLE
chore(release): the Play rollout is full, and says so in one place

### DIFF
--- a/apps/mobile/.eas/workflows/release.yml
+++ b/apps/mobile/.eas/workflows/release.yml
@@ -1,8 +1,9 @@
 # A store release: production builds for both platforms, then submission.
 #
 # Started by hand, on purpose. `production` auto-increments the build number
-# and `eas.json`'s submit profile opens Android at a 10% staged rollout; iOS
-# goes to App Store Connect for review. The iOS half needs a distribution
+# and `eas.json`'s submit profile releases Android to everyone at once
+# (`releaseStatus: completed`, no rollout key); iOS goes to App Store Connect
+# for review. The iOS half needs a distribution
 # certificate and an App Store Connect API key in EAS before it can run.
 name: Release
 on:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,7 @@ This is communication work, and it is part of the delivery:
 | **Minimum age**     | **16+** (was 18+ until September 2026; the Terms moved with it); age gate at sign-up, verified via `birthDate`                                                                                                                                                                                                                                                                                          |
 | **Licence**         | **BSD 3-Clause, public repo** — same as v1                                                                                                                                                                                                                                                                                                                                                              |
 | **Codebase**        | Written from scratch in langx2; the abandoned Expo rewrite used only as a screen/route reference                                                                                                                                                                                                                                                                                                        |
-| Release model       | Brownfield update — same bundle ID and package name, staged rollout                                                                                                                                                                                                                                                                                                                                     |
+| Release model       | Brownfield update — same bundle ID and package name; full release on Play, phased on iOS                                                                                                                                                                                                                                                                                                                |
 
 ## Open-source constraints
 
@@ -1055,10 +1055,10 @@ only thing that matters is preserving store identity.
 
 ### Releasing
 
-- **Play releases to everyone at once**, phased release on iOS. It was a 5–10%
-  staged rollout on Play until 4 September 2026 — see the release runbook for
-  what the stage was buying and what now has to be checked before the
-  submission instead of after it.
+- **Play releases to everyone at once**, phased release on iOS. There is no
+  staged rollout to widen — see the release runbook for what a stage would
+  have bought and what therefore has to be checked before the submission
+  rather than after it.
 - The existing keystore is imported into EAS; `versionCode`/`buildNumber` start
   **above 119**.
 - **App Privacy / Data Safety forms updated** — see

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -836,10 +836,11 @@ not needed again for any of them. What each step was, for a re-run:
 
 ## Release
 
-- **Play:** full release (`eas.json` sets `releaseStatus: completed`). It was a
-  10% staged rollout until 4 September 2026; Behic's call to release to
-  everyone at once. What the stage was buying is written below, and is now
-  bought by watching after the fact instead of before.
+- **Play:** full release, every time. `eas.json` sets
+  `releaseStatus: completed` and names no rollout, so a submission goes to
+  100% of users; there is no stage to widen afterwards and no Console step
+  after `eas submit`. What a stage would have bought is written below, and is
+  bought instead by watching after the fact.
 - **iOS:** phased release.
 - Watch crash-free sessions. The `minSdk` bump means some v1 devices will stop
   receiving updates — check the install base's OS distribution first so that is
@@ -850,9 +851,8 @@ not needed again for any of them. What each step was, for a re-run:
 Android's deadline was **31 May 2026 — already passed**. Expo SDK 57 / RN 0.86
 handle this, but any third-party native library that has not been rebuilt for
 16 KB pages will fail on newer devices. Verify with a real device or emulator
-image configured for 16 KB. This used to be gated behind the 10% stage; with a
-full release there is no stage to catch it, so it has to be checked on a device
-before the submission rather than after.
+image configured for 16 KB. A full release has no stage to catch it, so it has
+to be checked on a device before the submission rather than after.
 
 ## Location changes both privacy forms
 


### PR DESCRIPTION
`eas.json` has set `releaseStatus: completed` with no rollout key since 4 September 2026, so every submission already goes to 100% of users. Three places still described the 10% stage that preceded it:

- `apps/mobile/.eas/workflows/release.yml` claimed the submit profile "opens Android at a 10% staged rollout" — false, and the reason this keeps being reported as an open action item
- `docs/release-runbook.md` and `docs/architecture.md` carried the history as if the stage were still something to widen

They are removed rather than updated. What remains states the standing behaviour and the one consequence worth keeping: a full release has no stage to catch a bad build, so the 16 KB check belongs before the submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)