### PR TITLE
docs(release): both stores go to 100%, and iOS is no longer the exception

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,7 @@ This is communication work, and it is part of the delivery:
 | **Minimum age**     | **16+** (was 18+ until September 2026; the Terms moved with it); age gate at sign-up, verified via `birthDate`                                                                                                                                                                                                                                                                                          |
 | **Licence**         | **BSD 3-Clause, public repo** — same as v1                                                                                                                                                                                                                                                                                                                                                              |
 | **Codebase**        | Written from scratch in langx2; the abandoned Expo rewrite used only as a screen/route reference                                                                                                                                                                                                                                                                                                        |
-| Release model       | Brownfield update — same bundle ID and package name; full release on Play, phased on iOS                                                                                                                                                                                                                                                                                                                |
+| Release model       | Brownfield update — same bundle ID and package name; full release to everyone on both stores                                                                                                                                                                                                                                                                                                            |
 
 ## Open-source constraints
 
@@ -1055,10 +1055,10 @@ only thing that matters is preserving store identity.
 
 ### Releasing
 
-- **Play releases to everyone at once**, phased release on iOS. There is no
-  staged rollout to widen — see the release runbook for what a stage would
-  have bought and what therefore has to be checked before the submission
-  rather than after it.
+- **Both stores release to everyone at once.** No staged rollout on Play, no
+  phased release on iOS — see the release runbook for what a stage would have
+  bought and what therefore has to be checked before the submission rather
+  than after it.
 - The existing keystore is imported into EAS; `versionCode`/`buildNumber` start
   **above 119**.
 - **App Privacy / Data Safety forms updated** — see

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -836,12 +836,21 @@ not needed again for any of them. What each step was, for a re-run:
 
 ## Release
 
-- **Play:** full release, every time. `eas.json` sets
-  `releaseStatus: completed` and names no rollout, so a submission goes to
-  100% of users; there is no stage to widen afterwards and no Console step
-  after `eas submit`. What a stage would have bought is written below, and is
-  bought instead by watching after the fact.
-- **iOS:** phased release.
+**Both stores release to 100% of users, every time.** There is no stage to
+widen, on either platform, and no post-submission step to remember.
+
+- **Play:** `eas.json` sets `releaseStatus: completed` and names no rollout, so
+  a submission goes straight to everyone. Nothing to do in the Console after
+  `eas submit`.
+- **iOS:** the version page's **Phased Release for App Store Automatic
+  Updates** must read _Release update to all users immediately_. This is the
+  one that needs an eye: it is a per-version radio in App Store Connect, not a
+  repo setting, so it is checked when the version is prepared rather than
+  configured once.
+
+What a stage would have bought is written below, and is bought instead by
+watching after the fact.
+
 - Watch crash-free sessions. The `minSdk` bump means some v1 devices will stop
   receiving updates — check the install base's OS distribution first so that is
   a decision, not a surprise.


### PR DESCRIPTION
Play has released to everyone since 4 September 2026. iOS was still written down as a phased release, and 2.1's version page had already drifted to "release to all users immediately" without the docs noticing — the written model and the actual one disagreed.

Behic's call: 100% on both, always. The runbook states it once, at the top, instead of per platform.

The iOS half is the half that needs an eye, and the text now says so: phased release is a per-version radio in App Store Connect, not a repo setting, so it gets verified while the version is prepared. Play needs nothing — `releaseStatus: completed` in `eas.json` is the whole story.

Follows #1217, which removed the same drift on the Android side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)