### PR TITLE
Stop a meeting card printing the same clock twice

### DIFF
--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -419,9 +419,22 @@ export default function ChatScreen() {
    */
   function meetingTheirWhenFor(message: MessageDto): string {
     if (!message.meeting || !partner?.timezone) return ''
-    if (partner.timezone === me.data?.timezone) return ''
-    const at = clockFor(new Date(message.meeting.startsAt), partner.timezone)
-    return t('chat.meetingTheirTime', { time: at })
+    const at = new Date(message.meeting.startsAt)
+    const theirs = clockFor(at, partner.timezone)
+    /*
+     * Compared as drawn, not as named.
+     *
+     * Comparing the zone *identifiers* looked equivalent and is not: a reader
+     * whose own profile has no `timezone` falls back to the device, so the
+     * check ran against `undefined` and never matched — and the card drew
+     * "9:00 PM" over "9:00 PM theirs", which is the exact line this feature
+     * exists to avoid. Two zones can also differ by name and agree right now
+     * (`Europe/London` and `Africa/Abidjan` in winter), and that is the same
+     * useless line.
+     */
+    return theirs === clockFor(at, me.data?.timezone)
+      ? ''
+      : t('chat.meetingTheirTime', { time: theirs })
   }
 
   /**


### PR DESCRIPTION
Found on the simulator while verifying langx/langx#1214 on a real device.

The second clock is meant to be dropped when both people are in the same zone, and it was — by comparing the zone **identifiers**. That looked equivalent and is not.

A reader whose own profile carries no `timezone` falls back to the device, so the comparison ran against `undefined` and never matched. The card then drew:

```
Mon, Sep 7 at 9:00 PM
Mon, Sep 7 at 9:00 PM theirs
```

which is precisely the line the feature exists to avoid.

Comparing the two **rendered** clocks fixes that case and one it never covered: `Europe/London` and `Africa/Abidjan` are different names that agree all winter, and the line was as useless there.

`pnpm exec prettier --check`, mobile suite (728 tests) — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)