### PR TITLE
Bring the token messaging brief up to what shipped

### DIFF
--- a/docs/token-messaging-brief.md
+++ b/docs/token-messaging-brief.md
@@ -3,10 +3,12 @@
 For anyone writing public copy about the token: the marketing site, the
 litepaper at docs.langx.io, langx.io itself, and the store listings.
 
-The app and the website have to describe the same thing. Today they do not:
-the app calls it a non-transferable in-app point, and the website advertises
-**"Staking and Trading"** and a **"Future Marketplace"**. That gap is the whole
-reason this document exists.
+The app and the website have to describe the same thing. When this was written
+they did not: the app called it a non-transferable in-app point while the token
+website advertised **"Staking and Trading"** and a **"Future Marketplace"**.
+That gap is closed — what came off, and from where, is recorded below. The
+document stays because the rules that closed it are the rules for anything
+written next.
 
 ## What the token is
 
@@ -43,20 +45,28 @@ Call it **"LangX Token"**. Drop "Test Token" — v1 used that because the token
 was framed as a preview of something real, and there is nothing to preview any
 more. Keeping "test" would now be misleading in the opposite direction.
 
-## What must come off the site
+## What came off the site
 
-These are not stale phrasing, they are claims the product does not meet:
+These were not stale phrasing, they were claims the product does not meet. All
+of them are gone; the row stays so that nobody puts one back.
 
-| Currently on the site                | Status                                                                                       |
+| Claim                                | Status                                                                                       |
 | ------------------------------------ | -------------------------------------------------------------------------------------------- |
-| "Staking and Trading"                | **Remove.** Neither exists nor is planned.                                                   |
-| "Future Marketplace"                 | **Remove.** No marketplace is planned.                                                       |
-| crypto / exchange / withdraw framing | **Remove.** None of it applies.                                                              |
+| "Staking and Trading"                | **Removed.** Neither exists nor is planned.                                                  |
+| "Future Marketplace"                 | **Removed.** No marketplace is planned.                                                      |
+| crypto / exchange / withdraw framing | **Removed.** None of it applies.                                                             |
 | "Learn to Earn"                      | Keep only if it clearly means "earn points by learning". If it reads as earn-money, rewrite. |
 
-The litepaper needs an explicit note saying the on-chain design described in it
-**is not being built**. Leaving it up unqualified is worse than deleting it —
-it reads as a roadmap.
+token.langx.io now leads with "In-app points · No wallet · No trading · No
+cash". The litepaper carries the note this section asked for: `token/token.md`
+says the older version described wallets, staking, trading and an on-chain
+distribution layer and that none of it is being built, and `token/langx-nft.md`
+opens with the same. Leaving either up unqualified would have been worse than
+deleting it — it reads as a roadmap.
+
+One thing is not done: `SUMMARY.md` in the docs still lists a **Staking** page
+in its navigation, and `learn-2-earn/connect-wallet.md` is still there. A
+reviewer follows the nav, not the prose.
 
 ## Why this matters more than wording
 
@@ -82,7 +92,7 @@ that damages trust.
 - Keep a daily streak; hitting 7, 30, 100 and 365 days pays a bonus.
 - Weekly, monthly, yearly and all-time leaderboards.
 - Spend tokens on a **streak freeze** (rescues one missed day), on **filling in
-  a missed day** on your activity map (300 tokens, last 14 days, two a month),
+  a missed day** on your activity map (600 tokens, last 14 days, two a month),
   and on **cosmetic frames and titles** — ten of each, worn one at a time. That
   is the complete list of things to spend on, and it is complete on purpose: if
   tokens could buy a paid feature, farming tokens would become a substitute for


### PR DESCRIPTION
`docs/token-messaging-brief.md` opened by saying the app and the website describe the token differently, and listed three claims to get off the site. All of that is done, so the document was describing a gap that no longer exists — and it is the document anyone writing public copy is told to follow.

## What is now true

- **token.langx.io** leads with *"In-app points · No wallet · No trading · No cash"*. Staking, trading and the marketplace are gone from it.
- **The litepaper carries the note this brief asked for.** `token/token.md` says the older version described wallets, staking, trading and an on-chain distribution layer and that none of it is being built; `token/langx-nft.md` opens with the same.

So the intro moves to the past tense, and *"What must come off the site"* becomes *"What came off the site"*. The table stays rather than being deleted, so nobody puts one of those claims back.

## What is not done, and is now written down

`SUMMARY.md` still lists a **Staking** page in the docs navigation, and `learn-2-earn/connect-wallet.md` is still there. A reviewer follows the nav, not the prose — this is the same 3.1.5(b) exposure the brief is about, so it is recorded in the section rather than left for someone to notice.

## One number had drifted

Filling in a missed day is `TOKEN_RULES.sinks.dayRepair`, which is **600**. The brief said 300.

Every other figure was checked against the source and is correct: the 0–250 gift range, 14 days and two a month for the repair, ten frames and ten titles, Aurora's 365-day and 5,000-correction gate, the 1:100 legacy divisor, the referral figures (all quoted symbolically, which is why they did not rot), and *"about 700 tokens"* for a very active day — which is exactly the 200 message cap plus a 5% share of the 10,000 pool.

## Why this came up

langx.io mirrors `TOKEN_RULES` and I was reconciling it after `award.message` went 2 → 1. The website side is already merged (langx/website#159); this is the other half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
