### PR TITLE
Stop a recording at the ceiling instead of past it

### DIFF
--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -707,6 +707,23 @@ export default function ChatScreen() {
     setPendingMedia((items) => [...items, ...picked.media.slice(0, remaining)])
   }
 
+  /*
+   * The ceiling stops the recording, rather than letting it run past what the
+   * server will accept. `MAX_AUDIO_SECONDS` was a number the recorder computed
+   * and nobody read: a note could run to any length, and the refusal arrived
+   * after the bytes had been spoken and uploaded.
+   *
+   * It lands in the composer like any other, so the last thing that happens at
+   * the limit is a draft you can still listen to — not a message sent out from
+   * under you.
+   */
+  useEffect(() => {
+    if (!recorder.atLimit) return
+    void finishRecording()
+    // The flag alone, deliberately: `finishRecording` is re-made every render
+    // and listing it here would end a recording on every one of them.
+  }, [recorder.atLimit])
+
   async function toggleRecording(): Promise<void> {
     // Guarded at the microphone rather than at the send, because starting a
     // recording somebody is not allowed to send is a worse answer than not
@@ -726,6 +743,17 @@ export default function ChatScreen() {
       if (!started && recorder.error) void showAlert(t('chat.microphoneTitle'), recorder.error)
       return
     }
+    await finishRecording()
+  }
+
+  /**
+   * Stops and keeps what was said.
+   *
+   * Its own function because the ceiling reaches it too: the effect below ends
+   * a recording that has run to `MAX_AUDIO_SECONDS`, and what happens to those
+   * bytes must not depend on whether a person or the clock stopped it.
+   */
+  async function finishRecording(): Promise<void> {
     const recording = await recorder.stop()
     if (!recording) return
     /*

--- a/apps/mobile/src/components/AttachmentBar.tsx
+++ b/apps/mobile/src/components/AttachmentBar.tsx
@@ -1,5 +1,6 @@
 import Feather from '@expo/vector-icons/Feather'
 import { MAX_ATTACHMENTS, MAX_VIDEO_SECONDS } from '@langx/shared'
+import { useEffect } from 'react'
 import { Pressable, Text, View } from 'react-native'
 import { useT } from '../i18n'
 import { useVoiceRecorder } from '../hooks/useVoiceRecorder'
@@ -69,12 +70,29 @@ export function AttachmentBar({ pending, onPick, disabled }: AttachmentBarProps)
     if (picked.media.length > 0) onPick(picked.media.slice(0, remaining))
   }
 
+  /*
+   * The ceiling stops the recording rather than letting it run past what the
+   * server will accept — same rule as the chat composer, and for the same
+   * reason: the refusal used to arrive after the bytes had been spoken.
+   */
+  useEffect(() => {
+    if (!recorder.atLimit) return
+    void finishRecording()
+    // The flag alone, deliberately: `finishRecording` is re-made every render
+    // and listing it here would end a recording on every one of them.
+  }, [recorder.atLimit])
+
   async function toggleRecording(): Promise<void> {
     if (!recorder.isRecording) {
       const started = await recorder.start()
       if (!started && recorder.error) showToast(recorder.error)
       return
     }
+    await finishRecording()
+  }
+
+  /** Stops and keeps what was said, whether a person or the clock ended it. */
+  async function finishRecording(): Promise<void> {
     const recording = await recorder.stop()
     if (!recording) return
     onPick([{ kind: 'audio', ...recording }])

--- a/apps/mobile/src/hooks/useVoiceRecorder.ts
+++ b/apps/mobile/src/hooks/useVoiceRecorder.ts
@@ -100,7 +100,13 @@ export function useVoiceRecorder() {
   return {
     isRecording: state.isRecording,
     seconds,
-    atLimit: seconds >= MAX_AUDIO_SECONDS,
+    /*
+     * The recording in progress has reached the ceiling — not "the last one
+     * did". `isRecording` is part of the answer because the duration survives
+     * the stop, and a caller that stops on this flag would otherwise be told
+     * to stop again the moment it had.
+     */
+    atLimit: state.isRecording && seconds >= MAX_AUDIO_SECONDS,
     error,
     start,
     stop,


### PR DESCRIPTION
`useVoiceRecorder` computed `atLimit` and nobody read it, so a voice note could run to any length — past `MAX_AUDIO_SECONDS` (120) — and the refusal arrived after the bytes had been spoken and uploaded. Noticed while driving the simulator for #1220.

Two parts:

- `atLimit` now means *the recording in progress* has hit the ceiling. The duration survives the stop, so the old flag stayed true afterwards and a caller acting on it would have been told to stop again the moment it had.
- Both composers react to it through the same function a person's tap calls, so what happens to those bytes does not depend on who stopped the recording: in a thread the note lands in the composer as a draft you can still listen to (#1220), and on a post it joins the attachments.

No test: the hook reaches `expo-audio` and `react-native` at module scope, which mobile vitest cannot load, and pulling a one-line boolean into its own module to test it is not worth the indirection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)