### PR TITLE
fix(store): two mistranslations in the release notes

### DIFF
--- a/apps/mobile/fastlane/Fastfile
+++ b/apps/mobile/fastlane/Fastfile
@@ -17,8 +17,8 @@ default_platform(:ios)
 
 platform :ios do
   desc 'Put the store listing up: the localizations and their copy, then the screenshots'
-  # `fastlane store skip_metadata:true` re-runs just the screenshots, for when
-  # the copy is already up and only the images changed.
+  # `fastlane store skip_metadata:true` re-runs just the screenshots and
+  # `skip_screenshots:true` just the copy, for when only one of the two moved.
   lane :store do |options|
     app_store_connect_api_key(
       key_id: ENV.fetch('APP_STORE_CONNECT_API_KEY_KEY_ID'),
@@ -32,6 +32,7 @@ platform :ios do
     # this fills the draft version in, and a person presses the button.
     deliver(
       skip_metadata: options[:skip_metadata] || false,
+      skip_screenshots: options[:skip_screenshots] || false,
       force: true,
       submit_for_review: false,
       run_precheck_before_submit: false,

--- a/docs/store/listing.md
+++ b/docs/store/listing.md
@@ -455,8 +455,8 @@ does in the description.
 >
 > İki pakette çıkartmalar, her sohbet için.
 > Bir mesajdaki ifadeyi kaydet, kart olarak sakla.
-> Partnerine soru sor - kendi sorun, kendi şıkların, tek doğru cevap.
-> Buluşma öner, iki saatte birden gör, seninkinde ve onunkinde, bir saat önce hatırlatmayla.
+> Partnerine soru sor - sorusu senin, şıkları senin, tek doğru cevap.
+> Buluşma öner; hem senin saatinde hem onunkinde görünsün, bir saat önce hatırlatmayla.
 > Fotoğraf, video ve sesli not göndermek için daha hızlı bir ekran.
 >
 > Polyglot, kendi dilinde yazıp onun dilinde göndermeyi ve bir sohbette kaydettiğin ifadeleri Anki'de açılan bir dosya olarak dışa aktarmayı ekler.
@@ -471,8 +471,8 @@ does in the description.
 >
 > Stickers, en dos paquetes, para cualquier conversación.
 > Guarda una frase de un mensaje y consérvala como tarjeta.
-> Propón un cuestionario a tu compañero: tu pregunta, tus opciones, una respuesta correcta.
-> Propón una quedada y velá en los dos relojes, el tuyo y el suyo, con un recordatorio una hora antes.
+> Plantea un cuestionario a tu compañero: tu pregunta, tus opciones, una respuesta correcta.
+> Propón un encuentro y lo verás en los dos relojes, el tuyo y el suyo, con un recordatorio una hora antes.
 > Un panel más rápido para enviar fotos, vídeo y notas de voz.
 >
 > Polyglot añade escribir en tu idioma y enviar en el suyo, y exportar las frases guardadas de una conversación como archivo que se abre en Anki.


### PR DESCRIPTION
Found by reading the eight languages back after they were already live on the 2.1 draft, not by anyone reporting them.

**Turkish** — `iki saatte birden gör` reads as *see it in two hours at once*. The line is about a proposed meeting appearing in both people's clocks. Now `hem senin saatinde hem onunkinde görünsün`.

And `kendi sorun` collides with `sorun` = *problem*. `sorusu senin, şıkları senin` says the same thing with one reading.

**Spanish** — `velá` is not a form of *ver*. And `quedada` is Spain-only, while this localization is written to work in Mexico as well (see the note in `collect-store-screenshots.mjs` about why there is one Spanish and not two), so the meeting is `un encuentro`. While there, the two consecutive lines that both opened with `Propón` now don't.

Also adds `fastlane store skip_screenshots:true`, so a copy-only fix goes up without re-sending 192 images.

## What this is not

The other six languages read clean **to me**. That is not the same as having been read by someone who speaks them, and the listing should still get that before 2.1 is submitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)