### PR TITLE
Two comments still counting the old message rate

### DIFF
--- a/docs/v1-reference.md
+++ b/docs/v1-reference.md
@@ -118,7 +118,7 @@ that migrating balances would put money-bought currency into a system where
 | zero                          | 266       | zero                   | 0     |
 
 For scale: a very active day in v2 is about **700 tokens** (a 500 tokens ceiling on the
-daily pool share, plus the 100-message cap at 2 tokens each).
+daily pool share, plus the 200-message cap at 1 token each).
 
 ### Decided — a token converts to earned tokens, divided by 100
 

--- a/packages/shared/src/token.ts
+++ b/packages/shared/src/token.ts
@@ -132,7 +132,8 @@ export interface TokenRules {
   caps: {
     /**
      * Max messages that pay per **UTC** day. This counts messages, not
-     * tokens — the 101st message of the day awards nothing.
+     * tokens — at the current rate they happen to be the same number, but the
+     * cap is on rows: the 201st message of the day awards nothing.
      *
      * Deliberately UTC, unlike the streak. A cap is a ceiling on ledger rows,
      * and ledger rows are bucketed by UTC day/week/month; if the cap reset on


### PR DESCRIPTION
`award.message` went 2 → 1 and `messagesPerDay` 100 → 200. Both numbers moved;
two sentences about them did not.

- `TOKEN_RULES.caps.messagesPerDay` explains that the cap counts messages
  rather than tokens, and used "the 101st message" to make the point. At 200
  it is the 201st — and the example is weaker now that the two numbers
  coincide, so the comment says why it is still a cap on ledger rows.
- `docs/v1-reference.md` reaches the right total by the wrong route: a very
  active day is still ~700 tokens, but that is 500 from the pool plus 200
  messages at 1 each, not 100 at 2.

Comments and prose only — no behaviour, no values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)