### PR TITLE
Stamp every event with which LangX it came from

### DIFF
--- a/apps/mobile/src/lib/analytics.ts
+++ b/apps/mobile/src/lib/analytics.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native'
 import { createAnalyticsCore, type AnalyticsClient } from './analyticsCore'
 import { FLAG_KEYS, readBoolFlag, setBoolFlag } from './localFlags'
+import { stampSurface, surfaceName } from './analyticsEvents'
 
 /**
  * The app's whole surface onto PostHog.
@@ -27,6 +28,9 @@ import { FLAG_KEYS, readBoolFlag, setBoolFlag } from './localFlags'
  */
 
 const DEFAULT_HOST = 'https://eu.i.posthog.com'
+
+/** Which LangX this build is, stamped on every event. See `analyticsEvents.ts`. */
+const SURFACE = surfaceName(Platform.OS)
 
 function apiKey(): string | null {
   return process.env.EXPO_PUBLIC_POSTHOG_KEY || null
@@ -78,6 +82,9 @@ async function loadClient(): Promise<AnalyticsClient | null> {
       // only way to count an install that never reached a screen of ours.
       captureAppLifecycleEvents: true,
       persistence: 'file',
+      // Set here rather than through `register()` so the lifecycle events
+      // captured during construction carry it too.
+      before_send: (event) => stampSurface(event, SURFACE),
       ...(Platform.OS === 'web' ? { customStorage: webStorage } : {}),
       // Nothing here uses flags, surveys or remote config yet; each is a
       // request on boot, on a phone, for an answer nothing reads.

--- a/apps/mobile/src/lib/analyticsEvents.ts
+++ b/apps/mobile/src/lib/analyticsEvents.ts
@@ -127,3 +127,42 @@ export function sanitizeEventProperties(
   }
   return clean
 }
+
+/**
+ * Which LangX an event came from, stamped on every event the SDK sends.
+ *
+ * PostHog's free plan allows one project, so langx.io and token.langx.io write
+ * into this one too — their own `analytics` modules stamp `'website'` and
+ * `'token-website'` the same way. Without this the app's insights silently
+ * include marketing page views.
+ *
+ * `$os_name` already separates iOS from Android, but not the Expo web build:
+ * there it reports the browser's operating system, so app.langx.io would read
+ * as macOS or Windows rather than as us. Naming the three ourselves is one
+ * property to filter on instead of two to reason about.
+ *
+ * It does not remove the need for an `is not set` filter on the dashboards that
+ * already exist: every event captured before this shipped, and every event from
+ * a build already on a phone, carries no `langx_surface` at all.
+ *
+ * Lives here rather than in `analytics.ts` for the reason `analyticsCore.ts`
+ * does — that file imports React Native, and a test cannot.
+ */
+export function surfaceName(platformOS: string): string {
+  return `app-${platformOS}`
+}
+
+/**
+ * Stamps one outgoing event with its surface, for the SDK's `before_send`.
+ *
+ * The trap it exists for: `properties` is optional on the SDK's `CaptureEvent`,
+ * so a lifecycle event can arrive without one and assigning into it would
+ * throw. `null` passes through because `before_send` may be handed one.
+ */
+export function stampSurface<T extends { properties?: Record<string, unknown> } | null>(
+  event: T,
+  surface: string,
+): T {
+  if (event) event.properties = { ...event.properties, langx_surface: surface }
+  return event
+}

--- a/apps/mobile/src/lib/analyticsSurface.test.ts
+++ b/apps/mobile/src/lib/analyticsSurface.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { stampSurface, surfaceName } from './analyticsEvents'
+
+describe('surfaceName', () => {
+  it('names every platform as an app build, never as a website', () => {
+    // The website repositories stamp 'website' and 'token-website' into this
+    // same PostHog project; nothing here may collide with those.
+    expect(surfaceName('ios')).toBe('app-ios')
+    expect(surfaceName('android')).toBe('app-android')
+    expect(surfaceName('web')).toBe('app-web')
+  })
+})
+
+describe('stampSurface', () => {
+  it('adds the surface without dropping the properties already there', () => {
+    const event = { event: 'message_sent', properties: { kind: 'text' } }
+    expect(stampSurface(event, 'app-ios').properties).toEqual({
+      kind: 'text',
+      langx_surface: 'app-ios',
+    })
+  })
+
+  it('builds a properties object when the event arrived without one', () => {
+    // The trap this function exists for: `properties` is optional on the SDK's
+    // CaptureEvent, so assigning into it would throw on a lifecycle event.
+    const event: { event: string; properties?: Record<string, unknown> } = {
+      event: 'Application Opened',
+    }
+    expect(stampSurface(event, 'app-android').properties).toEqual({
+      langx_surface: 'app-android',
+    })
+  })
+
+  it('passes null through, because before_send may be handed one', () => {
+    expect(stampSurface(null, 'app-web')).toBeNull()
+  })
+})


### PR DESCRIPTION
PostHog's free plan allows one project, so langx.io and token.langx.io now write into the app's ([langx/website#161](https://github.com/langx/website/pull/161), [langx/token-website#23](https://github.com/langx/token-website/pull/23)). Those stamp `'website'` and `'token-website'`; this is the other side, so an insight can say which surface it is counting instead of quietly mixing marketing page views into app metrics.

## Each platform is named, not lumped together

`app-ios`, `app-android`, `app-web`.

`$os_name` already separates iOS from Android — it is hardcoded to `'Android'` on Android and comes from `expo-device` on iOS, and `expo-device` is installed here. What it does **not** separate is the Expo web build: `getPlatformOS()` is `'web'`, so the SDK falls through to the browser's operating system and app.langx.io reads as macOS or Windows rather than as us. One property to filter on beats two to reason about.

## Two implementation notes

**`before_send`, not `register()`.** `captureAppLifecycleEvents: true` fires Application Installed / Opened while the client is still being constructed, and a super property set on the following line would miss them. `before_send` is a `PostHogCoreOptions` field (`@posthog/core` 1.50.3) and is passed to the constructor, so it catches those too.

**`properties` is optional on this SDK's `CaptureEvent`** — unlike posthog-js, where it is required. A lifecycle event can arrive without one, so assigning into it would throw. The function rebuilds the object; a test holds that specific case.

The pure part lives in `analyticsEvents.ts` rather than beside the client, for the same reason `analyticsCore.ts` exists: `analytics.ts` imports React Native and vitest cannot parse its Flow syntax. I found that out by writing the test in the wrong place first.

## Verification

`pnpm typecheck` clean; `pnpm test` green across the monorepo — mobile 736 passed (4 new), api 977 passed. eslint and prettier clean.

## This does not replace the dashboard filter

Every event captured before this ships, and every event from a build already on someone's phone, carries no `langx_surface` at all. The app's existing dashboards still need `langx_surface is not set` to exclude web traffic; this only makes the taxonomy positive going forward.

## Privacy

Nothing about what the app collects changes. The value is a constant naming the build, carries nothing about the person using it, and is strictly less than the `$os_name` and `$device_type` the SDK already sends — so `docs/store/privacy-data-safety.md`, the store forms, and §2.4 of the privacy policy are unaffected. The three declarations in `analytics.ts` (`disableGeoip`, `enableSessionReplay`, the identify id) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)