### PR TITLE
chore: follow branding's move to 2.x and brand/

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -183,7 +183,7 @@ const config: ExpoConfig = {
   runtimeVersion: { policy: 'fingerprint' },
 
   /**
-   * The brand mark, from `branding/app-resources`. There was no `icon` at all
+   * The brand mark, from `branding/brand/icon/`. There was no `icon` at all
    * before this, which is to say every build shipped Expo's default.
    */
   icon: './assets/icons/default.png',

--- a/apps/mobile/scripts/collect-store-screenshots.mjs
+++ b/apps/mobile/scripts/collect-store-screenshots.mjs
@@ -35,9 +35,9 @@ const MOBILE = path.resolve(HERE, '..')
  */
 function brandingRoot() {
   const root = path.resolve(HERE, '..', process.env.BRANDING_DIR ?? '../../../branding')
-  if (!fs.existsSync(path.join(root, '2.0.x'))) {
+  if (!fs.existsSync(path.join(root, '2.x'))) {
     console.error(
-      `No 2.0.x in ${root}. Check out langx/branding next to this repo, or set BRANDING_DIR.`,
+      `No 2.x in ${root}. Check out langx/branding next to this repo, or set BRANDING_DIR.`,
     )
     process.exit(1)
   }
@@ -83,7 +83,7 @@ for (const [ours, apple] of Object.entries(LOCALES)) {
   const dir = path.join(OUT, apple)
   fs.mkdirSync(dir, { recursive: true })
   for (const slot of SLOTS) {
-    const from = path.join(BRANDING, '2.0.x', ours, 'ios', slot)
+    const from = path.join(BRANDING, '2.x', ours, 'ios', slot)
     if (!fs.existsSync(from)) {
       console.error(`Missing ${from}`)
       process.exit(1)

--- a/docs/insight.md
+++ b/docs/insight.md
@@ -48,7 +48,7 @@ behind it, and would inflate all of them.
 | Routes  | `apps/api/src/routes/public.ts`, beside the newsletter form and the token board |
 
 The three images are **downscales of `langx/branding`**, not new artwork:
-`app-resources/v2/brand/lockup-horizontal.png` and its dark twin at 128px tall,
+`brand/logo/lockup-horizontal.png` and its dark twin at 128px tall,
 and `logo-rounded.png` at 64² for the favicon. The masters are 1024px tall and
 about 145KB each, which is the right size for a store listing and the wrong one
 for a logo drawn thirty pixels high. They are copies kept by hand like every

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -500,8 +500,8 @@ a rank, so gold has to read as something bought rather than as the product.
       `website/static/images/features/`, which still show v1's UI
 - [ ] Re-shoot the store screenshots in the new identity. `branding/` is now a
       repo to work in and most of this is done there: `BRAND.md` is the v3
-      identity written down, `app-resources/v2/` carries the icons and splash
-      badges this app ships, and `2.0.x/` holds a full uploadable set — eight
+      identity written down, `brand/` carries the icons and splash
+      badges this app ships, and `2.x/` holds a full uploadable set — eight
       shots at each of the four slots App Store Connect takes an upload for, in
       all eight languages, plus the feature graphics. What is still open is
       that the screen inside each shot is rendered from the site's phone
@@ -521,7 +521,7 @@ node apps/mobile/scripts/collect-store-screenshots.mjs
 cd apps/mobile && fastlane deliver --skip_binary_upload --skip_metadata
 ```
 
-The first command lays `branding/2.0.x/<locale>/ios/<slot>/` out the way
+The first command lays `branding/2.x/<locale>/ios/<slot>/` out the way
 `deliver` expects — one flat folder per App Store locale, device inferred from
 each image's own dimensions, order taken from the filename. Its output is
 generated and gitignored; the images live in `branding`.

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -73,11 +73,11 @@ that repo means reconnecting the Pages project in the dashboard first.
 | `packages/shared/src/cosmetics.ts`             | `website/src/lib/data/token.ts`                              |
 | `docs/store/listing.md`                        | `website/src/lib/data/meta.ts`                               |
 | `packages/shared/src/token.ts`, `cosmetics.ts` | the numbers on token.langx.io and the token pages in `docs/` |
-| `apps/mobile/assets/`                          | `branding/app-resources/v2/` — the same bytes, copied        |
+| `apps/mobile/assets/`                          | `branding/brand/` — the same bytes, copied                   |
 | `apps/mobile/src/lib/theme/tokens.ts`          | `branding/BRAND.md` — the palette, the type and the scales   |
 | `apps/mobile/src/lib/theme/tokens.ts`          | `website/DESIGN.md` and `website/src/lib/scss/_themes.scss`  |
 
-Two run the other way. `branding/app-resources/v2/brand/` is the source of the
+Two run the other way. `branding/brand/logo/` is the source of the
 lockup and the favicon that the public stats page draws, downscaled into
 `apps/api/assets/` (see [`insight.md`](insight.md)); a redrawn lockup leaves
 those copies stale with nothing to say so.


### PR DESCRIPTION
[`langx/branding`](https://github.com/langx/branding) was reorganised in [langx/branding#6](https://github.com/langx/branding/pull/6): store artwork is now one folder for the whole 2.x line rather than a folder per release, and the current identity moved into `brand/` — icons at `brand/icon/`, splash badges at `brand/splash/`, the lockup and rounded mark at `brand/logo/`.

## The one that is not documentation

`apps/mobile/scripts/collect-store-screenshots.mjs` reads that folder by path and was broken by the rename — it exits on a missing `2.0.x` before copying anything, so `fastlane deliver` has nothing to send.

Verified by running it against the reorganised checkout:

```
en-US: 24 screenshots
tr: 24 screenshots
…
192 files in apps/mobile/fastlane/screenshots
```

## The rest

Paths in prose, pointing at folders that no longer exist:

| File | Was | Now |
| ---- | --- | --- |
| `apps/mobile/app.config.ts` | `branding/app-resources` | `branding/brand/icon/` |
| `docs/release-runbook.md` | `app-resources/v2/`, `branding/2.0.x/` | `brand/`, `branding/2.x/` |
| `docs/repo-map.md` | `branding/app-resources/v2/`, `…/v2/brand/` | `branding/brand/`, `branding/brand/logo/` |
| `docs/insight.md` | `app-resources/v2/brand/lockup-horizontal.png` | `brand/logo/lockup-horizontal.png` |

Paths only. No behaviour changes, and nothing adjacent touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8VdzBB7g4Q8PV7d41pCjf

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8VdzBB7g4Q8PV7d41pCjf)_