### PR TITLE
fix(insight): redirect the stats site's root from the route

### DIFF
--- a/apps/api/src/routes/public.test.ts
+++ b/apps/api/src/routes/public.test.ts
@@ -152,6 +152,27 @@ describe('the routes anybody can call', () => {
     })
   })
 
+  describe('the bare hostname of the stats site', () => {
+    it('sends the root of insight.* to the page', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/',
+        headers: { host: 'insight.langx.io' },
+      })
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/public/insight')
+    })
+
+    it('leaves every other host the root it had', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/',
+        headers: { host: 'api.langx.io' },
+      })
+      expect(response.statusCode).toBe(404)
+    })
+  })
+
   describe('the public stats page', () => {
     beforeEach(() => {
       resetPublicStatsCache()

--- a/apps/api/src/routes/public.ts
+++ b/apps/api/src/routes/public.ts
@@ -102,6 +102,26 @@ export const publicRoutes: FastifyPluginAsyncZod = async (app) => {
   )
 
   /**
+   * The bare hostname of the stats site.
+   *
+   * `insight.langx.io` is this same process, so without this its root answers
+   * with the API's 404 body — the page is at `/public/insight` and nothing
+   * sends anyone there. Cloudflare can redirect it too, and that is one more
+   * setting kept by hand in a dashboard nobody can read from here; doing it in
+   * the route means the behaviour ships with the page and a test holds it.
+   *
+   * Matched on the first label rather than the whole name, so a self-hosted
+   * instance gets the same behaviour without this file naming a domain. Every
+   * other host keeps the root it had: `api.langx.io/` is not a page.
+   */
+  app.get('/', async (request, reply) => {
+    if (request.hostname.split('.')[0] !== 'insight') {
+      throw new ApiError(ERROR_CODES.NOT_FOUND, 'Route not found')
+    }
+    return reply.redirect('/public/insight', 301)
+  })
+
+  /**
    * The numbers behind `insight.langx.io`: how much language exchange is
    * happening, and in which languages. Aggregates only — see
    * `modules/insight/publicStats.ts` for what may be on this page and what

--- a/docs/insight.md
+++ b/docs/insight.md
@@ -69,19 +69,30 @@ nothing on a public page is worth a database pass per visitor.
 
 ## Pointing the domain at it
 
-Not in this repo, and not automated — the same kind of by-hand step as
-everything in [`repo-map.md`](repo-map.md):
+Two by-hand steps in two dashboards, the same kind as everything in
+[`repo-map.md`](repo-map.md). The root of the hostname is **not** one of them:
+`GET /` redirects to the page from `routes/public.ts` when the host's first
+label is `insight`, so a Cloudflare redirect rule is not needed and one less
+setting lives somewhere nobody can read from a checkout.
 
-1. **Fly**: `fly certs add insight.langx.io -a langx-api`, then add the
-   `_acme-challenge` record it prints.
-2. **Cloudflare DNS**: `insight` as a CNAME to `langx-api.fly.dev`, proxied —
-   copy whatever `api` has, since that hostname is already this Fly app behind
-   Cloudflare and is known to work.
-3. **Cloudflare redirect rule** (301): `insight.langx.io/` →
-   `/public/insight`. Without it the bare hostname answers with the API's 404
-   body, because `/` is not a route.
+1. **Cloudflare DNS**: `insight` as `A` and `AAAA` to the same Fly addresses
+   `api` already uses, proxied. Copying `api` rather than inventing a record is
+   the whole trick — that hostname is this Fly app behind Cloudflare and is
+   known to work, and the zone's SSL mode already suits it.
+2. **Fly**: `fly certs add insight.langx.io -a langx-api`, then
+   `fly certs show insight.langx.io -a langx-api` until it reads `Issued`.
 
-`api.langx.io/public/insight` keeps working either way; the domain is a nicer
+**The order of those two is a trap, and it cost an afternoon.** Behind
+Cloudflare's proxy, Fly cannot do HTTP validation — Cloudflare terminates the
+TLS the challenge would arrive over. Fly says so and asks for a
+`_fly-ownership` TXT record instead; `fly certs setup insight.langx.io` prints
+it, and a TXT record has no proxy setting to get wrong. Until the certificate
+is issued, Cloudflare has nothing to connect to on the origin leg and the
+hostname answers **525** — which reads like a mistake in the DNS and is not
+one. The alternatives are to add that TXT record, or to leave the record
+unproxied until the certificate is issued and turn the proxy on afterwards.
+
+`api.langx.io/public/insight` keeps working throughout; the domain is a nicer
 address for the same page, not a second deployment of it.
 
 ## Changing what is on it


### PR DESCRIPTION
`insight.langx.io/` answers with the API's 404 body. The page is at `/public/insight` and nothing sends anyone there, so the bare hostname — the one people will actually type, and the one the app's Our Kitchen row links to — is a dead end.

The plan in #1228 was a Cloudflare redirect rule. It works, and it is one more setting kept by hand in a dashboard no checkout can read, that no test covers and that the code it belongs to cannot explain. In practice it also did not fire, and from outside the dashboard there is no way to see why.

`GET /` now does it:

```
insight.langx.io/     → 301 /public/insight
insight.example.org/  → 301 /public/insight
api.langx.io/         → 404   (unchanged)
```

Matched on the host's **first label**, not the whole name, so this file names no domain and a self-hosted instance gets the same behaviour for free. Every other host keeps the root it had — `api.langx.io/` is not a page and should not start pretending to be one.

A Cloudflare rule can still exist alongside this; it would simply fire first. Nothing needs to be deleted, and nothing needs to be added.

## Docs

`docs/insight.md` loses the redirect-rule step and gains the one that actually cost time. Behind Cloudflare's proxy, Fly cannot do HTTP validation — Cloudflare terminates the TLS the ACME challenge would arrive over — so Fly asks for a `_fly-ownership` TXT record instead. Until the certificate is issued, Cloudflare has nothing to connect to on the origin leg and the hostname answers **525**, which reads like a DNS mistake and is not one. The DNS step is also rewritten to say what was actually done: `A`/`AAAA` copied from `api`, rather than the CNAME the first draft suggested.

## Verification

`pnpm -r typecheck`, `pnpm lint` and `pnpm format:check` pass. The four host cases above were driven through the real `publicRoutes` plugin and are the output quoted, and two of them are now tests in `routes/public.test.ts`. `/public/insight` still answers 200 with the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gxzfyLJ6PvLnPN2wd6Hyb

---
_Generated by [Claude Code](https://claude.ai/code/session_018gxzfyLJ6PvLnPN2wd6Hyb)_