### PR TITLE
fix(insight): explain a 403, and how to read the funnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -207,7 +207,11 @@ EXPO_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 # thing here that reads rather than writes. The key is a *personal* API key
 # (PostHog → Settings → Personal API keys), which can read everything the
 # account can, so it stays on the machine that runs the command and never
-# anywhere else. The project id is the number in the project's own URL.
+# anywhere else, and PostHog scopes them — this one needs read access to the
+# project. The project id is the number in that project's own URL.
+#
+# A key PostHog does not accept answers 403, not 401. A placeholder left in
+# this file is the usual reason, and the script says so.
 #
 # The region is `eu` or `us` rather than a host, and that is deliberate: the
 # API lives in exactly those two places, the host it resolves to is a literal

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -136,6 +136,26 @@ right-hand column of that document's table. The two variables it needs are in
 `.env.example`; the key is a **personal** API key, which reads everything the
 account can and therefore stays on one machine.
 
+### Two things about the funnel that look like bugs
+
+**It disagrees with `insight.langx.io`, and both are right.** The public page
+counts rows in our own database, all of them, since the beginning. The funnel
+is _ordered_ and _windowed_: a person is on step three only if they did steps
+one and two first, and all of it inside the window. Somebody who joined last
+year and wrote today is a message on the public page and nothing at all in the
+funnel. The two answer different questions and will never match — a message
+total far above the funnel's message step is the normal shape, not a fault.
+
+**It counts measured installs, not installs.** Only a build with
+`EXPO_PUBLIC_POSTHOG_KEY` sends anything, and anyone who turned the Settings
+switch off sends nothing after that. Development builds are invisible by
+design. So the top of the funnel is the population the SDK could see, and
+every rate below it is a rate within that population.
+
+Neither is worth writing a number down for: run the command, the numbers are
+current. What is worth writing down is that both of these look like broken
+instrumentation the first time, and neither is.
+
 ## Checking it works
 
 ```bash

--- a/scripts/insight.mjs
+++ b/scripts/insight.mjs
@@ -108,8 +108,8 @@ async function query(body) {
   if (!response.ok) {
     const detail = (await response.text()).slice(0, 400)
     const hint =
-      response.status === 401
-        ? '\nA 401 is the key: it must be a *personal* API key, not the project write key.'
+      response.status === 401 || response.status === 403
+        ? '\nThat is the key. PostHog answers 403, not 401, for one it does not accept,\nwhich is why this line exists. It must be a *personal* API key rather than\nthe project write key, it must still be live, and PostHog scopes them — this\none needs read access to the project it is asking about.'
         : response.status === 404
           ? `\nA 404 is the project id: ${PROJECT_ID} is not a project on ${HOST}. It is the\nnumber in the project's own URL, and the region may be the other one.`
           : ''


### PR DESCRIPTION
Two things the first real run of `pnpm insight` turned up.

## A 403 said nothing

`scripts/insight.mjs` explained a 401 and was silent about a 403 — which is the status PostHog actually answers for a personal API key it does not accept. The one line written to help a reader arrived exactly when it could not fire:

```
PostHog answered 403.

{"type":"authentication_error","code":"authentication_failed","detail":"Personal API key found in request Authorization header is invalid.","attr":null}
```

Both statuses now say the same thing, and it names the second way a real key still fails: PostHog scopes personal API keys, and this one needs read access to the project it is asking about. `.env.example` says so too, and warns that a placeholder left in `.env` is the usual cause.

## Two things about the funnel that look like bugs

Both were asked within a minute of the first run, and both will be asked again by whoever runs it next, so `docs/analytics.md` now answers them:

- **It disagrees with `insight.langx.io`, and both are right.** The public page counts every row in our own database since the beginning; the funnel is ordered and windowed. Somebody who joined last year and wrote today is a message on the public page and nothing at all in the funnel. A message total far above the funnel's message step is the normal shape of that, not a fault.
- **It counts measured installs, not installs.** Only a build with `EXPO_PUBLIC_POSTHOG_KEY` sends anything, and anyone who turned the Settings switch off sends nothing after that. Every rate below the top is a rate within that population.

**The figures themselves are deliberately not written down.** This repository is public and `docs/decisions.md` is explicit that conversion may never be published — small pre-release numbers next to a paywall most of all. They are one command away and current; the reading of them is the part that would have been forgotten.

## Verification

The 403 was reproduced against a local server answering with PostHog's own body, then the same run with the hint printing. `pnpm lint` and `pnpm format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gxzfyLJ6PvLnPN2wd6Hyb