### PR TITLE
Redesign the transactional and notification email shell

### DIFF
--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -2,16 +2,30 @@ import { webUrl, type Locale } from '@langx/shared'
 import { translator } from '../i18n'
 
 /**
+ * The langx.io mark: two interlocking hooks, one in the brand yellow and one
+ * in ink, next to the wordmark set in the same weight the site uses for it —
+ * `website/src/lib/components/atoms/Logo.svelte`, so mail doesn't teach a
+ * different logo than the site does. `currentColor` becomes a hard-coded ink
+ * here — an email has no CSS custom property support to inherit it from.
+ */
+function logo(dir: 'ltr' | 'rtl'): string {
+  const gap = dir === 'rtl' ? 'margin-left' : 'margin-right'
+  return `<span style="font-size:20px; font-weight:800; letter-spacing:-0.02em; color:#111827;">
+    <svg width="15" height="22" viewBox="0 0 14.6 21.544" xmlns="http://www.w3.org/2000/svg" style="vertical-align:middle; ${gap}:8px;">
+      <path fill="#ffc409" d="m0 14.076 1.715-1.188s2.307 3.177 5.641 1.188a4.088 4.088 0 0 0 1.656-1.875 4.757 4.757 0 0 0-.311-3.842l1.817-1.115s2.745 4.625-1.305 8.207a6.717 6.717 0 0 1-5.509 1.239A6.3 6.3 0 0 1 0 14.076Z" />
+      <path fill="#111827" d="m14.539 4.475-1.712 1.2s-2.252-3.189-5.588-1.2A4.123 4.123 0 0 0 5.618 6.41a4.751 4.751 0 0 0 .221 3.783l-1.654 1.145S1.319 6.776 5.369 3.193a6.685 6.685 0 0 1 5.47-1.316 6.3 6.3 0 0 1 3.7 2.598Z" />
+    </svg>LangX</span>`
+}
+
+/**
  * Plain HTML, no @react-email dependency — Resend's `react` option is only
  * needed if you hand it a component, and one extra rendering dependency buys
  * nothing for a handful of short transactional emails.
  *
  * Table-based rather than `<div>`s: Outlook's desktop renderer is Word, not a
  * browser, and a `<table>` is the one layout primitive it doesn't mangle. The
- * two brand colours are the same ones the app uses for the same jobs —
- * `primary` (#ffc409) is the one committing button, `accent` (#3b6cf6) is
- * everything else interactive — so mail doesn't teach a different palette
- * than the product does.
+ * button colour is the same the app uses for its one committing action
+ * (`primary`, #ffc409).
  */
 function shell(locale: Locale, preheader: string, contentHtml: string, footerHtml: string): string {
   // `dir` matters more here than anywhere in the app: an email client has no
@@ -26,7 +40,7 @@ function shell(locale: Locale, preheader: string, contentHtml: string, footerHtm
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px; margin:0 auto;">
       <tr>
         <td style="padding:0 4px 20px; text-align:${align};">
-          <span style="font-size:20px; font-weight:800; color:#111827;">Lang<span style="color:#3b6cf6;">X</span></span>
+          ${logo(dir)}
         </td>
       </tr>
       <tr>

--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -2,6 +2,17 @@ import { webUrl, type Locale } from '@langx/shared'
 import { translator } from '../i18n'
 
 /**
+ * The site's display voice — `--font--title` in `website/src/lib/scss/_variables.scss`,
+ * Nunito 800 for the logo and headings, 700 for buttons. The site self-hosts
+ * it via `@fontsource`; mail pulls the same family from Google Fonts instead,
+ * since there is no built asset to link to here. Gmail ignores web fonts
+ * entirely and falls back to the stack that follows, so this only shows up
+ * in Apple Mail, Outlook.com and the like — never a downgrade, just an
+ * upgrade some clients don't take.
+ */
+const TITLE_FONT = "'Nunito', -apple-system, 'Segoe UI', Roboto, system-ui, sans-serif"
+
+/**
  * The langx.io mark, next to the wordmark set in the same weight the site
  * uses for it. An `<img>` pointing at the site's own favicon rather than the
  * inline SVG the header uses on `website/src/lib/components/atoms/Logo.svelte`
@@ -12,7 +23,7 @@ import { translator } from '../i18n'
  */
 function logo(dir: 'ltr' | 'rtl'): string {
   const gap = dir === 'rtl' ? 'margin-left' : 'margin-right'
-  return `<span style="font-size:20px; font-weight:800; letter-spacing:-0.02em; color:#111827;">
+  return `<span style="font-family:${TITLE_FONT}; font-size:20px; font-weight:800; letter-spacing:-0.02em; color:#111827;">
     <img src="https://langx.io/favicons/favicon-32x32.png" width="20" height="20" alt="" style="vertical-align:middle; ${gap}:8px;" />LangX</span>`
 }
 
@@ -34,6 +45,10 @@ function shell(locale: Locale, preheader: string, contentHtml: string, footerHtm
   const align = dir === 'rtl' ? 'right' : 'left'
   return `<!doctype html>
 <html lang="${locale}" dir="${dir}">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800&display=swap" />
+  </head>
   <body style="margin:0; padding:32px 16px; background:#f4f5f7; font-family:-apple-system,'Segoe UI',Roboto,system-ui,sans-serif;">
     <span style="display:none; overflow:hidden; line-height:0; max-height:0; opacity:0;">${preheader}</span>
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px; margin:0 auto;">
@@ -58,7 +73,7 @@ function shell(locale: Locale, preheader: string, contentHtml: string, footerHtm
 }
 
 function button(url: string, label: string): string {
-  return `<a href="${url}" style="display:inline-block; background:#ffc409; color:#201900; text-decoration:none; padding:13px 22px; border-radius:10px; font-weight:700; font-size:15px;">${label}</a>`
+  return `<a href="${url}" style="display:inline-block; background:#ffc409; color:#201900; text-decoration:none; padding:13px 22px; border-radius:10px; font-family:${TITLE_FONT}; font-weight:700; font-size:15px;">${label}</a>`
 }
 
 /** The shell for mail answering something somebody just did — sign up, reset, delete. */

--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -2,19 +2,18 @@ import { webUrl, type Locale } from '@langx/shared'
 import { translator } from '../i18n'
 
 /**
- * The langx.io mark: two interlocking hooks, one in the brand yellow and one
- * in ink, next to the wordmark set in the same weight the site uses for it —
- * `website/src/lib/components/atoms/Logo.svelte`, so mail doesn't teach a
- * different logo than the site does. `currentColor` becomes a hard-coded ink
- * here — an email has no CSS custom property support to inherit it from.
+ * The langx.io mark, next to the wordmark set in the same weight the site
+ * uses for it. An `<img>` pointing at the site's own favicon rather than the
+ * inline SVG the header uses on `website/src/lib/components/atoms/Logo.svelte`
+ * — Gmail strips `<svg>` from mail bodies outright, and drops `data:` image
+ * sources too, so a hosted file is the only version that survives. The
+ * favicon is square where the site's mark is tall, but it is the same two
+ * hooks and it is already live, with no new asset to host.
  */
 function logo(dir: 'ltr' | 'rtl'): string {
   const gap = dir === 'rtl' ? 'margin-left' : 'margin-right'
   return `<span style="font-size:20px; font-weight:800; letter-spacing:-0.02em; color:#111827;">
-    <svg width="15" height="22" viewBox="0 0 14.6 21.544" xmlns="http://www.w3.org/2000/svg" style="vertical-align:middle; ${gap}:8px;">
-      <path fill="#ffc409" d="m0 14.076 1.715-1.188s2.307 3.177 5.641 1.188a4.088 4.088 0 0 0 1.656-1.875 4.757 4.757 0 0 0-.311-3.842l1.817-1.115s2.745 4.625-1.305 8.207a6.717 6.717 0 0 1-5.509 1.239A6.3 6.3 0 0 1 0 14.076Z" />
-      <path fill="#111827" d="m14.539 4.475-1.712 1.2s-2.252-3.189-5.588-1.2A4.123 4.123 0 0 0 5.618 6.41a4.751 4.751 0 0 0 .221 3.783l-1.654 1.145S1.319 6.776 5.369 3.193a6.685 6.685 0 0 1 5.47-1.316 6.3 6.3 0 0 1 3.7 2.598Z" />
-    </svg>LangX</span>`
+    <img src="https://langx.io/favicons/favicon-32x32.png" width="20" height="20" alt="" style="vertical-align:middle; ${gap}:8px;" />LangX</span>`
 }
 
 /**

--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -4,31 +4,54 @@ import { translator } from '../i18n'
 /**
  * Plain HTML, no @react-email dependency — Resend's `react` option is only
  * needed if you hand it a component, and one extra rendering dependency buys
- * nothing for two short transactional emails.
+ * nothing for a handful of short transactional emails.
+ *
+ * Table-based rather than `<div>`s: Outlook's desktop renderer is Word, not a
+ * browser, and a `<table>` is the one layout primitive it doesn't mangle. The
+ * two brand colours are the same ones the app uses for the same jobs —
+ * `primary` (#ffc409) is the one committing button, `accent` (#3b6cf6) is
+ * everything else interactive — so mail doesn't teach a different palette
+ * than the product does.
  */
-function wrap(locale: Locale, preheader: string, bodyHtml: string): string {
-  const t = translator(locale)
+function shell(locale: Locale, preheader: string, contentHtml: string, footerHtml: string): string {
   // `dir` matters more here than anywhere in the app: an email client has no
   // layout engine of ours to fall back on, and an Arabic paragraph laid out
   // left to right is unreadable rather than merely wrong.
   const dir = locale === 'ar' ? 'rtl' : 'ltr'
+  const align = dir === 'rtl' ? 'right' : 'left'
   return `<!doctype html>
 <html lang="${locale}" dir="${dir}">
-  <body style="font-family: -apple-system, system-ui, sans-serif; color: #111; background: #f7f7f7; padding: 24px;">
-    <span style="display:none">${preheader}</span>
-    <div style="max-width: 480px; margin: 0 auto; background: #fff; border-radius: 12px; padding: 32px;">
-      <h1 style="font-size: 20px; margin: 0 0 16px;">LangX</h1>
-      ${bodyHtml}
-      <p style="color: #888; font-size: 12px; margin-top: 32px;">
-        ${t('email.ignore')}
-      </p>
-    </div>
+  <body style="margin:0; padding:32px 16px; background:#f4f5f7; font-family:-apple-system,'Segoe UI',Roboto,system-ui,sans-serif;">
+    <span style="display:none; overflow:hidden; line-height:0; max-height:0; opacity:0;">${preheader}</span>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px; margin:0 auto;">
+      <tr>
+        <td style="padding:0 4px 20px; text-align:${align};">
+          <span style="font-size:20px; font-weight:800; color:#111827;">Lang<span style="color:#3b6cf6;">X</span></span>
+        </td>
+      </tr>
+      <tr>
+        <td style="background:#ffffff; border:1px solid #e7e9ec; border-radius:16px; padding:32px; text-align:${align}; font-size:15px; line-height:1.6; color:#111827;">
+          ${contentHtml}
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:20px 4px 0; text-align:${align}; font-size:12px; line-height:1.6; color:#9aa1a9;">
+          ${footerHtml}
+        </td>
+      </tr>
+    </table>
   </body>
 </html>`
 }
 
 function button(url: string, label: string): string {
-  return `<a href="${url}" style="display:inline-block; background:#111; color:#fff; text-decoration:none; padding:12px 20px; border-radius:8px; font-weight:600;">${label}</a>`
+  return `<a href="${url}" style="display:inline-block; background:#ffc409; color:#201900; text-decoration:none; padding:13px 22px; border-radius:10px; font-weight:700; font-size:15px;">${label}</a>`
+}
+
+/** The shell for mail answering something somebody just did — sign up, reset, delete. */
+function wrap(locale: Locale, preheader: string, bodyHtml: string): string {
+  const t = translator(locale)
+  return shell(locale, preheader, bodyHtml, t('email.ignore'))
 }
 
 export interface Email {
@@ -58,26 +81,15 @@ export function notificationEmail(
   },
 ): { html: string } {
   const t = translator(locale)
-  const dir = locale === 'ar' ? 'rtl' : 'ltr'
-  const cta = options.cta ? `<p>${button(options.cta.url, options.cta.label)}</p>` : ''
-  return {
-    html: `<!doctype html>
-<html lang="${locale}" dir="${dir}">
-  <body style="font-family: -apple-system, system-ui, sans-serif; color: #111; background: #f7f7f7; padding: 24px;">
-    <span style="display:none">${options.preheader}</span>
-    <div style="max-width: 480px; margin: 0 auto; background: #fff; border-radius: 12px; padding: 32px;">
-      <h1 style="font-size: 20px; margin: 0 0 16px;">LangX</h1>
-      ${options.bodyHtml}
-      ${cta}
-      <p style="color: #888; font-size: 12px; margin-top: 32px;">
-        ${t('email.whyThisMail')}<br />
-        <a href="${options.unsubscribeUrl}" style="color:#888;">${t('email.unsubscribeLink')}</a>
+  const cta = options.cta
+    ? `<p style="margin:20px 0 0;">${button(options.cta.url, options.cta.label)}</p>`
+    : ''
+  const footer = `${t('email.whyThisMail')}<br />
+        <a href="${options.unsubscribeUrl}" style="color:#9aa1a9;">${t('email.unsubscribeLink')}</a>
         &middot;
-        <a href="${options.manageUrl}" style="color:#888;">${t('email.managePrefs')}</a>
-      </p>
-    </div>
-  </body>
-</html>`,
+        <a href="${options.manageUrl}" style="color:#9aa1a9;">${t('email.managePrefs')}</a>`
+  return {
+    html: shell(locale, options.preheader, `${options.bodyHtml}${cta}`, footer),
   }
 }
 
@@ -101,7 +113,7 @@ export function verificationEmail(url: string, locale: Locale): Email {
       t('email.verifyPreheader'),
       `<p>${t('email.verifyBody')}</p>
        <p>${button(url, t('email.verifyButton'))}</p>
-       <p style="font-size: 12px; color: #888;">${t('email.orPaste', { url })}</p>`,
+       <p style="font-size: 12px; color: #9aa1a9;">${t('email.orPaste', { url })}</p>`,
     ),
     text: t('email.verifyText', { url }),
   }
@@ -116,7 +128,7 @@ export function resetPasswordEmail(url: string, locale: Locale): Email {
       t('email.resetPreheader'),
       `<p>${t('email.resetBody')}</p>
        <p>${button(url, t('email.resetButton'))}</p>
-       <p style="font-size: 12px; color: #888;">${t('email.orPaste', { url })}</p>`,
+       <p style="font-size: 12px; color: #9aa1a9;">${t('email.orPaste', { url })}</p>`,
     ),
     text: t('email.resetText', { url }),
   }
@@ -138,7 +150,7 @@ export function magicLinkEmail(url: string, locale: Locale): Email {
       t('email.magicLinkPreheader'),
       `<p>${t('email.magicLinkBody')}</p>
        <p>${button(url, t('email.magicLinkButton'))}</p>
-       <p style="font-size: 12px; color: #888;">${t('email.orPaste', { url })}</p>`,
+       <p style="font-size: 12px; color: #9aa1a9;">${t('email.orPaste', { url })}</p>`,
     ),
     text: t('email.magicLinkText', { url }),
   }
@@ -163,7 +175,7 @@ export function deleteAccountEmail(url: string, locale: Locale): Email {
       t('email.deletePreheader'),
       `<p>${t('email.deleteBody')}</p>
        <p>${button(url, t('email.deleteButton'))}</p>
-       <p style="font-size: 12px; color: #888;">${t('email.orPaste', { url })}</p>`,
+       <p style="font-size: 12px; color: #9aa1a9;">${t('email.orPaste', { url })}</p>`,
     ),
     text: t('email.deleteText', { url }),
   }
@@ -187,7 +199,7 @@ export function existingAccountEmail(url: string, locale: Locale): Email {
       t('email.existingPreheader'),
       `<p>${t('email.existingBody')}</p>
        <p>${button(url, t('email.existingButton'))}</p>
-       <p style="font-size: 12px; color: #888;">${t('email.orPaste', { url })}</p>`,
+       <p style="font-size: 12px; color: #9aa1a9;">${t('email.orPaste', { url })}</p>`,
     ),
     text: t('email.existingText', { url }),
   }
@@ -254,7 +266,7 @@ export function unreadDigestEmail(
     subject,
     html: notificationEmail(locale, {
       preheader: t('email.digestPreheader'),
-      bodyHtml: `<p>${body}</p>${more ? `<p style="color:#888;">${more}</p>` : ''}`,
+      bodyHtml: `<p>${body}</p>${more ? `<p style="color:#9aa1a9;">${more}</p>` : ''}`,
       cta,
       unsubscribeUrl: unsubscribe,
       manageUrl: webUrl('/settings'),
@@ -297,7 +309,7 @@ export function profileVisitsEmail(
     subject,
     html: notificationEmail(locale, {
       preheader: t('email.visitsPreheader'),
-      bodyHtml: `<p>${body}</p><p style="color:#888;">${detail}</p>`,
+      bodyHtml: `<p>${body}</p><p style="color:#9aa1a9;">${detail}</p>`,
       cta,
       unsubscribeUrl: unsubscribe,
       manageUrl: webUrl('/settings'),


### PR DESCRIPTION
Every mail we send still goes out in the first shell written for it: a plain
`<div>`, `LangX` as a text heading, and a black button. This is the redesign
that was written for it on `claude/email-template-design-qcuf4z` and never
opened as a PR, so it never reached `main` and nobody has seen it. Same four
commits, rebased onto current `main`.

All of it is `apps/api/src/email/templates.ts` — one shell, so every mail that
goes through `wrap` or `notificationEmail` changes at once.

## What changes

- **Table-based layout instead of `<div>`s.** Outlook's desktop renderer is
  Word, not a browser, and a `<table>` is the one layout primitive it doesn't
  mangle.
- **The mark in the header**, next to the wordmark, replacing the text `<h1>`.
  A hosted `<img>` rather than the inline SVG the site's header uses: Gmail
  strips `<svg>` from mail bodies outright and drops `data:` sources too, so a
  hosted file is the only version that survives.
- **The button takes the app's `primary`** (`#ffc409`) instead of black — the
  same colour the app gives its one committing action.
- **Nunito**, the site's display font, for the logo and buttons. Gmail ignores
  web fonts and falls back to the system stack, so this is an upgrade some
  clients take and none are worse for.
- Footer grey moves `#888` → `#9aa1a9` to match.

RTL is preserved throughout — the header gap and the text alignment both flip
with `dir`, which matters more in mail than anywhere in the app, since there is
no layout engine of ours to fall back on.

Nothing about *what* the mail says changes: no copy, no i18n keys, no
plain-text half, and the unsubscribe footer and `List-Unsubscribe` handling are
untouched.

## Verification

`pnpm -r typecheck`, `pnpm lint` and `pnpm format:check` are clean. No test
asserts on the markup. The MongoDB-backed suites don't run in this environment
and skip — verified identical on `main` at the merge base, so it is the
environment, not this diff.

## One thing to eyeball before merging

The header image points at `https://langx.io/favicons/favicon-32x32.png`. That
host isn't reachable from where this was built, so the exact filename is
unverified — if it's wrong, every mail shows a broken image. The path shape is
right (`website/static/favicons/*` per the release runbook); it's the filename
that wants a second pair of eyes.

Also worth knowing: this only reaches inboxes once the API is deployed. Merging
alone won't change the mail anyone receives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Xhf2xUx6zj5HJ5HnrMJnq

---
_Generated by [Claude Code](https://claude.ai/code/session_014Xhf2xUx6zj5HJ5HnrMJnq)_