### PR TITLE
Chat: make the things you keep findable — starred rows, phrase from a message, and a media screen

### DIFF
--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -220,6 +220,46 @@ export const INDEXES: Partial<IndexSpec> = {
      */
     { key: { conversationId: 1, createdAt: -1, _id: -1 }, name: 'conversation_created_id' },
     /**
+     * The conversation-media screen: one thread's attachments, split into a
+     * visual tab (`type: { $in: ['image', 'video'] }`) and an audio one
+     * (`type: 'audio'`), each newest-first and paged.
+     *
+     * `type` sits *second*, ahead of the sort keys, and that placement is the
+     * whole index. Through `conversation_created_id` above, both tabs are
+     * bounded to the thread and then filter `type` over every message in it —
+     * which for the audio tab means walking a two-year conversation to find
+     * eleven voice notes, on every page of the list. Leading with
+     * `(conversationId, type)` makes each tab's scan cover only its own keys.
+     *
+     * What that placement costs, and why it is affordable:
+     *
+     * - `tab: 'audio'` is a plain equality, so the scan is one interval and
+     *   the trailing `(createdAt, _id)` supply the sort outright. This is the
+     *   tab the index exists for — a voice note is the rarest thing in a
+     *   thread.
+     * - `tab: 'visual'` is a two-point `$in`. A non-equality ahead of the sort
+     *   keys normally forfeits the index's ordering; the planner's
+     *   `explodeForSort` is what rescues this shape, turning it into two
+     *   point-bounded scans merged by `SORT_MERGE`. A two-way merge of sorted
+     *   streams is not a blocking in-memory sort, and two scans is far under
+     *   the explode ceiling. That merge is the *price* of the placement, not
+     *   its benefit.
+     *
+     * `_id` last for the reason `conversation_created_id` has it: the keyset
+     * cursor tiebreaks on it, and without it the sort falls back to memory
+     * whatever else is true. A new name rather than widening the index above,
+     * for the reason written there — and a genuinely different key shape
+     * besides, so that one stays the thread's own index.
+     *
+     * `deletedAt` and `hiddenFor` are deliberately absent. `hiddenFor` is read
+     * with `$ne`, which cannot be bounded at all; both stay residual filters
+     * over a scan already narrowed to one thread and one tab.
+     */
+    {
+      key: { conversationId: 1, type: 1, createdAt: -1, _id: -1 },
+      name: 'conversation_type_created',
+    },
+    /**
      * "How many did *they* send in this thread" — the media gate's fallback
      * for conversations written before `messageCountBy` existed. A count-only
      * scan of this index, instead of filtering `senderId` over every message

--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -533,6 +533,28 @@ export const INDEXES: Partial<IndexSpec> = {
     { key: { conversationId: 1, term: 1 }, name: 'conversation_term_unique', unique: true },
     // The deck screen, newest first.
     { key: { conversationId: 1, createdAt: -1, _id: -1 }, name: 'conversation_recent' },
+    /**
+     * `GET /me/phrases?scope=mine` — one person's cards across every thread.
+     * Both indexes above lead with `conversationId`, so neither can answer a
+     * question that names only the author.
+     *
+     * `_id` is in the key, unlike the `author_recent` on `postComments` and
+     * `pronunciationAnswers`: those sort on `createdAt` alone, and this read
+     * sorts `{ createdAt: -1, _id: -1 }` — the order `conversation_recent`
+     * above already serves — so two cards saved in the same millisecond come
+     * back stably instead of in whichever order the storage engine offers.
+     * Without `_id` here that tiebreak is an in-memory sort.
+     *
+     * `scope=all` is **not** served by this index and does not claim to be: it
+     * names conversations rather than an author and rides `conversation_recent`
+     * with an `$in`. Whether that `$in` keeps the index's ordering depends on
+     * how many threads it carries, which is why
+     * `PHRASE_SOURCE_CONVERSATION_LIMIT` is 200 — and why even the sorted case
+     * is affordable, since `conversation_term_unique` caps each thread's deck
+     * and bounds the candidate set a second time. One index does not close
+     * both scopes.
+     */
+    { key: { authorId: 1, createdAt: -1, _id: -1 }, name: 'author_recent' },
   ],
 
   [COLLECTIONS.postComments]: [

--- a/apps/api/src/modules/chat/conversationMedia.ts
+++ b/apps/api/src/modules/chat/conversationMedia.ts
@@ -1,0 +1,82 @@
+import type { Db, Filter } from 'mongodb'
+import type { MediaTab, MessageType } from '@langx/shared'
+import { COLLECTIONS } from '../../db/collections'
+import { decodeDateIdCursor, encodeDateIdCursor } from '../../lib/dateIdCursor'
+import { assertConversationAccess } from './access'
+import type { Message } from './conversations'
+import { toMessageView, type MessageView } from './messageView'
+
+/**
+ * The visual tab's two types, as index bounds.
+ *
+ * `$in`, never `$ne`: the note on `posts.kind_needs_correction` in
+ * `db/indexes.ts` records why — a `$ne` reads the same and cannot be bounded,
+ * which would turn each tab into a scan of the whole thread.
+ */
+const VISUAL_TYPES = ['image', 'video'] as const satisfies readonly MessageType[]
+
+export interface ConversationMediaPage {
+  items: MessageView[]
+  nextCursor: string | null
+}
+
+/**
+ * One thread's attachments, on their own screen, newest first.
+ *
+ * `{ items, nextCursor }` and nothing else, unlike the `MessagePage` beside
+ * it. The thread's window carries `participants`, `pinned` and
+ * `mediaLockedFor` because the chat screen has no other way to ask for them;
+ * a grid needs none of the three, and reusing that shape would tie a second
+ * screen to a contract it never reads.
+ *
+ * `assertConversationAccess` is the gate, as on every conversation-scoped
+ * read: a stranger gets the 404 that says nothing, and the block is
+ * re-checked on this call rather than trusted from when the thread started.
+ *
+ * **Filters what the thread deliberately does not.** `listMessages` keeps a
+ * withdrawn message and one hidden by the reader, because in a thread a
+ * tombstone holds the place of what was said. In a grid the same row is a
+ * blank square with nothing to say. And it cannot be left to the client: the
+ * `limit + 1` keyset page mints `nextCursor` from the last row the *server*
+ * kept, so dropping rows afterwards makes pages arrive short and, once a
+ * whole page is dropped, makes the list stop with more behind it.
+ */
+export async function listConversationMedia(
+  db: Db,
+  userId: string,
+  conversationId: string,
+  query: { tab: MediaTab; cursor?: string | undefined; limit: number },
+): Promise<ConversationMediaPage> {
+  const conversation = await assertConversationAccess(db, conversationId, userId)
+
+  const filter: Filter<Message> = {
+    conversationId: conversation._id,
+    type: query.tab === 'audio' ? 'audio' : { $in: [...VISUAL_TYPES] },
+    deletedAt: { $exists: false },
+    hiddenFor: { $ne: userId },
+  }
+
+  if (query.cursor) {
+    const { date, id } = decodeDateIdCursor(query.cursor)
+    // Keyset, not skip: an attachment sent while the reader is paging shifts
+    // an offset, which repeats or drops a tile.
+    filter.$or = [{ createdAt: { $lt: date } }, { createdAt: date, _id: { $lt: id } }]
+  }
+
+  // One over, so "is there another page" needs no second count.
+  const rows = await db
+    .collection<Message>(COLLECTIONS.messages)
+    .find(filter)
+    .sort({ createdAt: -1, _id: -1 })
+    .limit(query.limit + 1)
+    .toArray()
+
+  const hasMore = rows.length > query.limit
+  const page = hasMore ? rows.slice(0, query.limit) : rows
+  const last = page.at(-1)
+
+  return {
+    items: page.map((message) => toMessageView(message, userId)),
+    nextCursor: hasMore && last ? encodeDateIdCursor(last.createdAt, last._id) : null,
+  }
+}

--- a/apps/api/src/modules/chat/phraseCards.ts
+++ b/apps/api/src/modules/chat/phraseCards.ts
@@ -1,5 +1,8 @@
 import type { Db, ObjectId } from 'mongodb'
+import { PHRASE_SOURCE_CONVERSATION_LIMIT, type PhraseScope } from '@langx/shared'
 import { COLLECTIONS } from '../../db/collections'
+import { blockedUserIds } from '../moderation/blocks'
+import type { Conversation } from './conversations'
 
 export interface PhraseCard {
   _id: ObjectId
@@ -51,4 +54,112 @@ export async function listPhraseCards(db: Db, conversationId: ObjectId): Promise
     ...(row.example ? { example: row.example } : {}),
     createdAt: row.createdAt.toISOString(),
   }))
+}
+
+/** A card, plus which thread it came out of. */
+export interface CrossConversationPhraseCard extends PhraseCardView {
+  conversationId: string
+  /**
+   * The other side of the thread it was saved in, as an **id**. The name is
+   * what `/profiles/:id` and the client's profile cache already answer;
+   * reading it here would be a second, uncached copy of that lookup on every
+   * page. `listCorrectionsWritten` attaches `recipientId` the same way.
+   *
+   * Absent only if the conversation is gone, which the row tolerates by
+   * showing the card alone.
+   */
+  partnerId?: string
+}
+
+/**
+ * Every phrase one person can reach, across every thread, newest first.
+ *
+ * **The gate is in here, not in the route** — the one difference from
+ * `listPhraseCards` above, which takes no `userId` at all because
+ * `conversations.ts` puts `assertConversationAccess` in front of it. There is
+ * no single conversation to put in front of this one, so this function is the
+ * only place the check can live, and CLAUDE.md's rule is that access control
+ * lives with the read.
+ *
+ * A plain `find({ participants: userId })` for the conversation ids would be
+ * an authorization hole, not a shortcut. `assertConversationAccess` re-checks
+ * blocks on every call precisely because a block placed after the conversation
+ * exists has to cut off both REST and realtime access immediately; collecting
+ * ids with a raw `find` walks around that door and serves the cards of people
+ * who have blocked you. `blockedUserIds` is the two-sided list every other
+ * listing filters through, and `feed.ts` does the same thing for the same
+ * reason.
+ *
+ * **The block filter applies to `'mine'` too**, which is the one place this
+ * goes further than "your own rows are yours". A card's `example` is very
+ * often the *other* person's sentence — saving an incoming message as an
+ * example is now the ordinary way one gets written — so a card authored by
+ * the viewer can still be a quotation of somebody who has since blocked them.
+ * One filter for both scopes is also one place for the check to be right.
+ *
+ * A thread the viewer has deleted for themselves still contributes cards:
+ * `/conversations/:id/phrases` returns them too, and having only the aggregate
+ * view disagree would be the inconsistency.
+ */
+export async function listAllPhraseCards(
+  db: Db,
+  userId: string,
+  scope: PhraseScope,
+  limit: number,
+): Promise<CrossConversationPhraseCard[]> {
+  const [hidden, conversations] = await Promise.all([
+    blockedUserIds(db, userId),
+    /*
+     * Sorted and capped, so the truncation means "your most recent threads"
+     * rather than whichever rows the storage engine offered — and
+     * `participants_recent` already backs this exact order. The same
+     * `{ participants: userId }` five other places in this codebase write
+     * inline; no one-use helper for a sixth.
+     */
+    db
+      .collection<Conversation>(COLLECTIONS.conversations)
+      .find({ participants: userId }, { projection: { participants: 1 } })
+      .sort({ 'lastMessage.createdAt': -1 })
+      .limit(PHRASE_SOURCE_CONVERSATION_LIMIT)
+      .toArray(),
+  ])
+
+  const allowed = conversations.filter(
+    (conversation) => !conversation.participants.some((id) => id !== userId && hidden.includes(id)),
+  )
+  const partnerOf = new Map(
+    allowed.map((conversation) => [
+      conversation._id.toHexString(),
+      conversation.participants.find((id) => id !== userId),
+    ]),
+  )
+  const conversationIds = allowed.map((conversation) => conversation._id)
+
+  const rows = await db
+    .collection<PhraseCard>(COLLECTIONS.phraseCards)
+    .find(
+      scope === 'mine'
+        ? { authorId: userId, conversationId: { $in: conversationIds } }
+        : { conversationId: { $in: conversationIds } },
+    )
+    .sort({ createdAt: -1, _id: -1 })
+    .limit(limit)
+    .toArray()
+
+  return rows.map((row) => {
+    const conversationId = row.conversationId.toHexString()
+    const partnerId = partnerOf.get(conversationId)
+    return {
+      _id: row._id.toHexString(),
+      conversationId,
+      messageId: row.messageId.toHexString(),
+      authorId: row.authorId,
+      term: row.term,
+      meaning: row.meaning,
+      lang: row.lang,
+      ...(row.example ? { example: row.example } : {}),
+      ...(partnerId ? { partnerId } : {}),
+      createdAt: row.createdAt.toISOString(),
+    }
+  })
 }

--- a/apps/api/src/routes/conversations.test.ts
+++ b/apps/api/src/routes/conversations.test.ts
@@ -385,4 +385,135 @@ describe('Faz 4 — starting a conversation', () => {
       expect(response.json<{ initiations: { remaining: number } }>().initiations.remaining).toBe(2)
     })
   })
+
+  describe('GET /me/phrases', () => {
+    /** Two people, a thread, and a card saved by each of them. */
+    async function deck(prefix: string) {
+      const a = await newUser(`${prefix}-a@example.com`)
+      const b = await newUser(`${prefix}-b@example.com`)
+      const conversationId = (await startConversation(a, b.userId)).json<{ _id: string }>()._id
+      const { sendPhrase } = await import('../modules/chat/messages')
+      await sendPhrase(handle.db, a.userId, {
+        conversationId,
+        term: 'mine',
+        meaning: 'what I saved',
+        lang: 'en',
+      })
+      await sendPhrase(handle.db, b.userId, {
+        conversationId,
+        term: 'theirs',
+        meaning: 'what they saved',
+        lang: 'en',
+      })
+      return { a, b, conversationId }
+    }
+
+    /** The route is Polyglot-only, so every content test needs the tier. */
+    async function makePolyglot(userId: string) {
+      await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .updateOne({ _id: userId }, { $set: { 'entitlement.tier': 'pro_plus' } })
+    }
+
+    interface PhrasesBody {
+      items: { term: string; authorId: string; conversationId: string; partnerId?: string }[]
+    }
+
+    async function phrases(user: { cookie: string }, query = 'scope=mine') {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/me/phrases?${query}`,
+        headers: { cookie: user.cookie },
+      })
+      return { statusCode: response.statusCode, body: response.json<PhrasesBody>() }
+    }
+
+    it('returns only my own cards under scope=mine', async () => {
+      const { a } = await deck('phrases-mine')
+      await makePolyglot(a.userId)
+
+      const { statusCode, body } = await phrases(a)
+      expect(statusCode).toBe(200)
+      expect(body.items.map((card) => card.term)).toEqual(['mine'])
+      expect(body.items[0]?.authorId).toBe(a.userId)
+    })
+
+    it('includes the other person’s cards under scope=all', async () => {
+      const { a } = await deck('phrases-all')
+      await makePolyglot(a.userId)
+
+      const { body } = await phrases(a, 'scope=all')
+      expect([...body.items.map((card) => card.term)].sort()).toEqual(['mine', 'theirs'])
+    })
+
+    it('says which thread each card came from, and who the other side is', async () => {
+      const { a, b, conversationId } = await deck('phrases-partner')
+      await makePolyglot(a.userId)
+
+      const { body } = await phrases(a, 'scope=all')
+      for (const card of body.items) {
+        expect(card.conversationId).toBe(conversationId)
+        expect(card.partnerId).toBe(b.userId)
+      }
+    })
+
+    it('never shows a card from a thread I am not in, under either scope', async () => {
+      const mine = await deck('phrases-outsider-mine')
+      const theirs = await deck('phrases-outsider-theirs')
+      await makePolyglot(mine.a.userId)
+
+      for (const scope of ['scope=mine', 'scope=all']) {
+        const { body } = await phrases(mine.a, scope)
+        expect(body.items.every((card) => card.conversationId !== theirs.conversationId)).toBe(true)
+      }
+    })
+
+    /**
+     * The test this section exists for. A block placed after the thread was
+     * started has to cut the cards off immediately — which is why the ids come
+     * through `blockedUserIds` rather than a raw `find` on `participants`.
+     */
+    it('drops a blocked person’s cards from scope=all', async () => {
+      const { a, b } = await deck('phrases-blocked-all')
+      await makePolyglot(a.userId)
+      const { blockUser } = await import('../modules/moderation/blocks')
+      await blockUser(handle.db, b.userId, a.userId)
+
+      const { body } = await phrases(a, 'scope=all')
+      expect(body.items.map((card) => card.term)).not.toContain('theirs')
+    })
+
+    /**
+     * And from `mine` as well, which is the design decision rather than a
+     * consequence: a card I wrote is very often a quotation of their sentence
+     * in its example, so "my own rows" is not the same as "rows I may still
+     * read".
+     */
+    it('drops my own cards from that thread too', async () => {
+      const { a, b } = await deck('phrases-blocked-mine')
+      await makePolyglot(a.userId)
+      const { blockUser } = await import('../modules/moderation/blocks')
+      await blockUser(handle.db, b.userId, a.userId)
+
+      const { body } = await phrases(a, 'scope=mine')
+      expect(body.items).toEqual([])
+    })
+
+    it('refuses a free account with UPGRADE_REQUIRED, naming the feature', async () => {
+      const { a } = await deck('phrases-free')
+
+      for (const scope of ['scope=mine', 'scope=all']) {
+        const response = await app.inject({
+          method: 'GET',
+          url: `/me/phrases?${scope}`,
+          headers: { cookie: a.cookie },
+        })
+        expect(response.statusCode).toBe(403)
+        expect(response.json<{ code: string; feature: string }>()).toMatchObject({
+          code: 'UPGRADE_REQUIRED',
+          feature: 'deckExport',
+        })
+      }
+    })
+  })
 })

--- a/apps/api/src/routes/conversations.ts
+++ b/apps/api/src/routes/conversations.ts
@@ -1,10 +1,15 @@
-import { ERROR_CODES, startConversationSchema } from '@langx/shared'
+import {
+  ERROR_CODES,
+  hasFeature,
+  listAllPhrasesQuerySchema,
+  startConversationSchema,
+} from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { ApiError } from '../lib/ApiError'
 import { getQuotaStatus } from '../lib/quota'
 import { requireAuth, requireVerifiedEmail } from '../middleware/requireAuth'
 import { assertConversationAccess } from '../modules/chat/access'
-import { listPhraseCards } from '../modules/chat/phraseCards'
+import { listAllPhraseCards, listPhraseCards } from '../modules/chat/phraseCards'
 import { startConversation } from '../modules/chat/conversations'
 import { effectiveTier } from '../modules/profiles/entitlement'
 import { getProfile } from '../modules/profiles/profiles'
@@ -64,4 +69,46 @@ export const conversationRoutes: FastifyPluginAsyncZod = async (app) => {
     const conversation = await assertConversationAccess(app.mongo.db, id, request.userId)
     return reply.send({ items: await listPhraseCards(app.mongo.db, conversation._id) })
   })
+
+  /**
+   * Every phrase, across every thread.
+   *
+   * Under `/me/` for the reason `/me/starred` and `/me/corrections` are: it
+   * belongs to a person, not to one conversation.
+   *
+   * **The paywall is on the server here**, unlike the route above. That one
+   * hands back data a free reader is already looking at on the deck screen —
+   * its gate is on the *file*, so a client-side check is the honest place for
+   * it. This route exists only to be exported, and a client-only gate would
+   * hand the whole cross-conversation deck to `curl /me/phrases?scope=all`.
+   *
+   * The tier check is in the route while the *block* check has to live inside
+   * `listAllPhraseCards`: a block is a rule about which rows exist, and this
+   * is a rule about who may call the endpoint at all — which keeps the module
+   * usable by anything else that wants the same rows.
+   */
+  app.get(
+    '/me/phrases',
+    { preHandler: requireAuth, schema: { querystring: listAllPhrasesQuerySchema } },
+    async (request, reply) => {
+      const profile = await getProfile(app.mongo.db, request.userId)
+      if (!profile) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Profile not found')
+      if (!hasFeature(effectiveTier(profile), 'deckExport')) {
+        throw new ApiError(
+          ERROR_CODES.UPGRADE_REQUIRED,
+          'Exporting every deck is a Polyglot feature',
+          {
+            feature: 'deckExport',
+          },
+        )
+      }
+      const items = await listAllPhraseCards(
+        app.mongo.db,
+        request.userId,
+        request.query.scope,
+        request.query.limit,
+      )
+      return reply.send({ items })
+    },
+  )
 }

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -1278,6 +1278,205 @@ describe('Faz 5 — conversation/message history REST', () => {
       expect(profile?.quota.media).toHaveLength(1)
       expect(profile?.quota.initiations).toHaveLength(1) // just the conversation they opened
     })
+
+    describe('GET /conversations/:id/media', () => {
+      const audio = {
+        url: `${BUCKET}/messages/x/a.m4a`,
+        contentType: 'audio/m4a',
+        sizeBytes: 64 * 1024,
+        durationSeconds: 12,
+      }
+
+      /** One thread with a photo, then a video, then a voice note. */
+      async function withMedia(prefix: string) {
+        const fixture = await pair(prefix)
+        const { sendMediaMessage } = await import('../modules/chat/messages')
+        const send = async (attachment: typeof image | typeof video | typeof audio) => {
+          const { message } = await sendMediaMessage(
+            handle.db,
+            fixture.a.userId,
+            { conversationId: fixture.conversationId, attachments: [attachment] },
+            BUCKET,
+          )
+          return message._id.toHexString()
+        }
+        const imageId = await send(image)
+        const videoId = await send(video)
+        const audioId = await send(audio)
+        return { ...fixture, imageId, videoId, audioId }
+      }
+
+      /** Annotated rather than inferred: `inject().json()` is `any`. */
+      interface MediaBody {
+        items: { _id: string; type: string }[]
+        nextCursor: string | null
+      }
+
+      async function media(
+        user: { cookie: string },
+        conversationId: string,
+        query = 'tab=visual',
+      ): Promise<{ statusCode: number; body: MediaBody }> {
+        const response = await app.inject({
+          method: 'GET',
+          url: `/conversations/${conversationId}/media?${query}`,
+          headers: { cookie: user.cookie },
+        })
+        const body: MediaBody = response.json()
+        return { statusCode: response.statusCode, body }
+      }
+
+      it('puts photos and videos in one tab and leaves the voice note out', async () => {
+        const { a, conversationId, imageId, videoId } = await withMedia('media-tab-visual')
+
+        const { statusCode, body } = await media(a, conversationId)
+        expect(statusCode).toBe(200)
+        // Newest first: the video was sent after the photo.
+        expect(body.items.map((m) => m._id)).toEqual([videoId, imageId])
+        expect(body.nextCursor).toBeNull()
+      })
+
+      it('puts the voice note in its own tab and nothing else', async () => {
+        const { a, conversationId, audioId } = await withMedia('media-tab-audio')
+
+        const { body } = await media(a, conversationId, 'tab=audio')
+        expect(body.items.map((m) => m._id)).toEqual([audioId])
+      })
+
+      /**
+       * A tombstone holds its place in the thread and must not hold one in the
+       * grid, where it would be a blank square. Asserted on the `_id` rather
+       * than on the attachments: withdrawing unsets those anyway, so an
+       * emptied row would pass a check that only looked at what it carries.
+       */
+      it('leaves a withdrawn message out of both tabs', async () => {
+        const { a, conversationId, imageId, videoId } = await withMedia('media-withdrawn')
+        const { deleteMessage } = await import('../modules/chat/mutations')
+        await deleteMessage(handle.db, a.userId, {
+          conversationId,
+          messageId: imageId,
+          scope: 'everyone',
+        })
+
+        const { body } = await media(a, conversationId)
+        expect(body.items.map((m) => m._id)).toEqual([videoId])
+      })
+
+      /** "Delete for me" is one-sided, so the grid has to be one-sided too. */
+      it('hides a message from the reader who hid it and from nobody else', async () => {
+        const { a, b, conversationId, imageId, videoId } = await withMedia('media-hidden')
+        const { deleteMessage } = await import('../modules/chat/mutations')
+        await deleteMessage(handle.db, b.userId, {
+          conversationId,
+          messageId: imageId,
+          scope: 'me',
+        })
+
+        const hidden = await media(b, conversationId)
+        expect(hidden.body.items.map((m) => m._id)).toEqual([videoId])
+
+        const untouched = await media(a, conversationId)
+        expect(untouched.body.items.map((m) => m._id)).toEqual([videoId, imageId])
+      })
+
+      it('tells a stranger nothing, with the same 404 as a missing thread', async () => {
+        const { conversationId } = await withMedia('media-stranger')
+        const outsider = await newUser('media-outsider@example.com')
+
+        const { statusCode, body } = await media(outsider, conversationId)
+        expect(statusCode).toBe(404)
+        expect(JSON.stringify(body)).not.toContain(conversationId)
+      })
+
+      /**
+       * The gate is `assertConversationAccess`, which re-checks blocks on
+       * every call — not a participancy test that would keep serving a thread
+       * after one of them blocked the other.
+       */
+      it('refuses a thread with someone who has blocked the reader', async () => {
+        const { a, b, conversationId } = await withMedia('media-blocked')
+        const { blockUser } = await import('../modules/moderation/blocks')
+        await blockUser(handle.db, b.userId, a.userId)
+
+        const { statusCode } = await media(a, conversationId)
+        expect(statusCode).toBe(403)
+      })
+
+      it('pages with a cursor without repeating or dropping a tile', async () => {
+        const fixture = await pair('media-paging')
+        const { sendMediaMessage } = await import('../modules/chat/messages')
+        const wanted: string[] = []
+        for (let n = 0; n < 5; n++) {
+          const { message } = await sendMediaMessage(
+            handle.db,
+            fixture.a.userId,
+            {
+              conversationId: fixture.conversationId,
+              attachments: [{ ...image, url: `${BUCKET}/messages/x/page-${n}.jpg` }],
+            },
+            BUCKET,
+          )
+          wanted.push(message._id.toHexString())
+        }
+
+        const seen: string[] = []
+        let cursor: string | null = null
+        for (let guard = 0; guard < 10; guard++) {
+          const query = `tab=visual&limit=2${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`
+          const { body } = await media(fixture.a, fixture.conversationId, query)
+          seen.push(...body.items.map((m) => m._id))
+          cursor = body.nextCursor
+          if (!cursor) break
+        }
+
+        expect(seen).toHaveLength(wanted.length)
+        // A set, so a cursor that overlapped would fail here rather than pass
+        // on the count alone.
+        expect(new Set(seen).size).toBe(wanted.length)
+        expect([...seen].sort()).toEqual([...wanted].sort())
+      })
+
+      it('answers a cursor it did not mint with a 400, not a 500', async () => {
+        const { a, conversationId } = await withMedia('media-bad-cursor')
+
+        const { statusCode } = await media(a, conversationId, 'tab=visual&cursor=nonsense')
+        expect(statusCode).toBe(400)
+      })
+
+      /**
+       * Keeps the reasoning on `conversation_type_created` honest: the comment
+       * there claims the placement of `type` buys a bounded scan and that
+       * neither tab sorts in memory. Precedent for asserting a plan in a test
+       * is `discovery.test.ts`.
+       */
+      it('serves both tabs from the media index, without a blocking sort', async () => {
+        const { conversationId, a } = await withMedia('media-explain')
+
+        for (const type of [{ $in: ['image', 'video'] }, 'audio']) {
+          const plan = await handle.db
+            .collection(COLLECTIONS.messages)
+            .find({
+              conversationId: new ObjectId(conversationId),
+              type,
+              deletedAt: { $exists: false },
+              hiddenFor: { $ne: a.userId },
+            })
+            .sort({ createdAt: -1, _id: -1 })
+            .explain('queryPlanner')
+          /*
+           * The *winning* plan only. `queryPlanner` also carries
+           * `rejectedPlans`, and one of those legitimately is a collection
+           * scan — asserting over the whole object passes when run alone and
+           * fails the moment the planner has a second candidate to reject.
+           */
+          const { queryPlanner } = plan as { queryPlanner: { winningPlan: unknown } }
+          const shape = JSON.stringify(queryPlanner.winningPlan)
+          expect(shape).toContain('conversation_type_created')
+          expect(shape).not.toContain('COLLSCAN')
+          expect(shape).not.toContain('"stage":"SORT"')
+        }
+      })
+    })
   })
 
   describe('replies and the around window', () => {

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -1,6 +1,7 @@
 import {
   conversationFlagsSchema,
   ERROR_CODES,
+  listConversationMediaQuerySchema,
   listConversationsQuerySchema,
   listMessagesQuerySchema,
   listStarredQuerySchema,
@@ -18,6 +19,7 @@ import {
   markConversationRead,
 } from '../modules/chat/messages'
 import { assertConversationAccess } from '../modules/chat/access'
+import { listConversationMedia } from '../modules/chat/conversationMedia'
 import { toConversationView } from '../modules/chat/conversationView'
 import { toMessageView } from '../modules/chat/messageView'
 import { listCorrectionsWritten } from '../modules/chat/corrections'
@@ -155,6 +157,40 @@ export const messageRoutes: FastifyPluginAsyncZod = async (app) => {
         return reply.send(window)
       }
       const page = await listMessages(app.mongo.db, request.userId, id, rest)
+      return reply.send(page)
+    },
+  )
+
+  /**
+   * Everything this thread has attached, as its own screen.
+   *
+   * Its own route rather than a filter on the message window above: the grid
+   * pages over attachments alone, and asking the thread for them would mean
+   * walking every text message in between to find them — which is what the
+   * `conversation_type_created` index exists to avoid.
+   *
+   * Both halves of the request are declared, unlike the route above — as
+   * `feed.ts` and `follows.ts` do on every parameterised list. Without
+   * `params` in the schema `request.params` needs the cast that route still
+   * carries, and a cast is the thing that stops being checked the day the id
+   * gains a shape.
+   */
+  app.get(
+    '/conversations/:id/media',
+    {
+      preHandler: requireAuth,
+      schema: {
+        params: z.object({ id: z.string().trim().min(1) }),
+        querystring: listConversationMediaQuerySchema,
+      },
+    },
+    async (request, reply) => {
+      const page = await listConversationMedia(
+        app.mongo.db,
+        request.userId,
+        request.params.id,
+        request.query,
+      )
       return reply.send(page)
     },
   )

--- a/apps/mobile/app/(app)/all-phrases.tsx
+++ b/apps/mobile/app/(app)/all-phrases.tsx
@@ -1,0 +1,144 @@
+import { hasFeature, PHRASE_SCOPES, type PhraseScope } from '@langx/shared'
+import { useState } from 'react'
+import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from 'react-native'
+import { useAllPhraseCards, useEffectiveTier } from '../../src/api/queries'
+import { EmptyState } from '../../src/components/ui/EmptyState'
+import { Screen } from '../../src/components/ui/Screen'
+import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
+import { SegmentedControl } from '../../src/components/ui/SegmentedControl'
+import { useProfileCache } from '../../src/hooks/useProfileCache'
+import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
+import { useT } from '../../src/i18n'
+import { showAlert } from '../../src/lib/alert'
+import { deckCsv } from '../../src/lib/deckCsv'
+import { goBackTo } from '../../src/lib/navigation'
+import { openPaywall } from '../../src/lib/paywall'
+import { saveTextFile } from '../../src/lib/saveFile'
+import { makeStyles } from '../../src/lib/theme'
+
+/**
+ * Every saved phrase, from every conversation, in one place.
+ *
+ * The deck screen answers "what did the two of us keep"; this one answers
+ * "what have I kept", which is the question somebody asks when they want the
+ * file rather than the list.
+ *
+ * Polyglot end to end, unlike the per-conversation deck: there the gate is on
+ * the *file*, because the rows themselves are already on screen for free. Here
+ * the read exists only to be exported, so `/me/phrases` refuses a free account
+ * outright and this screen never asks. A reader who arrives anyway — a deep
+ * link, a subscription that lapsed while the screen was open — gets the
+ * paywall rather than an error.
+ */
+export default function AllPhrasesScreen() {
+  useScreenInteractive()
+  const styles = useStyles()
+  const t = useT()
+  const [scope, setScope] = useState<PhraseScope>('mine')
+
+  const canExport = hasFeature(useEffectiveTier(), 'deckExport')
+  const deck = useAllPhraseCards(scope, canExport)
+  const cards = deck.data?.items ?? []
+  const pull = usePullToRefresh(() => deck.refetch())
+
+  // The rows name the other side as an id; these are the names.
+  const partners = useProfileCache(
+    cards.flatMap((card) => (card.partnerId ? [card.partnerId] : [])),
+  )
+
+  async function exportDeck(): Promise<void> {
+    if (!canExport) {
+      openPaywall('deckExport', '/(app)/all-phrases')
+      return
+    }
+    const ok = await saveTextFile(deckCsv(cards), 'langx-phrases-all.csv', {
+      mimeType: 'text/csv',
+      uti: 'public.comma-separated-values-text',
+    })
+    if (!ok) void showAlert(t('chat.deckExportFailed'))
+  }
+
+  return (
+    <Screen fluid>
+      <ScreenHeader
+        title={t('chat.allPhrases')}
+        onBack={() => goBackTo('/(app)/settings/account')}
+        /*
+         * Always drawn, unlike the deck screen's — which hides it on an empty
+         * list. That is safe there and would be a trap here: a free reader's
+         * list is empty by construction, so hiding the button would put the
+         * paywall behind a condition that can never be true.
+         */
+        trailing={
+          <Pressable accessibilityRole="button" hitSlop={8} onPress={() => void exportDeck()}>
+            <Text style={styles.export}>{t('chat.deckExport')}</Text>
+          </Pressable>
+        }
+      />
+
+      <View style={styles.scope}>
+        <SegmentedControl<PhraseScope>
+          options={PHRASE_SCOPES.map((value) => ({
+            value,
+            label: t(value === 'mine' ? 'chat.phraseScopeMine' : 'chat.phraseScopeAll'),
+          }))}
+          selected={[scope]}
+          /*
+           * The scope is in the query key, so the server narrows the list and
+           * the client never filters a wider one — which is what keeps the
+           * file and the screen showing the same rows.
+           */
+          onToggle={(value) => setScope(value)}
+          accessibilityLabel={t('chat.phraseScopePicker')}
+        />
+      </View>
+
+      {canExport && deck.isPending ? (
+        <ActivityIndicator style={styles.loading} />
+      ) : (
+        <FlatList
+          data={cards}
+          keyExtractor={(card) => card._id}
+          contentContainerStyle={styles.list}
+          refreshControl={<RefreshControl {...pull} />}
+          ListEmptyComponent={
+            <EmptyState
+              icon="bookmark"
+              title={t('chat.allPhrases')}
+              body={t('chat.allPhrasesEmpty')}
+            />
+          }
+          renderItem={({ item }) => {
+            const name = item.partnerId ? partners[item.partnerId]?.displayName : undefined
+            return (
+              <View style={styles.card}>
+                <Text style={styles.term}>{item.term}</Text>
+                <Text style={styles.meaning}>{item.meaning}</Text>
+                {item.example ? <Text style={styles.example}>{item.example}</Text> : null}
+                {/*
+                  Where it came from, on screen rather than in the file: the CSV
+                  stays three positional columns because that is what Anki maps
+                  by position, and a fourth would break an existing import.
+                */}
+                {name ? <Text style={styles.from}>{t('chat.phraseFrom', { name })}</Text> : null}
+              </View>
+            )
+          }}
+        />
+      )}
+    </Screen>
+  )
+}
+
+const useStyles = makeStyles(({ colors, spacing }) => ({
+  export: { color: colors.accent, fontSize: 15, fontWeight: '700' },
+  scope: { paddingBottom: spacing.sm, paddingHorizontal: spacing.lg },
+  loading: { paddingVertical: spacing.xl },
+  list: { flexGrow: 1, gap: spacing.sm, padding: spacing.lg },
+  card: { borderBottomColor: colors.border, borderBottomWidth: 1, gap: 3, paddingVertical: 14 },
+  term: { color: colors.text, fontSize: 17, fontWeight: '700' },
+  meaning: { color: colors.text, fontSize: 15, lineHeight: 21 },
+  example: { color: colors.textMuted, fontSize: 14, fontStyle: 'italic', lineHeight: 20 },
+  from: { color: colors.textFaint, fontSize: 13, paddingTop: 2 },
+}))

--- a/apps/mobile/app/(app)/chat-media.tsx
+++ b/apps/mobile/app/(app)/chat-media.tsx
@@ -80,7 +80,13 @@ function tilesOf(messages: MessageDto[]): Tile[] {
  * Two tabs because photos and videos are looked at and a voice note is
  * listened to; one grid and one list is the whole difference, and it is enough
  * of one that they are separate `FlatList`s rather than one with a swapped
- * `renderItem`. Toggling `numColumns` on a live list forces a re-key and warns.
+ * `renderItem`.
+ *
+ * Both carry a `key`, which is the part that is easy to get wrong: two
+ * `FlatList` elements in the two arms of one ternary sit in the same slot of
+ * the tree, so React reuses the instance and only changes the props — and
+ * `numColumns` going from 3 to 1 on a live list is a hard render error, not a
+ * warning. The `key` is what makes them two components instead of one.
  */
 export default function ChatMediaScreen() {
   useScreenInteractive()
@@ -167,6 +173,7 @@ export default function ChatMediaScreen() {
         <ActivityIndicator style={styles.loading} />
       ) : tab === 'visual' ? (
         <FlatList
+          key="visual"
           data={tiles}
           keyExtractor={(tile) => tile._id}
           numColumns={COLUMNS}
@@ -204,6 +211,7 @@ export default function ChatMediaScreen() {
         />
       ) : (
         <FlatList
+          key="audio"
           data={messages}
           keyExtractor={(item) => item._id}
           contentContainerStyle={styles.list}

--- a/apps/mobile/app/(app)/chat-media.tsx
+++ b/apps/mobile/app/(app)/chat-media.tsx
@@ -1,0 +1,263 @@
+import {
+  attachmentsOf,
+  isVideoContentType,
+  type Media,
+  MEDIA_TABS,
+  type MediaTab,
+} from '@langx/shared'
+import { Feather } from '@expo/vector-icons'
+import { Image } from 'expo-image'
+import { useLocalSearchParams } from 'expo-router'
+import { useMemo, useState } from 'react'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  Text,
+  useWindowDimensions,
+  View,
+} from 'react-native'
+import { useConversationMedia, useMe, type MessageDto } from '../../src/api/queries'
+import { AudioBubble, VideoTile } from '../../src/components/MediaBubble'
+import { PhotoViewer } from '../../src/components/PhotoViewer'
+import { EmptyState } from '../../src/components/ui/EmptyState'
+import { Screen } from '../../src/components/ui/Screen'
+import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
+import { SegmentedControl } from '../../src/components/ui/SegmentedControl'
+import { useProfileCache } from '../../src/hooks/useProfileCache'
+import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
+import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
+import { useLocale, useT } from '../../src/i18n'
+import { dedupeById } from '../../src/lib/dedupeById'
+import { listState } from '../../src/lib/listState'
+import { dayLabel } from '../../src/lib/messageGroups'
+import { goBackTo } from '../../src/lib/navigation'
+import { makeStyles, useTheme } from '../../src/lib/theme'
+
+const COLUMNS = 3
+const GRID_GAP = 2
+
+/**
+ * One tile is one attachment, not one message.
+ *
+ * A message carries up to `MAX_ATTACHMENTS` files and its `type` is the kind
+ * of the *first* one — so a `type: 'image'` message can hold a video and the
+ * reverse. Flattening here is what makes the grid draw all six of a gallery
+ * rather than one square per send, and it lets each tile ask
+ * `isVideoContentType` about its own file.
+ */
+interface Tile {
+  /** `${messageId}:${index}` — one string for `keyExtractor` and `dedupeById`. */
+  _id: string
+  media: Media
+  senderId: string
+  createdAt: string
+}
+
+function tilesOf(messages: MessageDto[]): Tile[] {
+  return dedupeById(
+    messages.flatMap((message) =>
+      // Always through `attachmentsOf`: a v1-imported message carries `media`
+      // and no `attachments`, and the two have to look the same here.
+      attachmentsOf(message).map((media, index) => ({
+        _id: `${message._id}:${index}`,
+        media,
+        senderId: message.senderId,
+        createdAt: message.createdAt,
+      })),
+    ),
+  )
+}
+
+/**
+ * Everything this conversation has attached, away from the words.
+ *
+ * The third answer to "where did the thing from this thread go", beside the
+ * starred list and the phrase deck — and the one that needs no keeping first,
+ * because a photo is already saved by having been sent.
+ *
+ * Two tabs because photos and videos are looked at and a voice note is
+ * listened to; one grid and one list is the whole difference, and it is enough
+ * of one that they are separate `FlatList`s rather than one with a swapped
+ * `renderItem`. Toggling `numColumns` on a live list forces a re-key and warns.
+ */
+export default function ChatMediaScreen() {
+  useScreenInteractive()
+  const styles = useStyles()
+  const t = useT()
+  const { locale } = useLocale()
+  const { colors } = useTheme()
+  const { width } = useWindowDimensions()
+  const { id: conversationId } = useLocalSearchParams<{ id: string }>()
+  const [tab, setTab] = useState<MediaTab>('visual')
+
+  const page = useConversationMedia(conversationId, tab)
+  const me = useMe()
+
+  const messages = useMemo(() => page.data?.pages.flatMap((p) => p.items) ?? [], [page.data])
+  const tiles = useMemo(() => (tab === 'visual' ? tilesOf(messages) : []), [messages, tab])
+
+  /*
+   * Only the index is state; the album is derived.
+   *
+   * `post/[id].tsx` snapshots `{ items, index }` because a post's gallery is
+   * six fixed files. This list pages, so a snapshot taken when the viewer
+   * opened would trap the reader inside whatever had loaded by then.
+   * `PhotoViewer` re-reads `photos` on every render, so passing the derived
+   * array means a page fetched behind the open viewer becomes swipeable.
+   */
+  const [viewingAt, setViewingAt] = useState<number | null>(null)
+  const album = useMemo(
+    () => tiles.map((tile) => ({ url: tile.media.url, contentType: tile.media.contentType })),
+    [tiles],
+  )
+
+  const senders = useProfileCache(
+    messages.map((m) => m.senderId).filter((id) => id !== me.data?._id),
+  )
+  const pull = usePullToRefresh(() => page.refetch())
+  const size = Math.floor((width - GRID_GAP * (COLUMNS - 1)) / COLUMNS)
+
+  const state = listState({
+    isPending: page.isPending,
+    isError: page.isError,
+    itemCount: tab === 'visual' ? tiles.length : messages.length,
+  })
+
+  const empty = (
+    <EmptyState
+      icon={tab === 'visual' ? 'image' : 'mic'}
+      title={t(tab === 'visual' ? 'chatMedia.tabVisual' : 'chatMedia.tabAudio')}
+      body={t(tab === 'visual' ? 'chatMedia.emptyVisual' : 'chatMedia.emptyAudio')}
+    />
+  )
+
+  const paging = {
+    refreshControl: <RefreshControl {...pull} />,
+    onEndReachedThreshold: 0.5,
+    onEndReached: () => {
+      if (page.hasNextPage && !page.isFetchingNextPage) void page.fetchNextPage()
+    },
+    ListFooterComponent: page.isFetchingNextPage ? (
+      <ActivityIndicator style={styles.loading} />
+    ) : null,
+  }
+
+  return (
+    <Screen fluid>
+      <ScreenHeader
+        title={t('chatMedia.title')}
+        onBack={() => goBackTo(`/(app)/chat/${conversationId}`)}
+      />
+
+      <View style={styles.tabs}>
+        <SegmentedControl<MediaTab>
+          options={MEDIA_TABS.map((value) => ({
+            value,
+            label: t(value === 'visual' ? 'chatMedia.tabVisual' : 'chatMedia.tabAudio'),
+          }))}
+          selected={[tab]}
+          onToggle={(value) => setTab(value)}
+          accessibilityLabel={t('chatMedia.tabPicker')}
+        />
+      </View>
+
+      {state === 'skeleton' ? (
+        <ActivityIndicator style={styles.loading} />
+      ) : tab === 'visual' ? (
+        <FlatList
+          data={tiles}
+          keyExtractor={(tile) => tile._id}
+          numColumns={COLUMNS}
+          columnWrapperStyle={styles.gridRow}
+          contentContainerStyle={styles.grid}
+          ListEmptyComponent={empty}
+          {...paging}
+          renderItem={({ item, index }) => (
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => setViewingAt(index)}
+              style={({ pressed }) => [
+                styles.tile,
+                { height: size, width: size },
+                pressed && styles.tilePressed,
+              ]}
+            >
+              {isVideoContentType(item.media.contentType ?? '') ? (
+                <>
+                  {/*
+                    `VideoTile` rather than an `Image`: `expo-image` cannot draw
+                    a frame out of an mp4, so the square would be empty and the
+                    badge would be a badge on nothing.
+                  */}
+                  <VideoTile url={item.media.url} />
+                  <View style={styles.playBadge}>
+                    <Feather name="play" size={12} color={colors.onScrim} />
+                  </View>
+                </>
+              ) : (
+                <Image source={{ uri: item.media.url }} style={styles.fill} contentFit="cover" />
+              )}
+            </Pressable>
+          )}
+        />
+      ) : (
+        <FlatList
+          data={messages}
+          keyExtractor={(item) => item._id}
+          contentContainerStyle={styles.list}
+          ListEmptyComponent={empty}
+          {...paging}
+          renderItem={({ item }) => {
+            const media = attachmentsOf(item)[0]
+            if (!media) return null
+            const mine = item.senderId === me.data?._id
+            return (
+              <View style={styles.audioRow}>
+                <AudioBubble media={media} mine={mine} />
+                <Text style={styles.audioMeta}>
+                  {mine ? t('messageMeta.you') : (senders[item.senderId]?.displayName ?? '')}
+                  {' · '}
+                  {dayLabel(item.createdAt.slice(0, 10), { t, locale })}
+                </Text>
+              </View>
+            )
+          }}
+        />
+      )}
+
+      <PhotoViewer
+        photos={album}
+        index={viewingAt}
+        onClose={() => setViewingAt(null)}
+        onIndexChange={setViewingAt}
+      />
+    </Screen>
+  )
+}
+
+const useStyles = makeStyles(({ colors, spacing }) => ({
+  loading: { paddingVertical: spacing.xl },
+  tabs: { paddingBottom: spacing.md },
+  // Edge to edge: a media grid has no business with a page margin.
+  grid: { flexGrow: 1, gap: GRID_GAP, paddingBottom: spacing.xl },
+  gridRow: { gap: GRID_GAP },
+  tile: { backgroundColor: colors.fill, overflow: 'hidden' },
+  tilePressed: { opacity: 0.7 },
+  fill: { height: '100%', width: '100%' },
+  playBadge: {
+    alignItems: 'center',
+    backgroundColor: colors.scrim,
+    borderRadius: 13,
+    bottom: 6,
+    height: 26,
+    justifyContent: 'center',
+    position: 'absolute',
+    right: 6,
+    width: 26,
+  },
+  list: { flexGrow: 1, paddingBottom: spacing.xl },
+  audioRow: { gap: 6, paddingVertical: spacing.md },
+  audioMeta: { color: colors.textFaint, fontSize: 13 },
+}))

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -1352,6 +1352,9 @@ export default function ChatScreen() {
       // the thing I wanted to keep go — and differ only in how much shape it
       // had when it was kept.
       { label: t('chat.phraseDeck'), value: 'phrases' },
+      // The third answer to the same question, and the only one that needs
+      // nothing kept first: a photo is already saved by having been sent.
+      { label: t('chat.media'), value: 'media' },
       // The same toggle the list offers, where the design puts it as well.
       { label: pinned ? t('chats.unpin') : t('chats.pin'), value: 'pin' },
       { label: t('common.block'), value: 'block', destructive: true },
@@ -1362,6 +1365,8 @@ export default function ChatScreen() {
       router.push('/(app)/starred')
     } else if (choice === 'phrases') {
       router.push({ pathname: '/(app)/phrases', params: { id: conversationId } })
+    } else if (choice === 'media') {
+      router.push({ pathname: '/(app)/chat-media', params: { id: conversationId } })
     } else if (choice === 'pin') {
       flags.mutate({ conversationId, pinned: !pinned })
     } else if (choice === 'block') {

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -79,6 +79,8 @@ import {
 import { errorCodeOf } from '../../../src/lib/errors'
 import { listState } from '../../../src/lib/listState'
 import { messageActionsFor } from '../../../src/lib/messageActions'
+import { meetingClock } from '../../../src/lib/meetingClock'
+import { messagePreviewKey } from '../../../src/lib/messagePreview'
 import {
   openMessageMenu,
   type AnchorRect,
@@ -108,7 +110,7 @@ import { addMeetingToCalendar } from '../../../src/lib/addToCalendar'
 import { showToast } from '../../../src/lib/toast'
 import { messagesNewestFirst } from '../../../src/lib/messageCache'
 import { dayLabel, messageRows, type MessageRow } from '../../../src/lib/messageGroups'
-import { useDisplayNames, useLocale, useT, type MessageKey } from '../../../src/i18n'
+import { useDisplayNames, useLocale, useT } from '../../../src/i18n'
 import { planJump } from '../../../src/lib/messageJump'
 import { makeStyles, useTheme } from '../../../src/lib/theme'
 import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
@@ -429,7 +431,7 @@ export default function ChatScreen() {
   /** A proposal's time, in the reader's own zone. */
   function meetingWhenFor(message: MessageDto): string {
     if (!message.meeting) return ''
-    return clockFor(new Date(message.meeting.startsAt), me.data?.timezone)
+    return meetingClock(new Date(message.meeting.startsAt), me.data?.timezone, locale)
   }
 
   /**
@@ -442,7 +444,7 @@ export default function ChatScreen() {
   function meetingTheirWhenFor(message: MessageDto): string {
     if (!message.meeting || !partner?.timezone) return ''
     const at = new Date(message.meeting.startsAt)
-    const theirs = clockFor(at, partner.timezone)
+    const theirs = meetingClock(at, partner.timezone, locale)
     /*
      * Compared as drawn, not as named.
      *
@@ -454,26 +456,9 @@ export default function ChatScreen() {
      * (`Europe/London` and `Africa/Abidjan` in winter), and that is the same
      * useless line.
      */
-    return theirs === clockFor(at, me.data?.timezone)
+    return theirs === meetingClock(at, me.data?.timezone, locale)
       ? ''
       : t('chat.meetingTheirTime', { time: theirs })
-  }
-
-  /**
-   * Read off a profile's `timezone`, not the device's: the device clock
-   * follows wherever the phone is, and somebody reading this on a trip would
-   * be shown a time that is right for the airport and wrong for the call.
-   * `undefined` falls back to the device, which is the best guess left.
-   */
-  function clockFor(at: Date, zone: string | undefined): string {
-    return new Intl.DateTimeFormat(locale, {
-      weekday: 'short',
-      day: 'numeric',
-      month: 'short',
-      hour: 'numeric',
-      minute: '2-digit',
-      ...(zone ? { timeZone: zone } : {}),
-    }).format(at)
   }
 
   function meetingLengthFor(message: MessageDto): string {
@@ -1125,7 +1110,7 @@ export default function ChatScreen() {
     })
 
     const picked = await openMessageMenu({
-      preview: message.body || t(messageTypeKey(message.type)),
+      preview: message.body || t(messagePreviewKey(message.type)),
       mine: isMine(message),
       // So the menu lifts the picture out of the thread rather than the word
       // "Photo". Audio is left out on purpose: see `MessageMenuRequest`.
@@ -1417,7 +1402,7 @@ export default function ChatScreen() {
                 label: isMine(replyingTo)
                   ? t('chat.replyingToYourself')
                   : t('chat.replyingTo', { name: partner?.displayName ?? t('chat.them') }),
-                preview: replyingTo.body || t(messageTypeKey(replyingTo.type)),
+                preview: replyingTo.body || t(messagePreviewKey(replyingTo.type)),
                 clear: () => setReplyingTo(null),
               }
             : null
@@ -2114,13 +2099,6 @@ function pictureOf(message: MessageDto): MessageMenuRequest['picture'] {
   if (message.type !== 'image' && message.type !== 'video') return undefined
   const items = attachmentsOf(message)
   return items.length > 0 ? { kind: 'media', items } : undefined
-}
-
-/** What the sheet shows above the actions when a message has no text. */
-function messageTypeKey(type: MessageDto['type']): MessageKey {
-  if (type === 'image') return 'messageMeta.photo'
-  if (type === 'audio') return 'chat.voiceMessage'
-  return 'messageMeta.message'
 }
 
 /**

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -8,6 +8,7 @@ import {
   MAX_VIDEO_SECONDS,
   type Media,
   MESSAGE_REACTIONS,
+  PHRASE_EXAMPLE_MAX_LENGTH,
   hasFeature,
   webUrl,
   messageTranslationSchema,
@@ -1162,6 +1163,29 @@ export default function ChatScreen() {
       await emit('conversation:pin', {
         conversationId,
         messageId: pinned?.messageId === message._id ? null : message._id,
+      })
+    } else if (picked.id === 'phrase') {
+      /*
+       * Their sentence, already in the example field, with the term left for
+       * the reader to write — the word they want is a judgement the app cannot
+       * make from a sentence.
+       *
+       * Sliced to `PHRASE_EXAMPLE_MAX_LENGTH`, because `FormField`'s
+       * `maxLength` bounds *typing* and not a value handed to it: an unsliced
+       * 2000-character body would look accepted in the form and then be
+       * refused by `sendPhraseSchema` on save.
+       *
+       * `params`, never a query string built by hand: `routeLiterals.test.ts`
+       * treats an interpolated literal as a wildcard, so a typo in one is
+       * exactly what it cannot catch.
+       */
+      router.push({
+        pathname: '/(app)/phrase-card',
+        params: {
+          id: conversationId,
+          ...(translateInto ? { lang: translateInto } : {}),
+          example: message.body.slice(0, PHRASE_EXAMPLE_MAX_LENGTH),
+        },
       })
     } else if (picked.id === 'report') {
       await reportMessage(message)

--- a/apps/mobile/app/(app)/phrase-card.tsx
+++ b/apps/mobile/app/(app)/phrase-card.tsx
@@ -31,11 +31,21 @@ import { showToast } from '../../src/lib/toast'
 export default function PhraseCardScreen() {
   const styles = useStyles()
   const t = useT()
-  const { id: conversationId, lang } = useLocalSearchParams<{ id: string; lang?: string }>()
+  const {
+    id: conversationId,
+    lang,
+    example: quoted,
+  } = useLocalSearchParams<{ id: string; lang?: string; example?: string }>()
 
   const [term, setTerm] = useState('')
   const [meaning, setMeaning] = useState('')
-  const [example, setExample] = useState('')
+  /*
+   * Arrives filled when the card was started from a message — the sentence it
+   * was met in, already the example. `term` and `meaning` stay empty on
+   * purpose: the reader picks the word out of the sentence and says what it
+   * means, which is the part that makes it worth keeping.
+   */
+  const [example, setExample] = useState(quoted ?? '')
   const [saving, setSaving] = useState(false)
 
   const back = (): void => goBackTo(`/(app)/chat/${conversationId}`)

--- a/apps/mobile/app/(app)/phrases.tsx
+++ b/apps/mobile/app/(app)/phrases.tsx
@@ -88,6 +88,7 @@ export default function PhrasesScreen() {
           ListFooterComponent={
             <Pressable
               accessibilityRole="button"
+              hitSlop={12}
               onPress={() => router.push('/(app)/all-phrases')}
               style={styles.allLink}
             >
@@ -108,6 +109,6 @@ const useStyles = makeStyles(({ colors, spacing }) => ({
   term: { color: colors.text, fontSize: 17, fontWeight: '700' },
   meaning: { color: colors.text, fontSize: 15, lineHeight: 21 },
   example: { color: colors.textMuted, fontSize: 14, fontStyle: 'italic', lineHeight: 20 },
-  allLink: { paddingTop: spacing.lg },
+  allLink: { paddingBottom: spacing.md, paddingTop: spacing.lg },
   allLinkText: { color: colors.accent, fontSize: 15, fontWeight: '700' },
 }))

--- a/apps/mobile/app/(app)/phrases.tsx
+++ b/apps/mobile/app/(app)/phrases.tsx
@@ -1,5 +1,5 @@
 import { hasFeature } from '@langx/shared'
-import { useLocalSearchParams } from 'expo-router'
+import { router, useLocalSearchParams } from 'expo-router'
 import { FlatList, Pressable, Text, View } from 'react-native'
 import { useEffectiveTier, usePhraseCards } from '../../src/api/queries'
 import { EmptyState } from '../../src/components/ui/EmptyState'
@@ -80,6 +80,20 @@ export default function PhrasesScreen() {
               {item.example ? <Text style={styles.example}>{item.example}</Text> : null}
             </View>
           )}
+          /*
+           * A footer rather than a header row: this deck is what the reader
+           * came for, and the way out to every deck belongs after it. A footer
+           * also renders on an empty list, where the link is most useful.
+           */
+          ListFooterComponent={
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => router.push('/(app)/all-phrases')}
+              style={styles.allLink}
+            >
+              <Text style={styles.allLinkText}>{t('chat.allPhrases')}</Text>
+            </Pressable>
+          }
         />
       )}
     </Screen>
@@ -94,4 +108,6 @@ const useStyles = makeStyles(({ colors, spacing }) => ({
   term: { color: colors.text, fontSize: 17, fontWeight: '700' },
   meaning: { color: colors.text, fontSize: 15, lineHeight: 21 },
   example: { color: colors.textMuted, fontSize: 14, fontStyle: 'italic', lineHeight: 20 },
+  allLink: { paddingTop: spacing.lg },
+  allLinkText: { color: colors.accent, fontSize: 15, fontWeight: '700' },
 }))

--- a/apps/mobile/app/(app)/starred.tsx
+++ b/apps/mobile/app/(app)/starred.tsx
@@ -1,14 +1,22 @@
+import { attachmentsOf, isVideoContentType } from '@langx/shared'
+import { Feather } from '@expo/vector-icons'
+import { Image } from 'expo-image'
 import { router } from 'expo-router'
-import { ActivityIndicator, FlatList, Pressable, Text, View } from 'react-native'
+import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from 'react-native'
 import { useMe, useStarred, type MessageDto } from '../../src/api/queries'
+import { formatSeconds, VideoTile } from '../../src/components/MediaBubble'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
 import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
 import { useProfileCache } from '../../src/hooks/useProfileCache'
+import { usePullToRefresh } from '../../src/hooks/usePullToRefresh'
 import { dayLabel } from '../../src/lib/messageGroups'
 import { useLocale, useT } from '../../src/i18n'
+import { meetingClock } from '../../src/lib/meetingClock'
+import { messagePreviewKey } from '../../src/lib/messagePreview'
 import { goBackTo } from '../../src/lib/navigation'
-import { makeStyles } from '../../src/lib/theme'
+import { stickerAsset } from '../../src/lib/stickerAssets'
+import { makeStyles, useTheme } from '../../src/lib/theme'
 import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 
 /**
@@ -18,6 +26,12 @@ import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
  * all — without the screen, starring is a write with no read. Each row goes
  * back to the message in its thread through the same `?at=` window a reply
  * quote uses; the star does not copy the message, it points at it.
+ *
+ * Each row is drawn as the *kind* of thing it is. Every row used to read
+ * `body || 'Attachment'`, which meant a starred photo, voice note, phrase
+ * card, sticker, meeting and quiz all collapsed into one word — and a phrase
+ * card, whose `body` is empty by construction, was the most wrong of them.
+ * Starring worked; it just did not look like it had.
  */
 export default function StarredScreen() {
   useScreenInteractive()
@@ -25,6 +39,7 @@ export default function StarredScreen() {
   const starred = useStarred()
   const me = useMe()
   const t = useT()
+  const pull = usePullToRefresh(() => starred.refetch())
 
   const items = starred.data?.items ?? []
   // A message carries its sender's id and nothing else about them, so the
@@ -43,14 +58,23 @@ export default function StarredScreen() {
 
       {starred.isPending ? (
         <ActivityIndicator style={styles.loading} />
-      ) : items.length === 0 ? (
-        <EmptyState icon="star" title={t('starred.emptyTitle')} body={t('starred.emptyBody')} />
       ) : (
         <FlatList
           data={items}
           keyExtractor={(item) => item._id}
           contentContainerStyle={styles.list}
-          renderItem={({ item }) => <Row message={item} from={senderName(item)} styles={styles} />}
+          refreshControl={<RefreshControl {...pull} />}
+          /*
+           * Inside the list, not beside it. As a sibling it left a reader with
+           * nothing starred on a screen that could not be pulled to refresh —
+           * the one state where they are most likely to try.
+           */
+          ListEmptyComponent={
+            <EmptyState icon="star" title={t('starred.emptyTitle')} body={t('starred.emptyBody')} />
+          }
+          renderItem={({ item }) => (
+            <Row message={item} from={senderName(item)} zone={me.data?.timezone} styles={styles} />
+          )}
         />
       )}
     </Screen>
@@ -60,10 +84,12 @@ export default function StarredScreen() {
 function Row({
   message,
   from,
+  zone,
   styles,
 }: {
   message: MessageDto
   from: string
+  zone: string | undefined
   styles: ReturnType<typeof useStyles>
 }) {
   const t = useT()
@@ -83,14 +109,132 @@ function Row({
         </Text>
         <Text style={styles.when}>{dayLabel(message.createdAt.slice(0, 10), { t, locale })}</Text>
       </View>
-      <Text style={styles.body}>{message.body || t('messageMeta.attachment')}</Text>
+      <Preview message={message} zone={zone} styles={styles} />
     </Pressable>
   )
 }
 
-const useStyles = makeStyles(({ colors, font, spacing }) => ({
+/**
+ * The one line — or thumbnail and line — that says what was starred.
+ *
+ * A row is a pointer, not a copy: it says enough to recognise the message and
+ * nothing more, because the tap already opens the real one in its thread. So
+ * a voice note reports its length rather than carrying a player, and a photo
+ * is a small square rather than a bubble.
+ */
+function Preview({
+  message,
+  zone,
+  styles,
+}: {
+  message: MessageDto
+  zone: string | undefined
+  styles: ReturnType<typeof useStyles>
+}) {
+  const t = useT()
+  const { locale } = useLocale()
+  const { colors } = useTheme()
+
+  if (message.type === 'image' || message.type === 'video') {
+    // Read through `attachmentsOf`: a v1-imported message carries `media` and
+    // no `attachments`, and the two have to look the same here.
+    const first = attachmentsOf(message)[0]
+    /*
+     * By content type rather than the message's `type`: `type` is the kind of
+     * the *first* attachment, so a gallery led by a photo can still hold the
+     * video this row is showing.
+     */
+    const video = isVideoContentType(first?.contentType ?? '')
+    return (
+      <View style={styles.withThumb}>
+        {first ? (
+          <View style={styles.thumb}>
+            {/*
+              `VideoTile` rather than an `Image` for a video: `expo-image`
+              cannot draw a frame out of an mp4, so the square would be empty
+              and the play badge would be a badge on nothing.
+            */}
+            {video ? (
+              <VideoTile url={first.url} />
+            ) : (
+              <Image source={{ uri: first.url }} style={styles.thumbFill} contentFit="cover" />
+            )}
+            {video ? (
+              <View style={styles.playBadge}>
+                <Feather name="play" size={11} color={colors.onScrim} />
+              </View>
+            ) : null}
+          </View>
+        ) : null}
+        <Text style={styles.body} numberOfLines={2}>
+          {message.body || t(messagePreviewKey(message.type))}
+        </Text>
+      </View>
+    )
+  }
+
+  if (message.type === 'audio') {
+    const seconds = attachmentsOf(message)[0]?.durationSeconds
+    return (
+      <Text style={styles.body}>
+        {t('chat.voiceMessage')}
+        {seconds ? ` · ${formatSeconds(seconds)}` : ''}
+      </Text>
+    )
+  }
+
+  if (message.type === 'phrase' && message.phrase) {
+    return (
+      <View style={styles.stack}>
+        <Text style={styles.term}>{message.phrase.term}</Text>
+        <Text style={styles.meaning} numberOfLines={2}>
+          {message.phrase.meaning}
+        </Text>
+      </View>
+    )
+  }
+
+  if (message.type === 'sticker' && message.sticker) {
+    const asset = stickerAsset(message.sticker.packId, message.sticker.stickerId)
+    return asset ? (
+      <Image source={asset} style={styles.sticker} contentFit="contain" />
+    ) : (
+      <Text style={styles.body}>{t(messagePreviewKey('sticker'))}</Text>
+    )
+  }
+
+  if (message.type === 'meeting' && message.meeting) {
+    return (
+      <View style={styles.stack}>
+        <Text style={styles.term}>
+          {meetingClock(new Date(message.meeting.startsAt), zone, locale)}
+        </Text>
+        <Text style={styles.meaning}>{t(messagePreviewKey('meeting'))}</Text>
+      </View>
+    )
+  }
+
+  if (message.type === 'quiz' && message.quiz) {
+    return (
+      <View style={styles.stack}>
+        <Text style={styles.body} numberOfLines={2}>
+          {message.quiz.question}
+        </Text>
+        <Text style={styles.meaning}>{t(messagePreviewKey('quiz'))}</Text>
+      </View>
+    )
+  }
+
+  return (
+    <Text style={styles.body} numberOfLines={2}>
+      {message.body || t(messagePreviewKey(message.type))}
+    </Text>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, radius, spacing }) => ({
   loading: { paddingVertical: spacing.xl },
-  list: { paddingBottom: spacing.xl },
+  list: { flexGrow: 1, paddingBottom: spacing.xl },
   // v3 list language: flat rows on the ground, hairline dividers, no boxes.
   row: {
     borderBottomColor: colors.border,
@@ -107,5 +251,29 @@ const useStyles = makeStyles(({ colors, font, spacing }) => ({
   },
   from: { ...font.heading, color: colors.text, flexShrink: 1, fontSize: 14 },
   when: { color: colors.textFaint, fontSize: 13 },
-  body: { color: colors.text, fontSize: 16, lineHeight: 23 },
+  body: { color: colors.text, flexShrink: 1, fontSize: 16, lineHeight: 23 },
+  stack: { gap: 2 },
+  withThumb: { alignItems: 'center', flexDirection: 'row', gap: spacing.md },
+  thumb: {
+    backgroundColor: colors.fill,
+    borderRadius: radius.sm,
+    height: 52,
+    overflow: 'hidden',
+    width: 52,
+  },
+  thumbFill: { height: '100%', width: '100%' },
+  playBadge: {
+    alignItems: 'center',
+    backgroundColor: colors.scrim,
+    borderRadius: 11,
+    bottom: 4,
+    height: 22,
+    justifyContent: 'center',
+    position: 'absolute',
+    right: 4,
+    width: 22,
+  },
+  sticker: { height: 68, width: 68 },
+  term: { ...font.heading, color: colors.text, fontSize: 16 },
+  meaning: { color: colors.textMuted, fontSize: 14 },
 }))

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -15,6 +15,7 @@ import {
   type CheckInResult,
   type MediaKind,
   type MediaTab,
+  type PhraseScope,
   type MeetingStatus,
   type MessageAsk,
   type MessageTranslation,
@@ -121,6 +122,12 @@ export const keys = {
    * tabs cannot show the other tab's rows for a frame.
    */
   conversationMedia: (id: string, tab: string) => ['conversationMedia', id, tab] as const,
+  /**
+   * Under the same `['phraseCards']` prefix as the per-conversation deck: both
+   * are read on mount and neither is patched by the socket, so sharing the
+   * prefix costs nothing and makes "any deck" one invalidation.
+   */
+  allPhraseCards: (scope: string) => ['phraseCards', 'all', scope] as const,
   messages: (id: string) => ['messages', id] as const,
   /**
    * Deliberately a child of `messages(id)`: a socket patch written with
@@ -1703,6 +1710,31 @@ export function useConversationMedia(conversationId: string, tab: MediaTab) {
     initialPageParam: '',
     getNextPageParam: (last) => last.nextCursor ?? undefined,
     enabled: conversationId.length > 0,
+  })
+}
+
+export interface CrossPhraseCardDto extends PhraseCardDto {
+  conversationId: string
+  /** The other side of the thread it came from; resolve the name separately. */
+  partnerId?: string
+}
+
+/**
+ * Every saved phrase, across every conversation.
+ *
+ * `enabled` rather than an unconditional fetch: `/me/phrases` is Polyglot on
+ * the *server*, so for a free reader the request is a 403 asked for on
+ * purpose. The caller passes what it already knows about the tier, and the
+ * screen shows the paywall instead of an error state.
+ *
+ * Unpaged, because the route is: this read is the export, and a cursor would
+ * mean paging the whole deck before a file could be written.
+ */
+export function useAllPhraseCards(scope: PhraseScope, enabled: boolean) {
+  return useQuery({
+    queryKey: keys.allPhraseCards(scope),
+    queryFn: () => api.get<{ items: CrossPhraseCardDto[] }>(`/me/phrases?scope=${scope}`),
+    enabled,
   })
 }
 

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -14,6 +14,7 @@ import {
   type PlanTier,
   type CheckInResult,
   type MediaKind,
+  type MediaTab,
   type MeetingStatus,
   type MessageAsk,
   type MessageTranslation,
@@ -106,6 +107,20 @@ export const keys = {
    * the socket's incoming-message writer, which expects a paged list.
    */
   phraseCards: (id: string) => ['phraseCards', id] as const,
+  /**
+   * Its own prefix, and specifically **not** under `messages(id)`.
+   *
+   * That prefix is patched by the socket's incoming-message writer, whose only
+   * defence against a cache it does not belong in is a `prevCursor` a media
+   * page has never carried — so an arriving text message would be appended to
+   * the grid, and the page's absent `mediaLockedFor` would go to `NaN`. Being
+   * paged is what makes this dangerous rather than safe: the shape check
+   * passes. Same lesson as `phraseCards` above, from the other side.
+   *
+   * `tab` is in the key rather than filtered out of one cache, so switching
+   * tabs cannot show the other tab's rows for a frame.
+   */
+  conversationMedia: (id: string, tab: string) => ['conversationMedia', id, tab] as const,
   messages: (id: string) => ['messages', id] as const,
   /**
    * Deliberately a child of `messages(id)`: a socket patch written with
@@ -1655,6 +1670,40 @@ export interface PhraseCardDto {
   example?: string
   lang: string
   createdAt: string
+}
+
+export interface ConversationMediaPageDto {
+  items: MessageDto[]
+  nextCursor: string | null
+}
+
+/**
+ * One thread's attachments, a tab at a time.
+ *
+ * One parameterised hook rather than both tabs mounted at once, unlike
+ * `corrections.tsx` — there both tabs are lists of comparable value, so paying
+ * for the second request buys an instant switch. Here the grid is what the
+ * screen is for and the audio tab is the secondary one; a second request on
+ * open, for the tab most people never touch, is not worth it. What is lost is
+ * one skeleton on the first switch.
+ *
+ * No `placeholderData` either: the two tabs are different components reading
+ * differently shaped rows, so the "previous data" it would hand over is the
+ * wrong tab's.
+ */
+export function useConversationMedia(conversationId: string, tab: MediaTab) {
+  return useInfiniteQuery({
+    queryKey: keys.conversationMedia(conversationId, tab),
+    queryFn: ({ pageParam }) =>
+      api.get<ConversationMediaPageDto>(
+        `/conversations/${conversationId}/media?tab=${tab}${
+          pageParam ? `&cursor=${encodeURIComponent(pageParam)}` : ''
+        }`,
+      ),
+    initialPageParam: '',
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
+    enabled: conversationId.length > 0,
+  })
 }
 
 /**

--- a/apps/mobile/src/components/MediaBubble.tsx
+++ b/apps/mobile/src/components/MediaBubble.tsx
@@ -10,7 +10,7 @@ import { makeStyles, useTheme } from '../lib/theme'
 import { useT } from '../i18n'
 import { SLOW_PLAYBACK_RATE, NORMAL_PLAYBACK_RATE } from '../lib/playbackRate'
 
-function formatSeconds(total: number): string {
+export function formatSeconds(total: number): string {
   const minutes = Math.floor(total / 60)
   const seconds = Math.floor(total % 60)
   return `${minutes}:${String(seconds).padStart(2, '0')}`
@@ -402,7 +402,7 @@ export function VideoBubble({
 }
 
 /** A gallery tile's picture: the video, paused on its first frame. */
-function VideoTile({ url }: { url: string }) {
+export function VideoTile({ url }: { url: string }) {
   const styles = useStyles()
   const player = useVideoPlayer(url, (instance) => {
     instance.muted = true

--- a/apps/mobile/src/components/MessageBubble.tsx
+++ b/apps/mobile/src/components/MessageBubble.tsx
@@ -143,6 +143,15 @@ export const MessageBubble = memo(function MessageBubble({
    * On the bubble itself, not on the column it slides in: the quote above and
    * the clock below are part of the row but not of the bubble, and the menu's
    * lifted copy has to land on the bubble.
+   *
+   * **Every Pressable inside a card carries this too**, not just the outer one.
+   * The innermost Pressable wins the touch, so a card with its own buttons —
+   * a meeting's Accept, a quiz's options — swallowed the long press and the
+   * menu never opened on the part of the card people actually aim at. Worse,
+   * a child with `onPress` and no `onLongPress` fires it on release, so
+   * holding a proposed meeting to star it answered the meeting instead.
+   * Defining `onLongPress` is what suppresses that `onPress`, which is why the
+   * one addition fixes both halves.
    */
   const box = useRef<View>(null)
   const press = () => {
@@ -399,6 +408,7 @@ export const MessageBubble = memo(function MessageBubble({
                 <Pressable
                   accessibilityRole="button"
                   hitSlop={8}
+                  onLongPress={press}
                   onPress={() => onAddToCalendar(message)}
                 >
                   <Text style={styles.meetingCalendar}>{t('chat.meetingAddToCalendar')}</Text>
@@ -416,6 +426,7 @@ export const MessageBubble = memo(function MessageBubble({
                 <Pressable
                   accessibilityRole="button"
                   hitSlop={8}
+                  onLongPress={press}
                   onPress={() => onRespondMeeting(message, 'cancelled')}
                 >
                   <Text style={styles.meetingDecline}>{t('chat.meetingCancel')}</Text>
@@ -425,6 +436,7 @@ export const MessageBubble = memo(function MessageBubble({
                   <Pressable
                     accessibilityRole="button"
                     hitSlop={8}
+                    onLongPress={press}
                     onPress={() => onRespondMeeting(message, 'accepted')}
                   >
                     <Text style={styles.meetingAccept}>{t('chat.meetingAccept')}</Text>
@@ -432,6 +444,7 @@ export const MessageBubble = memo(function MessageBubble({
                   <Pressable
                     accessibilityRole="button"
                     hitSlop={8}
+                    onLongPress={press}
                     onPress={() => onRespondMeeting(message, 'declined')}
                   >
                     <Text style={styles.meetingDecline}>{t('chat.meetingDecline')}</Text>
@@ -494,6 +507,7 @@ export const MessageBubble = memo(function MessageBubble({
                  * would come back refused.
                  */
                 disabled={mine || answered}
+                onLongPress={press}
                 onPress={() => onAnswerQuiz(message, index)}
                 style={({ pressed }) => [
                   styles.quizOption,

--- a/apps/mobile/src/components/settings/SettingsRow.tsx
+++ b/apps/mobile/src/components/settings/SettingsRow.tsx
@@ -499,6 +499,31 @@ export function SettingsRow({ id, model, last = false }: SettingsRowProps) {
       )
     case 'account.blocked':
       return <BlockedPeopleRow last={last} />
+    /*
+     * Drawn on every tier and gated on press, the same way the incognito row
+     * is: a row that says which plan opens it teaches the feature, and a row
+     * that is missing teaches nothing.
+     *
+     * The gate is here rather than on the screen's export button because
+     * `/me/phrases` is Polyglot on the server — a free reader who reached the
+     * screen would find an empty list and no way to learn why.
+     */
+    case 'account.allPhrases':
+      return (
+        <ListRow
+          title={t('settings.exportPhrases')}
+          subtitle={t('settings.exportPhrasesBody')}
+          last={last}
+          {...(model.canDeckExport
+            ? {}
+            : { accessory: <Text style={styles.proTag}>{model.deckExportBadge}</Text> })}
+          onPress={() =>
+            model.canDeckExport
+              ? router.push('/(app)/all-phrases')
+              : openPaywall('deckExport', '/(app)/settings/account')
+          }
+        />
+      )
     case 'account.export':
       return (
         <ListRow

--- a/apps/mobile/src/hooks/useSettingsModel.ts
+++ b/apps/mobile/src/hooks/useSettingsModel.ts
@@ -1,4 +1,10 @@
-import { TIER_BADGES, TIER_NAMES, resolveNotificationPrefs, tierUnlocking } from '@langx/shared'
+import {
+  hasFeature,
+  TIER_BADGES,
+  TIER_NAMES,
+  resolveNotificationPrefs,
+  tierUnlocking,
+} from '@langx/shared'
 import { router } from 'expo-router'
 import { useEffect, useState } from 'react'
 import { Linking, Platform } from 'react-native'
@@ -150,6 +156,10 @@ export function useSettingsModel() {
   // The tag names the plan that unlocks the incognito row. It reads the real
   // table through `tierUnlocking`, so moving it between tiers moves the tag.
   const incognitoBadge = TIER_BADGES[tierUnlocking('incognito') ?? 'free']
+  // Same idiom for the cross-conversation deck: the row is drawn either way
+  // and says which plan opens it.
+  const canDeckExport = hasFeature(tier, 'deckExport')
+  const deckExportBadge = TIER_BADGES[tierUnlocking('deckExport') ?? 'free']
   const shareLocation = useShareLocation()
   const stopSharingLocation = useStopSharingLocation()
 
@@ -289,6 +299,8 @@ export function useSettingsModel() {
     analytics,
     analyticsRow,
     incognitoBadge,
+    canDeckExport,
+    deckExportBadge,
     shareLocation,
     sharingLocation,
     locationBusy,

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -122,6 +122,7 @@ export const ar: Localized<EnMessages> = {
     report: 'إبلاغ',
     correctedCannotEdit: 'مُصحَّحة — لا يمكن تعديلها',
     share: 'مشاركة',
+    savePhrase: 'حفظ كعبارة',
   },
 
   messageMeta: {

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -789,6 +789,16 @@ export const ar: Localized<EnMessages> = {
     deleteForMe: 'حذف عندي',
     actionFailed: 'لم تتم العملية',
     viewProfile: 'عرض الملف الشخصي',
+    media: 'الصور والرسائل الصوتية',
+  },
+
+  chatMedia: {
+    title: 'الوسائط',
+    tabVisual: 'صور وفيديو',
+    tabAudio: 'رسائل صوتية',
+    emptyVisual: 'ستُجمع هنا الصور ومقاطع الفيديو التي تتبادلانها.',
+    emptyAudio: 'ستُجمع هنا الرسائل الصوتية من هذه المحادثة.',
+    tabPicker: 'صور وفيديو أو رسائل صوتية',
   },
 
   messageMenu: {

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -134,6 +134,12 @@ export const ar: Localized<EnMessages> = {
     photo: 'صورة',
     message: 'رسالة',
     sending: 'جارٍ الإرسال',
+    video: 'فيديو',
+    sticker: 'ملصق',
+    phrase: 'عبارة',
+    meeting: 'اجتماع',
+    quiz: 'سؤال',
+    correction: 'تصحيح',
   },
 
   interests: {

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -790,6 +790,12 @@ export const ar: Localized<EnMessages> = {
     actionFailed: 'لم تتم العملية',
     viewProfile: 'عرض الملف الشخصي',
     media: 'الصور والرسائل الصوتية',
+    allPhrases: 'كل العبارات المحفوظة',
+    phraseScopeMine: 'عباراتي',
+    phraseScopeAll: 'الكل',
+    allPhrasesEmpty: 'احفظ عبارة في أي محادثة وستظهر هنا.',
+    phraseScopePicker: 'عباراتي أو كل بطاقة في محادثاتي',
+    phraseFrom: 'من {name}',
   },
 
   chatMedia: {
@@ -1291,6 +1297,8 @@ export const ar: Localized<EnMessages> = {
     signInUnlinked: 'تم إلغاء الربط.',
     signInLinkFailed: 'تعذّر الربط. حاول مرة أخرى.',
     signInUnlinkFailed: 'تعذّر إلغاء الربط. حاول مرة أخرى.',
+    exportPhrases: 'تصدير كل العبارات',
+    exportPhrasesBody: 'كل البطاقات التي حفظتها، من كل المحادثات، في ملف واحد.',
   },
 
   deletion: {
@@ -1722,7 +1730,8 @@ export const ar: Localized<EnMessages> = {
     sendTranslation: 'أرسل بلغته',
     sendTranslationBody: 'اكتب بلغتك؛ يُرسل الاثنان، فيقرأك دون تخمين.',
     deckExport: 'خذ عباراتك معك',
-    deckExportBody: 'صدّر العبارات المحفوظة في محادثة كملف. يفتح في Anki.',
+    deckExportBody:
+      'صدّر العبارات المحفوظة في محادثة، أو كل البطاقات التي حفظتها، كملف. يفتح في Anki.',
     advancedFiltersBody: 'ابحث عن جنس محدد، وحسب المدينة.',
     translationQuota: 'ترجم بقدر ما تحتاج',
     translationQuotaBody: '{count} ترجمة في اليوم — أكثر بكثير مما تستهلكه محادثة.',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -125,6 +125,12 @@ export const de: Localized<EnMessages> = {
     photo: 'Foto',
     message: 'Nachricht',
     sending: 'Wird gesendet',
+    video: 'Video',
+    sticker: 'Sticker',
+    phrase: 'Wendung',
+    meeting: 'Termin',
+    quiz: 'Quiz',
+    correction: 'Korrektur',
   },
 
   interests: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -113,6 +113,7 @@ export const de: Localized<EnMessages> = {
     report: 'Melden',
     correctedCannotEdit: 'Korrigiert — nicht mehr änderbar',
     share: 'Teilen',
+    savePhrase: 'Als Wendung speichern',
   },
 
   messageMeta: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -711,6 +711,16 @@ export const de: Localized<EnMessages> = {
     deleteForMe: 'Für mich löschen',
     actionFailed: 'Das hat nicht geklappt',
     viewProfile: 'Profil ansehen',
+    media: 'Fotos und Sprachnachrichten',
+  },
+
+  chatMedia: {
+    title: 'Medien',
+    tabVisual: 'Fotos & Video',
+    tabAudio: 'Sprachnachrichten',
+    emptyVisual: 'Fotos und Videos, die ihr euch schickt, sammeln sich hier.',
+    emptyAudio: 'Sprachnachrichten aus diesem Chat sammeln sich hier.',
+    tabPicker: 'Fotos und Video oder Sprachnachrichten',
   },
 
   messageMenu: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -712,6 +712,12 @@ export const de: Localized<EnMessages> = {
     actionFailed: 'Das hat nicht geklappt',
     viewProfile: 'Profil ansehen',
     media: 'Fotos und Sprachnachrichten',
+    allPhrases: 'Alle gespeicherten Wendungen',
+    phraseScopeMine: 'Meine',
+    phraseScopeAll: 'Alle',
+    allPhrasesEmpty: 'Speichere in einem Chat eine Wendung, dann steht sie hier.',
+    phraseScopePicker: 'Meine Karten oder alle Karten aus meinen Chats',
+    phraseFrom: 'Von {name}',
   },
 
   chatMedia: {
@@ -1139,6 +1145,8 @@ export const de: Localized<EnMessages> = {
     signInUnlinked: 'Getrennt.',
     signInLinkFailed: 'Verbinden fehlgeschlagen. Versuch es noch einmal.',
     signInUnlinkFailed: 'Trennen fehlgeschlagen. Versuch es noch einmal.',
+    exportPhrases: 'Alle Wendungen exportieren',
+    exportPhrasesBody: 'Alle gespeicherten Karten aus allen Chats, in einer Datei.',
   },
 
   deletion: {
@@ -1485,7 +1493,7 @@ export const de: Localized<EnMessages> = {
     sendTranslationBody: 'Schreib in deiner; beides geht raus, also lesen sie dich ohne zu raten.',
     deckExport: 'Nimm deine Wendungen mit',
     deckExportBody:
-      'Exportiere die gespeicherten Wendungen eines Chats als Datei. Sie öffnet sich in Anki.',
+      'Exportiere die gespeicherten Wendungen eines Chats — oder alle, die du gespeichert hast — als Datei. Sie öffnet sich in Anki.',
     advancedFiltersBody: 'Nach einem bestimmten Geschlecht und nach Stadt suchen.',
     translationQuota: 'Übersetze so viel du brauchst',
     translationQuotaBody: '{count} Übersetzungen am Tag — weit mehr als ein Gespräch braucht.',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -141,6 +141,7 @@ export const en = {
     report: 'Report',
     correctedCannotEdit: 'Corrected — can’t be edited',
     share: 'Share',
+    savePhrase: 'Save as a phrase',
   },
 
   messageMeta: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -725,6 +725,16 @@ export const en = {
     deleteForMe: 'Delete for me',
     actionFailed: 'That did not go through',
     viewProfile: 'View profile',
+    media: 'Photos and voice notes',
+  },
+
+  chatMedia: {
+    title: 'Media',
+    tabVisual: 'Photos & video',
+    tabAudio: 'Voice notes',
+    emptyVisual: 'Photos and video you send each other will collect here.',
+    emptyAudio: 'Voice notes from this chat will collect here.',
+    tabPicker: 'Photos and video, or voice notes',
   },
 
   messageMenu: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -726,6 +726,12 @@ export const en = {
     actionFailed: 'That did not go through',
     viewProfile: 'View profile',
     media: 'Photos and voice notes',
+    allPhrases: 'All saved phrases',
+    phraseScopeMine: 'Mine',
+    phraseScopeAll: 'Everything',
+    allPhrasesEmpty: 'Save a phrase in any conversation and it will show up here.',
+    phraseScopePicker: 'Mine, or every card in my conversations',
+    phraseFrom: 'From {name}',
   },
 
   chatMedia: {
@@ -1156,6 +1162,8 @@ export const en = {
     signInUnlinked: 'Disconnected.',
     signInLinkFailed: 'Could not connect. Try again.',
     signInUnlinkFailed: 'Could not disconnect. Try again.',
+    exportPhrases: 'Export every phrase',
+    exportPhrasesBody: 'Every card you have saved, from every conversation, as one file.',
   },
 
   deletion: {
@@ -1500,7 +1508,8 @@ export const en = {
     sendTranslation: 'Send in their language',
     sendTranslationBody: 'Write in yours; both go, so they read you without guessing.',
     deckExport: 'Take your phrases with you',
-    deckExportBody: 'Export a conversation’s saved phrases as a file. It opens in Anki.',
+    deckExportBody:
+      'Export one conversation’s saved phrases, or every card you have saved, as a file. It opens in Anki.',
     advancedFiltersBody: 'Search for a specific gender, and by city.',
     translationQuota: 'Translate as much as you need',
     translationQuotaBody: '{count} translations a day — far more than a conversation uses.',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -153,6 +153,12 @@ export const en = {
     photo: 'Photo',
     message: 'Message',
     sending: 'Sending',
+    video: 'Video',
+    sticker: 'Sticker',
+    phrase: 'Phrase',
+    meeting: 'Meeting',
+    quiz: 'Quiz',
+    correction: 'Correction',
   },
 
   /**

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -690,6 +690,12 @@ export const es: Localized<EnMessages> = {
     actionFailed: 'Eso no salió bien',
     viewProfile: 'Ver perfil',
     media: 'Fotos y notas de voz',
+    allPhrases: 'Todas las expresiones guardadas',
+    phraseScopeMine: 'Mías',
+    phraseScopeAll: 'Todas',
+    allPhrasesEmpty: 'Guarda una expresión en cualquier chat y aparecerá aquí.',
+    phraseScopePicker: 'Mías, o todas las tarjetas de mis chats',
+    phraseFrom: 'De {name}',
   },
 
   chatMedia: {
@@ -1112,6 +1118,8 @@ export const es: Localized<EnMessages> = {
     signInUnlinked: 'Desconectado.',
     signInLinkFailed: 'No se pudo conectar. Inténtalo de nuevo.',
     signInUnlinkFailed: 'No se pudo desconectar. Inténtalo de nuevo.',
+    exportPhrases: 'Exportar todas las expresiones',
+    exportPhrasesBody: 'Todas las tarjetas que has guardado, de todos los chats, en un archivo.',
   },
 
   deletion: {
@@ -1455,7 +1463,7 @@ export const es: Localized<EnMessages> = {
     sendTranslationBody: 'Escribe en el tuyo; van los dos, así te leen sin adivinar.',
     deckExport: 'Llévate tus expresiones',
     deckExportBody:
-      'Exporta las expresiones guardadas de una conversación. El archivo se abre en Anki.',
+      'Exporta las expresiones guardadas de una conversación, o todas las que has guardado, como archivo. Se abre en Anki.',
     advancedFiltersBody: 'Busca por un género concreto y por ciudad.',
     translationQuota: 'Traduce lo que necesites',
     translationQuotaBody: '{count} traducciones al día, mucho más de lo que usa una conversación.',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -112,6 +112,7 @@ export const es: Localized<EnMessages> = {
     report: 'Denunciar',
     correctedCannotEdit: 'Corregido: no se puede editar',
     share: 'Compartir',
+    savePhrase: 'Guardar como expresión',
   },
 
   messageMeta: {

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -124,6 +124,12 @@ export const es: Localized<EnMessages> = {
     photo: 'Foto',
     message: 'Mensaje',
     sending: 'Enviando',
+    video: 'Vídeo',
+    sticker: 'Sticker',
+    phrase: 'Expresión',
+    meeting: 'Reunión',
+    quiz: 'Pregunta',
+    correction: 'Corrección',
   },
 
   interests: {

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -689,6 +689,16 @@ export const es: Localized<EnMessages> = {
     deleteForMe: 'Eliminar para mí',
     actionFailed: 'Eso no salió bien',
     viewProfile: 'Ver perfil',
+    media: 'Fotos y notas de voz',
+  },
+
+  chatMedia: {
+    title: 'Multimedia',
+    tabVisual: 'Fotos y vídeo',
+    tabAudio: 'Notas de voz',
+    emptyVisual: 'Las fotos y los vídeos que os enviéis se juntarán aquí.',
+    emptyAudio: 'Las notas de voz de este chat se juntarán aquí.',
+    tabPicker: 'Fotos y vídeo, o notas de voz',
   },
 
   messageMenu: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -126,6 +126,12 @@ export const fr: Localized<EnMessages> = {
     photo: 'Photo',
     message: 'Message',
     sending: 'Envoi en cours',
+    video: 'Vidéo',
+    sticker: 'Sticker',
+    phrase: 'Expression',
+    meeting: 'Rendez-vous',
+    quiz: 'Quiz',
+    correction: 'Correction',
   },
 
   interests: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -692,6 +692,16 @@ export const fr: Localized<EnMessages> = {
     deleteForMe: 'Supprimer pour moi',
     actionFailed: 'Ça n’est pas passé',
     viewProfile: 'Voir le profil',
+    media: 'Photos et messages vocaux',
+  },
+
+  chatMedia: {
+    title: 'Médias',
+    tabVisual: 'Photos et vidéo',
+    tabAudio: 'Messages vocaux',
+    emptyVisual: 'Les photos et vidéos que vous vous envoyez s’accumuleront ici.',
+    emptyAudio: 'Les messages vocaux de cette conversation s’accumuleront ici.',
+    tabPicker: 'Photos et vidéo, ou messages vocaux',
   },
 
   messageMenu: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -693,6 +693,12 @@ export const fr: Localized<EnMessages> = {
     actionFailed: 'Ça n’est pas passé',
     viewProfile: 'Voir le profil',
     media: 'Photos et messages vocaux',
+    allPhrases: 'Toutes les expressions enregistrées',
+    phraseScopeMine: 'Les miennes',
+    phraseScopeAll: 'Toutes',
+    allPhrasesEmpty: 'Enregistre une expression dans une conversation et elle apparaîtra ici.',
+    phraseScopePicker: 'Les miennes, ou toutes les cartes de mes conversations',
+    phraseFrom: 'Avec {name}',
   },
 
   chatMedia: {
@@ -1121,6 +1127,9 @@ export const fr: Localized<EnMessages> = {
     signInUnlinked: 'Déconnecté.',
     signInLinkFailed: 'Connexion impossible. Réessayez.',
     signInUnlinkFailed: 'Déconnexion impossible. Réessayez.',
+    exportPhrases: 'Exporter toutes les expressions',
+    exportPhrasesBody:
+      'Toutes les cartes enregistrées, de toutes les conversations, dans un fichier.',
   },
 
   deletion: {
@@ -1465,7 +1474,7 @@ export const fr: Localized<EnMessages> = {
     sendTranslationBody: 'Écris dans la tienne ; les deux partent, on te lit sans deviner.',
     deckExport: 'Emporte tes expressions',
     deckExportBody:
-      'Exporte les expressions enregistrées d’une conversation. Le fichier s’ouvre dans Anki.',
+      'Exporte les expressions enregistrées d’une conversation, ou toutes celles que tu as gardées, dans un fichier. Il s’ouvre dans Anki.',
     advancedFiltersBody: 'Cherche un genre précis, et par ville.',
     translationQuota: 'Traduis autant que nécessaire',
     translationQuotaBody:

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -114,6 +114,7 @@ export const fr: Localized<EnMessages> = {
     report: 'Signaler',
     correctedCannotEdit: 'Corrigé — non modifiable',
     share: 'Partager',
+    savePhrase: 'Enregistrer comme expression',
   },
 
   messageMeta: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -121,6 +121,12 @@ export const ptBR: Localized<EnMessages> = {
     photo: 'Foto',
     message: 'Mensagem',
     sending: 'Enviando',
+    video: 'Vídeo',
+    sticker: 'Sticker',
+    phrase: 'Expressão',
+    meeting: 'Reunião',
+    quiz: 'Quiz',
+    correction: 'Correção',
   },
 
   interests: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -109,6 +109,7 @@ export const ptBR: Localized<EnMessages> = {
     report: 'Denunciar',
     correctedCannotEdit: 'Corrigida — não dá para editar',
     share: 'Compartilhar',
+    savePhrase: 'Salvar como expressão',
   },
 
   messageMeta: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -684,6 +684,12 @@ export const ptBR: Localized<EnMessages> = {
     actionFailed: 'Isso não foi',
     viewProfile: 'Ver perfil',
     media: 'Fotos e mensagens de voz',
+    allPhrases: 'Todas as expressões salvas',
+    phraseScopeMine: 'Minhas',
+    phraseScopeAll: 'Todas',
+    allPhrasesEmpty: 'Salve uma expressão em qualquer conversa e ela aparece aqui.',
+    phraseScopePicker: 'Minhas, ou todos os cartões das minhas conversas',
+    phraseFrom: 'Com {name}',
   },
 
   chatMedia: {
@@ -1108,6 +1114,8 @@ export const ptBR: Localized<EnMessages> = {
     signInUnlinked: 'Desconectado.',
     signInLinkFailed: 'Não foi possível conectar. Tente de novo.',
     signInUnlinkFailed: 'Não foi possível desconectar. Tente de novo.',
+    exportPhrases: 'Exportar todas as expressões',
+    exportPhrasesBody: 'Todos os cartões que você salvou, de todas as conversas, em um arquivo.',
   },
 
   deletion: {
@@ -1452,7 +1460,8 @@ export const ptBR: Localized<EnMessages> = {
     sendTranslation: 'Envie no idioma dela',
     sendTranslationBody: 'Escreva no seu; os dois vão, então te leem sem adivinhar.',
     deckExport: 'Leve suas expressões',
-    deckExportBody: 'Exporte as expressões salvas de uma conversa. O arquivo abre no Anki.',
+    deckExportBody:
+      'Exporte as expressões salvas de uma conversa, ou todos os cartões que você salvou, como arquivo. Abre no Anki.',
     advancedFiltersBody: 'Busque por um gênero específico e por cidade.',
     translationQuota: 'Traduza o quanto precisar',
     translationQuotaBody: '{count} traduções por dia — muito mais do que uma conversa usa.',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -683,6 +683,16 @@ export const ptBR: Localized<EnMessages> = {
     deleteForMe: 'Excluir para mim',
     actionFailed: 'Isso não foi',
     viewProfile: 'Ver perfil',
+    media: 'Fotos e mensagens de voz',
+  },
+
+  chatMedia: {
+    title: 'Mídia',
+    tabVisual: 'Fotos e vídeo',
+    tabAudio: 'Mensagens de voz',
+    emptyVisual: 'As fotos e os vídeos que vocês enviarem ficam aqui.',
+    emptyAudio: 'As mensagens de voz desta conversa ficam aqui.',
+    tabPicker: 'Fotos e vídeo, ou mensagens de voz',
   },
 
   messageMenu: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -132,6 +132,12 @@ export const ru: Localized<EnMessages> = {
     photo: 'Фото',
     message: 'Сообщение',
     sending: 'Отправляется',
+    video: 'Видео',
+    sticker: 'Стикер',
+    phrase: 'Выражение',
+    meeting: 'Встреча',
+    quiz: 'Викторина',
+    correction: 'Исправление',
   },
 
   interests: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -762,6 +762,16 @@ export const ru: Localized<EnMessages> = {
     deleteForMe: 'Удалить у себя',
     actionFailed: 'Не получилось',
     viewProfile: 'Открыть профиль',
+    media: 'Фото и голосовые',
+  },
+
+  chatMedia: {
+    title: 'Медиа',
+    tabVisual: 'Фото и видео',
+    tabAudio: 'Голосовые',
+    emptyVisual: 'Здесь соберутся фото и видео, которыми вы обменяетесь.',
+    emptyAudio: 'Здесь соберутся голосовые из этого чата.',
+    tabPicker: 'Фото и видео или голосовые',
   },
 
   messageMenu: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -763,6 +763,12 @@ export const ru: Localized<EnMessages> = {
     actionFailed: 'Не получилось',
     viewProfile: 'Открыть профиль',
     media: 'Фото и голосовые',
+    allPhrases: 'Все сохранённые выражения',
+    phraseScopeMine: 'Мои',
+    phraseScopeAll: 'Все',
+    allPhrasesEmpty: 'Сохрани выражение в любом чате — и оно появится здесь.',
+    phraseScopePicker: 'Мои или все карточки из моих чатов',
+    phraseFrom: 'С {name}',
   },
 
   chatMedia: {
@@ -1237,6 +1243,8 @@ export const ru: Localized<EnMessages> = {
     signInUnlinked: 'Отключено.',
     signInLinkFailed: 'Не удалось подключить. Попробуйте ещё раз.',
     signInUnlinkFailed: 'Не удалось отключить. Попробуйте ещё раз.',
+    exportPhrases: 'Экспорт всех выражений',
+    exportPhrasesBody: 'Все сохранённые карточки из всех чатов — одним файлом.',
   },
 
   deletion: {
@@ -1636,7 +1644,8 @@ export const ru: Localized<EnMessages> = {
     sendTranslation: 'Отправляй на их языке',
     sendTranslationBody: 'Пиши на своём — уйдут оба, и тебя прочтут без догадок.',
     deckExport: 'Забери свои выражения',
-    deckExportBody: 'Выгрузи сохранённые выражения беседы в файл. Он открывается в Anki.',
+    deckExportBody:
+      'Выгрузи сохранённые выражения одной беседы или все свои карточки в файл. Он открывается в Anki.',
     advancedFiltersBody: 'Поиск по конкретному полу и по городу.',
     translationQuota: 'Переводи сколько нужно',
     translationQuotaBody: '{count} переводов в день — намного больше, чем нужно для разговора.',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -120,6 +120,7 @@ export const ru: Localized<EnMessages> = {
     report: 'Пожаловаться',
     correctedCannotEdit: 'Исправлено — изменить нельзя',
     share: 'Поделиться',
+    savePhrase: 'Сохранить как выражение',
   },
 
   messageMeta: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -124,6 +124,7 @@ export const tr: Localized<EnMessages> = {
     report: 'Bildir',
     correctedCannotEdit: 'Düzeltilmiş — değiştirilemez',
     share: 'Paylaş',
+    savePhrase: 'İfade olarak kaydet',
   },
 
   messageMeta: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -690,6 +690,12 @@ export const tr: Localized<EnMessages> = {
     actionFailed: 'Bu işlem gerçekleşmedi',
     viewProfile: 'Profili gör',
     media: 'Fotoğraflar ve sesli notlar',
+    allPhrases: 'Tüm kaydedilen ifadeler',
+    phraseScopeMine: 'Benim',
+    phraseScopeAll: 'Hepsi',
+    allPhrasesEmpty: 'Herhangi bir sohbette bir ifade kaydet, burada görünür.',
+    phraseScopePicker: 'Benim kartlarım ya da sohbetlerimdeki her kart',
+    phraseFrom: '{name} ile',
   },
 
   chatMedia: {
@@ -1117,6 +1123,8 @@ export const tr: Localized<EnMessages> = {
     signInUnlinked: 'Bağlantı kesildi.',
     signInLinkFailed: 'Bağlanamadı. Tekrar dene.',
     signInUnlinkFailed: 'Bağlantı kesilemedi. Tekrar dene.',
+    exportPhrases: 'Tüm ifadeleri dışa aktar',
+    exportPhrasesBody: 'Her sohbetten kaydettiğin bütün kartlar, tek dosyada.',
   },
 
   deletion: {
@@ -1455,7 +1463,8 @@ export const tr: Localized<EnMessages> = {
     sendTranslation: 'Onun dilinde gönder',
     sendTranslationBody: 'Sen kendi dilinde yaz; ikisi birden gitsin, o tahmin etmeden okusun.',
     deckExport: 'İfadelerini yanında götür',
-    deckExportBody: 'Bir sohbetin kaydedilmiş ifadelerini dosya olarak dışa aktar. Anki’de açılır.',
+    deckExportBody:
+      'Bir sohbetin kaydedilmiş ifadelerini ya da kaydettiğin bütün kartları dosya olarak dışa aktar. Anki’de açılır.',
     advancedFiltersBody: 'Belirli bir cinsiyete ve şehre göre ara.',
     translationQuota: 'İhtiyacın kadar çeviri',
     translationQuotaBody: 'Günde {count} çeviri — bir sohbetin kullandığından çok daha fazla.',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -689,6 +689,16 @@ export const tr: Localized<EnMessages> = {
     deleteForMe: 'Benden sil',
     actionFailed: 'Bu işlem gerçekleşmedi',
     viewProfile: 'Profili gör',
+    media: 'Fotoğraflar ve sesli notlar',
+  },
+
+  chatMedia: {
+    title: 'Medya',
+    tabVisual: 'Fotoğraf ve video',
+    tabAudio: 'Sesli notlar',
+    emptyVisual: 'Birbirinize gönderdiğiniz fotoğraf ve videolar burada birikir.',
+    emptyAudio: 'Bu sohbetteki sesli notlar burada birikir.',
+    tabPicker: 'Fotoğraf ve video ya da sesli notlar',
   },
 
   messageMenu: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -136,6 +136,12 @@ export const tr: Localized<EnMessages> = {
     photo: 'Fotoğraf',
     message: 'Mesaj',
     sending: 'Gönderiliyor',
+    video: 'Video',
+    sticker: 'Sticker',
+    phrase: 'İfade',
+    meeting: 'Toplantı',
+    quiz: 'Soru',
+    correction: 'Düzeltme',
   },
 
   interests: {

--- a/apps/mobile/src/lib/meetingClock.test.ts
+++ b/apps/mobile/src/lib/meetingClock.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { meetingClock } from './meetingClock'
+
+/** A Wednesday, 21:30 UTC, so the zone shifts are visible in the output. */
+const at = new Date('2026-09-09T21:30:00.000Z')
+
+describe('meetingClock', () => {
+  it('writes the same instant differently in two zones', () => {
+    const toronto = meetingClock(at, 'America/Toronto', 'en')
+    const istanbul = meetingClock(at, 'Europe/Istanbul', 'en')
+    expect(toronto).toContain('5:30')
+    expect(istanbul).toContain('12:30')
+    expect(toronto).not.toBe(istanbul)
+  })
+
+  /**
+   * The zone is what the two readers disagree about, so a card with no zone
+   * has to still say something — the device's guess, not an empty string.
+   */
+  it('falls back to the device zone when the profile has none', () => {
+    expect(meetingClock(at, undefined, 'en')).not.toBe('')
+  })
+
+  it('writes the weekday and month in the reader’s language', () => {
+    expect(meetingClock(at, 'UTC', 'tr')).not.toBe(meetingClock(at, 'UTC', 'en'))
+  })
+})

--- a/apps/mobile/src/lib/meetingClock.ts
+++ b/apps/mobile/src/lib/meetingClock.ts
@@ -1,0 +1,26 @@
+import type { Locale } from '@langx/shared'
+
+/**
+ * A meeting's instant, written in one particular person's zone.
+ *
+ * Read off a profile's `timezone`, not the device's: the device clock follows
+ * wherever the phone is, and somebody reading this on a trip would be shown a
+ * time that is right for the airport and wrong for the call. `undefined` falls
+ * back to the device, which is the best guess left.
+ *
+ * Lived as a closure inside the chat screen until the starred list had to draw
+ * the same card in one line — two callers, so it is genuinely shared rather
+ * than extracted for its own sake, and being in `src/lib` is what makes it
+ * testable at all (`vitest.config.ts` collects only this directory and the
+ * catalogues).
+ */
+export function meetingClock(at: Date, zone: string | undefined, locale: Locale): string {
+  return new Intl.DateTimeFormat(locale, {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+    ...(zone ? { timeZone: zone } : {}),
+  }).format(at)
+}

--- a/apps/mobile/src/lib/messageActions.test.ts
+++ b/apps/mobile/src/lib/messageActions.test.ts
@@ -31,6 +31,7 @@ describe('messageActionsFor', () => {
       'delete',
       'star',
       'pin',
+      'phrase',
       'share',
       'report',
     ])
@@ -107,6 +108,33 @@ describe('messageActionsFor', () => {
     expect(edit?.label).toMatch(/Corrected/)
   })
 
+  describe('save as a phrase', () => {
+    it('is offered on the other person text', () => {
+      expect(ids()).toContain('phrase')
+    })
+
+    /** A deck is for what you met, not for what you already wrote. */
+    it('is not offered on my own message', () => {
+      expect(ids({ mine: true })).not.toContain('phrase')
+    })
+
+    /** A card is what it would produce; there is nothing to turn. */
+    it('is not offered on a phrase card', () => {
+      expect(ids({ type: 'phrase', hasBody: false })).not.toContain('phrase')
+      expect(ids({ type: 'phrase', hasBody: true })).not.toContain('phrase')
+    })
+
+    /**
+     * Nothing to put in the example. This is also what keeps it off a
+     * tombstone, whose `body` the server empties — hence no `deleted` flag on
+     * the context and no check for one here.
+     */
+    it('is not offered on a voice note with no caption', () => {
+      expect(ids({ type: 'audio', hasBody: false })).not.toContain('phrase')
+      expect(ids({ type: 'audio', hasBody: true })).toContain('phrase')
+    })
+  })
+
   it('names star and pin for what pressing them will do', () => {
     expect(find({ starred: true }, 'star')?.label).toBe('Unstar')
     expect(find({ starred: false }, 'star')?.label).toBe('Star')
@@ -125,7 +153,7 @@ describe('paginateActions', () => {
 
   it('puts the rest behind More', () => {
     const { actions, hasMore } = paginateActions(all, 'more')
-    expect(actions.map((a) => a.id)).toEqual(['star', 'pin', 'share', 'report'])
+    expect(actions.map((a) => a.id)).toEqual(['star', 'pin', 'phrase', 'share', 'report'])
     expect(hasMore).toBe(false)
   })
 

--- a/apps/mobile/src/lib/messageActions.test.ts
+++ b/apps/mobile/src/lib/messageActions.test.ts
@@ -1,3 +1,4 @@
+import { MESSAGE_TYPES } from '@langx/shared'
 import { describe, expect, it } from 'vitest'
 import { createTranslate } from '../i18n/runtime'
 import { messageActionsFor, paginateActions, type MessageActionContext } from './messageActions'
@@ -72,6 +73,22 @@ describe('messageActionsFor', () => {
     for (const mine of [true, false]) {
       expect(ids({ mine })).toContain('delete')
       expect(ids({ mine })).toContain('star')
+    }
+  })
+
+  /**
+   * Every *type*, not just every author.
+   *
+   * The case above varies `mine` and leaves `type: 'text'`, so "star works on
+   * anything" was an untested claim for eight of the nine types — which is
+   * how a meeting card could stop being starrable without a red test. A
+   * bodyless type is passed as bodyless, because that is the shape a meeting
+   * and a sticker actually arrive in.
+   */
+  it('offers star on every message type', () => {
+    for (const type of MESSAGE_TYPES) {
+      const hasBody = type === 'text' || type === 'correction'
+      expect(ids({ type, hasBody })).toContain('star')
     }
   })
 

--- a/apps/mobile/src/lib/messageActions.ts
+++ b/apps/mobile/src/lib/messageActions.ts
@@ -10,6 +10,7 @@ export const MESSAGE_ACTION_IDS = [
   'edit',
   'star',
   'pin',
+  'phrase',
   'share',
   'report',
 ] as const
@@ -165,6 +166,29 @@ export function messageActionsFor(context: MessageActionContext): MessageAction[
     icon: 'pin-outline',
     page: 'more',
   })
+
+  /**
+   * Turn what they said into a card in the deck, with their sentence already
+   * in the example field.
+   *
+   * Their message, because the point is to keep a phrase *encountered* rather
+   * than one you already know how to write; something to put in the example,
+   * because a card whose example is blank is the empty form the attachment
+   * menu already opens; and not on a phrase card, because a card is what this
+   * would produce.
+   *
+   * `hasBody` also removes the tombstone without a `deleted` check: a
+   * withdrawn message has an empty `body`, and a card quoting "This message
+   * was deleted" is the one thing this must not offer.
+   */
+  if (!context.mine && context.hasBody && context.type !== 'phrase') {
+    actions.push({
+      id: 'phrase',
+      label: t('messageActions.savePhrase'),
+      icon: 'bookmark-outline',
+      page: 'more',
+    })
+  }
 
   // Out through the platform sheet, as text: a message has no address of its
   // own, and a link into a private thread would resolve for nobody but the

--- a/apps/mobile/src/lib/messagePreview.test.ts
+++ b/apps/mobile/src/lib/messagePreview.test.ts
@@ -1,0 +1,41 @@
+import { MESSAGE_TYPES, SUPPORTED_LOCALES } from '@langx/shared'
+import { describe, expect, it } from 'vitest'
+import { createTranslate } from '../i18n/runtime'
+import { messagePreviewKey } from './messagePreview'
+
+describe('messagePreviewKey', () => {
+  /**
+   * The mirror of `apps/api`'s `previewFor.test.ts`, and the guard this file
+   * exists for.
+   *
+   * `translate` returns a missing key verbatim, so a key that no catalogue
+   * defines is not an error anywhere — it is the dotted path drawn on screen.
+   * The table is exhaustive by type, so what is left to check is that every
+   * key in it actually resolves, in every language. `catalogs.test.ts` uses
+   * the same `not.toBe(key)` trick for the same reason.
+   */
+  it('resolves to a real translation for every type, in every language', () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      const t = createTranslate(locale)
+      for (const type of MESSAGE_TYPES) {
+        const key = messagePreviewKey(type)
+        expect(t(key), `${locale} has no ${key} for ${type}`).not.toBe(key)
+      }
+    }
+  })
+
+  /**
+   * The bug that started this: the old table in `chat/[id].tsx` knew `image`
+   * and `audio`, and everything else fell through to "Message" — so a starred
+   * meeting and a starred sticker were indistinguishable from each other and
+   * from a message the screen could not read at all.
+   */
+  it('gives the bodyless types a name of their own', () => {
+    const t = createTranslate('en')
+    const named = MESSAGE_TYPES.filter((type) => type !== 'text').map((type) =>
+      t(messagePreviewKey(type)),
+    )
+    expect(new Set(named).size).toBe(named.length)
+    expect(named).not.toContain(t('messageMeta.message'))
+  })
+})

--- a/apps/mobile/src/lib/messagePreview.ts
+++ b/apps/mobile/src/lib/messagePreview.ts
@@ -1,0 +1,41 @@
+import type { MessageType } from '@langx/shared'
+import type { MessageKey } from '../i18n/runtime'
+
+/**
+ * What to call a message that has no text of its own.
+ *
+ * Used wherever a message is named rather than drawn: above the long-press
+ * menu, in the reply band, and in each row of the starred list. It lived in
+ * `chat/[id].tsx` and knew two of the nine types, so a starred meeting, quiz,
+ * phrase card, sticker or video all read "Message" — which is the same thing
+ * the screen says when it has no idea what it is looking at.
+ *
+ * The table is exhaustive against `MESSAGE_TYPES` rather than a `switch` with
+ * a default, so adding a tenth type is a compile error here instead of a
+ * silent tenth "Message". `apps/api`'s `previewFor` guards its own list the
+ * same way, and `previewFor.test.ts` is the mirror of this module's test.
+ *
+ * The keys deliberately cross namespaces — `messageMeta.photo` beside
+ * `chat.voiceMessage`. Gathering them all under `messageMeta.*` would be a
+ * rename with no behaviour in it, across eight catalogues.
+ *
+ * Takes `MessageType` from `@langx/shared`, **not** `MessageDto['type']`:
+ * `vitest.config.ts` collects only `src/lib/**` and `src/i18n/**`, and
+ * importing `react-native` from that graph fails with "Flow is not supported".
+ * `messageActions.ts` solves the same constraint the same way.
+ */
+const MESSAGE_PREVIEW_KEY = {
+  text: 'messageMeta.message',
+  correction: 'messageMeta.correction',
+  image: 'messageMeta.photo',
+  audio: 'chat.voiceMessage',
+  video: 'messageMeta.video',
+  phrase: 'messageMeta.phrase',
+  meeting: 'messageMeta.meeting',
+  quiz: 'messageMeta.quiz',
+  sticker: 'messageMeta.sticker',
+} as const satisfies Record<MessageType, MessageKey>
+
+export function messagePreviewKey(type: MessageType): MessageKey {
+  return MESSAGE_PREVIEW_KEY[type]
+}

--- a/apps/mobile/src/lib/settingsRegistry.ts
+++ b/apps/mobile/src/lib/settingsRegistry.ts
@@ -163,6 +163,11 @@ export const SETTINGS_SECTIONS: readonly SettingsSection[] = [
       { id: 'account.password', titleKey: 'settings.password', bodyKey: 'settings.passwordBody' },
       { id: 'account.devices', titleKey: 'linkDevice.title', bodyKey: 'settings.linkDeviceBody' },
       { id: 'account.blocked', titleKey: 'settings.blockedPeople' },
+      {
+        id: 'account.allPhrases',
+        titleKey: 'settings.exportPhrases',
+        bodyKey: 'settings.exportPhrasesBody',
+      },
       { id: 'account.export', titleKey: 'settings.exportData' },
       { id: 'account.delete', titleKey: 'settings.deleteAccount' },
     ],

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -528,6 +528,44 @@ export const listMessagesQuerySchema = z.object({
 })
 export type ListMessagesQuery = z.infer<typeof listMessagesQuerySchema>
 
+/**
+ * One tab, not one kind.
+ *
+ * `MEDIA_KINDS` cannot say this: the grid shows photos and videos together
+ * because they are looked at the same way, and a voice note is not looked at
+ * at all — it is a different screen's worth of behaviour in the same list.
+ */
+export const MEDIA_TABS = ['visual', 'audio'] as const
+export type MediaTab = (typeof MEDIA_TABS)[number]
+
+/**
+ * `GET /conversations/:id/media`.
+ *
+ * A page counts *messages*, and one message carries up to `MAX_ATTACHMENTS`
+ * files, so thirty messages is thirty to a hundred and eighty tiles. The
+ * ceiling belongs on the side that bounds the query; the grid flattens what
+ * arrives and does not care which.
+ *
+ * `cursor` is `.trim().min(1)`, following the corrections list rather than the
+ * message window above: the window's bare `z.string().optional()` accepts
+ * `?cursor=` and hands `''` to `decodeDateIdCursor`, which then reports a
+ * malformed cursor where none was sent.
+ */
+export const CONVERSATION_MEDIA_PAGE_SIZE_DEFAULT = 30
+export const CONVERSATION_MEDIA_PAGE_SIZE_MAX = 60
+
+export const listConversationMediaQuerySchema = z.object({
+  tab: z.enum(MEDIA_TABS).default('visual'),
+  cursor: z.string().trim().min(1).optional(),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(CONVERSATION_MEDIA_PAGE_SIZE_MAX)
+    .default(CONVERSATION_MEDIA_PAGE_SIZE_DEFAULT),
+})
+export type ListConversationMediaQuery = z.infer<typeof listConversationMediaQuerySchema>
+
 export const CONVERSATION_PAGE_SIZE_DEFAULT = 20
 export const CONVERSATION_PAGE_SIZE_MAX = 50
 

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -499,6 +499,43 @@ export const listStarredQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(STARRED_PAGE_SIZE_MAX).default(50),
 })
 
+/** `GET /me/phrases` — the deck across every thread, not one of them. */
+export const PHRASE_SCOPES = ['mine', 'all'] as const
+export type PhraseScope = (typeof PHRASE_SCOPES)[number]
+
+/**
+ * How many of somebody's threads the cross-conversation deck reads from.
+ *
+ * The result becomes an `$in`, and an `$in` is a list the planner carries —
+ * the same reason `FEED_FOLLOWING_SOURCE_LIMIT` exists, and its own constant
+ * rather than that one because a feed's audience ceiling and a deck's source
+ * ceiling have no reason to move together.
+ *
+ * 200 rather than 500: past a couple of hundred the planner stops being able
+ * to bound and order the scan per conversation and sorts the candidate set
+ * instead, and 200 threads is already far more than any account that has
+ * saved phrases in more than a handful.
+ */
+export const PHRASE_SOURCE_CONVERSATION_LIMIT = 200
+
+/**
+ * Unpaged and capped, like `/me/starred` and unlike `/me/corrections`.
+ *
+ * This read *is* the export: a cursor would mean the export button has to page
+ * the whole deck before it can write a file, and a file that silently holds
+ * the first page is worse than one that holds a documented ceiling. The
+ * ceiling is generous because `conversation_term_unique` already caps each
+ * thread at one row per phrase. The default equals the maximum on purpose —
+ * the screen and the file must show the same rows.
+ */
+export const ALL_PHRASES_MAX = 1000
+
+export const listAllPhrasesQuerySchema = z.object({
+  scope: z.enum(PHRASE_SCOPES).default('mine'),
+  limit: z.coerce.number().int().min(1).max(ALL_PHRASES_MAX).default(ALL_PHRASES_MAX),
+})
+export type ListAllPhrasesQuery = z.infer<typeof listAllPhrasesQuerySchema>
+
 export const MESSAGE_PAGE_SIZE_DEFAULT = 30
 export const MESSAGE_PAGE_SIZE_MAX = 100
 


### PR DESCRIPTION
Four changes to the same complaint: things kept out of a chat were hard to
find again, and one of them could not be kept at all.

### 1. Long press on a meeting or quiz card opens the menu

A card's own buttons — Accept/Decline/Cancel on a meeting, a quiz's options —
are `Pressable`s inside the bubble's `Pressable`, and only the outer one
carried `onLongPress`. The inner one wins the touch, so a long press on the
bottom third of a proposed meeting never reached the action sheet. Worse than
nothing: a child with `onPress` and no `onLongPress` fires on release however
long the hold was, so holding a meeting to star it *answered* the meeting.
Defining `onLongPress` fixes both at once.

The star action was never type-gated; the test that claimed to cover it only
varied the author, so eight of the nine message types went unchecked. It loops
`MESSAGE_TYPES` now.

### 2. Starred rows look like what they point at

Every row read `body || 'Attachment'`, so a starred photo, video, voice note,
phrase card, sticker, meeting and quiz collapsed into one word — and a phrase
card, whose `body` is empty by construction, was the most wrong of them.
Starring worked; it never looked like it had.

`messagePreviewKey` replaces the two-line table in the chat screen that knew
`image` and `audio` out of nine types, and is exhaustive against
`MESSAGE_TYPES` via `satisfies` — a tenth type is now a compile error.

### 3. Save a phrase from the message you met it in

The phrase card could only be started from the attachment menu, as an empty
form, even though the sentence you would type into the example field is
usually on screen one row above the keyboard. Long-pressing their message now
opens the form with that sentence already in the example; `term` and `meaning`
stay empty on purpose, since picking the word out and saying what it means is
the part that makes the card worth keeping.

### 4. A media screen for the thread

`GET /conversations/:id/media` pages one thread's attachments, split into a
visual tab and an audio one. The grid flattens messages into attachments, so a
six-file gallery draws as six tiles. Unlike the thread's own window it drops
withdrawn and reader-hidden messages server-side — in a chat a tombstone holds
the place of what was said, in a grid it is a blank square, and filtering
afterwards would make the keyset pages arrive short.

New index `conversation_type_created` puts `type` ahead of the sort keys so
each tab scans only its own keys; the note on it records what that costs the
visual tab's `$in` and why it is affordable.

### Checks

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and `pnpm test` all pass
locally (998 API tests across 76 files).

### Not covered

None of this has been run on a device or simulator yet — the API tests cover
the new route, but the media screen, the starred rows and the phrase prefill
have not been looked at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
