### PR TITLE
Tell people about a new version before the gate stops them

### DIFF
--- a/apps/api/scripts/maintenance.ts
+++ b/apps/api/scripts/maintenance.ts
@@ -1,5 +1,5 @@
 /**
- * Turn maintenance on and off, and set the minimum client version.
+ * Turn maintenance on and off, and set the client versions.
  *
  * A script rather than an admin endpoint: this is the control you reach for
  * when something is wrong, and it should not depend on the API being healthy
@@ -9,6 +9,7 @@
  *   pnpm --filter @langx/api exec tsx scripts/maintenance.ts on "Back at 14:00 UTC" 2026-08-27T14:00:00Z
  *   pnpm --filter @langx/api exec tsx scripts/maintenance.ts off
  *   pnpm --filter @langx/api exec tsx scripts/maintenance.ts min-version ios 2.1.0
+ *   pnpm --filter @langx/api exec tsx scripts/maintenance.ts latest-version ios 2.2.0
  *   pnpm --filter @langx/api exec tsx scripts/maintenance.ts flag translationEnabled false
  */
 import { appConfigSchema, minVersionSchema } from '@langx/shared'
@@ -56,6 +57,20 @@ async function main(): Promise<void> {
         console.log('Clients below it get 426 UPDATE_REQUIRED and a forced-update screen.')
         break
       }
+      case 'latest-version': {
+        const [platform, version] = args
+        // Same key check as `min-version`, and the same reason for it.
+        const platformKey = minVersionSchema.keyof().safeParse(platform)
+        if (!platformKey.success || !version) {
+          throw new Error('usage: latest-version <ios|android|web> <x.y.z>')
+        }
+        const current = await getAppConfig(db, Number.POSITIVE_INFINITY)
+        const next = { ...current.latestVersion, [platformKey.data]: version }
+        await updateAppConfig(db, { latestVersion: next })
+        console.log(`Latest ${platform} version is now ${version}`)
+        console.log('Clients below it get a dismissible banner. Nothing is blocked.')
+        break
+      }
       case 'flag': {
         const [name, value] = args
         // Same rule as `min-version`: only a flag the schema knows can be set.
@@ -72,7 +87,8 @@ async function main(): Promise<void> {
       }
       default:
         console.log(
-          'Commands: status | on [message] [untilIso] | off | min-version <p> <v> | flag <n> <bool>',
+          'Commands: status | on [message] [untilIso] | off | min-version <p> <v> | ' +
+            'latest-version <p> <v> | flag <n> <bool>',
         )
         process.exitCode = 1
     }

--- a/apps/api/src/modules/appConfig/appConfig.ts
+++ b/apps/api/src/modules/appConfig/appConfig.ts
@@ -2,8 +2,10 @@ import { DEFAULT_APP_CONFIG, type AppConfig } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 
-export interface AppConfigDoc extends Omit<AppConfig, 'updatedAt'> {
+export interface AppConfigDoc extends Omit<AppConfig, 'updatedAt' | 'latestVersion'> {
   _id: 'current'
+  /** Absent on documents written before `latestVersion` existed; see `toDto`. */
+  latestVersion?: AppConfig['latestVersion']
   updatedAt: Date
 }
 
@@ -26,6 +28,11 @@ function toDto(doc: AppConfigDoc | null): AppConfig {
   return {
     maintenance: doc.maintenance,
     minVersion: doc.minVersion,
+    // Defaulted rather than read straight through: the document predates this
+    // field on every deployment that already exists, and a config read is the
+    // one thing that must never fail — an undefined here would reach the
+    // client as a missing key and fail its schema.
+    latestVersion: doc.latestVersion ?? DEFAULT_APP_CONFIG.latestVersion,
     flags: doc.flags,
     updatedAt: doc.updatedAt.toISOString(),
   }
@@ -65,6 +72,7 @@ export async function updateAppConfig(
       $setOnInsert: {
         ...(patch.maintenance ? {} : { maintenance: DEFAULT_APP_CONFIG.maintenance }),
         ...(patch.minVersion ? {} : { minVersion: DEFAULT_APP_CONFIG.minVersion }),
+        ...(patch.latestVersion ? {} : { latestVersion: DEFAULT_APP_CONFIG.latestVersion }),
         ...(patch.flags ? {} : { flags: DEFAULT_APP_CONFIG.flags }),
       },
     },

--- a/apps/api/src/routes/appConfig.test.ts
+++ b/apps/api/src/routes/appConfig.test.ts
@@ -162,6 +162,33 @@ describe('app config, maintenance and the version gate', () => {
       })
       invalidateAppConfigCache()
     })
+
+    it('computes updateAvailable per platform without blocking anyone', async () => {
+      await updateAppConfig(handle.db, {
+        latestVersion: { ios: '2.2.0', android: '1.0.0', web: '1.0.0' },
+      })
+      invalidateAppConfigCache()
+
+      const oldIos = await get('/app-config', { 'x-app-platform': 'ios', 'x-app-version': '2.0.0' })
+      expect(oldIos.json<{ updateAvailable: boolean; updateRequired: boolean }>()).toMatchObject({
+        updateAvailable: true,
+        // The whole point of the second field: something newer exists and the
+        // client is still allowed to run.
+        updateRequired: false,
+      })
+
+      // Same version, different platform, nothing newer published there.
+      const android = await get('/app-config', {
+        'x-app-platform': 'android',
+        'x-app-version': '2.0.0',
+      })
+      expect(android.json<{ updateAvailable: boolean }>().updateAvailable).toBe(false)
+
+      await updateAppConfig(handle.db, {
+        latestVersion: { ios: '0.0.0', android: '0.0.0', web: '0.0.0' },
+      })
+      invalidateAppConfigCache()
+    })
   })
 
   describe('maintenance gate', () => {

--- a/apps/api/src/routes/appConfig.ts
+++ b/apps/api/src/routes/appConfig.ts
@@ -1,7 +1,9 @@
 import {
   APP_PLATFORM_HEADER,
   APP_VERSION_HEADER,
+  isUpdateAvailable,
   isUpdateRequired,
+  versionForPlatform,
   type AppConfigResponse,
 } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
@@ -19,13 +21,9 @@ export const appConfigRoutes: FastifyPluginAsyncZod = async (app) => {
     const config = await getAppConfig(app.mongo.db)
 
     const version = request.headers[APP_VERSION_HEADER] as string | undefined
-    const platform = (request.headers[APP_PLATFORM_HEADER] as string | undefined) ?? 'web'
-    const minimum =
-      platform === 'ios'
-        ? config.minVersion.ios
-        : platform === 'android'
-          ? config.minVersion.android
-          : config.minVersion.web
+    const platform = request.headers[APP_PLATFORM_HEADER] as string | undefined
+    const minimum = versionForPlatform(config.minVersion, platform)
+    const latest = versionForPlatform(config.latestVersion, platform)
 
     /**
      * Read off Better Auth rather than off `env`, because the two can
@@ -39,6 +37,7 @@ export const appConfigRoutes: FastifyPluginAsyncZod = async (app) => {
     const body: AppConfigResponse = {
       ...config,
       updateRequired: isUpdateRequired(version, minimum),
+      updateAvailable: isUpdateAvailable(version, latest),
       authProviders: {
         google: Boolean(registered.google),
         apple: Boolean(registered.apple),

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router'
 import { View } from 'react-native'
 import { DeletionBanner } from '../../src/components/DeletionBanner'
+import { UpdateBanner } from '../../src/components/UpdateBanner'
 import { useTheme } from '../../src/lib/theme'
 import { useNotificationRouting } from '../../src/hooks/useNotificationRouting'
 import { usePushRegistration } from '../../src/hooks/usePushRegistration'
@@ -63,6 +64,8 @@ export default function AppLayout() {
     <View style={{ backgroundColor: colors.bg, flex: 1 }}>
       {/* Above the navigator so a pending deletion is visible on every screen. */}
       <DeletionBanner />
+      {/* After it, and silent while it is up — only one bar takes the top. */}
+      <UpdateBanner />
       <Stack
         screenOptions={{
           headerShown: false,

--- a/apps/mobile/src/components/AppGate.tsx
+++ b/apps/mobile/src/components/AppGate.tsx
@@ -6,6 +6,8 @@ import { Linking, Platform, Text, View } from 'react-native'
 import { useAppConfig } from '../hooks/useAppConfig'
 import { useSignalAppReady } from '../hooks/useAppReady'
 import { makeStyles, useTheme } from '../lib/theme'
+import { showToast, TOAST_DURATION_MS } from '../lib/toast'
+import { currentTranslate } from '../i18n/runtime'
 import { useLocale, useT } from '../i18n'
 import { Button } from './ui/Button'
 import { Screen } from './ui/Screen'
@@ -68,10 +70,22 @@ export function AppGate({ children }: { children: ReactNode }) {
       try {
         const check = await Updates.checkForUpdateAsync()
         if (!check.isAvailable) return
-        await Updates.fetchUpdateAsync()
+        const fetched = await Updates.fetchUpdateAsync()
+        if (!fetched.isNew) return
         // Applied on the next launch rather than immediately: reloading under
         // someone mid-conversation is a worse experience than shipping the fix
-        // a few minutes later.
+        // a few minutes later. The toast is what stops that from being a
+        // silent decision — it says the update is here, and offers to bring
+        // the restart forward for anyone who would rather have it now.
+        //
+        // `currentTranslate()` rather than the `t` from this component: this
+        // effect runs once, and taking `t` as a dependency would re-run the
+        // whole check every time the locale changes.
+        const translate = currentTranslate()
+        showToast(translate('update.downloaded'), TOAST_DURATION_MS, {
+          label: translate('update.restart'),
+          onPress: () => void Updates.reloadAsync(),
+        })
       } catch {
         // An update check failing is not a reason to interrupt anyone.
       }

--- a/apps/mobile/src/components/ToastHost.tsx
+++ b/apps/mobile/src/components/ToastHost.tsx
@@ -62,6 +62,22 @@ export function ToastHost() {
         style={styles.pill}
       >
         <Text style={styles.text}>{toast.message}</Text>
+        {toast.action ? (
+          // Its own `Pressable` inside the pill's, so the two taps mean
+          // different things: the action runs, and anywhere else dismisses.
+          // Running it also dismisses — leaving the pill up after the tap
+          // would invite a second one.
+          <Pressable
+            accessibilityRole="button"
+            hitSlop={8}
+            onPress={() => {
+              toast.action?.onPress()
+              dismissToast(toast.id)
+            }}
+          >
+            <Text style={styles.action}>{toast.action.label}</Text>
+          </Pressable>
+        ) : null}
       </Pressable>
     </Animated.View>
   )
@@ -89,12 +105,30 @@ const useStyles = makeStyles(({ colors, spacing, radius, cardShadow }) => ({
   // happened, and the one yellow on a screen is reserved for the thing that
   // makes something happen.
   pill: {
+    alignItems: 'center',
     backgroundColor: colors.ink,
     borderRadius: radius.pill,
+    // A row only ever holds a sentence and one word, so it stays a row: the
+    // pill still hugs its content when there is no action.
+    flexDirection: 'row',
+    gap: spacing.md,
     maxWidth: 420,
     paddingHorizontal: spacing.lg + 4,
     paddingVertical: spacing.md,
     ...cardShadow,
   },
-  text: { color: colors.bg, fontSize: 14, fontWeight: '600', textAlign: 'center' },
+  // `flexShrink` rather than `flex: 1`, so a message with no action beside it
+  // is still centred on its own width instead of stretching to the maximum.
+  text: { color: colors.bg, flexShrink: 1, fontSize: 14, fontWeight: '600', textAlign: 'center' },
+  // Underlined in the message's own colour, the way `DeletionBanner` marks the
+  // action on its bar. A palette colour would be the obvious alternative and is
+  // the wrong one here: `ink` inverts with the scheme, so any single hue that
+  // reads on the near-black pill in light mode is washed out on the near-white
+  // one in dark.
+  action: {
+    color: colors.bg,
+    fontSize: 14,
+    fontWeight: '700',
+    textDecorationLine: 'underline',
+  },
 }))

--- a/apps/mobile/src/components/UpdateBanner.tsx
+++ b/apps/mobile/src/components/UpdateBanner.tsx
@@ -51,14 +51,30 @@ export function UpdateBanner() {
   }, [])
 
   const data = config.data
-  const latest = data ? versionForPlatform(data.latestVersion, appPlatform()) : ''
+  /*
+   * Both fields are read defensively, because `AppConfigResponse` is a cast
+   * and not a guarantee: `api.get` parses the body and trusts the type. An API
+   * older than this build answers without either of them — which is not a
+   * hypothetical but the normal state for as long as it takes to deploy the
+   * API after the web build and the OTA update have gone out on merge.
+   *
+   * Reading `.web` off an absent `latestVersion` would throw, and this renders
+   * above the navigator: the throw would take `(app)/_layout.tsx` down with it
+   * and every signed-in screen with that, which is the same failure
+   * `docs/decisions.md` records for the `expo-notifications` import. A banner
+   * nobody sees is the correct behaviour against a server that has not heard
+   * of it yet.
+   */
+  const latest = data?.latestVersion ? versionForPlatform(data.latestVersion, appPlatform()) : ''
 
   if (!data || dismissed === undefined) return null
   // One bar at the top at a time, and a pending deletion is the more urgent of
   // the two by a distance. `DeletionBanner` takes the status-bar inset when it
   // renders, so this one can take it unconditionally.
   if (me.data?.deletedAt) return null
-  if (!shouldShowUpdateNotice({ updateAvailable: data.updateAvailable, latest, dismissed })) {
+  if (
+    !shouldShowUpdateNotice({ updateAvailable: Boolean(data.updateAvailable), latest, dismissed })
+  ) {
     return null
   }
 

--- a/apps/mobile/src/components/UpdateBanner.tsx
+++ b/apps/mobile/src/components/UpdateBanner.tsx
@@ -1,0 +1,121 @@
+import Feather from '@expo/vector-icons/Feather'
+import { versionForPlatform } from '@langx/shared'
+import { useEffect, useState } from 'react'
+import { Platform, Pressable, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useMe } from '../api/queries'
+import { appPlatform, useAppConfig } from '../hooks/useAppConfig'
+import { FLAG_KEYS, readFlag, writeFlag } from '../lib/localFlags'
+import { openStoreListing } from '../lib/storeListing'
+import { makeStyles, spacing, useTheme } from '../lib/theme'
+import { shouldShowUpdateNotice } from '../lib/updateNotice'
+import { useT } from '../i18n'
+
+/**
+ * Says that a newer build than this one has been published, and offers to go
+ * and get it.
+ *
+ * The soft half of the version story. `AppGate` has the hard half: once
+ * `minVersion` passes this build the app stops dead, and the first anyone
+ * hears of it is a screen they cannot leave. This banner is what makes that
+ * not be the first thing they hear — it appears while the old build still
+ * works, so the forced screen only ever reaches someone who chose to wait.
+ *
+ * Dismissible, and per version: someone who does not want to update today
+ * should not be asked again until there is something else to ask about. See
+ * `lib/updateNotice.ts`.
+ *
+ * Deliberately not about over-the-air updates. Those do not change the version
+ * an installed binary reports, so they can neither raise this banner nor clear
+ * it; `AppGate` tells people about a downloaded OTA update itself, with a
+ * toast, because there is nowhere to send them for it.
+ */
+export function UpdateBanner() {
+  const styles = useStyles()
+  const { colors } = useTheme()
+  const t = useT()
+  const config = useAppConfig()
+  const me = useMe()
+  const insets = useSafeAreaInsets()
+
+  /*
+   * Three states, not two: `undefined` is "the flag has not been read yet".
+   * Starting at `null` would mean "never dismissed", and the banner would
+   * appear for a frame on every launch before the read came back and took it
+   * away again.
+   */
+  const [dismissed, setDismissed] = useState<string | null | undefined>(undefined)
+
+  useEffect(() => {
+    void readFlag(FLAG_KEYS.updateNoticeDismissed).then(setDismissed)
+  }, [])
+
+  const data = config.data
+  const latest = data ? versionForPlatform(data.latestVersion, appPlatform()) : ''
+
+  if (!data || dismissed === undefined) return null
+  // One bar at the top at a time, and a pending deletion is the more urgent of
+  // the two by a distance. `DeletionBanner` takes the status-bar inset when it
+  // renders, so this one can take it unconditionally.
+  if (me.data?.deletedAt) return null
+  if (!shouldShowUpdateNotice({ updateAvailable: data.updateAvailable, latest, dismissed })) {
+    return null
+  }
+
+  async function update(): Promise<void> {
+    // No store to send anyone to on the web, and none needed: the new build is
+    // already being served, and what they are running is a tab that has been
+    // open since before it went out.
+    if (Platform.OS === 'web') {
+      globalThis.location?.reload()
+      return
+    }
+    await openStoreListing()
+  }
+
+  return (
+    // Its own top inset, for the reason `DeletionBanner` carries one: it sits
+    // above the navigator, outside every `Screen`, and the layout does not
+    // inset for it.
+    <View style={[styles.root, { paddingTop: insets.top + spacing.sm }]}>
+      <View style={styles.text}>
+        <Text style={styles.title}>{t('update.bannerTitle')}</Text>
+        <Text style={styles.body}>{t('update.bannerBody')}</Text>
+      </View>
+      <Pressable onPress={() => void update()} hitSlop={8}>
+        <Text style={styles.action}>{t('common.update')}</Text>
+      </Pressable>
+      <Pressable
+        accessibilityLabel={t('update.dismiss')}
+        accessibilityRole="button"
+        hitSlop={8}
+        onPress={() => {
+          setDismissed(latest)
+          void writeFlag(FLAG_KEYS.updateNoticeDismissed, latest)
+        }}
+      >
+        <Feather name="x" size={18} color={colors.textMuted} />
+      </Pressable>
+    </View>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, spacing }) => ({
+  /*
+   * The soft blue tint rather than `DeletionBanner`'s red. Nothing here is
+   * wrong yet — the app works, and will keep working until `minVersion` says
+   * otherwise — so it reads as information, not as an alarm.
+   */
+  root: {
+    alignItems: 'center',
+    backgroundColor: colors.accentBg,
+    flexDirection: 'row',
+    gap: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+  },
+  text: { flex: 1 },
+  title: { ...font.caption, color: colors.text, fontWeight: '700' },
+  body: { ...font.caption, color: colors.textMuted },
+  action: { ...font.caption, color: colors.accent, fontWeight: '700' },
+}))

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -296,6 +296,14 @@ export const ar: Localized<EnMessages> = {
     updateBody: 'هذه النسخة من LangX لم تعد مدعومة. حدّث إلى أحدث نسخة للمتابعة.',
   },
 
+  update: {
+    downloaded: 'هناك نسخة جديدة جاهزة.',
+    restart: 'أعد التشغيل الآن',
+    bannerTitle: 'صدرت نسخة جديدة',
+    bannerBody: 'حدّث للحصول على أحدث نسخة من LangX.',
+    dismiss: 'إغلاق',
+  },
+
   intro: {
     slide1Title: 'تكلّم لغتك ومارس لغتهم',
     slide1Body:

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -248,6 +248,14 @@ export const de: Localized<EnMessages> = {
       'Diese Version von LangX wird nicht mehr unterstützt. Aktualisiere auf die neueste, um sie weiter zu nutzen.',
   },
 
+  update: {
+    downloaded: 'Eine neue Version ist bereit.',
+    restart: 'Jetzt neu starten',
+    bannerTitle: 'Neue Version verfügbar',
+    bannerBody: 'Aktualisiere für das neueste LangX.',
+    dismiss: 'Schließen',
+  },
+
   intro: {
     slide1Title: 'Sprich deine, üb ihre',
     slide1Body:

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -284,6 +284,19 @@ export const en = {
       'This version of LangX is no longer supported. Update to the latest one to keep using it.',
   },
 
+  /**
+   * The soft side of the version story: an over-the-air update that has landed
+   * in the background, and a store release newer than this build. `gate.*` is
+   * the hard side — the screen that stops a build too old to run at all.
+   */
+  update: {
+    downloaded: 'A new version is ready.',
+    restart: 'Restart now',
+    bannerTitle: 'A new version is out',
+    bannerBody: 'Update to get the latest LangX.',
+    dismiss: 'Dismiss',
+  },
+
   intro: {
     slide1Title: 'Speak yours, practise theirs',
     slide1Body:

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -246,6 +246,14 @@ export const es: Localized<EnMessages> = {
       'Esta versión de LangX ya no es compatible. Actualiza a la última para seguir usándola.',
   },
 
+  update: {
+    downloaded: 'Hay una nueva versión lista.',
+    restart: 'Reiniciar ahora',
+    bannerTitle: 'Nueva versión disponible',
+    bannerBody: 'Actualiza para tener lo último de LangX.',
+    dismiss: 'Descartar',
+  },
+
   intro: {
     slide1Title: 'Habla el tuyo, practica el suyo',
     slide1Body:

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -249,6 +249,14 @@ export const fr: Localized<EnMessages> = {
       'Cette version de LangX n’est plus prise en charge. Passe à la dernière pour continuer.',
   },
 
+  update: {
+    downloaded: 'Une nouvelle version est prête.',
+    restart: 'Redémarrer',
+    bannerTitle: 'Une nouvelle version est sortie',
+    bannerBody: 'Mets à jour pour profiter du dernier LangX.',
+    dismiss: 'Ignorer',
+  },
+
   intro: {
     slide1Title: 'Parle la tienne, pratique la leur',
     slide1Body:

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -243,6 +243,14 @@ export const ptBR: Localized<EnMessages> = {
       'Esta versão do LangX não é mais compatível. Atualize para a mais recente para continuar usando.',
   },
 
+  update: {
+    downloaded: 'Uma nova versão está pronta.',
+    restart: 'Reiniciar agora',
+    bannerTitle: 'Nova versão disponível',
+    bannerBody: 'Atualize para ter o LangX mais recente.',
+    dismiss: 'Dispensar',
+  },
+
   intro: {
     slide1Title: 'Fale a sua, pratique a deles',
     slide1Body:

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -284,6 +284,14 @@ export const ru: Localized<EnMessages> = {
       'Эта версия LangX больше не поддерживается. Обнови до последней, чтобы продолжить пользоваться.',
   },
 
+  update: {
+    downloaded: 'Новая версия готова.',
+    restart: 'Перезапустить',
+    bannerTitle: 'Вышла новая версия',
+    bannerBody: 'Обнови, чтобы получить последнюю версию LangX.',
+    dismiss: 'Закрыть',
+  },
+
   intro: {
     slide1Title: 'Говори на своём, практикуй их',
     slide1Body:

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -257,6 +257,14 @@ export const tr: Localized<EnMessages> = {
       'LangX’in bu sürümü artık desteklenmiyor. Kullanmaya devam etmek için en yenisine geç.',
   },
 
+  update: {
+    downloaded: 'Yeni sürüm hazır.',
+    restart: 'Şimdi yeniden başlat',
+    bannerTitle: 'Yeni sürüm çıktı',
+    bannerBody: 'LangX’in en yenisi için güncelle.',
+    dismiss: 'Kapat',
+  },
+
   intro: {
     slide1Title: 'Seninkini konuş, onlarınkini çalış',
     slide1Body:

--- a/apps/mobile/src/lib/localFlags.ts
+++ b/apps/mobile/src/lib/localFlags.ts
@@ -136,6 +136,17 @@ export const FLAG_KEYS = {
    * on this phone and means nothing anywhere else.
    */
   calendarEvents: 'calendarEvents',
+  /**
+   * The version whose "a new version is out" banner was dismissed here.
+   *
+   * The version rather than a boolean, so dismissing one release says nothing
+   * about the next; `lib/updateNotice.ts` holds the comparison.
+   *
+   * Device-level because the banner is: it asks you to update *this*
+   * installation, and the same account on a phone that is already current has
+   * nothing to dismiss.
+   */
+  updateNoticeDismissed: 'updateNoticeDismissed',
 } as const
 
 export type FlagKey = (typeof FLAG_KEYS)[keyof typeof FLAG_KEYS]

--- a/apps/mobile/src/lib/toast.ts
+++ b/apps/mobile/src/lib/toast.ts
@@ -14,16 +14,30 @@
  * you looked away for four seconds is exactly the outcome `alert.ts` exists to
  * prevent.
  *
+ * A toast may carry one `action`, and that does not make it a question. The
+ * distinction that keeps it out of `alert.ts` is what happens when the four
+ * seconds run out with nobody looking: an alert's answer decides what happens
+ * next, so it has to wait; an action here is a shortcut to something that is
+ * going to happen anyway, so letting it expire is a complete answer. The one
+ * caller is the downloaded-update notice — the update applies on the next
+ * launch either way, and the action only offers to bring that forward.
+ *
  * Same shape as `alert.ts` otherwise and for the same reason: the state lives
  * here, apart from the component that draws it, because `src/lib` is the only
  * directory the test setup can reach. The timer belongs to `ToastHost` so that
  * everything decided in this module stays a pure function of a queue.
  */
 
+export interface ToastAction {
+  label: string
+  onPress: () => void
+}
+
 export interface Toast {
   id: number
   message: string
   durationMs: number
+  action?: ToastAction
 }
 
 /** Long enough to read a short sentence without having to stop and read it. */
@@ -54,8 +68,14 @@ export function subscribeToToasts(next: Listener): () => void {
  * Queues rather than replaces, for the same reason alerts do: two things
  * finishing at once must not leave the user having seen only one of them.
  */
-export function showToast(message: string, durationMs: number = TOAST_DURATION_MS): void {
-  queue = [...queue, { id: nextId++, message, durationMs }]
+export function showToast(
+  message: string,
+  durationMs: number = TOAST_DURATION_MS,
+  action?: ToastAction,
+): void {
+  // Spread rather than assigned: `exactOptionalPropertyTypes` distinguishes an
+  // absent key from one holding `undefined`, and `Toast.action` is absent.
+  queue = [...queue, { id: nextId++, message, durationMs, ...(action ? { action } : {}) }]
   publish()
 }
 

--- a/apps/mobile/src/lib/updateNotice.test.ts
+++ b/apps/mobile/src/lib/updateNotice.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowUpdateNotice } from './updateNotice'
+
+const notice = (over: Partial<Parameters<typeof shouldShowUpdateNotice>[0]> = {}) =>
+  shouldShowUpdateNotice({ updateAvailable: true, latest: '2.2.0', dismissed: null, ...over })
+
+describe('shouldShowUpdateNotice', () => {
+  it('says nothing while the server says nothing', () => {
+    expect(notice({ updateAvailable: false })).toBe(false)
+    // Not even for a version this device has never dismissed: the server is
+    // the one that knows what has been published.
+    expect(notice({ updateAvailable: false, dismissed: '1.0.0' })).toBe(false)
+  })
+
+  it('shows an undismissed version', () => {
+    expect(notice()).toBe(true)
+    expect(notice({ dismissed: '2.1.0' })).toBe(true)
+  })
+
+  it('stays dismissed for the version it was dismissed at', () => {
+    expect(notice({ dismissed: '2.2.0' })).toBe(false)
+  })
+
+  it('comes back for the next release', () => {
+    expect(notice({ latest: '2.3.0', dismissed: '2.2.0' })).toBe(true)
+  })
+
+  it('stays dismissed when a release is pulled', () => {
+    // 2.3.0 dismissed, then withdrawn and `latestVersion` put back to 2.2.0.
+    // Nothing new has been published since they said no, so nothing is asked.
+    expect(notice({ latest: '2.2.0', dismissed: '2.3.0' })).toBe(false)
+  })
+
+  it('treats a value it cannot compare as never dismissed', () => {
+    expect(notice({ dismissed: 'yesterday' })).toBe(true)
+    expect(notice({ latest: 'nightly', dismissed: '2.2.0' })).toBe(true)
+  })
+})

--- a/apps/mobile/src/lib/updateNotice.ts
+++ b/apps/mobile/src/lib/updateNotice.ts
@@ -1,0 +1,31 @@
+import { compareVersions, isVersion } from '@langx/shared'
+
+/**
+ * Whether to draw the "a new version is out" banner.
+ *
+ * Pure, so `vitest.config.ts` reaches it — the same split as `reviewPrompt.ts`:
+ * the rule lives here, the storage and the React wiring in `UpdateBanner`.
+ *
+ * `dismissed` is the version whose banner was dismissed on this device, not a
+ * boolean. A boolean would answer the first release and then stay answered
+ * forever, which is the one thing a dismissible notice must not do: dismissing
+ * 2.2.0 has to say nothing at all about 2.3.0.
+ */
+export function shouldShowUpdateNotice(params: {
+  updateAvailable: boolean
+  latest: string
+  /** The version dismissed on this device, or null for "never dismissed". */
+  dismissed: string | null
+}): boolean {
+  const { updateAvailable, latest, dismissed } = params
+  if (!updateAvailable) return false
+  /*
+   * Anything unreadable on either side counts as not dismissed. The server has
+   * already said something newer exists; a stored value we cannot compare is
+   * not grounds for deciding on the user's behalf that they answered it — and
+   * the cost of being wrong in this direction is one banner they dismiss
+   * again, against a notice that never appears in the other.
+   */
+  if (!dismissed || !isVersion(dismissed) || !isVersion(latest)) return true
+  return compareVersions(dismissed, latest) < 0
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -917,8 +917,9 @@ nobody until the matching build ships.
 Launch never blocks on the network (`fallbackToCacheTimeout: 0`): the app
 starts on the bundle it has and picks up a new one in the background, applied
 on the **next** launch. Reloading under someone mid-conversation is worse than
-shipping the fix a few minutes later. A bad update is undone with
-`eas update:rollback`.
+shipping the fix a few minutes later — so a toast says the update has landed
+and offers to restart, and doing nothing is a complete answer. A bad update is
+undone with `eas update:rollback`.
 
 ### Runtime config
 
@@ -928,9 +929,10 @@ needs to tell the client something now":
 
 ```ts
 {
-  maintenance: { enabled, message, until },
-  minVersion:  { ios, android, web },
-  flags:       { translationEnabled, discoveryEnabled, signupsEnabled }
+  maintenance:   { enabled, message, until },
+  minVersion:    { ios, android, web },
+  latestVersion: { ios, android, web },
+  flags:         { translationEnabled, discoveryEnabled, signupsEnabled }
 }
 ```
 
@@ -968,6 +970,7 @@ API being healthy enough to authenticate you:
 tsx scripts/maintenance.ts on "Back at 14:00 UTC" 2026-08-27T14:00:00Z
 tsx scripts/maintenance.ts off
 tsx scripts/maintenance.ts min-version ios 2.1.0
+tsx scripts/maintenance.ts latest-version ios 2.2.0
 tsx scripts/maintenance.ts flag translationEnabled false
 ```
 
@@ -987,6 +990,24 @@ The client gate fails **open**. If `/app-config` is unreachable the app runs
 normally — a config endpoint being down must never be the reason a working app
 refuses to start. The server's own 503s remain the real enforcement; the screen
 only makes them legible.
+
+### Saying so before the gate does
+
+`latestVersion` is the same shape as `minVersion` and does none of the same
+things. Raising it sets `updateAvailable` on the response and nothing else: the
+client draws a dismissible banner above the navigator and carries on working.
+The point is that nobody's first news of a version problem should be a screen
+they cannot leave — by the time `minVersion` passes a build, its user has been
+offered the update for weeks and chosen to wait.
+
+Dismissal is stored per version on the device, so saying no to 2.2.0 says
+nothing about 2.3.0. Both defaults are `0.0.0`, which means a fresh or
+self-hosted deployment blocks nobody and nags nobody.
+
+Store versions, not OTA ones: an over-the-air update does not change the
+version an installed binary reports, so it can neither raise this banner nor
+clear it. That is why the two notices are separate — the OTA one is a toast
+with a restart, this one is a banner with a trip to the store.
 
 ## Account deletion and data rights
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -641,6 +641,23 @@ and EAS Update is already wired to the channels in `eas.json`), and
 store-updates-only (an urgent fix would take days and could never reach people
 who stop updating).
 
+## Updates — two notices, because there are two ways to get one
+
+An over-the-air update is already downloaded and one restart away; a store
+release is a trip out of the app. Wording those as one message would have to
+lie about one of them, so they are two: a toast that offers the restart, and a
+dismissible banner that offers the store.
+
+They also cannot be derived from each other. An installed binary reports the
+version it was installed at whatever OTA bundle it is running, so `latestVersion`
+cannot see that someone has taken an OTA fix, and the OTA check cannot see that
+a new binary exists. Each notice is raised by the only mechanism that knows.
+
+The banner exists at all because of what the gate feels like without it. A
+forced-update screen is correct and it is also the worst possible first
+mention of the subject; `latestVersion` moves the first mention weeks earlier,
+to a point where the app still works and the answer can be "not now".
+
 ## Maintenance — two switches on purpose
 
 The database-backed flag is the everyday one: a single write, no redeploy. The

--- a/packages/shared/src/appConfig.test.ts
+++ b/packages/shared/src/appConfig.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_APP_CONFIG,
+  isUpdateAvailable,
+  isUpdateRequired,
+  versionForPlatform,
+} from './appConfig'
+
+describe('isUpdateAvailable', () => {
+  it('is true only for a client behind the published version', () => {
+    expect(isUpdateAvailable('2.0.0', '2.1.0')).toBe(true)
+    expect(isUpdateAvailable('2.1.0', '2.1.0')).toBe(false)
+    // A build newer than what is published — a TestFlight tester, or a store
+    // release that has not been recorded here yet.
+    expect(isUpdateAvailable('2.2.0', '2.1.0')).toBe(false)
+  })
+
+  it('stays quiet for a version it cannot read', () => {
+    // Same permissive direction as `isUpdateRequired`: an unreadable header is
+    // our problem, and nagging someone over it would be answering it wrongly.
+    expect(isUpdateAvailable(undefined, '2.1.0')).toBe(false)
+    expect(isUpdateAvailable('nightly', '2.1.0')).toBe(false)
+    expect(isUpdateAvailable('2.0.0', 'unreleased')).toBe(false)
+  })
+
+  it('says nothing under the shipped defaults', () => {
+    expect(
+      isUpdateAvailable('1.0.0', versionForPlatform(DEFAULT_APP_CONFIG.latestVersion, 'ios')),
+    ).toBe(false)
+  })
+
+  it('is independent of updateRequired', () => {
+    // Raising the minimum without publishing anything is a real state: the
+    // gate blocks and there is nothing newer to offer.
+    expect(isUpdateRequired('2.0.0', '2.5.0')).toBe(true)
+    expect(isUpdateAvailable('2.0.0', '0.0.0')).toBe(false)
+  })
+})
+
+describe('versionForPlatform', () => {
+  const versions = { ios: '3.0.0', android: '2.0.0', web: '1.0.0' }
+
+  it('picks the platform’s own entry', () => {
+    expect(versionForPlatform(versions, 'ios')).toBe('3.0.0')
+    expect(versionForPlatform(versions, 'android')).toBe('2.0.0')
+    expect(versionForPlatform(versions, 'web')).toBe('1.0.0')
+  })
+
+  it('falls to web for anything it does not recognise', () => {
+    expect(versionForPlatform(versions, undefined)).toBe('1.0.0')
+    expect(versionForPlatform(versions, 'windows-phone')).toBe('1.0.0')
+  })
+})

--- a/packages/shared/src/appConfig.ts
+++ b/packages/shared/src/appConfig.ts
@@ -31,11 +31,26 @@ export const minVersionSchema = z.object({
   android: z.string(),
   web: z.string(),
 })
+/** Named for its first use; `latestVersion` is the same shape and shares it. */
 export type MinVersion = z.infer<typeof minVersionSchema>
 
 export const appConfigSchema = z.object({
   maintenance: maintenanceSchema,
   minVersion: minVersionSchema,
+  /**
+   * The newest build published to each platform's store.
+   *
+   * Deliberately not `minVersion`. That one stops an old client dead; this one
+   * only offers — raising it puts a dismissible banner in front of everyone
+   * still on something older, and does nothing else.
+   *
+   * Store versions, not over-the-air ones. An OTA update does not change the
+   * version an installed binary reports, so a client that has taken one still
+   * compares as the version it was installed at; the app tells people about a
+   * downloaded OTA update itself, and this field is only ever about the trip
+   * to the store.
+   */
+  latestVersion: minVersionSchema,
   /**
    * Kill switches for individual features. A provider outage should be one
    * database write, not a deploy.
@@ -54,6 +69,10 @@ export const DEFAULT_APP_CONFIG: Omit<AppConfig, 'updatedAt'> = {
   // Deliberately permissive by default: a fresh or self-hosted instance must
   // never lock out its own clients because nobody set this yet.
   minVersion: { ios: '0.0.0', android: '0.0.0', web: '0.0.0' },
+  // Quiet for the same reason `minVersion` is permissive: nobody is behind a
+  // version nobody has published, so a deployment that never sets this never
+  // nags anyone.
+  latestVersion: { ios: '0.0.0', android: '0.0.0', web: '0.0.0' },
   flags: { translationEnabled: true, discoveryEnabled: true, signupsEnabled: true },
 }
 
@@ -81,6 +100,14 @@ export type AuthProviders = z.infer<typeof authProvidersSchema>
 export const appConfigResponseSchema = appConfigSchema.extend({
   /** True when the calling client is older than its platform's minimum. */
   updateRequired: z.boolean(),
+  /**
+   * True when a newer build than the caller's exists for its platform.
+   *
+   * Advisory only — `updateRequired` is the one that blocks. Both are true at
+   * once whenever the minimum has been raised, and the gate wins: the client
+   * never gets far enough to draw a banner behind a screen it cannot leave.
+   */
+  updateAvailable: z.boolean(),
   authProviders: authProvidersSchema,
 })
 export type AppConfigResponse = z.infer<typeof appConfigResponseSchema>
@@ -118,16 +145,45 @@ export function compareVersions(a: string, b: string): number {
 }
 
 /**
- * Whether this client is too old to be served.
- *
- * A missing **or unparseable** version is never forced to update. Parsing junk
- * as `0.0.0` would compare below every minimum and lock the user out — which
- * is exactly backwards, since a header we cannot read is our problem, not
- * theirs. Being wrong permissively is the only safe direction here, and a test
- * caught this doing the opposite.
+ * A missing **or unparseable** version is never behind anything. Parsing junk
+ * as `0.0.0` would compare below every target and lock the user out — which is
+ * exactly backwards, since a header we cannot read is our problem, not theirs.
+ * Being wrong permissively is the only safe direction here, and a test caught
+ * this doing the opposite.
  */
-export function isUpdateRequired(clientVersion: string | undefined, minimum: string): boolean {
+function isOlderThan(clientVersion: string | undefined, target: string): boolean {
   if (!clientVersion || !isVersion(clientVersion)) return false
-  if (!isVersion(minimum)) return false
-  return compareVersions(clientVersion, minimum) < 0
+  if (!isVersion(target)) return false
+  return compareVersions(clientVersion, target) < 0
+}
+
+/** Whether this client is too old to be served. */
+export function isUpdateRequired(clientVersion: string | undefined, minimum: string): boolean {
+  return isOlderThan(clientVersion, minimum)
+}
+
+/**
+ * Whether something newer than this client has been published.
+ *
+ * The same comparison `isUpdateRequired` makes, against a different number and
+ * with a different consequence — kept apart because the two are set
+ * independently and read at opposite ends of the same response.
+ */
+export function isUpdateAvailable(clientVersion: string | undefined, latest: string): boolean {
+  return isOlderThan(clientVersion, latest)
+}
+
+/**
+ * The entry a client on `platform` should be compared against.
+ *
+ * Anything that is not `ios` or `android` falls to `web`, which is what an
+ * absent or unrecognised platform header should mean: the web build is the
+ * one you can be running without having installed anything.
+ */
+export function versionForPlatform(versions: MinVersion, platform: string | undefined): string {
+  return platform === 'ios'
+    ? versions.ios
+    : platform === 'android'
+      ? versions.android
+      : versions.web
 }


### PR DESCRIPTION
The only thing that ever mentioned a version was `AppGate`: once `minVersion` passed a build, the app stopped dead on a screen nobody could leave, and that was the first anyone heard of the subject. OTA updates were quieter still — downloaded in the background and applied on the next launch, with nothing said.

This adds the soft half of the version story. Two notices, because there are two ways to get a new version and one message would have to lie about one of them.

## The OTA toast

`AppGate` already fetched updates in the background; it now says so. A toast reports that the update is here and offers to restart, and letting it expire is a complete answer — the update applies on the next launch either way. That is also why it is a toast and not an alert: an alert's answer decides what happens next, and this one only offers to bring forward something already decided.

`lib/toast.ts` gains an optional `action` for it. Additive and backwards compatible — the other 84 callers are untouched — and the module comment now records why an action does not turn a toast into a question.

## The store banner

`latestVersion` joins the runtime config: the same per-platform shape as `minVersion`, and none of its consequences. Raising it sets `updateAvailable` on `/app-config`, and the client draws a dismissible banner above the navigator while the app carries on working.

The point is that nobody's first news of a version problem should be a screen they cannot leave. By the time `minVersion` passes a build, its user has been offered the update for weeks and chosen to wait.

Dismissal is stored per version on the device, so saying no to 2.2.0 says nothing about 2.3.0. The rule lives in `lib/updateNotice.ts` as a pure function, following the `reviewPrompt.ts` split, so the tests can reach it.

## Why neither can be derived from the other

An installed binary reports the version it was installed at, whatever OTA bundle it is running. So `latestVersion` cannot see that someone has taken an OTA fix, and the OTA check cannot see that a new binary exists. Each notice is raised by the only mechanism that knows about it. `latestVersion` means the store version, never the OTA one.

## Operating it

Both defaults are `0.0.0`, so this ships inert: a fresh or self-hosted deployment blocks nobody and nags nobody, and merging this changes nothing anyone can see. The banner appears only once the value is set:

```bash
tsx scripts/maintenance.ts latest-version ios 2.2.0
```

Documents written before this field default through `toDto`, so existing deployments read normally.

## Checks

`pnpm -r typecheck`, `pnpm lint` and `pnpm format:check` pass. `@langx/shared` (309) and `@langx/mobile` (744) tests pass, including the new `appConfig.test.ts` and `updateNotice.test.ts`.

The `apps/api` tests could not run where this was written: `mongodb-memory-server` downloads its binary from `fastdl.mongodb.org`, which that environment's network policy refuses with a 403. Every API test file skips for that reason, not because of this change. The new case in `appConfig.test.ts` — that `updateAvailable` is computed per platform and blocks nobody — is therefore unverified until CI runs it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfTsnzXXusCx9VBWfU78x8

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfTsnzXXusCx9VBWfU78x8)_