### PR TITLE
Release 2.2

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 API — Better Auth + REST + Socket.io in one Fastify process",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/mobile",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 client — iOS, Android and web from one Expo codebase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langx",
-  "version": "2.1",
+  "version": "2.2",
   "private": true,
   "description": "LangX v2 \u2014 language exchange app (Expo mobile/web + Fastify API + MongoDB Atlas)",
   "license": "BSD-3-Clause",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/shared",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "Contract shared by @langx/api and @langx/mobile: zod schemas, language and level tables, plan limits, token rules, error codes",


### PR DESCRIPTION
Version 2.1 → 2.2, cut with `pnpm release minor`: the root manifest and the three workspace packages, nothing else. The tag `v2.2` is pushed once this is on main; the store builds are made locally from that commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)