### PR TITLE
Turn on R8 for Android release builds

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -396,6 +396,32 @@ const config: ExpoConfig = {
         isIosBackgroundLocationEnabled: false,
       },
     ],
+    /*
+     * R8. The Expo template generates
+     * `minifyEnabled findProperty('android.enableMinifyInReleaseBuilds') ?: false`,
+     * so a release build ships unoptimised unless this plugin writes the
+     * property — which is why 2.0.0 (121) reads **App optimisation: Low,
+     * obfuscation 2 %** in Play Console, against a February 2027 deadline.
+     * `shrinkResources` is only legal with minification on, hence both
+     * together.
+     *
+     * The cost is that R8 renames what it cannot see being used, and
+     * everything reached by reflection is invisible to it. Debug builds never
+     * run R8, so nothing here shows up until a release build is exercised on a
+     * device; a missing keep rule surfaces as a crash in one screen, not a
+     * build failure. Anything that breaks gets a rule in
+     * `android/proguard-rules.pro` — which `expo prebuild` regenerates, so it
+     * belongs in this plugin's `extraProguardRules`, not in the generated file.
+     */
+    [
+      'expo-build-properties',
+      {
+        android: {
+          enableProguardInReleaseBuilds: true,
+          enableShrinkResourcesInReleaseBuilds: true,
+        },
+      },
+    ],
   ],
 
   experiments: {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -33,6 +33,7 @@
     "expo-asset": "~57.0.16",
     "expo-audio": "~57.0.4",
     "expo-blur": "~57.0.2",
+    "expo-build-properties": "~57.0.16",
     "expo-calendar": "~57.0.2",
     "expo-camera": "~57.0.4",
     "expo-clipboard": "~57.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       expo-blur:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
+      expo-build-properties:
+        specifier: ~57.0.16
+        version: 57.0.16(expo@57.0.20)
       expo-calendar:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))
@@ -3301,6 +3304,11 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
+
+  expo-build-properties@57.0.16:
+    resolution: {integrity: sha512-snEQKIn/sMEAFUc8x2aQTQa/rzJbfjsuLJ9YcGUh5iCN65nid7R2V8J3PKyMUFPVEST+cDNf8WDlgN8jOuveXw==}
+    peerDependencies:
+      expo: '*'
 
   expo-calendar@57.0.2:
     resolution: {integrity: sha512-9NWZFWQkrVx+GsEnMdvGoFORD7tH+2oXHxgFIpB7ASxg5R3nUmc4peFxSAuUMTC16VBIQAKYpZ++nnmqfed/CQ==}
@@ -8772,6 +8780,12 @@ snapshots:
       expo: 57.0.20(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-router@57.0.19)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
+
+  expo-build-properties@57.0.16(expo@57.0.20):
+    dependencies:
+      '@expo/schema-utils': 57.0.2
+      expo: 57.0.20(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-router@57.0.19)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      resolve-from: 5.0.0
 
   expo-calendar@57.0.2(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)):
     dependencies:


### PR DESCRIPTION
Re-applies `mobile/android-r8` (3 Sept) on today's `main`: the branch's only commit was never merged, and the reset-era clean-up nearly deleted it.

The Expo template generates `minifyEnabled findProperty('android.enableMinifyInReleaseBuilds') ?: false`, so a release build ships unoptimised unless a plugin writes the property — which is why 2.0.0 (121) reads **App optimisation: Low, obfuscation 2 %** in Play Console, against a February 2027 deadline. `expo-build-properties` turns on R8 and `shrinkResources` together (the latter is only legal with minification on).

Native build change: it does not reach installed builds over the air and is not in the 2.2 store build already in flight; it lands with the next store build.

`pnpm-lock.yaml` was edited by hand for the one new specifier — regenerating it on a Mac drops the fields Linux needs — and validated with `pnpm install --offline --frozen-lockfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
