### PR TITLE
Delete a purged account's PostHog person, through a queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -213,12 +213,19 @@ EXPO_PUBLIC_POSTHOG_KEY=
 EXPO_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 
 # `pnpm insight` reads the funnel back out of that project and writes it to a
-# private temporary file — the counterpart of insight.langx.io, and the only
-# thing here that reads rather than writes. The key is a *personal* API key
-# (PostHog → Settings → Personal API keys), which can read everything the
-# account can, so it stays on the machine that runs the command and never
-# anywhere else, and PostHog scopes them — this one needs read access to the
-# project. The project id is the number in that project's own URL.
+# private temporary file — the counterpart of insight.langx.io. The key is a
+# *personal* API key (PostHog → Settings → Personal API keys), and PostHog
+# scopes them: this one needs **read** access to the project and nothing more,
+# so it stays on the machine that runs the command and never anywhere else.
+# The project id is the number in that project's own URL.
+#
+# The API wants the same three names for a different job — deleting a person
+# when their account is purged — and it must NOT be given this key. That one
+# needs `person:write`, which is the difference between a credential that can
+# read your analytics and one that can erase them, and it lives on the server
+# rather than a laptop. Two keys, two scopes, two places. Unset on the API,
+# the purge still records what it owes and the drain does nothing; see
+# apps/api/src/modules/account/analyticsDeletions.ts.
 #
 # A key PostHog does not accept answers 403, not 401. A placeholder left in
 # this file is the usual reason, and the script says so.

--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -180,6 +180,18 @@ export const COLLECTIONS = {
    * a hash is kept, so the row is useless to anyone who reads the database.
    */
   deletionTokens: 'deletionTokens',
+  /**
+   * What a purged account is still owed at PostHog: one row per deleted
+   * account, holding the distinct id and nothing else.
+   *
+   * It exists because the purge deletes the row it is driven by. Everywhere
+   * else in `deletion.ts` a failed third-party call leaves an orphan we can
+   * live with — a file in a bucket nobody points at. A failed PostHog call
+   * would leave a *person*, with the profile gone and no `deletedAt` left to
+   * find it from, so the obligation has to outlive the account it came from.
+   * Written unconditionally, drained only when a key is configured.
+   */
+  analyticsDeletions: 'analyticsDeletions',
 } as const
 
 export type CollectionName = (typeof COLLECTIONS)[keyof typeof COLLECTIONS]

--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -414,6 +414,13 @@ export const INDEXES: Partial<IndexSpec> = {
     { key: { lastViewedAt: 1 }, name: 'ttl_90d', expireAfterSeconds: NINETY_DAYS },
   ],
 
+  [COLLECTIONS.analyticsDeletions]: [
+    // Oldest first, which is the order the drain sends them in. No unique
+    // index: the distinct id *is* `_id`, so a second purge of the same account
+    // cannot open a second row — the same trick `profiles` uses.
+    { key: { createdAt: 1 }, name: 'created_at' },
+  ],
+
   [COLLECTIONS.deletionTokens]: [
     // The lookup, and the "one live link per user" rule in one index: minting
     // a second replaces the first rather than leaving both spendable.

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -189,6 +189,23 @@ const envSchema = z.object({
    */
   REVENUECAT_FAKE_STORE: z.preprocess((v) => v === 'true' || v === '1', z.boolean()).default(false),
 
+  /**
+   * Deleting a person from PostHog when their account is purged. Separate from
+   * the key `pnpm insight` uses and deliberately narrower: that one is a
+   * read key that lives on a laptop, this one needs `person:write` and lives
+   * on the server, which is exactly the pair of properties you do not want in
+   * one credential.
+   *
+   * Unset, the purge still records what it owes (`analyticsDeletions`) and the
+   * drain does nothing, so an instance with no analytics keeps no queue it
+   * cannot empty and one that gains a key later still honours what it recorded
+   * while unconfigured. The region is `eu` or `us` for the reason
+   * `.env.example` gives — the host is a literal, not a setting.
+   */
+  POSTHOG_PERSONAL_API_KEY: emptyToUndefined(z.string().optional()),
+  POSTHOG_PROJECT_ID: emptyToUndefined(z.string().optional()),
+  POSTHOG_REGION: z.enum(['eu', 'us']).default('eu'),
+
   // Faz 2: username claim. Must match what the ETL used to hash legacy
   // emails into handleReservations.legacyEmailHash, or nothing ever matches.
   LEGACY_EMAIL_HASH_SALT: emptyToUndefined(z.string().optional()),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import { ensureIndexes } from './db/indexes'
 import { createEmailSender } from './email/sender'
 import { attachSentryErrorHandler, initSentry } from './observability/sentry'
 import { loadEnv, publicApiUrl, unsubscribeSecret } from './env'
+import { createPersonDeleterFromEnv } from './modules/analytics/personDeleter'
 import { createStorageProvider } from './storage/createStorageProvider'
 import { createTranslationProvider } from './translation/createTranslationProvider'
 import { createRevenueCatClientFromEnv } from './modules/billing/createRevenueCatClient'
@@ -34,6 +35,9 @@ async function main(): Promise<void> {
 
   const auth = await createAuth({ env, db, client, emailSender, revenueCat })
   const storage = createStorageProvider(env)
+  // `null` without a key: the purge still records what it owes, the drain
+  // simply does not run. See `modules/account/analyticsDeletions.ts`.
+  const analytics = createPersonDeleterFromEnv(env)
 
   const translation = createTranslationProvider(env)
 
@@ -76,7 +80,7 @@ async function main(): Promise<void> {
   // running behind them — they drive `runDailyPool` directly instead.
   const schedulers = [
     startDailyPoolScheduler(db, app.log),
-    startPurgeScheduler(db, app.log, { storage }),
+    startPurgeScheduler(db, app.log, { storage, ...(analytics ? { analytics } : {}) }),
     startStreakReminderScheduler(db, push, notificationEmail, app.log),
     startMeetingReminderScheduler(db, push, app.log),
     startLegacyImportScheduler(db, app.log),

--- a/apps/api/src/modules/account/analyticsDeletions.test.ts
+++ b/apps/api/src/modules/account/analyticsDeletions.test.ts
@@ -1,0 +1,135 @@
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import { ensureIndexes } from '../../db/indexes'
+import type { PersonDeleter } from '../analytics/personDeleter'
+import {
+  type AnalyticsDeletion,
+  drainAnalyticsDeletions,
+  recordAnalyticsDeletion,
+} from './analyticsDeletions'
+
+/**
+ * The queue exists because the purge deletes the row it is driven by, so a
+ * PostHog call that fails has nothing left to be retried from. Everything
+ * below is about that: what survives a failure, and what does not survive a
+ * success.
+ */
+describe('the analytics deletion queue', () => {
+  let replSet: MongoMemoryReplSet
+  let handle: DbHandle
+
+  /** Records the ids it was given, and fails on command. */
+  function fakeDeleter(): PersonDeleter & { calls: string[][]; failWith: string | null } {
+    const state = {
+      calls: [] as string[][],
+      failWith: null as string | null,
+      deletePersons(distinctIds: readonly string[]): Promise<void> {
+        state.calls.push([...distinctIds])
+        return state.failWith ? Promise.reject(new Error(state.failWith)) : Promise.resolve()
+      },
+    }
+    return state
+  }
+
+  function rows(): Promise<AnalyticsDeletion[]> {
+    return handle.db
+      .collection<AnalyticsDeletion>(COLLECTIONS.analyticsDeletions)
+      .find({})
+      .sort({ createdAt: 1 })
+      .toArray()
+  }
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+    handle = await connectToDatabase(replSet.getUri(), 'langx_analytics_deletion_test')
+    await ensureIndexes(handle.db)
+  }, 120_000)
+
+  afterAll(async () => {
+    await handle?.close()
+    await replSet?.stop()
+  })
+
+  beforeEach(async () => {
+    await handle.db.collection(COLLECTIONS.analyticsDeletions).deleteMany({})
+  })
+
+  it('records one row per account, and only one however often it is asked', async () => {
+    const first = new Date('2026-09-01T00:00:00.000Z')
+    const later = new Date('2026-09-02T00:00:00.000Z')
+    await recordAnalyticsDeletion(handle.db, 'aaaaaaaaaaaaaaaaaaaaaaaa', first)
+    await recordAnalyticsDeletion(handle.db, 'aaaaaaaaaaaaaaaaaaaaaaaa', later)
+
+    const [row, ...rest] = await rows()
+    expect(rest).toEqual([])
+    // The first sighting is the one that counts: the queue drains oldest
+    // first, and a re-record must not send an account to the back of it.
+    expect(row?.createdAt).toEqual(first)
+    expect(row?.attempts).toBe(0)
+  })
+
+  it('sends the distinct ids and clears what PostHog accepted', async () => {
+    const deleter = fakeDeleter()
+    await recordAnalyticsDeletion(handle.db, 'aaaaaaaaaaaaaaaaaaaaaaaa', new Date('2026-09-01'))
+    await recordAnalyticsDeletion(handle.db, 'bbbbbbbbbbbbbbbbbbbbbbbb', new Date('2026-09-02'))
+
+    const result = await drainAnalyticsDeletions(handle.db, deleter)
+
+    expect(result).toEqual({ deleted: 2, failed: 0 })
+    // Oldest first, and the *string* id — the ObjectId form `authId` produces
+    // would match nothing at PostHog and report success doing it.
+    expect(deleter.calls).toEqual([['aaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbb']])
+    expect(await rows()).toEqual([])
+  })
+
+  it('keeps every row when the call fails, and counts the attempt', async () => {
+    const deleter = fakeDeleter()
+    deleter.failWith = 'PostHog bulk_delete failed: 403'
+    await recordAnalyticsDeletion(handle.db, 'cccccccccccccccccccccccc', new Date('2026-09-01'))
+
+    const result = await drainAnalyticsDeletions(handle.db, deleter, {
+      now: new Date('2026-09-03T10:00:00.000Z'),
+    })
+
+    expect(result).toEqual({ deleted: 0, failed: 1 })
+    const [row] = await rows()
+    // The account is already gone. If this row went too, the person would
+    // survive at PostHog with nothing left anywhere that knows it should not.
+    expect(row?._id).toBe('cccccccccccccccccccccccc')
+    expect(row?.attempts).toBe(1)
+    expect(row?.lastError).toContain('403')
+    expect(row?.lastAttemptAt).toEqual(new Date('2026-09-03T10:00:00.000Z'))
+  })
+
+  it('retries on the next drain and succeeds', async () => {
+    const deleter = fakeDeleter()
+    deleter.failWith = 'nope'
+    await recordAnalyticsDeletion(handle.db, 'dddddddddddddddddddddddd', new Date('2026-09-01'))
+    await drainAnalyticsDeletions(handle.db, deleter)
+
+    deleter.failWith = null
+    expect(await drainAnalyticsDeletions(handle.db, deleter)).toEqual({ deleted: 1, failed: 0 })
+    expect(await rows()).toEqual([])
+  })
+
+  it('calls nothing when the queue is empty', async () => {
+    const deleter = fakeDeleter()
+    expect(await drainAnalyticsDeletions(handle.db, deleter)).toEqual({ deleted: 0, failed: 0 })
+    expect(deleter.calls).toEqual([])
+  })
+
+  it('never sends more than one batch, however much is waiting', async () => {
+    const deleter = fakeDeleter()
+    for (let i = 0; i < 5; i++) {
+      await recordAnalyticsDeletion(handle.db, `${i}`.padEnd(24, 'e'), new Date(2026, 8, i + 1))
+    }
+
+    const result = await drainAnalyticsDeletions(handle.db, deleter, { limit: 2 })
+
+    expect(result).toEqual({ deleted: 2, failed: 0 })
+    expect(deleter.calls).toEqual([['0eeeeeeeeeeeeeeeeeeeeeee', '1eeeeeeeeeeeeeeeeeeeeeee']])
+    expect((await rows()).length).toBe(3)
+  })
+})

--- a/apps/api/src/modules/account/analyticsDeletions.ts
+++ b/apps/api/src/modules/account/analyticsDeletions.ts
@@ -1,0 +1,91 @@
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { PERSON_DELETE_BATCH, type PersonDeleter } from '../analytics/personDeleter'
+
+/**
+ * One deleted account, still owed a deletion at PostHog.
+ *
+ * `_id` is the distinct id, which is `profiles._id`, which is the Better Auth
+ * user id as a string. Using it as the key rather than a field is what makes a
+ * second enqueue of the same account impossible without an index to enforce
+ * it — and it means `lib/authId.ts` never enters this file: the ObjectId form
+ * would match nothing at PostHog and report success doing it.
+ */
+export interface AnalyticsDeletion {
+  _id: string
+  createdAt: Date
+  attempts: number
+  lastAttemptAt?: Date
+  lastError?: string
+}
+
+/**
+ * Records what the purge owes PostHog, in the same breath as deleting the
+ * account.
+ *
+ * Unconditional — not gated on a key being configured. An instance with no
+ * analytics accumulates rows it never sends, which costs a string and a date
+ * per deleted account; the other way round, a key that is briefly missing at
+ * purge time loses the obligation permanently, with the profile already gone
+ * and nothing left to find it from. Only one of those two is recoverable.
+ */
+export function recordAnalyticsDeletion(db: Db, userId: string, now: Date): Promise<unknown> {
+  return db
+    .collection<AnalyticsDeletion>(COLLECTIONS.analyticsDeletions)
+    .updateOne({ _id: userId }, { $setOnInsert: { createdAt: now, attempts: 0 } }, { upsert: true })
+}
+
+export interface DrainResult {
+  /** Rows PostHog accepted and that are now gone from the queue. */
+  deleted: number
+  /** Rows tried and left behind, with the attempt counted. */
+  failed: number
+}
+
+/**
+ * Sends one batch of the queue to PostHog and clears what it accepted.
+ *
+ * One call per tick, not a loop: the queue is drained by an hourly scheduler
+ * and a thousand accounts an hour is far past any rate this app can produce,
+ * so there is nothing to gain from emptying it faster and something to lose
+ * from a tight retry loop against a key that has just been revoked.
+ *
+ * A failure leaves every row in place with `attempts` incremented. That is the
+ * whole point of the collection: the account is already gone, so the only
+ * record that the deletion is still owed is this one, and it has to survive
+ * being unable to do the work.
+ */
+export async function drainAnalyticsDeletions(
+  db: Db,
+  deleter: PersonDeleter,
+  options: { now?: Date; limit?: number } = {},
+): Promise<DrainResult> {
+  const now = options.now ?? new Date()
+  const collection = db.collection<AnalyticsDeletion>(COLLECTIONS.analyticsDeletions)
+  const pending = await collection
+    .find({}, { projection: { _id: 1 } })
+    .sort({ createdAt: 1 })
+    .limit(Math.min(options.limit ?? PERSON_DELETE_BATCH, PERSON_DELETE_BATCH))
+    .toArray()
+  if (pending.length === 0) return { deleted: 0, failed: 0 }
+
+  const ids = pending.map((row) => row._id)
+  try {
+    await deleter.deletePersons(ids)
+  } catch (error) {
+    await collection.updateMany(
+      { _id: { $in: ids } },
+      {
+        $inc: { attempts: 1 },
+        $set: {
+          lastAttemptAt: now,
+          lastError: error instanceof Error ? error.message.slice(0, 300) : 'unknown error',
+        },
+      },
+    )
+    return { deleted: 0, failed: ids.length }
+  }
+
+  await collection.deleteMany({ _id: { $in: ids } })
+  return { deleted: ids.length, failed: 0 }
+}

--- a/apps/api/src/modules/account/deletion.ts
+++ b/apps/api/src/modules/account/deletion.ts
@@ -9,6 +9,7 @@ import {
 import { randomUUID } from 'node:crypto'
 import { ObjectId, type Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
+import { recordAnalyticsDeletion } from './analyticsDeletions'
 import { ApiError } from '../../lib/ApiError'
 import { authId } from '../../lib/authId'
 import type { StorageProvider } from '../../storage/StorageProvider'
@@ -317,6 +318,11 @@ export async function purgeExpiredAccounts(
       db.collection(COLLECTIONS.session).deleteMany({ userId: authId(userId) }),
       db.collection(COLLECTIONS.account).deleteMany({ userId: authId(userId) }),
       db.collection(COLLECTIONS.user).deleteOne({ _id: authId(userId) as unknown as never }),
+      // In the same breath as the rows, because after this there is no
+      // `deletedAt` left to find the account from and no second chance to
+      // notice we still owe PostHog a deletion. `analyticsDeletions` says why
+      // it is written whether or not a key is configured.
+      recordAnalyticsDeletion(db, userId, now),
     ])
 
     userIds.push(userId)

--- a/apps/api/src/modules/account/purgeScheduler.ts
+++ b/apps/api/src/modules/account/purgeScheduler.ts
@@ -1,6 +1,8 @@
 import type { Db } from 'mongodb'
 import type { StorageProvider } from '../../storage/StorageProvider'
 import type { SchedulerLogger } from '../tokens/poolScheduler'
+import type { PersonDeleter } from '../analytics/personDeleter'
+import { drainAnalyticsDeletions } from './analyticsDeletions'
 import { purgeExpiredAccounts } from './deletion'
 import { purgeStaleGuests } from '../profiles/purgeGuests'
 
@@ -18,7 +20,7 @@ export const PURGE_INTERVAL_MS = 60 * 60 * 1000
 export function startPurgeScheduler(
   db: Db,
   logger: SchedulerLogger,
-  options: { intervalMs?: number; storage?: StorageProvider } = {},
+  options: { intervalMs?: number; storage?: StorageProvider; analytics?: PersonDeleter } = {},
 ): { stop: () => void } {
   const intervalMs = options.intervalMs ?? PURGE_INTERVAL_MS
   let running = false
@@ -43,6 +45,22 @@ export function startPurgeScheduler(
       const guests = await purgeStaleGuests(db)
       if (guests.purged > 0) {
         logger.info({ purged: guests.purged }, 'stale guest sessions purged')
+      }
+
+      /*
+       * The deletions the purge above recorded, plus anything an earlier tick
+       * could not send. Last in the tick and after the accounts, so a PostHog
+       * outage delays the analytics half and never the account half — the
+       * queue exists precisely so those two can fail apart.
+       *
+       * Unconfigured means leave it alone, not "nothing to do": an instance
+       * that gains a key later still owes what it recorded without one.
+       */
+      if (options.analytics) {
+        const analytics = await drainAnalyticsDeletions(db, options.analytics)
+        if (analytics.deleted > 0 || analytics.failed > 0) {
+          logger.info(analytics, 'analytics person deletions drained')
+        }
       }
     } catch (error) {
       logger.error({ err: error }, 'account purge failed')

--- a/apps/api/src/modules/analytics/personDeleter.ts
+++ b/apps/api/src/modules/analytics/personDeleter.ts
@@ -1,0 +1,78 @@
+import type { Env } from '../../env'
+
+/**
+ * Deleting people from PostHog, which is the only thing this server ever asks
+ * PostHog to do — events are sent from the app, never from here.
+ *
+ * `bulk_delete` takes distinct ids directly, so nothing has to look a person
+ * up first. That matters more than it sounds: our distinct id is the Better
+ * Auth user id in its string form, which is also `profiles._id`, so the id the
+ * purge already holds is the id PostHog wants. A lookup step would have been
+ * one more call that can fail between deleting an account and finishing the
+ * job.
+ */
+export interface PersonDeleter {
+  /** Up to `PERSON_DELETE_BATCH` distinct ids. Resolves only if PostHog accepted them. */
+  deletePersons(distinctIds: readonly string[]): Promise<void>
+}
+
+/** PostHog's documented ceiling for one `bulk_delete` call. */
+export const PERSON_DELETE_BATCH = 1000
+
+/**
+ * `eu.posthog.com`, not `eu.i.posthog.com`. The second is the ingestion host
+ * the app sends events to and it does not serve this API; `scripts/insight.mjs`
+ * resolves the same two literals the same way, and for the same reason — a
+ * settable host is only ever a way to send a personal API key somewhere it was
+ * not meant to go.
+ */
+const HOSTS = { eu: 'https://eu.posthog.com', us: 'https://us.posthog.com' } as const
+
+export function createPostHogPersonDeleter(
+  apiKey: string,
+  projectId: string,
+  region: 'eu' | 'us',
+): PersonDeleter {
+  return {
+    async deletePersons(distinctIds) {
+      if (distinctIds.length === 0) return
+      const response = await fetch(
+        `${HOSTS[region]}/api/projects/${projectId}/persons/bulk_delete/`,
+        {
+          method: 'POST',
+          headers: { authorization: `Bearer ${apiKey}`, 'content-type': 'application/json' },
+          body: JSON.stringify({
+            distinct_ids: [...distinctIds],
+            // The person alone is not what was promised. Events and recordings
+            // are the data itself, and PostHog keeps them unless asked.
+            delete_events: true,
+            delete_recordings: true,
+          }),
+        },
+      )
+      // 202: queued. PostHog does the work asynchronously, out of hours on
+      // Cloud, so accepted is the strongest answer this call can ever get and
+      // the queue row is right to go once it arrives.
+      if (!response.ok) {
+        const body = await response.text().catch(() => '')
+        // A key without `person:write` answers 403 here, not 401 — the same
+        // trap `scripts/insight.mjs` documents for the read key.
+        throw new Error(`PostHog bulk_delete failed: ${response.status} ${body.slice(0, 200)}`)
+      }
+    },
+  }
+}
+
+/**
+ * `null` rather than a no-op object: the caller has to decide what an
+ * unconfigured instance means, and here it means "leave the queue alone",
+ * which is different from "there was nothing to do".
+ */
+export function createPersonDeleterFromEnv(env: Env): PersonDeleter | null {
+  if (!env.POSTHOG_PERSONAL_API_KEY || !env.POSTHOG_PROJECT_ID) return null
+  return createPostHogPersonDeleter(
+    env.POSTHOG_PERSONAL_API_KEY,
+    env.POSTHOG_PROJECT_ID,
+    env.POSTHOG_REGION,
+  )
+}

--- a/apps/api/src/routes/moderation.test.ts
+++ b/apps/api/src/routes/moderation.test.ts
@@ -718,6 +718,18 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
         .findOne({ senderId: userId })
       expect(message?.body).toBe('')
       expect(message?.deletedWithAccount).toBe(true)
+
+      /*
+       * The one thing the purge leaves behind on purpose: what it still owes
+       * PostHog. Every row above is gone, so this is now the only record that
+       * the account existed at all — and it holds the *string* id, which is
+       * the distinct id the app identified with. The ObjectId form would match
+       * nothing at PostHog and report success doing it.
+       */
+      const owed = await handle.db
+        .collection(COLLECTIONS.analyticsDeletions)
+        .findOne({ _id: userId as never })
+      expect(owed, 'the purge recorded no analytics deletion').not.toBeNull()
     })
 
     /**

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -109,11 +109,32 @@ Set up once, in dashboards, not in code:
 
 ## Deletion
 
-Events are keyed by our user id, which is what makes them findable. What is not
-built yet is the removal: account deletion (`/me/delete`, 30-day grace) does
-not call PostHog's person-deletion API. Until it does, a deletion request that
-asks for analytics as well is handled by hand in the PostHog UI (Persons → the
-id → Delete), and the privacy policy must not promise more than that.
+Events are keyed by our user id, which is what makes them findable — and, since
+9 September 2026, deletable. When the 30-day grace period expires and
+`purgeExpiredAccounts` runs, the same tick asks PostHog to delete the person,
+their events and their recordings, keyed by that id.
+
+It goes through a queue rather than a direct call, and the reason is the shape
+of the purge. Everywhere else in `deletion.ts` a failed third-party call leaves
+an orphan we can live with: a file in a bucket nobody points at. PostHog is not
+like that. The purge is driven by `deletedAt <= cutoff` on a row it then
+deletes, so a failed call would leave a _person_ with the profile already gone
+and nothing left to find it from — the obligation has to outlive the account.
+So the purge writes one row into `analyticsDeletions`, keyed by the distinct id,
+in the same `Promise.all` as the deletions themselves; `drainAnalyticsDeletions`
+empties it hourly, one `bulk_delete` batch at a time, and leaves every row in
+place with `attempts` incremented when PostHog says no.
+
+Two consequences worth knowing. The row is written whether or not a key is
+configured — an instance that gains one later still honours what it recorded
+without one — so an unconfigured deployment accumulates rows it never sends,
+which costs a string and a date per deleted account. And the key the API needs
+is **not** the one `pnpm insight` uses: that is a read key on a laptop, this
+one needs `person:write` and lives on the server.
+
+PostHog's own deletion is asynchronous — `bulk_delete` answers `202` and the
+event data is cleared out of hours — so "accepted" is the strongest answer the
+call can get, and it is what clears the queue row.
 
 ## Reading it without the dashboard
 

--- a/docs/store/privacy-data-safety.md
+++ b/docs/store/privacy-data-safety.md
@@ -144,10 +144,13 @@ Purchase events reach PostHog through RevenueCat's server-side integration, not
 through a second SDK in the app; what RevenueCat sends is its own subscription
 events, under the same user id.
 
-**Deletion is not automatic yet.** `/me/delete` does not call PostHog's
-person-deletion API; until it does, analytics data for a deleted account is
-removed by hand ([`analytics.md`](../analytics.md) → _Deletion_). The privacy
-policy must not say otherwise.
+**Deletion is automatic since 9 September 2026.** When the 30-day grace period
+expires, the purge asks PostHog to delete the person, their events and their
+recordings, keyed by the same user id. It goes through a queue that survives a
+failed call, because by then the account itself is gone
+([`analytics.md`](../analytics.md) → _Deletion_). PostHog processes the request
+asynchronously, so the privacy policy should say the data is _requested for
+deletion_ at that point rather than erased the same second.
 
 ## Sharing with third parties
 


### PR DESCRIPTION
`/me/delete` never told PostHog anything. A deleted account's events outlived the account, removal was a manual click in the PostHog UI, and both `docs/analytics.md` and `docs/store/privacy-data-safety.md` said so in as many words — the second one constraining what the privacy policy is allowed to claim.

## The identity was already in hand

The app calls `identify()` with the Better Auth user id and nothing else (`apps/mobile/app/_layout.tsx:191`). That is the string form, which is `profiles._id`, which is the `userId` the purge loop already holds at `deletion.ts:131`. PostHog's `bulk_delete` takes distinct ids directly — up to 1000 — so there is no person lookup standing between deleting an account and finishing the job.

`authId()` deliberately appears nowhere in this path. The ObjectId form would match nothing at PostHog and report success doing it, which is the exact failure `lib/authId.ts` exists to warn about.

## Why a queue and not a call

Everywhere else in `deletion.ts`, a failed third-party call leaves an orphan we can live with: a file in a bucket nobody points at, which is why the storage branch swallows its failures on purpose.

PostHog is not like that. The purge is driven by `deletedAt <= cutoff` on a row it then deletes, so a failed call would leave a **person** with the profile already gone and nothing anywhere that knows it should not exist. The obligation has to outlive the account it came from.

So `purgeExpiredAccounts` writes one row into a new `analyticsDeletions` collection — keyed by the distinct id, in the same `Promise.all` as the deletions themselves — and `drainAnalyticsDeletions` empties it on the existing hourly purge tick, one `bulk_delete` batch at a time. A refusal leaves every row in place with `attempts` incremented and the error recorded; the next tick tries again.

The queue is drained **after** the accounts, so a PostHog outage delays the analytics half and never the account half. That separation is the whole point of it.

## Two decisions worth reviewing

**The row is written whether or not a key is configured.** An instance with no analytics accumulates rows it never sends — a string and a date per deleted account. The other way round, a key briefly absent at purge time loses the obligation permanently, with the profile already gone. Only one of those two is recoverable, so it records unconditionally and the drain simply does not run without a key.

**`_id` is the distinct id.** No unique index needed: a second purge of the same account cannot open a second row, the same way `profiles` works. `$setOnInsert` keeps the original `createdAt` so a re-record cannot send an account to the back of an oldest-first queue.

## The key is a new one, not the existing one

`.env.example` previously promised that `POSTHOG_PERSONAL_API_KEY` "stays on the machine that runs the command and never anywhere else". That stops being true for the API, so rather than quietly reusing it the file now says there are two keys: the read key `pnpm insight` uses on a laptop, and a `person:write` key on the server. `POSTHOG_PERSONAL_API_KEY` / `POSTHOG_PROJECT_ID` / `POSTHOG_REGION` are optional in `apps/api/src/env.ts`; unset, the feature is dormant and the app boots exactly as before.

**The endpoint contract was read out of PostHog's own OpenAPI schema, not a docs page** — `POST /api/projects/{id}/persons/bulk_delete/`, body `{ distinct_ids, delete_events, delete_recordings }`, `202`. An `OPTIONS` with the existing read key answers `403 "API key missing required scope 'person:write'"`, which is how the scope was confirmed. Host is `eu.posthog.com`, not the ingestion host `eu.i.posthog.com`.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — green (api 1057, mobile 755, shared 315).

New `analyticsDeletions.test.ts`, six cases against a real replica set: one row per account however often it is recorded, oldest-first ordering, the string id reaching the deleter, a failure keeping every row and counting the attempt, the retry succeeding on the next drain, and the batch cap. `moderation.test.ts`'s end-to-end purge now also asserts the row is left behind after everything else is gone.

Not exercised against PostHog itself — that needs the `person:write` key, and it would delete real people.

## Before it does anything on production

- [ ] Create a **second** personal API key in PostHog scoped to `person:write` (not the insight key).
- [ ] `fly secrets set POSTHOG_PERSONAL_API_KEY=… POSTHOG_PROJECT_ID=265343 POSTHOG_REGION=eu -a langx-api`.
- [ ] Until then the queue fills and nothing drains, which is the intended dormant state — no backlog is lost.
- [ ] The privacy policy can now say deletion is requested automatically; note PostHog processes it asynchronously, so "requested for deletion" is the accurate phrasing, not "erased immediately".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
