### PR TITLE
chore(release): the version goes back to 2.1

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/api",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 API — Better Auth + REST + Socket.io in one Fastify process",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/mobile",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 client — iOS, Android and web from one Expo codebase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langx",
-  "version": "2.2",
+  "version": "2.1",
   "private": true,
   "description": "LangX v2 \u2014 language exchange app (Expo mobile/web + Fastify API + MongoDB Atlas)",
   "license": "BSD-3-Clause",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/shared",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "Contract shared by @langx/api and @langx/mobile: zod schemas, language and level tables, plan limits, token rules, error codes",


### PR DESCRIPTION
The store builds made on 9 September — 2.2 (143) on Android, 2.2 (146) on
iOS — carry a number that has not shipped and is still being written. 2.1
never reached a binary: its tag was cut on 7 September and left unpushed on
`main`, while that day's store round went out as 2.0 (137/138). The stores
would therefore have gone from 2.0 straight to 2.2.

This puts the four manifests back to 2.1. It reverts the `Release 2.2`
commit and nothing else; no code changes.

Already done outside the repo:

- The `v2.2` tag and its "LangX 2.2" Release page are deleted.
- `v2.1` is tagged on the merge of this pull request, not on the 7 September
  release commit, because `github-release.yml` refuses a tag whose number is
  not the one in `package.json` — and every commit between the two says 2.2.
  The Release will name everything merged since v2.0, which is what the
  builds contain.

Note for the store round: builds 143 and 146 are stamped 2.2 inside the
binary and that cannot be edited after the fact. The next build off `main`
is 2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)