### PR TITLE
Release 2.2

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 API — Better Auth + REST + Socket.io in one Fastify process",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/mobile",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 client — iOS, Android and web from one Expo codebase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langx",
-  "version": "2.1",
+  "version": "2.2",
   "private": true,
   "description": "LangX v2 \u2014 language exchange app (Expo mobile/web + Fastify API + MongoDB Atlas)",
   "license": "BSD-3-Clause",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/shared",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "Contract shared by @langx/api and @langx/mobile: zod schemas, language and level tables, plan limits, token rules, error codes",


### PR DESCRIPTION
The four manifests go back to 2.2, so `app.config.ts` — and with it the store
binaries and the web build — carries 2.2 again.

2.1 is already Ready for Distribution in App Store Connect (build 143), and the
2.2 version page there is waiting on a build. The last build off `main`, iOS 147,
came out stamped 2.1 and so cannot be attached to it; this bump is what makes the
next build a 2.2 one.

`v2.2` is tagged locally and deliberately not pushed — the tag is what writes the
GitHub Release, and that is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)