### PR TITLE
Let somebody turn the meeting reminder off

### DIFF
--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -480,6 +480,45 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
   })
 
   /**
+   * The kind the request schema forgot. An unknown key is stripped rather
+   * than refused, so the write went missing behind a 200 and the switch came
+   * back on at the next fetch — invisible from the screen and from the
+   * sender's own tests, which write the preference straight to Mongo.
+   */
+  it('writes the meetings switch it used to drop', async () => {
+    const user = await newUser('meetings@example.com')
+    await app.inject({
+      method: 'POST',
+      url: '/profiles',
+      headers: { cookie: user.cookie },
+      payload: onboardingBody({ handle: 'meetingsuser' }),
+    })
+
+    const updated = await app.inject({
+      method: 'PATCH',
+      url: '/profiles/me',
+      headers: { cookie: user.cookie },
+      payload: { settings: { notifications: { meetings: { push: false } } } },
+    })
+
+    expect(updated.statusCode, updated.body).toBe(200)
+    expect(
+      updated.json<{ settings: { notifications: Record<string, unknown> } }>().settings
+        .notifications.meetings,
+    ).toEqual({ push: false, email: false })
+
+    const reread = await app.inject({
+      method: 'GET',
+      url: '/profiles/me',
+      headers: { cookie: user.cookie },
+    })
+    expect(
+      reread.json<{ settings: { notifications: Record<string, unknown> } }>().settings.notifications
+        .meetings,
+    ).toEqual({ push: false, email: false })
+  })
+
+  /**
    * The translation target is one of the person's *native* languages or
    * nothing: a learning language is refused (translating into it defeats the
    * purpose), and `null` removes the key so the default — the first native

--- a/packages/shared/src/notifications.test.ts
+++ b/packages/shared/src/notifications.test.ts
@@ -157,6 +157,20 @@ describe('notificationPrefsSchema', () => {
   it('refuses the channel-less shape it replaces', () => {
     expect(notificationPrefsSchema.safeParse({ messages: false }).success).toBe(false)
   })
+
+  /**
+   * A kind the schema forgets is worse than one it rejects: zod strips an
+   * unknown key and reports success, so the request writes nothing and the
+   * switch springs back on the next fetch with no error anywhere. `meetings`
+   * spent its whole life like that. Nothing links the two lists at compile
+   * time, so this is what has to notice the next one.
+   */
+  it('keeps every kind the app can send', () => {
+    for (const type of NOTIFICATION_TYPES) {
+      const parsed = notificationPrefsSchema.parse({ [type]: { push: false, email: false } })
+      expect(parsed).toEqual({ [type]: { push: false, email: false } })
+    }
+  })
 })
 
 describe('promotionsRefused', () => {

--- a/packages/shared/src/notifications.ts
+++ b/packages/shared/src/notifications.ts
@@ -104,6 +104,7 @@ export const notificationPrefsSchema = z
     streak: channelPrefsSchema,
     badges: channelPrefsSchema,
     profileVisits: channelPrefsSchema,
+    meetings: channelPrefsSchema,
     promotions: channelPrefsSchema,
   })
   .partial()


### PR DESCRIPTION
`meetings` has been a notification kind since the reminder shipped. It has a default (`DEFAULT_NOTIFICATION_PREFS`), the sender reads it (`meetingReminders.ts`), the settings screen draws a row for it off `NOTIFICATION_TYPES`, and all eight locales name it.

Only `notificationPrefsSchema` never learned about it. The schema is not `.strict()`, so zod **strips** the unknown key instead of refusing it: `PATCH /profiles/me` with `{settings:{notifications:{meetings:{push:false}}}}` answered 200, wrote nothing, and the switch sprang back on at the next profile fetch. No error anywhere — on the phone, in the API, or in the logs.

## What changed

- `packages/shared/src/notifications.ts` — `meetings: channelPrefsSchema` in the request schema, in `NOTIFICATION_TYPES` order.
- `packages/shared/src/notifications.test.ts` — parse every kind in `NOTIFICATION_TYPES` and assert the key survives. Nothing links the two lists at compile time, so this is what has to notice the next one. Verified red before the fix (`{}` came back where the kind should have been).
- `apps/api/src/routes/profiles.test.ts` — a `meetings` round-trip through `PATCH` and back out of `GET /profiles/me`, because the schema test alone does not prove the handler writes it.

Nothing else needed touching: the update handler is generic over whatever survives the schema, `setEmailNotifications` already iterates `NOTIFICATION_TYPES`, and the mobile rows are built from that list too.

## Why the tests missed it

`meetingReminders.test.ts` writes preferences straight to Mongo, bypassing the schema. `profiles.test.ts` round-tripped `streak` and `promotions` — both of which the schema knew about.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and the `@langx/shared` suite (316 tests) all pass locally. The `@langx/api` suites could not run in this sandbox: `mongodb-memory-server` fetches its `mongod` binary from `fastdl.mongodb.org`, which the environment's network policy blocks. The new `profiles.test.ts` case is therefore unverified locally and relies on CI.

## Noticed, not fixed

- `apps/api/src/i18n/messages/*.ts` — `email.kind` has no `badges` or `meetings` entry, so a badge email's unsubscribe page renders a raw key path. Separate bug.
- Two stale counts in comments: `notifications.test.ts` says "the other seven" and `apps/mobile/src/hooks/useSettingsModel.ts:87` says "The ten cells"; it is six kinds × two channels = twelve. This PR does not change the count, so it does not change the comments either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUXhwAjqjey3ZmSKLWPjdZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUXhwAjqjey3ZmSKLWPjdZ)_