### PR TITLE
Delete the files a purged account leaves in the bucket

### DIFF
--- a/apps/api/src/modules/account/deletion.ts
+++ b/apps/api/src/modules/account/deletion.ts
@@ -19,7 +19,7 @@ interface AttachmentRow {
   attachments?: Media[]
   media?: Media
 }
-import { supportsPut } from '../../storage/StorageProvider'
+import { supportsPrefixDelete, supportsPut } from '../../storage/StorageProvider'
 import type { Conversation, Message } from '../chat/conversations'
 import type { Profile } from '../profiles/profiles'
 
@@ -109,8 +109,8 @@ export interface PurgeResult {
  *   nowhere else. That keeps an audit trail of the economy (totals still
  *   reconcile) while making the rows genuinely anonymous. The *aggregates* are
  *   deleted, which is what removes the account from every leaderboard.
- * - Everything else — profile, devices, views, blocks, subscriptions, auth
- *   rows, and the images in the bucket — goes completely.
+ * - Everything else — profile, devices, views, blocks, subscriptions, share
+ *   cards, auth rows, and the images in the bucket — goes completely.
  */
 export async function purgeExpiredAccounts(
   db: Db,
@@ -196,6 +196,17 @@ export async function purgeExpiredAccounts(
           .toArray(),
       ])
 
+      /*
+       * Share cards. The row carries the URL, so these need no more than
+       * being read — which is the whole bug: nothing read them, and a card is
+       * reachable at a public `/s/<id>` that outlives the account it is
+       * about. `card_owner` in `db/indexes.ts` was already there for this.
+       */
+      const cards = await db
+        .collection<{ imageUrl: string }>(COLLECTIONS.shareCards)
+        .find({ userId }, { projection: { imageUrl: 1 } })
+        .toArray()
+
       const urls = [
         profile.avatarUrl,
         ...(profile.photos ?? []).map((p) => p.url),
@@ -209,6 +220,7 @@ export async function purgeExpiredAccounts(
             ...attachmentsOf(row).map((item) => item.url),
             (row as { slowMedia?: Media }).slowMedia?.url,
           ]),
+        ...cards.map((card) => card.imageUrl),
       ]
       for (const url of urls) {
         if (!url) continue
@@ -226,6 +238,26 @@ export async function purgeExpiredAccounts(
           // failure mode is an orphaned file rather than an account that never
           // gets purged.
         }
+      }
+    }
+
+    /*
+     * The one kind of file no row points at. A bug report goes to an email
+     * and into no table of ours — see `routes/feedback.ts` for why — so the
+     * sweep above cannot reach its attachments however carefully it reads.
+     * The prefix is the only handle the upload kept, which is why it chose
+     * one — and until this, nothing had ever used it.
+     *
+     * Its own capability check, outside the block above: listing objects and
+     * writing them are separate things a provider may or may not do.
+     */
+    if (options.storage && supportsPrefixDelete(options.storage)) {
+      try {
+        objectsDeleted += await options.storage.deleteByPrefix(`feedback/${userId}/`)
+      } catch {
+        // Swallowed for the reason the per-object failure above is: an
+        // orphaned file is a better outcome than an account that never gets
+        // purged.
       }
     }
 
@@ -313,6 +345,10 @@ export async function purgeExpiredAccounts(
       db.collection(COLLECTIONS.tokenAggregates).deleteMany({ userId }),
       db.collection(COLLECTIONS.dailyActivity).deleteMany({ userId }),
       db.collection(COLLECTIONS.subscriptions).deleteMany({ userId }),
+      // The rows behind the images deleted above. A card's `_id` is a public
+      // `/s/<id>` page about a person, so leaving it is leaving a profile
+      // fragment up after the profile is gone.
+      db.collection(COLLECTIONS.shareCards).deleteMany({ userId }),
       // Better Auth's own rows. Deleting the `user` document is what makes the
       // email reusable and the account genuinely gone rather than orphaned.
       db.collection(COLLECTIONS.session).deleteMany({ userId: authId(userId) }),

--- a/apps/api/src/modules/cards/shareCards.ts
+++ b/apps/api/src/modules/cards/shareCards.ts
@@ -67,8 +67,9 @@ export async function createShareCard(
   )
 
   const id = randomUUID().replaceAll('-', '').slice(0, 22)
-  // Under the owner's own prefix, like every other object they own, so the
-  // account purge sweeps these out with the rest of their media.
+  // Under the owner's own prefix, like every other object they own. What the
+  // account purge actually finds it by is `imageUrl` on the row below — the
+  // prefix is for reading a bucket listing, not for deleting.
   const imageUrl = await storage.putObject(`cards/${input.userId}/${id}.png`, png, 'image/png')
 
   const card: ShareCard = {

--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -86,9 +86,10 @@ export const feedbackRoutes: FastifyPluginAsyncZod = async (app) => {
         )
       }
 
-      // Its own prefix, keyed by user, for the same reason `posts/` is: the
-      // account-deletion purge finds a person's objects by prefix, and proof
-      // of a bug is still their file.
+      // Its own prefix, keyed by user, and load-bearing rather than tidy: a
+      // report is written to no table of ours, so this prefix is the only
+      // thing that can find the file again. The account purge sweeps it with
+      // `deleteByPrefix` — proof of a bug is still their file.
       const extension = objectExtension(contentType)
       const key = `feedback/${request.userId}/${randomUUID()}.${extension}`
       return reply.send(await app.storage.getUploadUrl(key, contentType))

--- a/apps/api/src/routes/media.ts
+++ b/apps/api/src/routes/media.ts
@@ -50,7 +50,9 @@ export const mediaRoutes: FastifyPluginAsyncZod = async (app) => {
   )
 
   // Gallery photos take the same presigned path as the avatar, into their own
-  // key prefix so the account-deletion purge can find them by prefix later.
+  // key prefix. The account-deletion purge finds them through `photos` on the
+  // profile, as it does the avatar — the prefix keeps a bucket listing
+  // readable, nothing more.
   app.post(
     '/me/photos/upload-url',
     {
@@ -103,8 +105,10 @@ export const mediaRoutes: FastifyPluginAsyncZod = async (app) => {
         )
       }
 
-      // Keyed by conversation so the account purge can find a user's
-      // attachments, and so a leaked key reveals nothing about who is talking.
+      // Keyed by conversation so a leaked key reveals nothing about who is
+      // talking. The account purge finds these through the message rows the
+      // sender left behind; it could not do it from this prefix, which says
+      // nothing about who uploaded.
       const extension = objectExtension(contentType)
       const key = `messages/${conversation._id.toHexString()}/${randomUUID()}.${extension}`
       return reply.send(await app.storage.getUploadUrl(key, contentType))
@@ -121,8 +125,8 @@ export const mediaRoutes: FastifyPluginAsyncZod = async (app) => {
    * nothing.
    *
    * Keyed by *user*, not by post, because the post does not exist yet when the
-   * URL is signed — unlike a conversation. That also keeps the deletion purge
-   * able to find a person's uploads by prefix.
+   * URL is signed — unlike a conversation. The deletion purge finds these
+   * through the post and correction rows, not through the prefix.
    */
   app.post(
     '/posts/upload-url',

--- a/apps/api/src/routes/moderation.test.ts
+++ b/apps/api/src/routes/moderation.test.ts
@@ -938,6 +938,7 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
         getUploadUrl: () => Promise.reject(new Error('unused')),
         putObject: () => Promise.resolve(''),
         deleteObject: () => Promise.reject(new Error('bucket unreachable')),
+        deleteByPrefix: () => Promise.reject(new Error('bucket unreachable')),
         keyFromPublicUrl: () => 'avatars/x.jpg',
       }
       await handle.db
@@ -962,6 +963,121 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
           .collection(COLLECTIONS.profiles)
           .countDocuments({ _id: user.userId as never }),
       ).toBe(0)
+    })
+
+    /**
+     * The one kind of file no row points at. A bug report is written to no
+     * collection of ours, so the URL-by-URL sweep the rest of this describe
+     * exercises cannot reach its attachments — the prefix the upload chose is
+     * the only handle left, and until now nothing used it.
+     */
+    it("sweeps the bug reports nothing else can find, and only the purged account's", async () => {
+      const user = await newUser()
+      const objects = new Set([
+        `feedback/${user.userId}/report.jpg`,
+        `feedback/${user.userId}/second.png`,
+        'feedback/somebody-else/theirs.jpg',
+      ])
+      const prefixes: string[] = []
+      const storage = {
+        getUploadUrl: () => Promise.reject(new Error('unused')),
+        putObject: () => Promise.resolve(''),
+        deleteObject: () => Promise.resolve(),
+        deleteByPrefix: (prefix: string) => {
+          prefixes.push(prefix)
+          let deleted = 0
+          for (const key of objects) {
+            if (!key.startsWith(prefix)) continue
+            objects.delete(key)
+            deleted++
+          }
+          return Promise.resolve(deleted)
+        },
+        keyFromPublicUrl: () => null,
+      }
+
+      await post(user, '/me/delete', { confirm: 'DELETE' })
+      const result = await purgeExpiredAccounts(handle.db, {
+        now: new Date(Date.now() + (ACCOUNT_DELETION_GRACE_DAYS + 1) * 86_400_000),
+        storage,
+      })
+
+      // `toContain`, not `toEqual`: another account expiring in the same run
+      // is a legitimate second prefix. What must be exact is which objects
+      // survive.
+      expect(prefixes).toContain(`feedback/${user.userId}/`)
+      expect(result.objectsDeleted).toBe(2)
+      // Somebody else's report is not swept by a prefix that ends in a slash.
+      expect([...objects]).toEqual(['feedback/somebody-else/theirs.jpg'])
+    })
+
+    /**
+     * A share card is a public `/s/<id>` page about a person. The image was
+     * always reachable by URL and the row always answered for it, so leaving
+     * either behind keeps a profile fragment up after the profile is gone.
+     */
+    it('deletes the share cards, both the image and the row', async () => {
+      const user = await newUser()
+      await handle.db.collection(COLLECTIONS.shareCards).insertOne({
+        _id: 'cardid' as never,
+        userId: user.userId,
+        kind: 'streak',
+        shape: 'story',
+        imageUrl: `https://cdn.example.com/cards/${user.userId}/cardid.png`,
+        headline: 'a hundred days',
+        caption: 'on LangX',
+        handle: 'someone',
+        createdAt: new Date(),
+      })
+
+      const deleted: string[] = []
+      const storage = {
+        getUploadUrl: () => Promise.reject(new Error('unused')),
+        putObject: () => Promise.resolve(''),
+        deleteObject: (key: string) => {
+          deleted.push(key)
+          return Promise.resolve()
+        },
+        keyFromPublicUrl: (url: string) =>
+          url.startsWith('https://cdn.example.com/')
+            ? url.slice('https://cdn.example.com/'.length)
+            : null,
+      }
+
+      await post(user, '/me/delete', { confirm: 'DELETE' })
+      await purgeExpiredAccounts(handle.db, {
+        now: new Date(Date.now() + (ACCOUNT_DELETION_GRACE_DAYS + 1) * 86_400_000),
+        storage,
+      })
+
+      expect(deleted).toContain(`cards/${user.userId}/cardid.png`)
+      expect(
+        await handle.db.collection(COLLECTIONS.shareCards).countDocuments({ userId: user.userId }),
+      ).toBe(0)
+    })
+
+    /**
+     * Listing objects is a capability a provider may not have — the
+     * unconfigured one has none at all. The purge asks before it calls, and
+     * an account whose reports outlive it is still better than one that
+     * cannot be deleted.
+     */
+    it('purges with a provider that cannot list objects', async () => {
+      const user = await newUser()
+      const storage = {
+        getUploadUrl: () => Promise.reject(new Error('unused')),
+        putObject: () => Promise.resolve(''),
+        deleteObject: () => Promise.resolve(),
+        keyFromPublicUrl: () => null,
+      }
+
+      await post(user, '/me/delete', { confirm: 'DELETE' })
+      const result = await purgeExpiredAccounts(handle.db, {
+        now: new Date(Date.now() + (ACCOUNT_DELETION_GRACE_DAYS + 1) * 86_400_000),
+        storage,
+      })
+
+      expect(result.userIds).toContain(user.userId)
     })
 
     it('keeps the token ledger as an anonymous audit trail but drops the aggregates', async () => {

--- a/apps/api/src/storage/StorageProvider.ts
+++ b/apps/api/src/storage/StorageProvider.ts
@@ -54,6 +54,32 @@ export interface StorageProviderWithPut extends StorageProvider {
   keyFromPublicUrl(url: string): string | null
 }
 
+/**
+ * Deleting by prefix rather than by key, for the objects no row points at.
+ *
+ * The purge finds a person's files through the documents that reference them,
+ * which works for everything the app stores a URL for. A bug report's
+ * attachment is the exception: it goes to an email and into no table of ours,
+ * so the only handle we kept on it is the prefix the upload chose. Without
+ * this it stays in the bucket forever, publicly fetchable, after the account
+ * that sent it is gone.
+ *
+ * Its own interface rather than another method on `StorageProviderWithPut`,
+ * for the reason that one is separate from `StorageProvider`: a provider that
+ * cannot list objects is still a usable provider, and the purge asks before
+ * it calls.
+ */
+export interface StorageProviderWithPrefixDelete extends StorageProvider {
+  /** How many objects went — the purge counts them, so it must be the truth. */
+  deleteByPrefix(prefix: string): Promise<number>
+}
+
 export function supportsPut(provider: StorageProvider): provider is StorageProviderWithPut {
   return typeof (provider as StorageProviderWithPut).putObject === 'function'
+}
+
+export function supportsPrefixDelete(
+  provider: StorageProvider,
+): provider is StorageProviderWithPrefixDelete {
+  return typeof (provider as StorageProviderWithPrefixDelete).deleteByPrefix === 'function'
 }

--- a/apps/api/src/storage/s3StorageProvider.test.ts
+++ b/apps/api/src/storage/s3StorageProvider.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { S3StorageProvider } from './s3StorageProvider'
+
+const provider = new S3StorageProvider({
+  endpoint: 'https://s3.example.test',
+  region: 'us-east-1',
+  bucket: 'langx-test',
+  accessKeyId: 'key',
+  secretAccessKey: 'secret',
+  publicBaseUrl: 'https://cdn.example.test',
+})
+
+describe('deleteByPrefix', () => {
+  /**
+   * The one call in this file that can destroy data it was not asked about.
+   * An empty prefix matches the whole bucket and `feedback/u1` also matches
+   * `feedback/u10/`, so the shape is checked before anything is listed —
+   * the purge builds these from a user id, and a blank id must throw rather
+   * than sweep.
+   */
+  it('refuses a prefix that is not a directory', async () => {
+    await expect(provider.deleteByPrefix('')).rejects.toThrow(/must end in/)
+    await expect(provider.deleteByPrefix('feedback')).rejects.toThrow(/must end in/)
+    await expect(provider.deleteByPrefix('feedback/u1')).rejects.toThrow(/must end in/)
+  })
+})

--- a/apps/api/src/storage/s3StorageProvider.ts
+++ b/apps/api/src/storage/s3StorageProvider.ts
@@ -1,11 +1,16 @@
 import {
   DeleteObjectCommand,
   GetObjectCommand,
+  ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
-import type { StorageProviderWithPut, UploadUrl } from './StorageProvider'
+import type {
+  StorageProviderWithPrefixDelete,
+  StorageProviderWithPut,
+  UploadUrl,
+} from './StorageProvider'
 
 const UPLOAD_URL_TTL_SECONDS = 5 * 60
 
@@ -24,7 +29,7 @@ export interface S3StorageConfig {
  * / `createStorageProvider`). `forcePathStyle` is the safe default across
  * S3-compatible providers that aren't AWS itself.
  */
-export class S3StorageProvider implements StorageProviderWithPut {
+export class S3StorageProvider implements StorageProviderWithPut, StorageProviderWithPrefixDelete {
   readonly #client: S3Client
   readonly #bucket: string
   readonly #publicBaseUrl: string
@@ -84,6 +89,38 @@ export class S3StorageProvider implements StorageProviderWithPut {
     // S3 delete is already idempotent — a missing key returns 204, not an
     // error — so nothing extra is needed to make a retried purge safe.
     await this.#client.send(new DeleteObjectCommand({ Bucket: this.#bucket, Key: key }))
+  }
+
+  async deleteByPrefix(prefix: string): Promise<number> {
+    // A prefix that does not end in `/` is a prefix by accident: `feedback/u1`
+    // also matches `feedback/u10/`, and an empty one matches the whole bucket.
+    // The purge builds these from a user id, so the day one arrives empty is
+    // the day this throws instead of emptying the bucket.
+    if (!prefix.endsWith('/')) {
+      throw new Error(`Refusing to delete by prefix ${JSON.stringify(prefix)} — it must end in "/"`)
+    }
+
+    let deleted = 0
+    let continuationToken: string | undefined
+    do {
+      const listed = await this.#client.send(
+        new ListObjectsV2Command({
+          Bucket: this.#bucket,
+          Prefix: prefix,
+          ContinuationToken: continuationToken,
+        }),
+      )
+      for (const object of listed.Contents ?? []) {
+        if (!object.Key) continue
+        // One key at a time rather than `DeleteObjects`: a person's bug
+        // reports are tens of objects, not thousands, and the batch call is
+        // the corner of the S3 API where compatible providers differ most.
+        await this.deleteObject(object.Key)
+        deleted++
+      }
+      continuationToken = listed.IsTruncated ? listed.NextContinuationToken : undefined
+    } while (continuationToken)
+    return deleted
   }
 
   keyFromPublicUrl(url: string): string | null {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -203,10 +203,12 @@ presigned uploads — B2 and R2 run the same code, the target is an env variable
 Keys are prefixed `avatars/{userId}/`, `photos/{userId}/`,
 `messages/{conversationId}/` and `posts/{userId}/`. The feed's prefix is keyed
 by user rather than by post because the post does not exist when the URL is
-signed; every prefix is one the account purge can sweep. Attachments on posts
-and corrections share `mediaSchema` and `PLAN_LIMITS.mediaPer24h` with chat —
-one shape, one ceiling table, one abuse budget. The ceilings are per kind, in
-`MEDIA_LIMITS`: 8MB for an image, 16MB and two minutes for a voice note, 64MB
+signed. The account purge deletes these through the rows that reference them;
+`feedback/{userId}/` is the exception it sweeps by prefix, because a bug report
+is written to no collection and no row points at its attachments. Attachments
+on posts and corrections share `mediaSchema` and `PLAN_LIMITS.mediaPer24h` with
+chat — one shape, one ceiling table, one abuse budget. The ceilings are per
+kind, in `MEDIA_LIMITS`: 8MB for an image, 16MB and two minutes for a voice note, 64MB
 and sixty seconds for a video. A message or a post carries up to
 `MAX_ATTACHMENTS` of them and spends one unit of the budget however many that
 is — the per-file byte ceiling is what bounds storage, not the count.


### PR DESCRIPTION
Two kinds of object outlived the account they belonged to, and a comment next to each said otherwise. "Permanently removed" was not true for either.

## `feedback/<userId>/` — the hard one

The purge finds a person's files by reading the rows that reference them and resolving each URL with `keyFromPublicUrl`. A bug report is written to **no table of ours** — it goes to an email and a GitHub issue and nowhere else, deliberately (`routes/feedback.ts`). So no row ever pointed at those objects and nothing could have found them; they stayed publicly fetchable forever.

`routes/feedback.ts` said *"the account-deletion purge finds a person's objects by prefix"*. It never did — there was no listing capability anywhere in the codebase.

- `StorageProvider.ts` — a new `StorageProviderWithPrefixDelete` + `supportsPrefixDelete`, its own interface next to `supportsPut` rather than another method on `StorageProviderWithPut`. Listing objects and writing them are separate things a provider may or may not do, and adding a required method to the existing interface would have broken three unrelated test doubles.
- `s3StorageProvider.ts` — `deleteByPrefix` over a `ListObjectsV2` continuation loop, one `DeleteObjectCommand` per key. Not `DeleteObjects`: a person's reports are tens of objects, and the batch call is the corner of the S3 API where compatible providers differ most. It refuses a prefix that does not end in a slash — an empty one matches the whole bucket, and `feedback/u1` also matches `feedback/u10/`.
- `deletion.ts` — the sweep, under its own capability check, with the same swallow-per-failure discipline as the URL loop.

## `cards/<userId>/` — the easy one

The row carries `imageUrl`, and the `card_owner` index in `db/indexes.ts` was already there with a comment about a purge that never read it. Nothing more was needed than reading it. The rows go too: a card's `_id` is a public `/s/<id>` page about a person, so leaving one up leaves a profile fragment after the profile is gone.

## Comments

Four places described a prefix sweep that did not exist — `feedback.ts`, `shareCards.ts`, `media.ts` (three of them) and `docs/architecture.md`. They are corrected rather than deleted; believing them is how this happened. Where the outcome was right for the wrong reason (avatars, photos, posts) the comment now names the mechanism that actually deletes them.

Avatars, photos, posts and message attachments keep going the way they always did, through their rows — switching them to prefix sweeps would be a behaviour change beyond this bug, and `messages/` is keyed by conversation so it could not be swept by prefix anyway.

## Tests

In `moderation.test.ts`'s purge describe:
- a report under the purged account's prefix goes, and another user's does not
- a share card's image **and** row go
- the storage-unavailable case now rejects `deleteByPrefix` too, and the account is still purged
- a provider with no `deleteByPrefix` at all still purges

Plus `s3StorageProvider.test.ts` for the prefix guard.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and the `s3StorageProvider` suite pass locally.

**The `moderation.test.ts` cases could not be run here.** `mongodb-memory-server` fetches its `mongod` binary from `fastdl.mongodb.org`, which this environment's network policy blocks (403 on CONNECT), and there is no system `mongod` to fall back to. Every purge assertion in this PR is therefore unverified locally and depends on CI. Flagging it rather than implying otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUXhwAjqjey3ZmSKLWPjdZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUXhwAjqjey3ZmSKLWPjdZ)_