### PR TITLE
Name a Release after its tag

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Create the release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${GITHUB_REF_NAME}" --title "LangX ${GITHUB_REF_NAME#v}" --generate-notes
+        run: gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/api",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 API — Better Auth + REST + Socket.io in one Fastify process",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/mobile",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "LangX v2 client — iOS, Android and web from one Expo codebase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langx",
-  "version": "2.2",
+  "version": "2.3",
   "private": true,
   "description": "LangX v2 \u2014 language exchange app (Expo mobile/web + Fastify API + MongoDB Atlas)",
   "license": "BSD-3-Clause",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langx/shared",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "license": "BSD-3-Clause",
   "description": "Contract shared by @langx/api and @langx/mobile: zod schemas, language and level tables, plan limits, token rules, error codes",


### PR DESCRIPTION
The Releases list had **LangX 2.1** and **LangX 2.2** sitting above `v2.0` and every `v0.x` before them. The tag is what people search for and link to, so `github-release.yml` now titles a Release with the tag itself and the list reads as one series again.

The two that were already published have been renamed by hand (`gh release edit v2.1 --title v2.1`, same for `v2.2`); this change is what stops the next one coming out as "LangX 2.3".

Nothing else in the workflow moves — the guard that the tag must match `package.json` is untouched.

Note: this branch also carries `Release 2.3`, the version bump to 2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)