### PR TITLE
Name a Release after its tag

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Create the release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${GITHUB_REF_NAME}" --title "LangX ${GITHUB_REF_NAME#v}" --generate-notes
+        run: gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes


### PR DESCRIPTION
The Releases list had **LangX 2.1** and **LangX 2.2** sitting above `v2.0` and every `v0.x` before them. The tag is what people search for and link to, so `github-release.yml` now titles a Release with the tag itself and the list reads as one series again.

The two that were already published have been renamed by hand (`gh release edit v2.1 --title v2.1`, same for `v2.2`); this change is what stops the next one coming out as "LangX 2.3".

Nothing else in the workflow moves — the guard that the tag must match `package.json` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)