### PR TITLE
Hold the store build number in the repo, one number for both platforms

### DIFF
--- a/apps/mobile/.eas/workflows/release.yml
+++ b/apps/mobile/.eas/workflows/release.yml
@@ -1,9 +1,10 @@
 # A store release: production builds for both platforms, then submission.
 #
-# Started by hand, on purpose. `production` auto-increments the build number
-# and `eas.json`'s submit profile releases Android to everyone at once
-# (`releaseStatus: completed`, no rollout key); iOS goes to App Store Connect
-# for review. The iOS half needs a distribution
+# Started by hand, on purpose. The build number is `buildNumber` in the root
+# package.json — `pnpm release build` bumps it, and both stores refuse a
+# second upload on the same number. `eas.json`'s submit profile releases
+# Android to everyone at once (`releaseStatus: completed`, no rollout key);
+# iOS goes to App Store Connect for review. The iOS half needs a distribution
 # certificate and an App Store Connect API key in EAS before it can run.
 name: Release
 on:

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -8,11 +8,11 @@
 import { ANDROID_PACKAGE, APP_LINK_HOST, IOS_BUNDLE_ID } from '@langx/shared/appIdentity'
 import { APP_SCHEMES } from '@langx/shared/appScheme'
 import type { ExpoConfig } from 'expo/config'
-// The one place the version is written is the root package.json; `pnpm
-// release` bumps it and tags the commit, and everything else reads it. The
+// The one place the version and the build number are written is the root
+// package.json; `pnpm release` bumps them and everything else reads them. The
 // import attribute is what lets Expo's config loader read JSON whichever way
 // it evaluates this file.
-import { version } from '../../package.json' with { type: 'json' }
+import { buildNumber, version } from '../../package.json' with { type: 'json' }
 
 /**
  * v2 ships as an **update to the existing store listings**, not a new app.
@@ -31,12 +31,20 @@ import { version } from '../../package.json' with { type: 'json' }
  *     against a file on the domain, so these entries do nothing until
  *     `apps/mobile/public/.well-known/` is actually served from that host.
  *
- * The build number and Android versionCode are deliberately absent: `eas.json`
- * sets `appVersionSource: "remote"`, so EAS owns them and hands one out per
- * build. They were declared here until 3 September 2026, which silently broke
- * every `production` build — `autoIncrement` cannot write back into a dynamic
- * config, so the build failed before it started. The remote counter has to
- * stay above the published 119.
+ * `ios.buildNumber` and `android.versionCode` are one number, `buildNumber`
+ * in the root package.json, so the two stores cannot drift apart. They had:
+ * EAS's remote counters (`appVersionSource: "remote"`) increment per platform,
+ * and by 10 September 2026 iOS stood at 148 against Android's 146. `pnpm
+ * release minor` bumps the number with the version; `pnpm release build`
+ * bumps it alone, for a rebuild inside a round. Nothing auto-increments —
+ * `autoIncrement` cannot write back into a dynamic config, which is what
+ * silently broke every `production` build until 3 September 2026. The number
+ * has to stay above the published 119.
+ *
+ * A number in the config is a number in the fingerprint, and a fingerprint
+ * that changed on every build would leave no installed binary matching the
+ * update `main` publishes. `fingerprint.config.js` keeps the version fields
+ * out of it.
  */
 // Existing EAS project, carried over from the abandoned rewrite.
 const EAS_PROJECT_ID = 'c331c0a6-b2fc-4664-a9a3-c04d1fb2c115'
@@ -55,6 +63,7 @@ const config: ExpoConfig = {
 
   ios: {
     bundleIdentifier: IOS_BUNDLE_ID,
+    buildNumber: String(buildNumber),
     supportsTablet: true,
     // The app encrypts nothing of its own; it only speaks HTTPS through the
     // system stack, which Apple's export rules exempt. Answering that here
@@ -74,6 +83,7 @@ const config: ExpoConfig = {
 
   android: {
     package: ANDROID_PACKAGE,
+    versionCode: buildNumber,
     /**
      * Android 13+'s predictive back: the system previews where back leads
      * before the gesture commits. `react-native-screens` drives the stack's

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 12.5.1",
-    "appVersionSource": "remote"
+    "appVersionSource": "local"
   },
   "build": {
     "development": {
@@ -14,7 +14,6 @@
     "production": {
       "channel": "production",
       "environment": "production",
-      "autoIncrement": true,
       "env": {
         "EXPO_PUBLIC_API_URL": "https://api.langx.io"
       },

--- a/apps/mobile/fingerprint.config.js
+++ b/apps/mobile/fingerprint.config.js
@@ -1,0 +1,14 @@
+// Keeps the version and the build number out of the fingerprint. The runtime
+// version is meant to change when the native layer does; a number that changes
+// on every build would make each store build its own runtime, and the update
+// `main` publishes would match no installed binary. Two entries are needed
+// because the number reaches the config in two ways: as `ios.buildNumber` /
+// `android.versionCode` (the skip), and as the root package.json that
+// `app.config.ts` imports, which the fingerprint hashes as a file (the ignore).
+// Neither eas-cli nor expo-updates applies either on its own. The second skip
+// is the library's default, which setting the field replaces.
+/** @type {import('expo/fingerprint').Config} */
+module.exports = {
+  sourceSkips: ['ExpoConfigVersions', 'PackageJsonAndroidAndIosScriptsIfNotContainRun'],
+  ignorePaths: ['../../package.json'],
+}

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -51,9 +51,13 @@ leftovers. They are not.
 | `scheme`                 | **Both** schemes. v1 registered `tech.newchapter.languagexchange` (lowercase x). Ship only `langx` and every deep link already in the wild breaks. |
 | App links                | `https://app.langx.io`, `autoVerify` — carried from v1's AndroidManifest. Declaring them is half the job; see the next section                     |
 
-`versionCode` and `buildNumber` must both start **above 119**, the published
-v1 version. EAS owns them (`appVersionSource: "remote"`) and hands one out per
-build; the version name is a separate thing, see _Shipping runs on expo.dev_ below.
+`versionCode` and `buildNumber` are one number, `buildNumber` in the root
+`package.json`, so the two stores cannot drift apart; `pnpm release minor`
+bumps it with the version and `pnpm release build` bumps it alone, for a
+rebuild inside a round. It must stay **above 119**, the published v1 version.
+`apps/mobile/fingerprint.config.js` keeps it out of the runtime fingerprint,
+which is what lets a rebuild keep receiving the updates its predecessors do.
+The version name is a separate thing, see _Shipping runs on expo.dev_ below.
 
 ## The API has to be deployed, and it has to be deployed early
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "langx",
   "version": "2.2",
+  "buildNumber": 148,
   "private": true,
   "description": "LangX v2 \u2014 language exchange app (Expo mobile/web + Fastify API + MongoDB Atlas)",
   "license": "BSD-3-Clause",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -3,8 +3,9 @@
  * Cuts a release: bumps the version, commits it and tags the commit. One
  * command instead of four files edited by hand and a tag typed from memory.
  *
- *     pnpm release minor    2.0 -> 2.1
- *     pnpm release major    2.1 -> 3.0
+ *     pnpm release minor    2.0 -> 2.1, build 148 -> 149
+ *     pnpm release major    2.1 -> 3.0, build 149 -> 150
+ *     pnpm release build    build 150 -> 151, the version untouched
  *     pnpm release --print  prints the current version and exits
  *
  * The version is two numbers, `major.minor`, and lives in the root
@@ -13,6 +14,12 @@
  * the same number with a `.0` on the end, because `pnpm deploy` matches
  * `@langx/shared@workspace:*` by semver and `2.0` is not one — the API image
  * stopped building the first time the two digits reached those files.
+ *
+ * The build number lives next to the version, as `buildNumber`, and is both
+ * `ios.buildNumber` and `android.versionCode`, so the stores cannot drift
+ * apart. A release bumps it because a new version is a new binary; `build`
+ * bumps it alone, for a rebuild inside a round (a store refuses a second
+ * upload on the same number). Neither store lets it go down.
  *
  * Nothing is pushed. `main` is protected and releases go through the same
  * pull request as everything else; the script prints the two commands that
@@ -45,6 +52,31 @@ function readVersion() {
   return version
 }
 
+function readBuildNumber() {
+  const { buildNumber } = JSON.parse(readFileSync(join(root, ROOT_MANIFEST), 'utf8'))
+  if (!Number.isInteger(buildNumber) || buildNumber < 1) {
+    throw new Error(`root package.json buildNumber must be a positive integer, got ${buildNumber}`)
+  }
+  return buildNumber
+}
+
+/**
+ * A string replacement, not a parse-and-serialise round trip: the file keeps
+ * its key order, indentation and trailing newline exactly, so the diff is one
+ * line and prettier has nothing to say about it.
+ */
+function replaceField(manifest, pattern, value) {
+  const path = join(root, manifest)
+  const source = readFileSync(path, 'utf8')
+  const updated = source.replace(pattern, (_match, prefix) => `${prefix}${value}`)
+  if (updated === source) throw new Error(`${manifest} has nothing matching ${pattern} to update`)
+  writeFileSync(path, updated)
+}
+
+function writeBuildNumber(next) {
+  replaceField(ROOT_MANIFEST, /^(\s*"buildNumber":\s*)\d+/m, next)
+}
+
 function bumped(version, part) {
   const [, major, minor] = VERSION.exec(version)
   return part === 'major' ? `${Number(major) + 1}.0` : `${major}.${Number(minor) + 1}`
@@ -64,7 +96,7 @@ function printVersion() {
 }
 
 function usage() {
-  console.error('usage: pnpm release <major|minor>  |  pnpm release --print')
+  console.error('usage: pnpm release <major|minor|build>  |  pnpm release --print')
   process.exit(2)
 }
 
@@ -82,32 +114,36 @@ function release(part) {
   if (git('tag', '--list', tag) !== '') fail(`${tag} already exists`)
 
   for (const manifest of MANIFESTS) {
-    const path = join(root, manifest)
     const value = manifest === ROOT_MANIFEST ? next : `${next}.0`
-    // A string replacement, not a parse-and-serialise round trip: the files
-    // keep their key order, indentation and trailing newline exactly, so the
-    // diff is one line per file and prettier has nothing to say about it.
-    const source = readFileSync(path, 'utf8')
-    const updated = source.replace(
-      /^(\s*"version":\s*)"[^"]*"/m,
-      (_match, prefix) => `${prefix}${JSON.stringify(value)}`,
-    )
-    if (updated === source) throw new Error(`${manifest} has no "version" field to update`)
-    writeFileSync(path, updated)
+    replaceField(manifest, /^(\s*"version":\s*)"[^"]*"/m, JSON.stringify(value))
   }
+  const build = readBuildNumber() + 1
+  writeBuildNumber(build)
 
   git('add', ...MANIFESTS)
   git('commit', '--quiet', '--message', `Release ${next}`)
   git('tag', '--annotate', '--message', `LangX ${next}`, tag)
 
   const branch = git('rev-parse', '--abbrev-ref', 'HEAD')
-  console.log(`${current} -> ${next}, committed and tagged ${tag}. To finish:`)
+  console.log(`${current} -> ${next} (build ${build}), committed and tagged ${tag}. To finish:`)
   console.log('')
   console.log(`    git push -u origin ${branch}`)
   console.log(`    git push origin ${tag}`)
   console.log('')
   console.log('Push the tag once the release commit is on main; the tag is what creates the')
   console.log('GitHub Release. A store build is still release.yml on expo.dev.')
+}
+
+function releaseBuild() {
+  if (git('status', '--porcelain') !== '') {
+    fail('the working tree has uncommitted changes; commit or stash them first')
+  }
+  const current = readBuildNumber()
+  const next = current + 1
+  writeBuildNumber(next)
+  git('add', ROOT_MANIFEST)
+  git('commit', '--quiet', '--message', `Build ${next}`)
+  console.log(`build ${current} -> ${next}, committed. Push the branch; build once it is on main.`)
 }
 
 // A switch that dispatches to functions taking no input, rather than an
@@ -125,6 +161,9 @@ switch (process.argv[2]) {
     break
   case 'minor':
     release('minor')
+    break
+  case 'build':
+    releaseBuild()
     break
   default:
     usage()


### PR DESCRIPTION
## What

- `buildNumber` in the root `package.json` is now both `ios.buildNumber` and `android.versionCode`, so the two stores cannot drift apart (they had: iOS 148 vs Android 146).
- `eas.json`: `appVersionSource: "local"`, `autoIncrement` removed.
- `pnpm release minor|major` bumps the build number with the version; new `pnpm release build` bumps it alone, for a rebuild inside a round.
- `apps/mobile/fingerprint.config.js` keeps the number out of the runtime fingerprint: `ExpoConfigVersions` for the config fields, plus `ignorePaths` for the root `package.json`, which the fingerprint hashes as a file because `app.config.ts` imports it. Neither eas-cli nor expo-updates applies either on its own.
- Runbook and `release.yml` comment updated.

## Verified

- `expo config --type public` resolves `2.2`, `ios.buildNumber: "148"`, `android.versionCode: 148`.
- `expo-updates fingerprint:generate` with the number at 148 and at 149 gives the same hash on both platforms.
- `pnpm release build` and `pnpm release minor` exercised in a throwaway clone: `Build 149`, then `Release 2.3` with build 150 and tag `v2.3`.
- typecheck, lint, format:check, 2137 tests: all green.

## One-time cost

The fingerprint changes once with this merge (the version leaves the hash, the root `package.json` leaves the sources). Binaries built before it — iOS 148 in review, Android 146 live — stop matching updates published from `main` until a binary built after it ships. From then on, build-number bumps no longer change the runtime, and neither do version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
