### PR TITLE
Draw a face on a shared profile that has no photo

### DIFF
--- a/apps/api/src/modules/profiles/sharedProfile.ts
+++ b/apps/api/src/modules/profiles/sharedProfile.ts
@@ -17,7 +17,8 @@ import type { Profile } from './profiles'
  *   - **Age, city, photos.** Individually mild; together they are the set that
  *     makes a link somebody did not expect to be public feel like one. The
  *     card exists to say "this is a real person on LangX, open the app" — none
- *     of these help it do that.
+ *     of these help it do that. The gallery stays out; the *avatar* is the one
+ *     picture somebody picked to be their face, and it is here.
  *   - **Online status and last-active.** A presence beacon addressable by
  *     guessing a handle, with no account needed to watch it.
  *   - **Streak, tokens, tier, follower counts.** Numbers about someone,
@@ -25,6 +26,14 @@ import type { Profile } from './profiles'
  *
  * What is here is what a link has to carry to be worth following: who they
  * are, and what they are here to practise.
+ *
+ * The account id is here, and used to not be. It is what `/public/avatar/:seed`
+ * draws a face from, and without it the one page strangers reach was the only
+ * place an account with no avatar fell all the way through to its initials
+ * while every screen inside the app drew it a face. The id buys nothing on its
+ * own — every route that takes one asks for a session first, and the avatar
+ * route answers for ids nobody holds precisely so it cannot be asked whether
+ * an account exists.
  */
 export async function getSharedProfile(db: Db, handle: string): Promise<SharedProfile> {
   const profile = await db.collection<Profile>(COLLECTIONS.profiles).findOne(
@@ -59,6 +68,7 @@ export async function getSharedProfile(db: Db, handle: string): Promise<SharedPr
   if (!profile) throw new ApiError('NOT_FOUND', 'Profile not found')
 
   return {
+    _id: profile._id,
     handle: profile.handle,
     displayName: profile.displayName ?? profile.handle,
     ...(profile.avatarUrl ? { avatarUrl: profile.avatarUrl } : {}),

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -807,11 +807,26 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
       >()
 
       expect(Object.keys(body).sort()).toEqual(
-        ['bio', 'displayName', 'handle', 'learning', 'nativeLanguages'].sort(),
+        ['_id', 'bio', 'displayName', 'handle', 'learning', 'nativeLanguages'].sort(),
       )
-      for (const absent of ['age', 'photos', 'streak', 'isOnline', 'tier', 'city', '_id']) {
+      for (const absent of ['age', 'photos', 'streak', 'isOnline', 'tier', 'city']) {
         expect(body[absent], absent).toBeUndefined()
       }
+    })
+
+    /**
+     * The id is the seed `/public/avatar/:seed` draws from, and the only
+     * reason it is on this DTO: without it the page strangers reach was the
+     * one place a photoless account fell through to its initials.
+     */
+    it('carries the account id, so a photoless profile still gets its drawn face', async () => {
+      const user = await seed('public-avatar-seed@example.com', 'publicthree')
+      const body = (await app.inject({ method: 'GET', url: '/public/profiles/publicthree' })).json<
+        Record<string, unknown>
+      >()
+
+      expect(body._id).toBe(user.userId)
+      expect(body.avatarUrl).toBeUndefined()
     })
 
     it('is a 404 for a handle nobody holds', async () => {

--- a/apps/mobile/app/[username].tsx
+++ b/apps/mobile/app/[username].tsx
@@ -130,10 +130,9 @@ export default function SharedProfileScreen() {
           carry: no age, no streak, no account age, no online dot. */}
       <View style={styles.hero}>
         {/*
-          No generated face here, and deliberately. The public profile DTO does
-          not carry the account id — a test asserts it — and the avatar route
-          takes an id and nothing else, so this page keeps the initials rather
-          than reopening a decision made for the open internet.
+          The same three-step fallback as everywhere inside the app — photo,
+          then the face drawn from the account id, then initials. Only the
+          photo opens: a generated face has no full-size version to show.
         */}
         {user.avatarUrl ? (
           <Pressable
@@ -144,7 +143,7 @@ export default function SharedProfileScreen() {
             <Avatar url={user.avatarUrl} name={user.displayName} size={96} />
           </Pressable>
         ) : (
-          <Avatar url={user.avatarUrl} name={user.displayName} size={96} />
+          <Avatar name={user.displayName} seed={user._id} size={96} />
         )}
         {user.avatarUrl ? (
           <PhotoViewer

--- a/packages/shared/src/profile.ts
+++ b/packages/shared/src/profile.ts
@@ -384,6 +384,12 @@ export type PhotoRemoveInput = z.infer<typeof photoRemoveSchema>
  * and why.
  */
 export const sharedProfileSchema = z.object({
+  /**
+   * Only so the page can ask `/public/avatar/:seed` for the drawn face an
+   * account without a photo already has everywhere else — see
+   * `getSharedProfile`. Nothing else on this DTO is keyed by it.
+   */
+  _id: z.string(),
   handle: z.string(),
   displayName: z.string(),
   avatarUrl: z.string().optional(),


### PR DESCRIPTION
`app.langx.io/<handle>` opened in a private window showed initials for an
account with no avatar, while every screen inside the app draws that account a
face from `/public/avatar/:seed`. A shared link therefore looked emptier than
the profile it points at — which is what @emily and @langx look like today
(both have gallery photos and no avatar; 72 of 81 production profiles have no
avatar at all).

The public profile DTO now carries the account id, so the signed-out page uses
the same three-step fallback as the rest of the app: photo → drawn face →
initials. The id buys nothing on its own — every route that takes one asks for
a session first, and the avatar route answers for ids nobody holds precisely so
it cannot be used to ask whether an account exists.

The gallery stays out of the public card. Only the avatar — the one picture
somebody picked to be their face — is public, as before.

Verified signed out against a local API with a photoless profile: the drawn
face renders where the initials used to be. A profile that *does* have an
avatar (e.g. `app.langx.io/anna` on production) is unchanged.

Needs an API deploy (`fly deploy -a langx-api`) for the effect; the web build
alone falls back to today's initials, so the two can ship in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)