### PR TITLE
Security notices: a new device, a changed password, a sign-in method added or removed

### DIFF
--- a/apps/api/scripts/backfill-known-devices.ts
+++ b/apps/api/scripts/backfill-known-devices.ts
@@ -1,0 +1,98 @@
+/**
+ * Records the devices people are **already** signed in on, so switching the
+ * security notices on does not tell a hundred people their own phone is new.
+ *
+ * `knownDevices` starts empty. Without this, the first sign-in after the
+ * deploy is, by the only definition the code has, a sign-in from a device
+ * that has never been seen — and everybody who signs in that week gets a
+ * "new sign-in to your account" letter about the laptop they are reading it
+ * on. Which is the exact mail people learn to ignore, on the exact feature
+ * that has to be believed.
+ *
+ * `session` is the source: Better Auth stores the user agent on every row,
+ * and a live session *is* a device somebody is using. The rows expire in a
+ * week, so this covers the people who have signed in recently — which is the
+ * same set that would otherwise have been mailed. Anybody older gets one
+ * notice on their next sign-in, correctly.
+ *
+ * Idempotent: `claimNewDevice` upserts on `<userId>:<fingerprint>`, so
+ * running it twice writes nothing the second time. Run it **before**
+ * `fly deploy`, or in the same minute — the window between the deploy and
+ * this is the window the burst happens in.
+ *
+ * Usage:
+ *   pnpm --filter @langx/api exec tsx --env-file=../../.env --env-file=../../.env.prod \
+ *     scripts/backfill-known-devices.ts [--confirm]
+ */
+import { connectToDatabase } from '../src/db/client'
+import { COLLECTIONS } from '../src/db/collections'
+import { loadEnv } from '../src/env'
+import { deviceIdentity } from '../src/modules/security/deviceLabel'
+import { claimNewDevice } from '../src/modules/security/knownDevices'
+
+interface SessionRow {
+  userId: unknown
+  userAgent?: string
+  createdAt?: Date
+}
+
+async function main(): Promise<void> {
+  const confirm = process.argv.includes('--confirm')
+  const env = loadEnv()
+  const { db, close } = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
+
+  try {
+    const sessions = await db
+      .collection<SessionRow>(COLLECTIONS.session)
+      .find({}, { projection: { userId: 1, userAgent: 1, createdAt: 1 } })
+      .toArray()
+
+    // One row per person per device family, oldest first, so `firstSeenAt`
+    // ends up as close to the truth as the sessions can say.
+    const pairs = new Map<string, { userId: string; fingerprint: string; at: Date }>()
+    let noAgent = 0
+    for (const session of sessions) {
+      if (!session.userAgent) {
+        noAgent++
+        continue
+      }
+      const userId = String(session.userId)
+      const { fingerprint } = deviceIdentity(session.userAgent)
+      const key = `${userId}:${fingerprint}`
+      const at = session.createdAt ?? new Date()
+      const existing = pairs.get(key)
+      if (!existing || at < existing.at) pairs.set(key, { userId, fingerprint, at })
+    }
+
+    const byFingerprint = new Map<string, number>()
+    for (const { fingerprint } of pairs.values()) {
+      byFingerprint.set(fingerprint, (byFingerprint.get(fingerprint) ?? 0) + 1)
+    }
+
+    console.log(`known devices from ${sessions.length} sessions on ${env.MONGODB_DB}`)
+    console.log(`  device rows to write: ${pairs.size}`)
+    console.log(`  people covered: ${new Set([...pairs.values()].map((p) => p.userId)).size}`)
+    console.log(`  sessions with no user agent: ${noAgent}`)
+    for (const [fingerprint, count] of [...byFingerprint].sort((a, b) => b[1] - a[1])) {
+      console.log(`    ${fingerprint}: ${count}`)
+    }
+
+    if (!confirm) {
+      console.log('\n(dry run — re-run with --confirm to write)')
+      return
+    }
+
+    let written = 0
+    for (const { userId, fingerprint, at } of pairs.values()) {
+      if (await claimNewDevice(db, userId, fingerprint, { at })) written++
+    }
+    console.log(`\nwrote ${written} (the rest were already recorded)`)
+  } finally {
+    await close()
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/api/src/auth.security.test.ts
+++ b/apps/api/src/auth.security.test.ts
@@ -1,0 +1,182 @@
+import type { FastifyInstance } from 'fastify'
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { buildApp } from './app'
+import { createAuth } from './auth'
+import { connectToDatabase, type DbHandle } from './db/client'
+import { COLLECTIONS } from './db/collections'
+import { ensureIndexes } from './db/indexes'
+import { loadEnv } from './env'
+import { createRevenueCatClientFromEnv } from './modules/billing/createRevenueCatClient'
+import { LoggingPushSender } from './modules/push/devices'
+import { createStorageProvider } from './storage/createStorageProvider'
+import { CapturingEmailSender, signUpAndSignIn } from './testSupport/authFlow'
+import { createTranslationProvider } from './translation/createTranslationProvider'
+
+const PASSWORD = 'correct horse battery staple'
+const IPHONE =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1'
+const WINDOWS =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36'
+
+/**
+ * The security notices as they actually fire: through Better Auth's own
+ * endpoints, from the `after` hook, with a user agent on the request.
+ */
+describe('what a sign-in tells the person it belongs to', () => {
+  let replSet: MongoMemoryReplSet
+  let handle: DbHandle
+  let app: FastifyInstance
+  let emailSender: CapturingEmailSender
+  let push: LoggingPushSender
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+    handle = await connectToDatabase(replSet.getUri(), 'langx_auth_security_test')
+    const env = loadEnv({
+      NODE_ENV: 'test',
+      MONGODB_URI: replSet.getUri(),
+      MONGODB_DB: 'langx_auth_security_test',
+      LOG_LEVEL: 'silent',
+      BETTER_AUTH_SECRET: 'a'.repeat(32),
+      BETTER_AUTH_URL: 'http://localhost:4000',
+    })
+    await ensureIndexes(handle.db)
+    emailSender = new CapturingEmailSender()
+    push = new LoggingPushSender()
+    const auth = await createAuth({ env, db: handle.db, client: handle.client, emailSender, push })
+    app = await buildApp({
+      env,
+      client: handle.client,
+      db: handle.db,
+      auth,
+      storage: createStorageProvider(env),
+      translation: createTranslationProvider(env),
+      revenueCat: createRevenueCatClientFromEnv(env),
+      email: emailSender,
+      push,
+    })
+    await app.ready()
+
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      const warmUp = await app.inject({
+        method: 'POST',
+        url: '/api/auth/sign-up/email',
+        payload: { email: `warmup-${attempt}@example.com`, password: PASSWORD, name: 'Warm Up' },
+      })
+      if (warmUp.statusCode === 200) break
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+  }, 120_000)
+
+  afterAll(async () => {
+    await app.close()
+    await handle.close()
+    await replSet.stop()
+  })
+
+  beforeEach(() => {
+    emailSender.messages.length = 0
+    push.sent.length = 0
+  })
+
+  async function newUser(): Promise<{ email: string; userId: string }> {
+    const user = await signUpAndSignIn(app, emailSender, {
+      email: `sec-${Math.random().toString(36).slice(2, 10)}@example.com`,
+      password: PASSWORD,
+      name: 'Test',
+    })
+    return { email: user.email, userId: user.userId }
+  }
+
+  function signIn(email: string, userAgent: string, country?: string) {
+    return app.inject({
+      method: 'POST',
+      url: '/api/auth/sign-in/email',
+      headers: { 'user-agent': userAgent, ...(country ? { 'cf-ipcountry': country } : {}) },
+      payload: { email, password: PASSWORD },
+    })
+  }
+
+  const securityMails = () =>
+    emailSender.messages.filter((message) => /sign-in|password/i.test(message.subject))
+
+  it('writes on the first sign-in from a device and stays quiet on the next', async () => {
+    const { email } = await newUser()
+    emailSender.messages.length = 0
+
+    const first = await signIn(email, IPHONE, 'TR')
+    expect(first.statusCode).toBe(200)
+    expect(securityMails()).toHaveLength(1)
+    expect(securityMails()[0]?.html).toContain('Safari on iPhone')
+    expect(securityMails()[0]?.html).toContain('Türkiye')
+
+    emailSender.messages.length = 0
+    expect((await signIn(email, IPHONE, 'TR')).statusCode).toBe(200)
+    expect(securityMails()).toHaveLength(0)
+  })
+
+  it('writes again when the device really is a different one', async () => {
+    const { email } = await newUser()
+    await signIn(email, IPHONE)
+    emailSender.messages.length = 0
+
+    await signIn(email, WINDOWS)
+    expect(securityMails()).toHaveLength(1)
+    expect(securityMails()[0]?.html).toContain('Chrome on Windows')
+  })
+
+  /**
+   * Being told you signed in seconds after creating the account is noise, and
+   * the verification mail is already on its way.
+   */
+  it('says nothing about the sign-up itself', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/auth/sign-up/email',
+      headers: { 'user-agent': IPHONE },
+      payload: {
+        email: `fresh-${Math.random().toString(36).slice(2, 10)}@example.com`,
+        password: PASSWORD,
+        name: 'Fresh',
+      },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(securityMails()).toHaveLength(0)
+  })
+
+  it('records the device so a later sign-in is an ordinary one', async () => {
+    const { email, userId } = await newUser()
+    await signIn(email, IPHONE)
+    const rows = await handle.db.collection(COLLECTIONS.knownDevices).find({ userId }).toArray()
+    expect(rows.map((row) => row._id)).toContain(`${userId}:ios-safari`)
+  })
+
+  it('writes when the password changes', async () => {
+    const user = await signUpAndSignIn(app, emailSender, {
+      email: `pw-${Math.random().toString(36).slice(2, 10)}@example.com`,
+      password: PASSWORD,
+      name: 'Test',
+    })
+    emailSender.messages.length = 0
+
+    const changed = await app.inject({
+      method: 'POST',
+      url: '/api/auth/change-password',
+      headers: { cookie: user.cookie, 'user-agent': WINDOWS },
+      payload: { currentPassword: PASSWORD, newPassword: 'a different long password' },
+    })
+    expect(changed.statusCode, changed.body).toBe(200)
+    const mail = securityMails()
+    expect(mail).toHaveLength(1)
+    expect(mail[0]?.subject).toMatch(/password/i)
+    expect(mail[0]?.html).toContain('Chrome on Windows')
+  })
+
+  /** The notice is not a notification: no switch behind it, no header to opt out with. */
+  it('sends the notice with no unsubscribe header at all', async () => {
+    const { email } = await newUser()
+    await signIn(email, WINDOWS)
+    expect(securityMails()[0]?.headers).toBeUndefined()
+  })
+})

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -37,6 +37,16 @@ import { localeFromHeader } from './i18n'
 import { nativeLocaleFor } from './modules/profiles/localeFor'
 import { publicApiUrl, type Env } from './env'
 import type { RevenueCatClient } from './modules/billing/revenueCatClient'
+import { LoggingPushSender, type PushSender } from './modules/push/devices'
+import { countryFromHeaders, deviceIdentity } from './modules/security/deviceLabel'
+import { claimNewDevice } from './modules/security/knownDevices'
+import {
+  notifyNewSignIn,
+  notifyPasswordChanged,
+  notifySignInMethodChanged,
+  type SecurityContext,
+  type SecurityNotifier,
+} from './modules/security/notify'
 
 /**
  * Where Apple POSTs the credential back from. Fixed by Apple, not by us or by
@@ -62,13 +72,32 @@ export interface CreateAuthOptions {
    * simply means no gift is attempted.
    */
   revenueCat?: RevenueCatClient
+  /**
+   * For the security notices, which go to a phone as well as an inbox. Left
+   * out — as most tests do — the mail still goes and nothing buzzes.
+   */
+  push?: PushSender
 }
 
 /**
  * `betterAuth()` itself is synchronous, but wiring Apple requires signing a
  * JWT first (see auth/appleClientSecret.ts), so construction is async.
  */
-export async function createAuth({ env, db, client, emailSender, revenueCat }: CreateAuthOptions) {
+/**
+ * Every route that ends with a different password on the account. Reset and
+ * set are here beside change: an attacker who used a stolen inbox to reset
+ * the password is exactly who this mail is about.
+ */
+const PASSWORD_CHANGE_PATHS = new Set(['/change-password', '/set-password', '/reset-password'])
+
+export async function createAuth({
+  env,
+  db,
+  client,
+  emailSender,
+  revenueCat,
+  push,
+}: CreateAuthOptions) {
   const baseURL = publicApiUrl(env)
 
   const socialProviders: NonNullable<Parameters<typeof betterAuth>[0]['socialProviders']> = {}
@@ -147,6 +176,72 @@ export async function createAuth({ env, db, client, emailSender, revenueCat }: C
    */
   let sendExistingAccountLink: ((email: string, headers: Headers) => Promise<void>) | undefined =
     undefined
+
+  const security: SecurityNotifier = {
+    email: emailSender,
+    push: push ?? new LoggingPushSender(),
+    logger: console,
+  }
+
+  /**
+   * The security notices, hung off one `after` hook rather than four.
+   *
+   * Keyed on what the endpoint *did* — `ctx.context.newSession` means a
+   * session was created, whatever route made it — rather than on a list of
+   * paths, because that list is exactly the thing a future Better Auth plugin
+   * would silently add to. A sign-up is excluded on purpose: being told you
+   * signed in seconds after creating the account is noise, and the
+   * verification mail is already on its way.
+   *
+   * Nothing is awaited into the response beyond the notice itself, and
+   * `notifySecurityEvent` swallows its own failures — a mail provider having
+   * a bad minute must not turn a correct password into an error page.
+   */
+  async function tellThemAboutIt(ctx: {
+    path: string
+    headers?: Headers | undefined
+    context: {
+      newSession?: { user: { id: string } } | null | undefined
+      session?: { user: { id: string } } | undefined
+    }
+  }): Promise<void> {
+    const headers = ctx.headers
+    const identity = deviceIdentity(headers?.get('user-agent'))
+    const country = countryFromHeaders(headers)
+    const at = new Date()
+    const detail: SecurityContext = { device: identity.label, ...(country ? { country } : {}), at }
+
+    if (PASSWORD_CHANGE_PATHS.has(ctx.path)) {
+      const userId = ctx.context.newSession?.user.id ?? ctx.context.session?.user.id
+      if (userId) await notifyPasswordChanged(db, security, userId, detail)
+      return
+    }
+    if (ctx.path === '/unlink-account' || ctx.path === '/link-social') {
+      const userId = ctx.context.session?.user.id
+      if (userId) {
+        await notifySignInMethodChanged(
+          db,
+          security,
+          userId,
+          ctx.path === '/link-social' ? 'linked' : 'unlinked',
+          detail,
+        )
+      }
+      return
+    }
+
+    if (ctx.path.startsWith('/sign-up')) return
+    const created = ctx.context.newSession
+    if (!created) return
+    // The row is written whether or not anybody is told, so the *next* sign-in
+    // from this device is an ordinary one. Only a device we had not seen
+    // earns a letter.
+    const isNew = await claimNewDevice(db, created.user.id, identity.fingerprint, {
+      ...(country ? { country } : {}),
+      at,
+    })
+    if (isNew) await notifyNewSignIn(db, security, created.user.id, detail)
+  }
 
   const auth = betterAuth({
     baseURL,
@@ -313,9 +408,11 @@ export async function createAuth({ env, db, client, emailSender, revenueCat }: C
        * creates a session sets its own.
        */
       after: createAuthMiddleware(async (ctx) => {
-        if (ctx.path !== '/device/token') return
-        const created = ctx.context.newSession
-        if (created) await setSessionCookie(ctx, created)
+        if (ctx.path === '/device/token') {
+          const created = ctx.context.newSession
+          if (created) await setSessionCookie(ctx, created)
+        }
+        await tellThemAboutIt(ctx)
       }),
     },
 

--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -155,6 +155,12 @@ export const COLLECTIONS = {
    */
   meetingReminders: 'meetingReminders',
   /**
+   * The devices an account has signed in from, keyed `<userId>:<fingerprint>`
+   * so the insert failing is what says "we have seen this one". No TTL: a
+   * device does not stop having been seen. See `security/knownDevices.ts`.
+   */
+  knownDevices: 'knownDevices',
+  /**
    * One row per person per campaign, written *before* the send. The unique
    * index on `{campaignId, userId}` is the only thing that makes re-running a
    * half-finished campaign safe.

--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -683,6 +683,11 @@ export const INDEXES: Partial<IndexSpec> = {
     { key: { campaignId: 1, sentAt: -1 }, name: 'campaign_recent' },
   ],
 
+  [COLLECTIONS.knownDevices]: [
+    // What the purge deletes by. The `_id` already carries the uniqueness.
+    { key: { userId: 1 }, name: 'device_owner' },
+  ],
+
   [COLLECTIONS.jobRuns]: [
     // The only defence against a double-run cron distributing the pool twice.
     { key: { job: 1, periodKey: 1 }, name: 'job_period_unique', unique: true },

--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -350,6 +350,73 @@ export function existingAccountLinkEmail(url: string, locale: Locale): Email {
   }
 }
 
+/** The four things this app tells somebody about their own account. */
+export type SecurityEvent = 'newSignIn' | 'passwordChanged' | 'methodLinked' | 'methodUnlinked'
+
+/**
+ * A security notice: a new device, a changed password, a sign-in method
+ * connected or disconnected.
+ *
+ * `wrap`, not `notificationEmail`, and the difference is the whole point. A
+ * notification mail's footer says how to stop it arriving; this one has no
+ * way to stop, because there is no switch behind it — see
+ * `modules/security/notify.ts`. What it carries instead is the detail
+ * somebody needs to recognise their own action, and one button for when they
+ * do not.
+ *
+ * The time is written in UTC and says so. Guessing a timezone from an IP is
+ * how a mail tells somebody in Toronto that they signed in at 09:00 when
+ * their clock said 04:00, and the reader is checking this line against their
+ * memory of the last ten minutes.
+ */
+export function securityEmail(
+  locale: Locale,
+  event: SecurityEvent,
+  detail: { device?: string; place?: string; at: Date },
+): Email {
+  const t = translator(locale)
+  const when = `${detail.at.toISOString().slice(0, 16).replace('T', ' ')} UTC`
+  const rows: [string, string][] = [
+    ...(detail.device ? ([[t('email.securityDevice'), detail.device]] as [string, string][]) : []),
+    ...(detail.place ? ([[t('email.securityPlace'), detail.place]] as [string, string][]) : []),
+    [t('email.securityWhen'), when],
+  ]
+  const table = `<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:20px 0 0;">
+        ${rows
+          .map(
+            ([label, value]) =>
+              `<tr><td style="padding:4px 16px 4px 0; font-size:14px; line-height:22px; color:#62676d;">${label}</td><td style="padding:4px 0; font-size:14px; line-height:22px; color:#17191c;"><strong>${escapeHtml(value)}</strong></td></tr>`,
+          )
+          .join('\n        ')}
+      </table>`
+
+  const title = t(`email.security.${event}Title` as never)
+  const body = t(`email.security.${event}Body` as never)
+  const url = webUrl('/settings/password')
+  return {
+    subject: title,
+    html: wrap(
+      locale,
+      body,
+      `<p><strong style="font-family:${TITLE_FONT}; font-size:20px; line-height:26px;">${title}</strong></p>
+       <p>${body}</p>
+       ${table}
+       <p style="margin:24px 0 0;">${t('email.securityNotYou')}</p>
+       <p>${button(url, t('email.securityButton'))}</p>`,
+    ),
+    text: [
+      title,
+      '',
+      body,
+      '',
+      ...rows.map(([label, value]) => `${label}: ${value}`),
+      '',
+      t('email.securityNotYou'),
+      url,
+    ].join('\n'),
+  }
+}
+
 /**
  * The streak nudge, for somebody with no phone signed in.
  *

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -29,6 +29,15 @@ export const ar: Localized<ServerMessages> = {
       other: '{count} رمز مقابل بلاغك 🎉',
     },
     bountyBody: 'قرأنا ما أرسلته، وقد كان يستحق.',
+    /** Security, which no preference can switch off. */
+    securityBody: 'افتح LangX إن لم تكن أنت.',
+    securityBodyDevice: 'من {device}. افتح LangX إن لم تكن أنت.',
+    security: {
+      newSignInTitle: 'تسجيل دخول جديد إلى حسابك',
+      passwordChangedTitle: 'تم تغيير كلمة المرور',
+      methodLinkedTitle: 'تمت إضافة طريقة تسجيل دخول',
+      methodUnlinkedTitle: 'تمت إزالة طريقة تسجيل دخول',
+    },
   },
 
   email: {
@@ -127,6 +136,43 @@ export const ar: Localized<ServerMessages> = {
     unsubscribedTitle: 'تم — لن تصلك بعد الآن.',
     unsubscribedBody: 'يمكنك تشغيلها متى شئت من LangX في الإعدادات ← الإشعارات.',
     unsubscribeInvalid: 'هذا الرابط غير صالح. افتح LangX وغيّره من الإعدادات ← الإشعارات.',
+
+    /**
+
+     * The security notices. No switch behind them and no unsubscribe —
+
+     * see `modules/security/notify.ts`.
+
+     */
+
+    securityDevice: 'الجهاز',
+
+    securityPlace: 'المكان',
+
+    securityWhen: 'الوقت',
+
+    securityNotYou:
+      'إن لم تكن أنت، غيّر كلمة المرور الآن — سيؤدي ذلك إلى تسجيل الخروج من كل الأجهزة الأخرى.',
+
+    securityButton: 'تغيير كلمة المرور',
+
+    security: {
+      newSignInTitle: 'تسجيل دخول جديد إلى حسابك في LangX',
+
+      newSignInBody: 'سجّل أحدهم الدخول إلى حسابك من جهاز لم نره من قبل.',
+
+      passwordChangedTitle: 'تم تغيير كلمة مرور LangX',
+
+      passwordChangedBody: 'تم تغيير كلمة مرور حسابك للتو.',
+
+      methodLinkedTitle: 'تمت إضافة طريقة تسجيل دخول إلى حسابك في LangX',
+
+      methodLinkedBody: 'تم ربط تسجيل الدخول بحساب Google أو Apple بحسابك.',
+
+      methodUnlinkedTitle: 'تمت إزالة طريقة تسجيل دخول من حسابك في LangX',
+
+      methodUnlinkedBody: 'تم فصل إحدى طرق تسجيل الدخول إلى حسابك.',
+    },
 
     kind: {
       messages: 'ملخّصات الرسائل',

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -23,6 +23,15 @@ export const de: Localized<ServerMessages> = {
       other: '{count} Token für deinen Hinweis 🎉',
     },
     bountyBody: 'Wir haben gelesen, was du geschickt hast – es hat sich gelohnt.',
+    /** Security, which no preference can switch off. */
+    securityBody: 'Öffne LangX, falls du das nicht warst.',
+    securityBodyDevice: 'Von {device}. Öffne LangX, falls du das nicht warst.',
+    security: {
+      newSignInTitle: 'Neue Anmeldung bei deinem Konto',
+      passwordChangedTitle: 'Dein Passwort wurde geändert',
+      methodLinkedTitle: 'Anmeldemethode hinzugefügt',
+      methodUnlinkedTitle: 'Anmeldemethode entfernt',
+    },
   },
 
   email: {
@@ -129,6 +138,43 @@ export const de: Localized<ServerMessages> = {
       'Du kannst sie jederzeit in LangX unter Einstellungen → Mitteilungen wieder einschalten.',
     unsubscribeInvalid:
       'Dieser Link ist ungültig. Öffne LangX und ändere es unter Einstellungen → Mitteilungen.',
+
+    /**
+
+     * The security notices. No switch behind them and no unsubscribe —
+
+     * see `modules/security/notify.ts`.
+
+     */
+
+    securityDevice: 'Gerät',
+
+    securityPlace: 'Ort',
+
+    securityWhen: 'Zeitpunkt',
+
+    securityNotYou:
+      'Warst du das nicht, ändere sofort dein Passwort — das meldet alle anderen Geräte ab.',
+
+    securityButton: 'Passwort ändern',
+
+    security: {
+      newSignInTitle: 'Neue Anmeldung bei deinem LangX-Konto',
+
+      newSignInBody: 'Jemand hat sich von einem uns unbekannten Gerät bei deinem Konto angemeldet.',
+
+      passwordChangedTitle: 'Dein LangX-Passwort wurde geändert',
+
+      passwordChangedBody: 'Das Passwort deines Kontos wurde soeben geändert.',
+
+      methodLinkedTitle: 'Deinem LangX-Konto wurde eine Anmeldemethode hinzugefügt',
+
+      methodLinkedBody: 'Die Anmeldung mit Google oder Apple wurde mit deinem Konto verbunden.',
+
+      methodUnlinkedTitle: 'Aus deinem LangX-Konto wurde eine Anmeldemethode entfernt',
+
+      methodUnlinkedBody: 'Eine Möglichkeit, dich anzumelden, wurde entfernt.',
+    },
 
     kind: {
       messages: 'Nachrichtenübersichten',

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -27,6 +27,15 @@ export const en = {
       other: '{count} tokens for your report 🎉',
     },
     bountyBody: 'We read what you sent, and it was worth it.',
+    /** Security, which no preference can switch off. */
+    securityBody: 'Open LangX if this was not you.',
+    securityBodyDevice: 'From {device}. Open LangX if this was not you.',
+    security: {
+      newSignInTitle: 'New sign-in to your account',
+      passwordChangedTitle: 'Your password was changed',
+      methodLinkedTitle: 'A sign-in method was added',
+      methodUnlinkedTitle: 'A sign-in method was removed',
+    },
   },
 
   email: {
@@ -134,6 +143,43 @@ export const en = {
     unsubscribedBody: 'You can turn them back on any time in LangX under Settings → Notifications.',
     unsubscribeInvalid:
       'This link is not valid. Open LangX and change it under Settings → Notifications.',
+
+    /**
+
+     * The security notices. No switch behind them and no unsubscribe —
+
+     * see `modules/security/notify.ts`.
+
+     */
+
+    securityDevice: 'Device',
+
+    securityPlace: 'Place',
+
+    securityWhen: 'When',
+
+    securityNotYou:
+      "If this wasn't you, change your password now — it signs out every other device.",
+
+    securityButton: 'Change my password',
+
+    security: {
+      newSignInTitle: 'New sign-in to your LangX account',
+
+      newSignInBody: 'Somebody signed in to your account from a device we have not seen before.',
+
+      passwordChangedTitle: 'Your LangX password was changed',
+
+      passwordChangedBody: 'The password on your account was just changed.',
+
+      methodLinkedTitle: 'A sign-in method was added to your LangX account',
+
+      methodLinkedBody: 'Google or Apple sign-in was connected to your account.',
+
+      methodUnlinkedTitle: 'A sign-in method was removed from your LangX account',
+
+      methodUnlinkedBody: 'A way of signing in to your account was disconnected.',
+    },
 
     /** Named in the sentence above, so they read as objects, not headings. */
     kind: {

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -23,6 +23,15 @@ export const es: Localized<ServerMessages> = {
       other: '{count} fichas por tu aviso 🎉',
     },
     bountyBody: 'Leímos lo que nos enviaste y valió la pena.',
+    /** Security, which no preference can switch off. */
+    securityBody: 'Abre LangX si no fuiste tú.',
+    securityBodyDevice: 'Desde {device}. Abre LangX si no fuiste tú.',
+    security: {
+      newSignInTitle: 'Nuevo inicio de sesión en tu cuenta',
+      passwordChangedTitle: 'Tu contraseña ha cambiado',
+      methodLinkedTitle: 'Método de inicio de sesión añadido',
+      methodUnlinkedTitle: 'Método de inicio de sesión eliminado',
+    },
   },
 
   email: {
@@ -128,6 +137,44 @@ export const es: Localized<ServerMessages> = {
       'Puedes volver a activarlos cuando quieras en LangX, en Ajustes → Notificaciones.',
     unsubscribeInvalid:
       'Este enlace no es válido. Abre LangX y cámbialo en Ajustes → Notificaciones.',
+
+    /**
+
+     * The security notices. No switch behind them and no unsubscribe —
+
+     * see `modules/security/notify.ts`.
+
+     */
+
+    securityDevice: 'Dispositivo',
+
+    securityPlace: 'Lugar',
+
+    securityWhen: 'Cuándo',
+
+    securityNotYou:
+      'Si no fuiste tú, cambia tu contraseña ahora: cierra la sesión en todos los demás dispositivos.',
+
+    securityButton: 'Cambiar mi contraseña',
+
+    security: {
+      newSignInTitle: 'Nuevo inicio de sesión en tu cuenta de LangX',
+
+      newSignInBody:
+        'Alguien inició sesión en tu cuenta desde un dispositivo que no habíamos visto antes.',
+
+      passwordChangedTitle: 'Tu contraseña de LangX ha cambiado',
+
+      passwordChangedBody: 'La contraseña de tu cuenta acaba de cambiarse.',
+
+      methodLinkedTitle: 'Se añadió un método de inicio de sesión a tu cuenta de LangX',
+
+      methodLinkedBody: 'Se conectó el inicio de sesión con Google o Apple a tu cuenta.',
+
+      methodUnlinkedTitle: 'Se eliminó un método de inicio de sesión de tu cuenta de LangX',
+
+      methodUnlinkedBody: 'Se desconectó una forma de iniciar sesión en tu cuenta.',
+    },
 
     kind: {
       messages: 'los resúmenes de mensajes',

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -23,6 +23,15 @@ export const fr: Localized<ServerMessages> = {
       other: '{count} jetons pour ton signalement 🎉',
     },
     bountyBody: 'On a lu ce que tu nous as envoyé, et ça valait le coup.',
+    /** Security, which no preference can switch off. */
+    securityBody: 'Ouvrez LangX si ce n’était pas vous.',
+    securityBodyDevice: 'Depuis {device}. Ouvrez LangX si ce n’était pas vous.',
+    security: {
+      newSignInTitle: 'Nouvelle connexion à votre compte',
+      passwordChangedTitle: 'Votre mot de passe a été modifié',
+      methodLinkedTitle: 'Méthode de connexion ajoutée',
+      methodUnlinkedTitle: 'Méthode de connexion retirée',
+    },
   },
 
   email: {
@@ -130,6 +139,44 @@ export const fr: Localized<ServerMessages> = {
       'Vous pouvez les réactiver à tout moment dans LangX, sous Réglages → Notifications.',
     unsubscribeInvalid:
       'Ce lien n’est pas valide. Ouvrez LangX et modifiez-le dans Réglages → Notifications.',
+
+    /**
+
+     * The security notices. No switch behind them and no unsubscribe —
+
+     * see `modules/security/notify.ts`.
+
+     */
+
+    securityDevice: 'Appareil',
+
+    securityPlace: 'Lieu',
+
+    securityWhen: 'Quand',
+
+    securityNotYou:
+      'Si ce n’était pas vous, changez votre mot de passe maintenant : cela déconnecte tous les autres appareils.',
+
+    securityButton: 'Changer mon mot de passe',
+
+    security: {
+      newSignInTitle: 'Nouvelle connexion à votre compte LangX',
+
+      newSignInBody:
+        'Quelqu’un s’est connecté à votre compte depuis un appareil que nous n’avions jamais vu.',
+
+      passwordChangedTitle: 'Votre mot de passe LangX a été modifié',
+
+      passwordChangedBody: 'Le mot de passe de votre compte vient d’être modifié.',
+
+      methodLinkedTitle: 'Une méthode de connexion a été ajoutée à votre compte LangX',
+
+      methodLinkedBody: 'La connexion avec Google ou Apple a été associée à votre compte.',
+
+      methodUnlinkedTitle: 'Une méthode de connexion a été retirée de votre compte LangX',
+
+      methodUnlinkedBody: 'Une façon de vous connecter a été déconnectée.',
+    },
 
     kind: {
       messages: 'les résumés de messages',

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -23,6 +23,15 @@ export const ptBR: Localized<ServerMessages> = {
       other: '{count} fichas pelo seu aviso 🎉',
     },
     bountyBody: 'Lemos o que você enviou, e valeu a pena.',
+    /** Security, which no preference can switch off. */
+    securityBody: 'Abra o LangX se não foi você.',
+    securityBodyDevice: 'De {device}. Abra o LangX se não foi você.',
+    security: {
+      newSignInTitle: 'Novo acesso à sua conta',
+      passwordChangedTitle: 'Sua senha foi alterada',
+      methodLinkedTitle: 'Método de login adicionado',
+      methodUnlinkedTitle: 'Método de login removido',
+    },
   },
 
   email: {
@@ -125,6 +134,43 @@ export const ptBR: Localized<ServerMessages> = {
     unsubscribedBody: 'Você pode reativar quando quiser no LangX, em Configurações → Notificações.',
     unsubscribeInvalid:
       'Este link não é válido. Abra o LangX e altere em Configurações → Notificações.',
+
+    /**
+
+     * The security notices. No switch behind them and no unsubscribe —
+
+     * see `modules/security/notify.ts`.
+
+     */
+
+    securityDevice: 'Dispositivo',
+
+    securityPlace: 'Local',
+
+    securityWhen: 'Quando',
+
+    securityNotYou:
+      'Se não foi você, mude sua senha agora — isso desconecta todos os outros dispositivos.',
+
+    securityButton: 'Mudar minha senha',
+
+    security: {
+      newSignInTitle: 'Novo acesso à sua conta LangX',
+
+      newSignInBody: 'Alguém entrou na sua conta a partir de um dispositivo que nunca vimos antes.',
+
+      passwordChangedTitle: 'Sua senha do LangX foi alterada',
+
+      passwordChangedBody: 'A senha da sua conta acabou de ser alterada.',
+
+      methodLinkedTitle: 'Um método de login foi adicionado à sua conta LangX',
+
+      methodLinkedBody: 'O login com Google ou Apple foi conectado à sua conta.',
+
+      methodUnlinkedTitle: 'Um método de login foi removido da sua conta LangX',
+
+      methodUnlinkedBody: 'Uma forma de entrar na sua conta foi desconectada.',
+    },
 
     kind: {
       messages: 'os resumos de mensagens',

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -35,6 +35,15 @@ export const ru: Localized<ServerMessages> = {
       other: '{count} жетона за твоё сообщение 🎉',
     },
     bountyBody: 'Мы прочитали то, что ты прислал, — это того стоило.',
+    /** Security, which no preference can switch off. */
+    securityBody: 'Откройте LangX, если это были не вы.',
+    securityBodyDevice: 'С устройства {device}. Откройте LangX, если это были не вы.',
+    security: {
+      newSignInTitle: 'Новый вход в аккаунт',
+      passwordChangedTitle: 'Пароль изменён',
+      methodLinkedTitle: 'Добавлен способ входа',
+      methodUnlinkedTitle: 'Удалён способ входа',
+    },
   },
 
   email: {
@@ -139,6 +148,43 @@ export const ru: Localized<ServerMessages> = {
     unsubscribedBody: 'Включить обратно можно в любой момент в LangX: Настройки → Уведомления.',
     unsubscribeInvalid:
       'Ссылка недействительна. Откройте LangX и измените это в Настройках → Уведомления.',
+
+    /**
+
+     * The security notices. No switch behind them and no unsubscribe —
+
+     * see `modules/security/notify.ts`.
+
+     */
+
+    securityDevice: 'Устройство',
+
+    securityPlace: 'Место',
+
+    securityWhen: 'Когда',
+
+    securityNotYou:
+      'Если это были не вы, сразу смените пароль — это завершит сеансы на всех остальных устройствах.',
+
+    securityButton: 'Сменить пароль',
+
+    security: {
+      newSignInTitle: 'Новый вход в ваш аккаунт LangX',
+
+      newSignInBody: 'Кто-то вошёл в ваш аккаунт с устройства, которого мы раньше не видели.',
+
+      passwordChangedTitle: 'Пароль LangX изменён',
+
+      passwordChangedBody: 'Пароль вашего аккаунта только что изменили.',
+
+      methodLinkedTitle: 'К вашему аккаунту LangX добавлен способ входа',
+
+      methodLinkedBody: 'К аккаунту подключён вход через Google или Apple.',
+
+      methodUnlinkedTitle: 'Из вашего аккаунта LangX удалён способ входа',
+
+      methodUnlinkedBody: 'Один из способов входа в аккаунт отключён.',
+    },
 
     kind: {
       messages: 'сводки сообщений',

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -17,6 +17,15 @@ export const tr: Localized<ServerMessages> = {
       other: 'Bildirimin için {count} jeton 🎉',
     },
     bountyBody: 'Yazdıklarını okuduk, değdi.',
+    /** Security, which no preference can switch off. */
+    securityBody: 'Bu sen değilsen LangX’i aç.',
+    securityBodyDevice: '{device} üzerinden. Bu sen değilsen LangX’i aç.',
+    security: {
+      newSignInTitle: 'Hesabına yeni giriş',
+      passwordChangedTitle: 'Şifren değiştirildi',
+      methodLinkedTitle: 'Yeni giriş yöntemi eklendi',
+      methodUnlinkedTitle: 'Bir giriş yöntemi kaldırıldı',
+    },
   },
 
   email: {
@@ -114,6 +123,43 @@ export const tr: Localized<ServerMessages> = {
     unsubscribedBody: 'İstediğin zaman LangX’te Ayarlar → Bildirimler’den geri açabilirsin.',
     unsubscribeInvalid:
       'Bu bağlantı geçerli değil. LangX’i açıp Ayarlar → Bildirimler’den değiştir.',
+
+    /**
+
+     * The security notices. No switch behind them and no unsubscribe —
+
+     * see `modules/security/notify.ts`.
+
+     */
+
+    securityDevice: 'Cihaz',
+
+    securityPlace: 'Konum',
+
+    securityWhen: 'Zaman',
+
+    securityNotYou:
+      'Bu sen değilsen şifreni hemen değiştir — bu, diğer tüm cihazlardaki oturumları kapatır.',
+
+    securityButton: 'Şifremi değiştir',
+
+    security: {
+      newSignInTitle: 'LangX hesabına yeni giriş',
+
+      newSignInBody: 'Hesabına daha önce görmediğimiz bir cihazdan giriş yapıldı.',
+
+      passwordChangedTitle: 'LangX şifren değiştirildi',
+
+      passwordChangedBody: 'Hesabının şifresi az önce değiştirildi.',
+
+      methodLinkedTitle: 'LangX hesabına yeni bir giriş yöntemi eklendi',
+
+      methodLinkedBody: 'Hesabına Google veya Apple ile giriş bağlandı.',
+
+      methodUnlinkedTitle: 'LangX hesabından bir giriş yöntemi kaldırıldı',
+
+      methodUnlinkedBody: 'Hesabına giriş yollarından biri kaldırıldı.',
+    },
 
     kind: {
       messages: 'mesaj özetleri',

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,15 +33,17 @@ async function main(): Promise<void> {
   // verification hands the v1 loyalty gift out through it.
   const revenueCat = createRevenueCatClientFromEnv(env)
 
-  const auth = await createAuth({ env, db, client, emailSender, revenueCat })
+  // Before `createAuth`: the security notices it sends go to a phone as well
+  // as an inbox.
+  const push = new ExpoPushSender(env.EXPO_ACCESS_TOKEN)
+
+  const auth = await createAuth({ env, db, client, emailSender, revenueCat, push })
   const storage = createStorageProvider(env)
   // `null` without a key: the purge still records what it owes, the drain
   // simply does not run. See `modules/account/analyticsDeletions.ts`.
   const analytics = createPersonDeleterFromEnv(env)
 
   const translation = createTranslationProvider(env)
-
-  const push = new ExpoPushSender(env.EXPO_ACCESS_TOKEN)
 
   /**
    * What every notification sender needs: an outbox, the secret its

--- a/apps/api/src/modules/account/deletion.ts
+++ b/apps/api/src/modules/account/deletion.ts
@@ -349,6 +349,7 @@ export async function purgeExpiredAccounts(
       // `/s/<id>` page about a person, so leaving it is leaving a profile
       // fragment up after the profile is gone.
       db.collection(COLLECTIONS.shareCards).deleteMany({ userId }),
+      db.collection(COLLECTIONS.knownDevices).deleteMany({ userId }),
       // Better Auth's own rows. Deleting the `user` document is what makes the
       // email reusable and the account genuinely gone rather than orphaned.
       db.collection(COLLECTIONS.session).deleteMany({ userId: authId(userId) }),

--- a/apps/api/src/modules/security/deviceLabel.test.ts
+++ b/apps/api/src/modules/security/deviceLabel.test.ts
@@ -15,6 +15,9 @@ const AGENTS = {
     'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Mobile Safari/537.36',
   edge: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36 Edg/152.0.0.0',
   expoIos: 'LangX/2.2 CFNetwork/1568.100.1 Darwin/24.0.0',
+  /** What React Native actually sends, taken off `session` in production. */
+  bareIos: 'CFNetwork/1568.100.1 Darwin/24.0.0',
+  bareAndroid: 'okhttp/4.12.0',
   curl: 'curl/8.5.0',
 }
 
@@ -55,6 +58,26 @@ describe('naming the device somebody signed in from', () => {
     const now = deviceIdentity(AGENTS.windowsChrome).fingerprint
     const later = deviceIdentity(AGENTS.windowsChrome.replace('152.0.0.0', '191.0.3.7')).fingerprint
     expect(later).toBe(now)
+  })
+
+  /**
+   * React Native sends no browser user agent at all. Fifty-three production
+   * sessions carried `okhttp/4.12.0`, and reading those literally told people
+   * they had signed in from "okhttp".
+   */
+  it('knows the app by the library it speaks through', () => {
+    expect(deviceIdentity(AGENTS.bareAndroid)).toEqual({
+      fingerprint: 'android-app',
+      label: 'the LangX app on Android',
+    })
+    expect(deviceIdentity(AGENTS.bareIos)).toEqual({
+      fingerprint: 'ios-app',
+      label: 'the LangX app on iPhone',
+    })
+    // And the two ways in from one phone are one device, not two.
+    expect(deviceIdentity(AGENTS.expoIos).fingerprint).toBe(
+      deviceIdentity(AGENTS.bareIos).fingerprint,
+    )
   })
 
   it('names a script by what it called itself, and an absent agent not at all', () => {

--- a/apps/api/src/modules/security/deviceLabel.test.ts
+++ b/apps/api/src/modules/security/deviceLabel.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { countryFromHeaders, deviceIdentity } from './deviceLabel'
+
+/** Real strings, taken off `session.userAgent` in production. */
+const AGENTS = {
+  iphoneFirefox:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/154.0 Mobile/15E148 Safari/604.1',
+  windowsChrome:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36',
+  macSafari:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15',
+  iphoneSafari:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+  androidChrome:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Mobile Safari/537.36',
+  edge: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36 Edg/152.0.0.0',
+  expoIos: 'LangX/2.2 CFNetwork/1568.100.1 Darwin/24.0.0',
+  curl: 'curl/8.5.0',
+}
+
+describe('naming the device somebody signed in from', () => {
+  it('reads the four shapes people actually arrive in', () => {
+    expect(deviceIdentity(AGENTS.iphoneSafari)).toEqual({
+      fingerprint: 'ios-safari',
+      label: 'Safari on iPhone',
+    })
+    expect(deviceIdentity(AGENTS.androidChrome)).toEqual({
+      fingerprint: 'android-chrome',
+      label: 'Chrome on Android',
+    })
+    expect(deviceIdentity(AGENTS.macSafari)).toEqual({
+      fingerprint: 'macos-safari',
+      label: 'Safari on Mac',
+    })
+    expect(deviceIdentity(AGENTS.expoIos)).toEqual({
+      fingerprint: 'ios-app',
+      label: 'the LangX app on iPhone',
+    })
+  })
+
+  /**
+   * Every browser claims to be several of the others, which is why the order
+   * of the tests inside `browserOf` is the whole implementation.
+   */
+  it('is not fooled by a browser claiming to be another one', () => {
+    expect(deviceIdentity(AGENTS.edge).label).toBe('Edge on Windows')
+    expect(deviceIdentity(AGENTS.windowsChrome).label).toBe('Chrome on Windows')
+    expect(deviceIdentity(AGENTS.iphoneFirefox).label).toBe('Firefox on iPhone')
+    // An iPhone's user agent says "like Mac OS X", and it is not a Mac.
+    expect(deviceIdentity(AGENTS.iphoneFirefox).fingerprint).toBe('ios-firefox')
+  })
+
+  /** A version bump is not a new device; a mail that says so is one people mute. */
+  it('gives one fingerprint across versions of the same browser', () => {
+    const now = deviceIdentity(AGENTS.windowsChrome).fingerprint
+    const later = deviceIdentity(AGENTS.windowsChrome.replace('152.0.0.0', '191.0.3.7')).fingerprint
+    expect(later).toBe(now)
+  })
+
+  it('names a script by what it called itself, and an absent agent not at all', () => {
+    expect(deviceIdentity(AGENTS.curl)).toEqual({ fingerprint: 'other-curl', label: 'curl' })
+    expect(deviceIdentity('').fingerprint).toBe('unknown')
+    expect(deviceIdentity(undefined).fingerprint).toBe('unknown')
+  })
+
+  it('takes the country from the edge, and only a real one', () => {
+    const of = (value?: string) =>
+      countryFromHeaders(value ? new Headers({ 'cf-ipcountry': value }) : new Headers())
+    expect(of('tr')).toBe('TR')
+    expect(of('CA')).toBe('CA')
+    // Cloudflare's own "we do not know", and its code for Tor.
+    expect(of('XX')).toBeUndefined()
+    expect(of('T1')).toBeUndefined()
+    expect(of('nonsense')).toBeUndefined()
+    expect(of()).toBeUndefined()
+    expect(countryFromHeaders(undefined)).toBeUndefined()
+  })
+})

--- a/apps/api/src/modules/security/deviceLabel.ts
+++ b/apps/api/src/modules/security/deviceLabel.ts
@@ -1,0 +1,95 @@
+/**
+ * What to call the thing somebody just signed in from.
+ *
+ * Two answers, and they are used for different things. The **fingerprint** is
+ * what decides whether this device is new — coarse on purpose, because a
+ * browser version bump is not a new device and a mail that says so is a mail
+ * people learn to ignore. The **label** is what a person reads: "Safari on
+ * iPhone", the shape every other service words it in.
+ *
+ * Not a user-agent library. Those carry a regex database the size of this
+ * app's whole i18n catalogue, and they exist to tell Chrome 118 from Chrome
+ * 119 — precisely the distinction being thrown away here.
+ */
+
+export interface DeviceIdentity {
+  /** Stable across versions: `ios-safari`, `android-chrome`, `macos-app`. */
+  fingerprint: string
+  /** For the mail: "Safari on iPhone". */
+  label: string
+}
+
+const UNKNOWN: DeviceIdentity = { fingerprint: 'unknown', label: 'an unrecognised device' }
+
+/** Ours first: the app's own requests should not read as "Safari on iPhone". */
+function appIdentity(userAgent: string): DeviceIdentity | null {
+  if (/\bExpo\b|LangX/i.test(userAgent)) {
+    if (/\bAndroid\b/i.test(userAgent))
+      return { fingerprint: 'android-app', label: 'the LangX app on Android' }
+    if (/\biPhone|iPad|iOS|CFNetwork\b/i.test(userAgent)) {
+      return { fingerprint: 'ios-app', label: 'the LangX app on iPhone' }
+    }
+    return { fingerprint: 'app', label: 'the LangX app' }
+  }
+  return null
+}
+
+function platformOf(userAgent: string): { key: string; name: string } {
+  if (/\biPad\b/i.test(userAgent)) return { key: 'ipados', name: 'iPad' }
+  if (/\biPhone\b/i.test(userAgent)) return { key: 'ios', name: 'iPhone' }
+  if (/\bAndroid\b/i.test(userAgent)) return { key: 'android', name: 'Android' }
+  if (/\bWindows\b/i.test(userAgent)) return { key: 'windows', name: 'Windows' }
+  // Mac has to come after iOS: an iPhone's UA says "like Mac OS X".
+  if (/\bMac OS X|Macintosh\b/i.test(userAgent)) return { key: 'macos', name: 'Mac' }
+  if (/\bCrOS\b/i.test(userAgent)) return { key: 'chromeos', name: 'ChromeOS' }
+  if (/\bLinux\b/i.test(userAgent)) return { key: 'linux', name: 'Linux' }
+  return { key: 'other', name: 'an unrecognised device' }
+}
+
+/**
+ * Order matters more than the patterns do. Every one of these browsers claims
+ * to be several of the others — Edge says "Chrome", Chrome says "Safari" —
+ * so the most specific name has to be tested first.
+ */
+function browserOf(userAgent: string): { key: string; name: string } | null {
+  if (/\bEdgA?\b|\bEdge\//i.test(userAgent)) return { key: 'edge', name: 'Edge' }
+  if (/\bOPR\b|\bOpera\b/i.test(userAgent)) return { key: 'opera', name: 'Opera' }
+  if (/\bFxiOS\b|\bFirefox\b/i.test(userAgent)) return { key: 'firefox', name: 'Firefox' }
+  if (/\bSamsungBrowser\b/i.test(userAgent)) return { key: 'samsung', name: 'Samsung Internet' }
+  if (/\bCriOS\b|\bChrome\b/i.test(userAgent)) return { key: 'chrome', name: 'Chrome' }
+  if (/\bSafari\b/i.test(userAgent)) return { key: 'safari', name: 'Safari' }
+  return null
+}
+
+export function deviceIdentity(userAgent: string | undefined | null): DeviceIdentity {
+  const agent = (userAgent ?? '').trim()
+  if (agent.length === 0) return UNKNOWN
+
+  const app = appIdentity(agent)
+  if (app) return app
+
+  const platform = platformOf(agent)
+  const browser = browserOf(agent)
+  if (!browser) {
+    // curl, a bot, a script: named by what it said it was, up to a point.
+    const name = agent.split(/[\s/]/)[0] ?? 'unknown'
+    return { fingerprint: `other-${name.toLowerCase().slice(0, 24)}`, label: name.slice(0, 24) }
+  }
+  return {
+    fingerprint: `${platform.key}-${browser.key}`,
+    label: `${browser.name} on ${platform.name}`,
+  }
+}
+
+/**
+ * The country Cloudflare says the request came from, as a two-letter code.
+ *
+ * `cf-ipcountry` is set at the edge and cannot be forged by the client — the
+ * origin only accepts proxied requests (see `EDGE_SECRET`). `XX` is
+ * Cloudflare's own "unknown", and `T1` is Tor; both are treated as no answer.
+ */
+export function countryFromHeaders(headers: Headers | undefined): string | undefined {
+  const value = headers?.get('cf-ipcountry')?.trim().toUpperCase()
+  if (!value || value === 'XX' || value === 'T1') return undefined
+  return /^[A-Z]{2}$/.test(value) ? value : undefined
+}

--- a/apps/api/src/modules/security/deviceLabel.ts
+++ b/apps/api/src/modules/security/deviceLabel.ts
@@ -21,17 +21,29 @@ export interface DeviceIdentity {
 
 const UNKNOWN: DeviceIdentity = { fingerprint: 'unknown', label: 'an unrecognised device' }
 
-/** Ours first: the app's own requests should not read as "Safari on iPhone". */
+/**
+ * Ours first: the app's own requests should not read as "Safari on iPhone",
+ * and they must not read as the HTTP library either.
+ *
+ * React Native does not send a browser user agent. On Android it sends
+ * `okhttp/4.x` and nothing else, and on iOS `CFNetwork/… Darwin/…` — which
+ * a run against production turned into fifty-three people being told they had
+ * signed in from "okhttp". Nothing else in this app's traffic uses either
+ * library, so both are read as the app.
+ */
 function appIdentity(userAgent: string): DeviceIdentity | null {
-  if (/\bExpo\b|LangX/i.test(userAgent)) {
-    if (/\bAndroid\b/i.test(userAgent))
-      return { fingerprint: 'android-app', label: 'the LangX app on Android' }
-    if (/\biPhone|iPad|iOS|CFNetwork\b/i.test(userAgent)) {
-      return { fingerprint: 'ios-app', label: 'the LangX app on iPhone' }
-    }
-    return { fingerprint: 'app', label: 'the LangX app' }
+  const named = /\bExpo\b|LangX/i.test(userAgent)
+  if (named ? /\bAndroid\b/i.test(userAgent) : /^okhttp\//i.test(userAgent)) {
+    return { fingerprint: 'android-app', label: 'the LangX app on Android' }
   }
-  return null
+  if (
+    named
+      ? /\biPhone|iPad|iOS|CFNetwork\b/i.test(userAgent)
+      : /\bCFNetwork\b/i.test(userAgent) && /\bDarwin\b/i.test(userAgent)
+  ) {
+    return { fingerprint: 'ios-app', label: 'the LangX app on iPhone' }
+  }
+  return named ? { fingerprint: 'app', label: 'the LangX app' } : null
 }
 
 function platformOf(userAgent: string): { key: string; name: string } {

--- a/apps/api/src/modules/security/knownDevices.ts
+++ b/apps/api/src/modules/security/knownDevices.ts
@@ -1,0 +1,57 @@
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+
+/**
+ * The devices an account has signed in from, so a sign-in from a new one can
+ * be told apart from the ordinary kind.
+ *
+ * Not read off `session`: those rows expire in a week, so a person who signs
+ * in every fortnight would be told every fortnight that their own phone was
+ * new — which is how a security mail becomes the one people filter away. This
+ * has no TTL, because "we have seen this device before" does not stop being
+ * true.
+ *
+ * The `_id` carries the uniqueness, so the insert failing **is** the check:
+ * two sign-ins racing each other produce one mail, not two.
+ */
+export interface KnownDevice {
+  /** `<userId>:<fingerprint>` */
+  _id: string
+  userId: string
+  fingerprint: string
+  /** Read back by nothing yet; here so the row can answer "since when". */
+  firstSeenAt: Date
+  lastSeenAt: Date
+  /** The last country this device was seen from, when the edge said. */
+  country?: string
+}
+
+/**
+ * Records the device and answers whether it had been seen before.
+ *
+ * `true` means new — mail them. The very first device on a brand-new account
+ * is new too, and the caller is what decides not to write about it: somebody
+ * who just signed up does not need to be told they signed in.
+ */
+export async function claimNewDevice(
+  db: Db,
+  userId: string,
+  fingerprint: string,
+  options: { country?: string; at?: Date } = {},
+): Promise<boolean> {
+  const at = options.at ?? new Date()
+  const result = await db.collection<KnownDevice>(COLLECTIONS.knownDevices).updateOne(
+    { _id: `${userId}:${fingerprint}` },
+    {
+      $set: { lastSeenAt: at, ...(options.country ? { country: options.country } : {}) },
+      $setOnInsert: { userId, fingerprint, firstSeenAt: at },
+    },
+    { upsert: true },
+  )
+  return result.upsertedCount > 0
+}
+
+/** Everything this account has signed in from. For the purge to delete. */
+export async function forgetDevices(db: Db, userId: string): Promise<void> {
+  await db.collection<KnownDevice>(COLLECTIONS.knownDevices).deleteMany({ userId })
+}

--- a/apps/api/src/modules/security/notify.test.ts
+++ b/apps/api/src/modules/security/notify.test.ts
@@ -1,0 +1,175 @@
+import { ObjectId } from 'mongodb'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import { ensureIndexes } from '../../db/indexes'
+import { authId } from '../../lib/authId'
+import { CapturingEmailSender } from '../../testSupport/authFlow'
+import { LoggingPushSender } from '../push/devices'
+import { claimNewDevice } from './knownDevices'
+import { notifyNewSignIn, notifyPasswordChanged, type SecurityNotifier } from './notify'
+
+describe('telling somebody about their own account', () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+  let email: CapturingEmailSender
+  let push: LoggingPushSender
+  let senders: SecurityNotifier
+  const errors: object[] = []
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'security_test')
+    await ensureIndexes(handle.db)
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    for (const name of [
+      COLLECTIONS.profiles,
+      COLLECTIONS.user,
+      COLLECTIONS.devices,
+      COLLECTIONS.knownDevices,
+    ]) {
+      await handle.db.collection(name).deleteMany({})
+    }
+    errors.length = 0
+    email = new CapturingEmailSender()
+    push = new LoggingPushSender()
+    senders = { email, push, logger: { error: (obj) => errors.push(obj) } }
+  })
+
+  async function newAccount(
+    opts: { verified?: boolean; notifications?: unknown; device?: boolean; locale?: string } = {},
+  ): Promise<string> {
+    const userId = new ObjectId().toHexString()
+    await handle.db.collection(COLLECTIONS.profiles).insertOne({
+      _id: userId,
+      handle: `h${userId.slice(0, 8)}`,
+      // Everything off, on both channels — the case these notices ignore.
+      settings: { discoverable: true, notifications: opts.notifications ?? false },
+      nativeLanguages: [{ code: opts.locale ?? 'en' }],
+    } as never)
+    await handle.db.collection(COLLECTIONS.user).insertOne({
+      _id: authId(userId),
+      email: `${userId}@example.com`,
+      emailVerified: opts.verified ?? true,
+    })
+    if (opts.device !== false) {
+      await handle.db.collection(COLLECTIONS.devices).insertOne({
+        userId,
+        pushToken: `ExponentPushToken[${userId.slice(0, 10)}]`,
+        platform: 'ios',
+        locale: opts.locale ?? 'en',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+    }
+    return userId
+  }
+
+  /**
+   * The rule the whole module turns on: a notice about a possible compromise
+   * has to arrive even from an account whose owner switched everything off.
+   */
+  it('sends on both channels to somebody who turned every notification off', async () => {
+    const userId = await newAccount({ notifications: false })
+    await notifyNewSignIn(handle.db, senders, userId, {
+      device: 'Safari on iPhone',
+      country: 'TR',
+      at: new Date('2026-09-14T09:05:00Z'),
+    })
+
+    expect(email.messages).toHaveLength(1)
+    expect(push.sent).toHaveLength(1)
+    const message = email.messages[0]
+    expect(message?.subject).toContain('New sign-in')
+    expect(message?.html).toContain('Safari on iPhone')
+    // The country code becomes a name, and the time says which clock it is on.
+    expect(message?.html).toContain('Türkiye')
+    expect(message?.html).toContain('2026-09-14 09:05 UTC')
+  })
+
+  /** No switch behind it, so no unsubscribe link and no List-Unsubscribe header. */
+  it('offers no way to turn it off, because there is none', async () => {
+    const userId = await newAccount()
+    await notifyPasswordChanged(handle.db, senders, userId, { device: 'Chrome on Windows' })
+    const message = email.messages[0]
+    expect(message?.headers).toBeUndefined()
+    expect(message?.html).not.toContain('unsubscribe')
+    expect(message?.text).not.toContain('unsubscribe')
+    // What it offers instead: the one action that helps.
+    expect(message?.html).toContain('/settings/password')
+  })
+
+  it('never writes to an address nobody proved', async () => {
+    const userId = await newAccount({ verified: false })
+    await notifyNewSignIn(handle.db, senders, userId, { device: 'Chrome on Windows' })
+    expect(email.messages).toHaveLength(0)
+    // The phone still hears about it: the device is the account's, whatever
+    // the address turns out to be.
+    expect(push.sent).toHaveLength(1)
+  })
+
+  it('says it in the language the reader speaks', async () => {
+    const userId = await newAccount({ locale: 'tr' })
+    await notifyPasswordChanged(handle.db, senders, userId, {})
+    expect(email.messages[0]?.subject).toContain('şifren')
+  })
+
+  /** A mail provider having a bad minute must not break a correct password. */
+  it('logs a failure rather than throwing it at the caller', async () => {
+    const userId = await newAccount()
+    const failing: SecurityNotifier = {
+      ...senders,
+      email: { deliverable: true, send: () => Promise.reject(new Error('resend down')) },
+    }
+    await expect(notifyPasswordChanged(handle.db, failing, userId, {})).resolves.toBeUndefined()
+    expect(errors).toHaveLength(1)
+    // And the push still went.
+    expect(push.sent).toHaveLength(1)
+  })
+
+  it('says nothing at all about an account with no address and no device', async () => {
+    const userId = await newAccount({ verified: false, device: false })
+    await notifyNewSignIn(handle.db, senders, userId, {})
+    expect(email.messages).toHaveLength(0)
+    expect(push.sent).toHaveLength(0)
+    expect(errors).toHaveLength(0)
+  })
+
+  describe('which devices count as new', () => {
+    it('is new once, and ordinary every time after', async () => {
+      const userId = await newAccount()
+      expect(await claimNewDevice(handle.db, userId, 'ios-safari')).toBe(true)
+      expect(await claimNewDevice(handle.db, userId, 'ios-safari')).toBe(false)
+      // A different device on the same account is its own answer.
+      expect(await claimNewDevice(handle.db, userId, 'windows-chrome')).toBe(true)
+    })
+
+    /** Two sign-ins racing each other are one letter, not two. */
+    it('lets exactly one of two simultaneous sign-ins be the first', async () => {
+      const userId = await newAccount()
+      const [first, second] = await Promise.all([
+        claimNewDevice(handle.db, userId, 'ios-safari'),
+        claimNewDevice(handle.db, userId, 'ios-safari'),
+      ])
+      expect([first, second].filter(Boolean)).toHaveLength(1)
+    })
+
+    it('keeps the last country it was seen from', async () => {
+      const userId = await newAccount()
+      await claimNewDevice(handle.db, userId, 'ios-safari', { country: 'TR' })
+      await claimNewDevice(handle.db, userId, 'ios-safari', { country: 'CA' })
+      const row = await handle.db
+        .collection(COLLECTIONS.knownDevices)
+        .findOne({ _id: `${userId}:ios-safari` as never })
+      expect(row).toMatchObject({ country: 'CA' })
+    })
+  })
+})

--- a/apps/api/src/modules/security/notify.ts
+++ b/apps/api/src/modules/security/notify.ts
@@ -1,0 +1,147 @@
+import { getCountry, webUrl } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { securityEmail, type SecurityEvent } from '../../email/templates'
+import type { EmailSender } from '../../email/sender'
+import { translator } from '../../i18n'
+import { emailFor } from '../profiles/emailFor'
+import { localeFor } from '../profiles/localeFor'
+import { sendPush, tokensByLocale, type PushSender } from '../push/devices'
+
+/**
+ * What this app tells somebody about their own account's security, and the
+ * one rule the whole module turns on: **none of it asks a preference.**
+ *
+ * Every other push checks `notificationsAllowed` and every other mail goes
+ * through `sendNotificationEmail`. These do not, for the reason the bounty
+ * receipt does not: a switch whose honest label is "do not tell me when
+ * somebody signs in as me" is not a setting anybody should be offered, and a
+ * notice about a possible compromise is the one message that has to arrive
+ * even from an account whose owner turned everything else off. There is no
+ * unsubscribe link for the same reason — the mail carries no
+ * `List-Unsubscribe`, because it is not a list.
+ *
+ * Both channels, and not as a fallback for each other: an attacker who has
+ * the phone should not be able to keep the mail from arriving, and a phone
+ * that is off should not cost somebody the notice. The push goes to every
+ * device already registered, which for a sign-in is precisely the devices
+ * that are *not* the one signing in.
+ *
+ * Nothing here throws into the caller. These fire from an auth hook — the
+ * response to a sign-in — and a mail provider having a bad minute must never
+ * turn somebody's correct password into an error page.
+ */
+
+export interface SecurityNotifier {
+  email: EmailSender
+  push: PushSender
+  logger: { error: (obj: object, msg: string) => void }
+}
+
+export interface SecurityContext {
+  /** "Safari on iPhone", from `deviceIdentity`. */
+  device?: string
+  /** Two-letter code from the edge; rendered as a country name. */
+  country?: string
+  at?: Date
+}
+
+/**
+ * English country names, which is what `COUNTRIES` holds — the list is a
+ * form's options, not a translated catalogue. A place name in the wrong
+ * language still answers the question the line is there for ("was this you,
+ * in Germany?"), and inventing eight translations of two hundred countries
+ * to avoid that would be a worse trade than it looks.
+ */
+function placeFor(context: SecurityContext): string | undefined {
+  if (!context.country) return undefined
+  return getCountry(context.country)?.name ?? context.country
+}
+
+/**
+ * Sends one security notice on both channels.
+ *
+ * Exported for the tests and for `auth.ts`, which is the only caller; the
+ * named wrappers below are what it actually reaches for, so the event names
+ * stay in one place rather than as strings at four call sites.
+ */
+export async function notifySecurityEvent(
+  db: Db,
+  senders: SecurityNotifier,
+  input: { userId: string; event: SecurityEvent; context?: SecurityContext },
+): Promise<void> {
+  const context = input.context ?? {}
+  try {
+    const address = await emailFor(db, input.userId)
+    // An unverified address may belong to somebody else entirely, and this is
+    // the last mail that should be sent to a stranger.
+    if (address?.verified) {
+      const locale = await localeFor(db, input.userId)
+      await senders.email.send({
+        to: address.email,
+        ...securityEmail(locale, input.event, {
+          ...(context.device ? { device: context.device } : {}),
+          ...(placeFor(context) ? { place: placeFor(context) as string } : {}),
+          at: context.at ?? new Date(),
+        }),
+      })
+    }
+  } catch (error) {
+    senders.logger.error({ err: error, event: input.event }, 'security email failed')
+  }
+
+  try {
+    const byLocale = await tokensByLocale(db, input.userId)
+    for (const [locale, tokens] of byLocale) {
+      if (tokens.length === 0) continue
+      const t = translator(locale)
+      await sendPush(db, senders.push, {
+        to: tokens,
+        title: t(`push.security.${input.event}Title` as never),
+        body: context.device
+          ? t('push.securityBodyDevice', { device: context.device })
+          : t('push.securityBody'),
+        data: { kind: 'security' },
+      })
+    }
+  } catch (error) {
+    senders.logger.error({ err: error, event: input.event }, 'security push failed')
+  }
+}
+
+/** Somebody signed in from a device this account has not been seen on. */
+export function notifyNewSignIn(
+  db: Db,
+  senders: SecurityNotifier,
+  userId: string,
+  context: SecurityContext,
+): Promise<void> {
+  return notifySecurityEvent(db, senders, { userId, event: 'newSignIn', context })
+}
+
+/** A password was set, changed or reset. */
+export function notifyPasswordChanged(
+  db: Db,
+  senders: SecurityNotifier,
+  userId: string,
+  context: SecurityContext,
+): Promise<void> {
+  return notifySecurityEvent(db, senders, { userId, event: 'passwordChanged', context })
+}
+
+/** Google or Apple was connected to, or disconnected from, the account. */
+export function notifySignInMethodChanged(
+  db: Db,
+  senders: SecurityNotifier,
+  userId: string,
+  change: 'linked' | 'unlinked',
+  context: SecurityContext,
+): Promise<void> {
+  return notifySecurityEvent(db, senders, {
+    userId,
+    event: change === 'linked' ? 'methodLinked' : 'methodUnlinked',
+    context,
+  })
+}
+
+/** Where every one of these mails sends somebody who did not do it. */
+export const SECURITY_ACTION_URL = webUrl('/settings/password')

--- a/apps/mobile/src/lib/notificationRoute.test.ts
+++ b/apps/mobile/src/lib/notificationRoute.test.ts
@@ -32,4 +32,8 @@ describe('notificationRoute', () => {
     // difference between the free count and the Pro list is drawn.
     expect(notificationRoute({ kind: 'profileVisits' })).toBe('/viewers')
   })
+
+  it('sends a security notice to the screen that changes the password', () => {
+    expect(notificationRoute({ kind: 'security' })).toBe('/settings/password')
+  })
 })

--- a/apps/mobile/src/lib/notificationRoute.ts
+++ b/apps/mobile/src/lib/notificationRoute.ts
@@ -49,5 +49,9 @@ export function notificationRoute(data: unknown): Href | null {
       // The count is what the notification said; the names are behind the
       // paywall this screen draws. Landing here is the whole point of it.
       return '/viewers'
+    case 'security':
+      // "Somebody signed in as you" has one useful next step, and it is the
+      // screen that changes the password — which signs every other device out.
+      return '/settings/password'
   }
 }

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3640,3 +3640,46 @@ reports a permanent bounce or a spam complaint about a mailbox we should not
 write to again. `createProfile` checks it before seeding the v1 consent. A
 transient bounce is deliberately not on it: a full mailbox is a bad day, not
 a dead address.
+
+## A security notice has no switch, and no unsubscribe
+
+Somebody could sign in to this app from a stranger's laptop and nothing
+would say so. Four events now do: a sign-in from a device the account has
+not been seen on, a password change (including a reset — an attacker with a
+stolen inbox is exactly who the mail is about), and a sign-in method
+connected or disconnected.
+
+**None of them asks a preference**, and both channels fire rather than one
+falling back to the other. The reasoning is the bounty receipt's: a setting
+whose honest label is "do not tell me when somebody signs in as me" is not
+one to offer, and an attacker who has the phone must not be able to keep the
+mail from arriving. So no `notificationsAllowed` check, no
+`sendNotificationEmail`, no `List-Unsubscribe` header — it is not a list.
+The mail carries the device, the country the edge reported and the time in
+UTC (labelled as such: guessing a timezone from an IP is how a notice tells
+somebody in Toronto they signed in at an hour they were asleep), and one
+button, to the screen that changes the password and signs every other device
+out.
+
+**"A device we have not seen" is its own collection.** The obvious source
+was `session`, and it is wrong: those rows expire in a week, so a person who
+signs in every fortnight would be told every fortnight that their own phone
+was new — which is how a security mail becomes the one people filter away.
+`knownDevices` is keyed `<userId>:<fingerprint>` with no TTL, so the insert
+failing is what says "seen before", and two sign-ins racing each other
+produce one letter.
+
+The fingerprint is deliberately coarse — `ios-safari`, `android-chrome`,
+`ios-app` — because a browser version bump is not a new device. It comes
+from about forty lines of regex rather than a user-agent library: those
+carry a pattern database the size of this app's whole i18n catalogue in
+order to tell Chrome 118 from Chrome 119, which is the one distinction being
+thrown away here.
+
+All of it hangs off a single Better Auth `after` hook keyed on
+`ctx.context.newSession` rather than on a list of sign-in paths, because
+that list is exactly the thing a future plugin would silently add to. A
+sign-up is excluded: being told you signed in seconds after creating the
+account is noise. Nothing thrown inside is allowed to reach the caller —
+these fire on the response to a correct password, and a mail provider having
+a bad minute must not turn that into an error page.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -74,6 +74,14 @@ only one instance can own a given day, every notification pass claims a row
 in `notificationLedger` before it sends, and a campaign claims each recipient
 in `emailCampaigns` — so nobody is told the same thing twice.
 
+Four things are told to a person about their own account and ask no
+preference at all: a sign-in from a device the account has not been seen on,
+a changed password, and a sign-in method connected or disconnected. They go
+by mail _and_ push, carry no unsubscribe, and reach an account whose owner
+switched every other notification off — a switch whose honest label is "do
+not tell me when somebody signs in as me" is not one to offer. `knownDevices`
+is what makes "a device we have not seen" answerable; it has no TTL.
+
 Nothing is sent to an address on `emailSuppressions`, service mail included:
 a permanent bounce or a spam complaint reported by Resend's webhook
 (`POST /webhooks/resend`, signed with `RESEND_WEBHOOK_SECRET`) puts an address

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -80,7 +80,10 @@ a changed password, and a sign-in method connected or disconnected. They go
 by mail _and_ push, carry no unsubscribe, and reach an account whose owner
 switched every other notification off — a switch whose honest label is "do
 not tell me when somebody signs in as me" is not one to offer. `knownDevices`
-is what makes "a device we have not seen" answerable; it has no TTL.
+is what makes "a device we have not seen" answerable; it has no TTL — and it
+starts empty, so `scripts/backfill-known-devices.ts` has to run before the
+first deploy that carries this, or everybody's next sign-in is a "new device"
+letter about the phone they are holding.
 
 Nothing is sent to an address on `emailSuppressions`, service mail included:
 a permanent bounce or a spam complaint reported by Resend's webhook

--- a/packages/shared/src/push.ts
+++ b/packages/shared/src/push.ts
@@ -47,6 +47,12 @@ export const PUSH_KINDS = [
   'profileVisits',
   'meetingReminder',
   'bountyPaid',
+  /**
+   * A new device, a changed password, a sign-in method connected or removed.
+   * No preference gates it — see `modules/security/notify.ts` — so it is the
+   * one kind with no row on the settings screen.
+   */
+  'security',
 ] as const
 export type PushKind = (typeof PUSH_KINDS)[number]
 


### PR DESCRIPTION
PR B of the email + push programme. Four things this app now tells somebody about their own account.

## What changes

| Event | Trigger | Channels |
| --- | --- | --- |
| New sign-in | any endpoint that created a session, from a device `knownDevices` has not seen | mail + push |
| Password changed | `/change-password`, `/set-password`, `/reset-password` | mail + push |
| Sign-in method added | `/link-social` | mail + push |
| Sign-in method removed | `/unlink-account` | mail + push |

**None of them asks a preference**, and neither channel is a fallback for the other: a setting whose honest label is "do not tell me when somebody signs in as me" is not one to offer, and an attacker who has the phone must not be able to keep the mail from arriving. No `notificationsAllowed`, no `sendNotificationEmail`, no `List-Unsubscribe` header — it is not a list. The mail names the device, the country the edge reported and the time in UTC (labelled), with one button to the screen that changes the password and signs every other device out.

## Why a new collection

`session` was the obvious source for "have we seen this device" and it is wrong — rows expire in a week, so somebody signing in every fortnight would be told every fortnight that their own phone was new. `knownDevices` is keyed `<userId>:<fingerprint>`, has no TTL, and the insert failing *is* the check, so two simultaneous sign-ins produce one letter. It is deleted with the account.

The fingerprint is coarse (`ios-safari`, `android-chrome`, `ios-app`) from ~40 lines of regex rather than a UA library: those exist to tell Chrome 118 from Chrome 119, which is the distinction being thrown away.

## Also here

- New push kind `security`, routed to `/settings/password` in the app.
- Eight locales for the four mails and the four push titles.
- One Better Auth `after` hook keyed on `ctx.context.newSession` rather than a list of paths — that list is what a future plugin would silently add to. Sign-up is excluded.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — green (api 91 files, mobile 93, shared 26).
- `src/auth.security.test.ts` drives it end to end through Better Auth's own endpoints: first sign-in from an iPhone writes, the second does not, Windows writes again, sign-up writes nothing, a password change writes, and the notice carries no unsubscribe header.
- `notify.test.ts` covers the account with everything switched off, the unverified address, the reader's own language, and a mail provider failing without breaking the caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)