### PR TITLE
Welcome mail, verification reminder, and the two things billing says out loud

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -32,11 +32,13 @@ import {
   magicLinkEmail,
   resetPasswordEmail,
   verificationEmail,
+  verifyReminderEmail,
 } from './email/templates'
 import { localeFromHeader } from './i18n'
 import { nativeLocaleFor } from './modules/profiles/localeFor'
 import { publicApiUrl, type Env } from './env'
 import type { RevenueCatClient } from './modules/billing/revenueCatClient'
+import { alreadyClaimed } from './modules/notifications/ledger'
 import { LoggingPushSender, type PushSender } from './modules/push/devices'
 import { countryFromHeaders, deviceIdentity } from './modules/security/deviceLabel'
 import { claimNewDevice } from './modules/security/knownDevices'
@@ -327,7 +329,16 @@ export async function createAuth({
       sendOnSignUp: true,
       autoSignInAfterVerification: true,
       sendVerificationEmail: async ({ user, url }, request) => {
-        const email = verificationEmail(url, await mailLocale(user.id, request?.headers))
+        const locale = await mailLocale(user.id, request?.headers)
+        /*
+         * The same link, worded twice. `runVerifyReminderPass` claims the
+         * ledger row before it asks for this send, so the row's presence is
+         * what says "this is the second letter" — and a reminder that
+         * repeated the first one verbatim is the one a mail client stacks
+         * under "similar messages" and nobody opens.
+         */
+        const isReminder = await alreadyClaimed(db, 'verifyReminder', user.id, 'once')
+        const email = isReminder ? verifyReminderEmail(url, locale) : verificationEmail(url, locale)
         await emailSender.send({ to: user.email, ...email })
       },
       // Clicking the link is proof of the address, so a matching v1 profile

--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -350,6 +350,98 @@ export function existingAccountLinkEmail(url: string, locale: Locale): Email {
   }
 }
 
+/**
+ * "Welcome to LangX", the moment onboarding finishes.
+ *
+ * Transactional, not a notification: it answers something somebody just did,
+ * the way the verification mail does, and it goes once in an account's life.
+ * `wrap`, therefore, and no unsubscribe — the mail carries no preference to
+ * withdraw.
+ *
+ * Three lines of what to do next rather than a tour. The app is open on the
+ * other screen; this is the copy somebody reads on the bus tomorrow.
+ */
+export function welcomeEmail(locale: Locale, input: { name: string; handle: string }): Email {
+  const t = translator(locale)
+  const url = webUrl('/discover')
+  const steps = [t('email.welcomeStep1'), t('email.welcomeStep2'), t('email.welcomeStep3')]
+  return {
+    subject: t('email.welcomeSubject'),
+    html: wrap(
+      locale,
+      t('email.welcomePreheader'),
+      `<p><strong style="font-family:${TITLE_FONT}; font-size:20px; line-height:26px;">${t('email.welcomeTitle', { name: escapeHtml(input.name) })}</strong></p>
+       <p>${t('email.welcomeBody', { handle: escapeHtml(input.handle) })}</p>
+       <ul style="margin:20px 0 0; padding-left:20px; color:#17191c;">
+         ${steps.map((step) => `<li style="margin-bottom:8px;">${step}</li>`).join('\n         ')}
+       </ul>
+       <p style="margin:24px 0 0;">${button(url, t('email.welcomeButton'))}</p>`,
+    ),
+    text: [
+      t('email.welcomeTitle', { name: input.name }),
+      '',
+      t('email.welcomeBody', { handle: input.handle }),
+      '',
+      ...steps.map((step) => `- ${step}`),
+      '',
+      url,
+    ].join('\n'),
+  }
+}
+
+/**
+ * "You still need to confirm your address", a day after signing up.
+ *
+ * The same link as the first mail, because it is the same job — and the
+ * first one is the mail most likely to have landed in a spam folder, since
+ * it arrives before this domain has ever written to that address before.
+ */
+export function verifyReminderEmail(url: string, locale: Locale): Email {
+  const t = translator(locale)
+  return {
+    subject: t('email.verifyReminderSubject'),
+    html: wrap(
+      locale,
+      t('email.verifyReminderPreheader'),
+      `<p>${t('email.verifyReminderBody')}</p>
+       <p>${button(url, t('email.verifyButton'))}</p>
+       <p style="font-size: 12px; color: #62676d;">${t('email.orPaste', { url })}</p>`,
+    ),
+    text: t('email.verifyReminderText', { url }),
+  }
+}
+
+/**
+ * The two things billing says out loud: a payment that failed, and a plan
+ * that has ended.
+ *
+ * Transactional for the same reason the bounty receipt is — this is money,
+ * and "do not tell me my payment failed" is not a preference worth offering.
+ * A renewal that succeeds says nothing: the store already mails a receipt,
+ * and a second one from us is the noise that gets a sender filtered.
+ */
+export function billingEmail(
+  locale: Locale,
+  event: 'paymentFailed' | 'planEnded',
+  input: { tier: string },
+): Email {
+  const t = translator(locale)
+  const url = webUrl('/settings/plan')
+  const title = t(`email.billing.${event}Title` as never)
+  return {
+    subject: title,
+    html: wrap(
+      locale,
+      t(`email.billing.${event}Body` as never),
+      `<p><strong style="font-family:${TITLE_FONT}; font-size:20px; line-height:26px;">${title}</strong></p>
+       <p>${t(`email.billing.${event}Body` as never)}</p>
+       <p style="color:#62676d;">${t('email.billingPlan', { tier: escapeHtml(input.tier) })}</p>
+       <p style="margin:24px 0 0;">${button(url, t(`email.billing.${event}Button` as never))}</p>`,
+    ),
+    text: [title, '', t(`email.billing.${event}Body` as never), '', url].join('\n'),
+  }
+}
+
 /** The four things this app tells somebody about their own account. */
 export type SecurityEvent = 'newSignIn' | 'passwordChanged' | 'methodLinked' | 'methodUnlinked'
 

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -30,6 +30,10 @@ export const ar: Localized<ServerMessages> = {
     },
     bountyBody: 'قرأنا ما أرسلته، وقد كان يستحق.',
     /** Security, which no preference can switch off. */
+    /** Billing, which no preference gates either. */
+    billingFailedTitle: 'لم تتم عملية الدفع',
+    billingEndedTitle: 'انتهت خطتك',
+    billingBody: 'انقر للاطلاع على خطتك.',
     securityBody: 'افتح LangX إن لم تكن أنت.',
     securityBodyDevice: 'من {device}. افتح LangX إن لم تكن أنت.',
     security: {
@@ -136,6 +140,54 @@ export const ar: Localized<ServerMessages> = {
     unsubscribedTitle: 'تم — لن تصلك بعد الآن.',
     unsubscribedBody: 'يمكنك تشغيلها متى شئت من LangX في الإعدادات ← الإشعارات.',
     unsubscribeInvalid: 'هذا الرابط غير صالح. افتح LangX وغيّره من الإعدادات ← الإشعارات.',
+
+    /** Onboarding finished: one mail, once in an account's life. */
+
+    welcomeSubject: 'أهلاً بك في LangX',
+
+    welcomePreheader: 'محادثتك الأولى على بُعد نقرة',
+
+    welcomeTitle: 'أهلاً، {name}',
+
+    welcomeBody: 'ملفك الشخصي متاح على ‎@{handle}‎. هذا ما يبدأ به معظم الناس:',
+
+    welcomeStep1: 'ابحث عن شخص يتحدث اللغة التي تتعلمها وألقِ التحية.',
+
+    welcomeStep2: 'انشر جملة في الموجز ودع الآخرين يصححونها.',
+
+    welcomeStep3: 'عُد غداً — يومان متتاليان يبدآن سلسلة.',
+
+    welcomeButton: 'ابحث عن شخص للتدرب معه',
+
+    /** A day later, for an address nobody confirmed. */
+
+    verifyReminderSubject: 'أكّد عنوان بريدك الإلكتروني',
+
+    verifyReminderPreheader: 'نقرة واحدة ويصبح حسابك جاهزاً',
+
+    verifyReminderBody:
+      'ينقص حسابك في LangX شيء واحد: إثبات أن هذا العنوان لك. الرابط أدناه يقوم بذلك.',
+
+    verifyReminderText: 'أكّد عنوان بريدك الإلكتروني: {url}',
+
+    /** Money, so no switch — see `billingEmail`. */
+
+    billingPlan: 'الخطة: {tier}',
+
+    billing: {
+      paymentFailedTitle: 'لم تتم عملية الدفع في LangX',
+
+      paymentFailedBody:
+        'لم يتمكن المتجر من تحصيل قيمة اشتراكك. سيحاول مرة أخرى، وتبقى خطتك فعّالة في هذه الأثناء.',
+
+      paymentFailedButton: 'تحقق من خطتي',
+
+      planEndedTitle: 'انتهت خطتك في LangX',
+
+      planEndedBody: 'انتهى اشتراكك وعاد حسابك إلى الخطة المجانية. كل ما أنشأته ما زال موجوداً.',
+
+      planEndedButton: 'اطّلع على الخطط',
+    },
 
     /**
 

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -24,6 +24,10 @@ export const de: Localized<ServerMessages> = {
     },
     bountyBody: 'Wir haben gelesen, was du geschickt hast – es hat sich gelohnt.',
     /** Security, which no preference can switch off. */
+    /** Billing, which no preference gates either. */
+    billingFailedTitle: 'Deine Zahlung ist fehlgeschlagen',
+    billingEndedTitle: 'Dein Tarif ist beendet',
+    billingBody: 'Tippe, um deinen Tarif zu prüfen.',
     securityBody: 'Öffne LangX, falls du das nicht warst.',
     securityBodyDevice: 'Von {device}. Öffne LangX, falls du das nicht warst.',
     security: {
@@ -138,6 +142,55 @@ export const de: Localized<ServerMessages> = {
       'Du kannst sie jederzeit in LangX unter Einstellungen → Mitteilungen wieder einschalten.',
     unsubscribeInvalid:
       'Dieser Link ist ungültig. Öffne LangX und ändere es unter Einstellungen → Mitteilungen.',
+
+    /** Onboarding finished: one mail, once in an account's life. */
+
+    welcomeSubject: 'Willkommen bei LangX',
+
+    welcomePreheader: 'Dein erstes Gespräch ist einen Tipp entfernt',
+
+    welcomeTitle: 'Willkommen, {name}',
+
+    welcomeBody: 'Dein Profil ist unter @{handle} online. Das machen die meisten zuerst:',
+
+    welcomeStep1: 'Finde jemanden, der deine Lernsprache spricht, und sag Hallo.',
+
+    welcomeStep2: 'Poste einen Satz im Feed und lass ihn korrigieren.',
+
+    welcomeStep3: 'Komm morgen wieder — zwei Tage hintereinander starten eine Serie.',
+
+    welcomeButton: 'Jemanden zum Üben finden',
+
+    /** A day later, for an address nobody confirmed. */
+
+    verifyReminderSubject: 'Bestätige deine E-Mail-Adresse',
+
+    verifyReminderPreheader: 'Ein Tipp und dein Konto ist bereit',
+
+    verifyReminderBody:
+      'Deinem LangX-Konto fehlt nur eines: der Nachweis, dass diese Adresse dir gehört. Der Link unten erledigt das.',
+
+    verifyReminderText: 'Bestätige deine E-Mail-Adresse: {url}',
+
+    /** Money, so no switch — see `billingEmail`. */
+
+    billingPlan: 'Tarif: {tier}',
+
+    billing: {
+      paymentFailedTitle: 'Deine LangX-Zahlung ist fehlgeschlagen',
+
+      paymentFailedBody:
+        'Der Store konnte die Zahlung für dein Abo nicht einziehen. Er versucht es erneut; dein Tarif bleibt vorerst aktiv.',
+
+      paymentFailedButton: 'Meinen Tarif prüfen',
+
+      planEndedTitle: 'Dein LangX-Tarif ist beendet',
+
+      planEndedBody:
+        'Dein Abo ist beendet und dein Konto ist zurück im kostenlosen Tarif. Alles, was du erstellt hast, ist noch da.',
+
+      planEndedButton: 'Tarife ansehen',
+    },
 
     /**
 

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -28,6 +28,10 @@ export const en = {
     },
     bountyBody: 'We read what you sent, and it was worth it.',
     /** Security, which no preference can switch off. */
+    /** Billing, which no preference gates either. */
+    billingFailedTitle: 'Your payment did not go through',
+    billingEndedTitle: 'Your plan has ended',
+    billingBody: 'Tap to check your plan.',
     securityBody: 'Open LangX if this was not you.',
     securityBodyDevice: 'From {device}. Open LangX if this was not you.',
     security: {
@@ -143,6 +147,55 @@ export const en = {
     unsubscribedBody: 'You can turn them back on any time in LangX under Settings → Notifications.',
     unsubscribeInvalid:
       'This link is not valid. Open LangX and change it under Settings → Notifications.',
+
+    /** Onboarding finished: one mail, once in an account's life. */
+
+    welcomeSubject: 'Welcome to LangX',
+
+    welcomePreheader: 'Your first conversation is a tap away',
+
+    welcomeTitle: 'Welcome, {name}',
+
+    welcomeBody: 'Your profile is live at @{handle}. Here is what people do first:',
+
+    welcomeStep1: 'Find someone who speaks what you are learning, and say hello.',
+
+    welcomeStep2: 'Post a sentence to the Feed and let people correct it.',
+
+    welcomeStep3: 'Come back tomorrow — two days in a row starts a streak.',
+
+    welcomeButton: 'Find someone to practise with',
+
+    /** A day later, for an address nobody confirmed. */
+
+    verifyReminderSubject: 'Confirm your email address',
+
+    verifyReminderPreheader: 'One tap and your account is ready',
+
+    verifyReminderBody:
+      'Your LangX account is waiting for one thing: proof that this address is yours. The link below does it.',
+
+    verifyReminderText: 'Confirm your email address: {url}',
+
+    /** Money, so no switch — see `billingEmail`. */
+
+    billingPlan: 'Plan: {tier}',
+
+    billing: {
+      paymentFailedTitle: 'Your LangX payment did not go through',
+
+      paymentFailedBody:
+        'The store could not take the payment for your subscription. It will try again, and your plan stays active in the meantime.',
+
+      paymentFailedButton: 'Check my plan',
+
+      planEndedTitle: 'Your LangX plan has ended',
+
+      planEndedBody:
+        'Your subscription has ended and your account is back on the free plan. Everything you made is still there.',
+
+      planEndedButton: 'See the plans',
+    },
 
     /**
 

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -24,6 +24,10 @@ export const es: Localized<ServerMessages> = {
     },
     bountyBody: 'Leímos lo que nos enviaste y valió la pena.',
     /** Security, which no preference can switch off. */
+    /** Billing, which no preference gates either. */
+    billingFailedTitle: 'Tu pago no se pudo procesar',
+    billingEndedTitle: 'Tu plan ha terminado',
+    billingBody: 'Toca para ver tu plan.',
     securityBody: 'Abre LangX si no fuiste tú.',
     securityBodyDevice: 'Desde {device}. Abre LangX si no fuiste tú.',
     security: {
@@ -137,6 +141,55 @@ export const es: Localized<ServerMessages> = {
       'Puedes volver a activarlos cuando quieras en LangX, en Ajustes → Notificaciones.',
     unsubscribeInvalid:
       'Este enlace no es válido. Abre LangX y cámbialo en Ajustes → Notificaciones.',
+
+    /** Onboarding finished: one mail, once in an account's life. */
+
+    welcomeSubject: 'Te damos la bienvenida a LangX',
+
+    welcomePreheader: 'Tu primera conversación está a un toque',
+
+    welcomeTitle: 'Hola, {name}',
+
+    welcomeBody: 'Tu perfil ya está en @{handle}. Esto es lo que hace la gente primero:',
+
+    welcomeStep1: 'Encuentra a alguien que hable lo que estás aprendiendo y salúdalo.',
+
+    welcomeStep2: 'Publica una frase en el Feed y deja que la corrijan.',
+
+    welcomeStep3: 'Vuelve mañana: dos días seguidos inician una racha.',
+
+    welcomeButton: 'Buscar con quién practicar',
+
+    /** A day later, for an address nobody confirmed. */
+
+    verifyReminderSubject: 'Confirma tu correo electrónico',
+
+    verifyReminderPreheader: 'Un toque y tu cuenta estará lista',
+
+    verifyReminderBody:
+      'A tu cuenta de LangX solo le falta una cosa: comprobar que este correo es tuyo. El enlace de abajo lo hace.',
+
+    verifyReminderText: 'Confirma tu correo electrónico: {url}',
+
+    /** Money, so no switch — see `billingEmail`. */
+
+    billingPlan: 'Plan: {tier}',
+
+    billing: {
+      paymentFailedTitle: 'Tu pago de LangX no se pudo procesar',
+
+      paymentFailedBody:
+        'La tienda no pudo cobrar tu suscripción. Lo intentará de nuevo y tu plan sigue activo mientras tanto.',
+
+      paymentFailedButton: 'Ver mi plan',
+
+      planEndedTitle: 'Tu plan de LangX ha terminado',
+
+      planEndedBody:
+        'Tu suscripción terminó y tu cuenta volvió al plan gratuito. Todo lo que creaste sigue ahí.',
+
+      planEndedButton: 'Ver los planes',
+    },
 
     /**
 

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -24,6 +24,10 @@ export const fr: Localized<ServerMessages> = {
     },
     bountyBody: 'On a lu ce que tu nous as envoyé, et ça valait le coup.',
     /** Security, which no preference can switch off. */
+    /** Billing, which no preference gates either. */
+    billingFailedTitle: 'Votre paiement n’a pas abouti',
+    billingEndedTitle: 'Votre formule a pris fin',
+    billingBody: 'Touchez pour vérifier votre formule.',
     securityBody: 'Ouvrez LangX si ce n’était pas vous.',
     securityBodyDevice: 'Depuis {device}. Ouvrez LangX si ce n’était pas vous.',
     security: {
@@ -139,6 +143,55 @@ export const fr: Localized<ServerMessages> = {
       'Vous pouvez les réactiver à tout moment dans LangX, sous Réglages → Notifications.',
     unsubscribeInvalid:
       'Ce lien n’est pas valide. Ouvrez LangX et modifiez-le dans Réglages → Notifications.',
+
+    /** Onboarding finished: one mail, once in an account's life. */
+
+    welcomeSubject: 'Bienvenue sur LangX',
+
+    welcomePreheader: 'Votre première conversation est à un geste',
+
+    welcomeTitle: 'Bienvenue, {name}',
+
+    welcomeBody: 'Votre profil est en ligne sur @{handle}. Voici ce que les gens font en premier :',
+
+    welcomeStep1: 'Trouvez quelqu’un qui parle la langue que vous apprenez et dites bonjour.',
+
+    welcomeStep2: 'Publiez une phrase dans le Fil et laissez-la corriger.',
+
+    welcomeStep3: 'Revenez demain — deux jours d’affilée lancent une série.',
+
+    welcomeButton: 'Trouver quelqu’un pour pratiquer',
+
+    /** A day later, for an address nobody confirmed. */
+
+    verifyReminderSubject: 'Confirmez votre adresse e-mail',
+
+    verifyReminderPreheader: 'Un geste et votre compte est prêt',
+
+    verifyReminderBody:
+      'Il ne manque qu’une chose à votre compte LangX : la preuve que cette adresse est la vôtre. Le lien ci-dessous s’en charge.',
+
+    verifyReminderText: 'Confirmez votre adresse e-mail : {url}',
+
+    /** Money, so no switch — see `billingEmail`. */
+
+    billingPlan: 'Formule : {tier}',
+
+    billing: {
+      paymentFailedTitle: 'Votre paiement LangX n’a pas abouti',
+
+      paymentFailedBody:
+        'La boutique n’a pas pu prélever votre abonnement. Elle réessaiera, et votre formule reste active entre-temps.',
+
+      paymentFailedButton: 'Vérifier ma formule',
+
+      planEndedTitle: 'Votre formule LangX a pris fin',
+
+      planEndedBody:
+        'Votre abonnement a pris fin et votre compte est revenu à la formule gratuite. Tout ce que vous avez créé est toujours là.',
+
+      planEndedButton: 'Voir les formules',
+    },
 
     /**
 

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -24,6 +24,10 @@ export const ptBR: Localized<ServerMessages> = {
     },
     bountyBody: 'Lemos o que você enviou, e valeu a pena.',
     /** Security, which no preference can switch off. */
+    /** Billing, which no preference gates either. */
+    billingFailedTitle: 'Seu pagamento não foi concluído',
+    billingEndedTitle: 'Seu plano terminou',
+    billingBody: 'Toque para ver seu plano.',
     securityBody: 'Abra o LangX se não foi você.',
     securityBodyDevice: 'De {device}. Abra o LangX se não foi você.',
     security: {
@@ -134,6 +138,55 @@ export const ptBR: Localized<ServerMessages> = {
     unsubscribedBody: 'Você pode reativar quando quiser no LangX, em Configurações → Notificações.',
     unsubscribeInvalid:
       'Este link não é válido. Abra o LangX e altere em Configurações → Notificações.',
+
+    /** Onboarding finished: one mail, once in an account's life. */
+
+    welcomeSubject: 'Boas-vindas ao LangX',
+
+    welcomePreheader: 'Sua primeira conversa está a um toque',
+
+    welcomeTitle: 'Boas-vindas, {name}',
+
+    welcomeBody: 'Seu perfil está no ar em @{handle}. É isto que as pessoas fazem primeiro:',
+
+    welcomeStep1: 'Encontre alguém que fale o que você está aprendendo e diga oi.',
+
+    welcomeStep2: 'Publique uma frase no Feed e deixe que corrijam.',
+
+    welcomeStep3: 'Volte amanhã — dois dias seguidos começam uma sequência.',
+
+    welcomeButton: 'Encontrar alguém para praticar',
+
+    /** A day later, for an address nobody confirmed. */
+
+    verifyReminderSubject: 'Confirme seu e-mail',
+
+    verifyReminderPreheader: 'Um toque e sua conta está pronta',
+
+    verifyReminderBody:
+      'Falta só uma coisa para sua conta do LangX: a prova de que este e-mail é seu. O link abaixo resolve.',
+
+    verifyReminderText: 'Confirme seu e-mail: {url}',
+
+    /** Money, so no switch — see `billingEmail`. */
+
+    billingPlan: 'Plano: {tier}',
+
+    billing: {
+      paymentFailedTitle: 'Seu pagamento do LangX não foi concluído',
+
+      paymentFailedBody:
+        'A loja não conseguiu cobrar sua assinatura. Ela tentará de novo, e seu plano continua ativo enquanto isso.',
+
+      paymentFailedButton: 'Ver meu plano',
+
+      planEndedTitle: 'Seu plano do LangX terminou',
+
+      planEndedBody:
+        'Sua assinatura terminou e sua conta voltou ao plano gratuito. Tudo o que você criou continua lá.',
+
+      planEndedButton: 'Ver os planos',
+    },
 
     /**
 

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -36,6 +36,10 @@ export const ru: Localized<ServerMessages> = {
     },
     bountyBody: 'Мы прочитали то, что ты прислал, — это того стоило.',
     /** Security, which no preference can switch off. */
+    /** Billing, which no preference gates either. */
+    billingFailedTitle: 'Платёж не прошёл',
+    billingEndedTitle: 'Ваш тариф закончился',
+    billingBody: 'Нажмите, чтобы проверить тариф.',
     securityBody: 'Откройте LangX, если это были не вы.',
     securityBodyDevice: 'С устройства {device}. Откройте LangX, если это были не вы.',
     security: {
@@ -148,6 +152,55 @@ export const ru: Localized<ServerMessages> = {
     unsubscribedBody: 'Включить обратно можно в любой момент в LangX: Настройки → Уведомления.',
     unsubscribeInvalid:
       'Ссылка недействительна. Откройте LangX и измените это в Настройках → Уведомления.',
+
+    /** Onboarding finished: one mail, once in an account's life. */
+
+    welcomeSubject: 'Добро пожаловать в LangX',
+
+    welcomePreheader: 'До первого разговора — одно касание',
+
+    welcomeTitle: 'Добро пожаловать, {name}',
+
+    welcomeBody: 'Ваш профиль доступен по адресу @{handle}. Вот с чего обычно начинают:',
+
+    welcomeStep1: 'Найдите того, кто говорит на языке, который вы учите, и поздоровайтесь.',
+
+    welcomeStep2: 'Опубликуйте фразу в Ленте и дайте её исправить.',
+
+    welcomeStep3: 'Возвращайтесь завтра — два дня подряд начинают серию.',
+
+    welcomeButton: 'Найти собеседника',
+
+    /** A day later, for an address nobody confirmed. */
+
+    verifyReminderSubject: 'Подтвердите адрес электронной почты',
+
+    verifyReminderPreheader: 'Одно касание — и аккаунт готов',
+
+    verifyReminderBody:
+      'Вашему аккаунту LangX не хватает одного: подтверждения, что этот адрес ваш. Ссылка ниже это сделает.',
+
+    verifyReminderText: 'Подтвердите адрес электронной почты: {url}',
+
+    /** Money, so no switch — see `billingEmail`. */
+
+    billingPlan: 'Тариф: {tier}',
+
+    billing: {
+      paymentFailedTitle: 'Платёж LangX не прошёл',
+
+      paymentFailedBody:
+        'Магазин не смог списать оплату подписки. Он попробует снова, а ваш тариф пока остаётся активным.',
+
+      paymentFailedButton: 'Проверить тариф',
+
+      planEndedTitle: 'Ваш тариф LangX закончился',
+
+      planEndedBody:
+        'Подписка закончилась, и аккаунт вернулся на бесплатный тариф. Всё, что вы создали, на месте.',
+
+      planEndedButton: 'Посмотреть тарифы',
+    },
 
     /**
 

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -18,6 +18,10 @@ export const tr: Localized<ServerMessages> = {
     },
     bountyBody: 'Yazdıklarını okuduk, değdi.',
     /** Security, which no preference can switch off. */
+    /** Billing, which no preference gates either. */
+    billingFailedTitle: 'Ödemen alınamadı',
+    billingEndedTitle: 'Planın sona erdi',
+    billingBody: 'Planını kontrol etmek için dokun.',
     securityBody: 'Bu sen değilsen LangX’i aç.',
     securityBodyDevice: '{device} üzerinden. Bu sen değilsen LangX’i aç.',
     security: {
@@ -123,6 +127,55 @@ export const tr: Localized<ServerMessages> = {
     unsubscribedBody: 'İstediğin zaman LangX’te Ayarlar → Bildirimler’den geri açabilirsin.',
     unsubscribeInvalid:
       'Bu bağlantı geçerli değil. LangX’i açıp Ayarlar → Bildirimler’den değiştir.',
+
+    /** Onboarding finished: one mail, once in an account's life. */
+
+    welcomeSubject: 'LangX’e hoş geldin',
+
+    welcomePreheader: 'İlk sohbetin bir dokunuş uzağında',
+
+    welcomeTitle: 'Hoş geldin, {name}',
+
+    welcomeBody: 'Profilin @{handle} adresinde yayında. İnsanlar genelde önce şunları yapıyor:',
+
+    welcomeStep1: 'Öğrendiğin dili konuşan birini bul ve selam ver.',
+
+    welcomeStep2: 'Akış’a bir cümle yaz, insanlar düzeltsin.',
+
+    welcomeStep3: 'Yarın da gel — üst üste iki gün seriyi başlatır.',
+
+    welcomeButton: 'Pratik yapacak birini bul',
+
+    /** A day later, for an address nobody confirmed. */
+
+    verifyReminderSubject: 'E-posta adresini doğrula',
+
+    verifyReminderPreheader: 'Tek dokunuş, hesabın hazır',
+
+    verifyReminderBody:
+      'LangX hesabın tek bir şeyi bekliyor: bu adresin sana ait olduğunun kanıtı. Aşağıdaki bağlantı bunu yapar.',
+
+    verifyReminderText: 'E-posta adresini doğrula: {url}',
+
+    /** Money, so no switch — see `billingEmail`. */
+
+    billingPlan: 'Plan: {tier}',
+
+    billing: {
+      paymentFailedTitle: 'LangX ödemen alınamadı',
+
+      paymentFailedBody:
+        'Mağaza aboneliğinin ödemesini alamadı. Tekrar deneyecek; bu sırada planın etkin kalır.',
+
+      paymentFailedButton: 'Planımı kontrol et',
+
+      planEndedTitle: 'LangX planın sona erdi',
+
+      planEndedBody:
+        'Aboneliğin sona erdi ve hesabın ücretsiz plana döndü. Oluşturduğun her şey duruyor.',
+
+      planEndedButton: 'Planlara bak',
+    },
 
     /**
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -89,6 +89,11 @@ async function main(): Promise<void> {
     startLegacyImportScheduler(db, app.log),
     startNotificationScheduler(db, { push, email: notificationEmail }, app.log, {
       ...(env.STORAGE_PUBLIC_BASE_URL ? { storagePublicBaseUrl: env.STORAGE_PUBLIC_BASE_URL } : {}),
+      // Better Auth mints the link and sends it through the same hook the
+      // first one used; `verifyReminder.ts` only decides who and when.
+      resendVerification: async (email) => {
+        await auth.api.sendVerificationEmail({ body: { email } })
+      },
     }),
   ]
 

--- a/apps/api/src/modules/billing/notify.ts
+++ b/apps/api/src/modules/billing/notify.ts
@@ -1,0 +1,67 @@
+import type { PlanTier } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { billingEmail } from '../../email/templates'
+import type { EmailSender } from '../../email/sender'
+import { translator } from '../../i18n'
+import { emailFor } from '../profiles/emailFor'
+import { localeFor } from '../profiles/localeFor'
+import { sendPush, tokensByLocale, type PushSender } from '../push/devices'
+
+/**
+ * What billing says out loud, and — like the security notices and the bounty
+ * receipt — **without asking a preference**.
+ *
+ * This is money. "Do not tell me my payment failed" is not a setting worth
+ * offering, and the first somebody would otherwise hear of a failed card is
+ * their plan ending. A renewal that *succeeds* says nothing: the store
+ * already mails a receipt, and a second one from us is the noise that gets a
+ * sender filtered.
+ *
+ * Nothing thrown here reaches the webhook handler. RevenueCat retries
+ * anything that is not a 2xx, so an error escaping would have the whole event
+ * redelivered — and the entitlement, which is the part that matters, has
+ * already been written by then.
+ */
+export interface BillingNotifier {
+  email: EmailSender
+  push: PushSender
+  logger: { error: (obj: object, msg: string) => void }
+}
+
+export type BillingEvent = 'paymentFailed' | 'planEnded'
+
+export async function notifyBilling(
+  db: Db,
+  senders: BillingNotifier,
+  userId: string,
+  event: BillingEvent,
+  tier: PlanTier,
+): Promise<void> {
+  try {
+    const address = await emailFor(db, userId)
+    if (address?.verified) {
+      const locale = await localeFor(db, userId)
+      await senders.email.send({
+        to: address.email,
+        ...billingEmail(locale, event, { tier }),
+      })
+    }
+  } catch (error) {
+    senders.logger.error({ err: error, event }, 'billing email failed')
+  }
+
+  try {
+    for (const [locale, tokens] of await tokensByLocale(db, userId)) {
+      if (tokens.length === 0) continue
+      const t = translator(locale)
+      await sendPush(db, senders.push, {
+        to: tokens,
+        title: t(event === 'paymentFailed' ? 'push.billingFailedTitle' : 'push.billingEndedTitle'),
+        body: t('push.billingBody'),
+        data: { kind: 'billing' },
+      })
+    }
+  } catch (error) {
+    senders.logger.error({ err: error, event }, 'billing push failed')
+  }
+}

--- a/apps/api/src/modules/billing/webhook.ts
+++ b/apps/api/src/modules/billing/webhook.ts
@@ -11,6 +11,7 @@ import { creditReferrerForSubscription } from '../referrals/settle'
 import type { Profile } from '../profiles/profiles'
 import { refreshEntitlement, refreshEntitlementIfHeld } from './refresh'
 import type { RevenueCatClient } from './revenueCatClient'
+import { notifyBilling, type BillingNotifier } from './notify'
 
 export interface SubscriptionRecord {
   eventId: string
@@ -50,6 +51,7 @@ export async function processRevenueCatWebhook(
   db: Db,
   event: RevenueCatEvent,
   client?: RevenueCatClient,
+  notify?: BillingNotifier,
 ): Promise<WebhookResult> {
   // TRANSFER events have no `app_user_id` at all — the recipient arrives in
   // `transferred_to`. Only the first id matters: RevenueCat lists the target
@@ -81,6 +83,13 @@ export async function processRevenueCatWebhook(
 
   const profiles = db.collection<Profile>(COLLECTIONS.profiles)
   const now = new Date()
+
+  // Read before anything is written: the mail says which plan this was about,
+  // and by the time an EXPIRATION has been applied the answer is "free".
+  const previousTier = notify
+    ? ((await profiles.findOne({ _id: userId }, { projection: { entitlement: 1 } }))?.entitlement
+        ?.tier ?? 'free')
+    : 'free'
 
   if (GRANT_SET.has(event.type)) {
     /*
@@ -149,23 +158,43 @@ export async function processRevenueCatWebhook(
     // `pro`, and no field on this event can tell us that. So ask RevenueCat
     // what they hold *now*; only if that is impossible (no secret key, or the
     // API is down) do we fall back to the event's own pessimistic reading.
-    if (client && (await reconciled(db, client, userId))) return { processed: true }
-
-    const entitlement: Profile['entitlement'] = {
-      tier: 'free',
-      willRenew: false,
-      store: record.store,
-      updatedAt: now,
+    if (!client || !(await reconciled(db, client, userId))) {
+      const entitlement: Profile['entitlement'] = {
+        tier: 'free',
+        willRenew: false,
+        store: record.store,
+        updatedAt: now,
+      }
+      await profiles.updateOne({ _id: userId }, { $set: { entitlement, updatedAt: now } })
     }
-    await profiles.updateOne({ _id: userId }, { $set: { entitlement, updatedAt: now } })
+    /*
+     * Said only when something was actually lost, which is why it is asked
+     * after the write rather than derived from the event. An EXPIRATION on a
+     * Pro+ subscription whose plain Pro runs on ends nothing from the
+     * subscriber's point of view, and `reconciled` is what knows that.
+     */
+    if (notify && previousTier !== 'free') {
+      const left = await profiles.findOne({ _id: userId }, { projection: { entitlement: 1 } })
+      if ((left?.entitlement?.tier ?? 'free') === 'free') {
+        await notifyBilling(db, notify, userId, 'planEnded', previousTier)
+      }
+    }
   } else if (CANCEL_SET.has(event.type)) {
     // Access continues until expiresAt — only the renewal intent changes.
     await profiles.updateOne(
       { _id: userId },
       { $set: { 'entitlement.willRenew': false, updatedAt: now } },
     )
+  } else if (event.type === 'BILLING_ISSUE' && notify) {
+    /*
+     * The one event that changes no entitlement and still has to be said out
+     * loud. The store will retry, and the subscription stays active while it
+     * does — but the card that failed is a thing only its owner can fix, and
+     * the first they would otherwise hear of it is the plan ending.
+     */
+    await notifyBilling(db, notify, userId, 'paymentFailed', previousTier)
   }
-  // BILLING_ISSUE and anything unrecognized: recorded above for audit, no entitlement change.
+  // Anything else unrecognized: recorded above for audit, no entitlement change.
 
   return { processed: true }
 }

--- a/apps/api/src/modules/notifications/ledger.ts
+++ b/apps/api/src/modules/notifications/ledger.ts
@@ -7,6 +7,7 @@ export type NotificationJob =
   | 'profileVisitsPush'
   | 'profileVisitsEmail'
   | 'badgeEarned'
+  | 'verifyReminder'
   /** A promotional pass. The prefix is what `recentlyMarketed` scans for. */
   | `promo.${string}`
 

--- a/apps/api/src/modules/notifications/scheduler.ts
+++ b/apps/api/src/modules/notifications/scheduler.ts
@@ -6,6 +6,7 @@ import { runBadgeRoundUpPass } from './badges'
 import { runCampaignQueuePass } from './campaignQueue'
 import { runProfileVisitsEmailPass, runProfileVisitsPushPass } from './profileVisits'
 import { runUnreadDigestPass } from './unreadDigest'
+import { runVerifyReminderPass } from './verifyReminder'
 
 /**
  * Every thirty minutes, like the streak reminder — and for the same reason.
@@ -29,7 +30,16 @@ export function startNotificationScheduler(
   db: Db,
   senders: { push: PushSender; email: NotificationEmailContext },
   logger: SchedulerLogger,
-  options: { intervalMs?: number; storagePublicBaseUrl?: string } = {},
+  options: {
+    intervalMs?: number
+    storagePublicBaseUrl?: string
+    /**
+     * Asks Better Auth to mail a fresh verification link. Left out — as the
+     * tests do — the reminder simply does not run; every other pass is
+     * unaffected.
+     */
+    resendVerification?: (email: string) => Promise<void>
+  } = {},
 ): { stop: () => void } {
   const intervalMs = options.intervalMs ?? NOTIFICATION_INTERVAL_MS
   let running = false
@@ -46,6 +56,17 @@ export function startNotificationScheduler(
         run('profile visit push', () => runProfileVisitsPushPass(db, senders.push, now)),
         run('profile visit email', () => runProfileVisitsEmailPass(db, senders.email, now)),
         run('badge round-up', () => runBadgeRoundUpPass(db, senders, now, logger)),
+        ...(options.resendVerification
+          ? [
+              run('verify reminder', () =>
+                runVerifyReminderPass(
+                  db,
+                  options.resendVerification as (email: string) => Promise<void>,
+                  now,
+                ),
+              ),
+            ]
+          : []),
         run('campaign queue', () =>
           runCampaignQueuePass(db, senders.email, now, {
             tickMinutes: intervalMs / 60_000,

--- a/apps/api/src/modules/notifications/verifyReminder.test.ts
+++ b/apps/api/src/modules/notifications/verifyReminder.test.ts
@@ -1,0 +1,95 @@
+import { ObjectId } from 'mongodb'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import { alreadyClaimed } from './ledger'
+import { runVerifyReminderPass } from './verifyReminder'
+
+const HOUR = 60 * 60 * 1000
+const NOW = new Date('2026-09-14T12:00:00Z')
+
+describe('the second attempt at the verification link', () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'verify_reminder_test')
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    for (const name of [COLLECTIONS.user, COLLECTIONS.notificationLedger]) {
+      await handle.db.collection(name).deleteMany({})
+    }
+  })
+
+  async function newUser(
+    opts: {
+      hoursOld?: number
+      verified?: boolean
+      anonymous?: boolean
+      fromV1?: boolean
+      email?: string | null
+    } = {},
+  ): Promise<string> {
+    const _id = new ObjectId()
+    await handle.db.collection(COLLECTIONS.user).insertOne({
+      _id,
+      ...(opts.email === null ? {} : { email: opts.email ?? `${_id.toHexString()}@example.com` }),
+      emailVerified: opts.verified ?? false,
+      ...(opts.anonymous ? { isAnonymous: true } : {}),
+      ...(opts.fromV1 ? { precreatedFromV1: { at: NOW, legacyUserId: 'v1' } } : {}),
+      createdAt: new Date(NOW.getTime() - (opts.hoursOld ?? 30) * HOUR),
+    })
+    return _id.toHexString()
+  }
+
+  it('writes once to an address nobody confirmed, and never again', async () => {
+    const userId = await newUser()
+    const resend = vi.fn().mockResolvedValue(undefined)
+
+    expect(await runVerifyReminderPass(handle.db, resend, NOW)).toEqual({ sent: 1 })
+    expect(resend).toHaveBeenCalledWith(`${userId}@example.com`)
+    // The claim is what says "already asked", and it is what `auth.ts` reads
+    // to word the second letter as a reminder.
+    expect(await alreadyClaimed(handle.db, 'verifyReminder', userId, 'once')).toBe(true)
+
+    expect(await runVerifyReminderPass(handle.db, resend, NOW)).toEqual({ sent: 0 })
+    expect(resend).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits a day, and gives up after a week', async () => {
+    await newUser({ hoursOld: 2 })
+    await newUser({ hoursOld: 24 * 9 })
+    const resend = vi.fn().mockResolvedValue(undefined)
+    expect(await runVerifyReminderPass(handle.db, resend, NOW)).toEqual({ sent: 0 })
+  })
+
+  it('leaves alone the accounts this was never about', async () => {
+    await newUser({ verified: true })
+    await newUser({ anonymous: true })
+    // The v1 rows are verified by the script, and their owners have their own
+    // letter waiting.
+    await newUser({ fromV1: true })
+    await newUser({ email: null })
+
+    const resend = vi.fn().mockResolvedValue(undefined)
+    expect(await runVerifyReminderPass(handle.db, resend, NOW)).toEqual({ sent: 0 })
+    expect(resend).not.toHaveBeenCalled()
+  })
+
+  /** A link that failed to send is not worth trying again tomorrow. */
+  it('keeps the claim when the send fails, and says so', async () => {
+    const userId = await newUser()
+    const resend = vi.fn().mockRejectedValue(new Error('resend down'))
+    expect(await runVerifyReminderPass(handle.db, resend, NOW)).toEqual({ sent: 0, failed: 1 })
+    expect(await alreadyClaimed(handle.db, 'verifyReminder', userId, 'once')).toBe(true)
+    expect(await runVerifyReminderPass(handle.db, resend, NOW)).toEqual({ sent: 0 })
+  })
+})

--- a/apps/api/src/modules/notifications/verifyReminder.ts
+++ b/apps/api/src/modules/notifications/verifyReminder.ts
@@ -1,0 +1,97 @@
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { claimOnce } from './ledger'
+
+const HOUR_MS = 60 * 60 * 1000
+
+/**
+ * How long to wait before asking again. A day: long enough that somebody who
+ * simply put their phone down has had the evening to come back, short enough
+ * that the account is still a thing they remember starting.
+ */
+export const VERIFY_REMINDER_AFTER_HOURS = 24
+
+/**
+ * And the far end. A week-old unverified account is not somebody who missed
+ * the mail; it is somebody who changed their mind, or an address that was
+ * never theirs. Either way a second letter is the last one.
+ */
+export const VERIFY_REMINDER_MAX_AGE_HOURS = 24 * 7
+
+interface UserRow {
+  _id: unknown
+  email?: string
+  emailVerified?: boolean
+  isAnonymous?: boolean
+  createdAt?: Date
+  precreatedFromV1?: unknown
+}
+
+/**
+ * One more attempt at the mail that gets lost most often.
+ *
+ * The verification link is the first thing this domain ever writes to a new
+ * address, which is precisely when a spam folder is most willing to take it —
+ * and an account that never verifies can do nothing at all: onboarding is
+ * behind `requireVerifiedEmail`.
+ *
+ * **Exactly once per account**, claimed in the ledger before the send. Not
+ * once per day: an unverified account that hears from us daily is a
+ * complaint, and the complaint lands on the domain every *other* mail leaves
+ * from.
+ *
+ * Sends nothing to a guest (their address resolves nowhere), nothing to a
+ * pre-created v1 row (those are verified by the script and their owner has a
+ * different letter waiting), and nothing to an account older than
+ * `VERIFY_REMINDER_MAX_AGE_HOURS`, so switching this on does not write to
+ * every abandoned sign-up this app has ever had.
+ */
+export async function runVerifyReminderPass(
+  db: Db,
+  resend: (email: string) => Promise<void>,
+  now: Date = new Date(),
+): Promise<{ sent: number; failed?: number }> {
+  const users = await db
+    .collection<UserRow>(COLLECTIONS.user)
+    .find(
+      {
+        emailVerified: { $ne: true },
+        isAnonymous: { $ne: true },
+        precreatedFromV1: { $exists: false },
+        createdAt: {
+          $lte: new Date(now.getTime() - VERIFY_REMINDER_AFTER_HOURS * HOUR_MS),
+          $gte: new Date(now.getTime() - VERIFY_REMINDER_MAX_AGE_HOURS * HOUR_MS),
+        },
+      },
+      { projection: { email: 1 } },
+    )
+    .toArray()
+
+  let sent = 0
+  let failed = 0
+  for (const user of users) {
+    if (!user.email) continue
+    /*
+     * Claimed *before* the send, and read again by `sendVerificationEmail` in
+     * `auth.ts` — which is how the second letter knows to word itself as a
+     * reminder rather than repeating the first one verbatim. The claim is
+     * also what makes this exactly once: an unverified account that hears
+     * from us daily is a complaint, and the complaint lands on the domain
+     * every other mail leaves from.
+     */
+    if (!(await claimOnce(db, 'verifyReminder', String(user._id), 'once'))) continue
+    try {
+      // Better Auth mints and sends the link; this pass only decides who and
+      // when. A second link is not a second account — the first still works
+      // until it expires.
+      await resend(user.email)
+      sent++
+    } catch {
+      // The claim stays. A link that failed to send is not worth trying again
+      // tomorrow, and the app can always ask for one.
+      failed++
+    }
+  }
+
+  return failed > 0 ? { sent, failed } : { sent }
+}

--- a/apps/api/src/modules/profiles/welcome.ts
+++ b/apps/api/src/modules/profiles/welcome.ts
@@ -1,0 +1,30 @@
+import type { FastifyInstance } from 'fastify'
+import { welcomeEmail } from '../../email/templates'
+import { emailFor } from './emailFor'
+import { localeFor } from './localeFor'
+
+/**
+ * "Welcome to LangX", sent the moment onboarding finishes.
+ *
+ * Transactional, like the verification mail it follows: it answers something
+ * somebody just did, it goes once in an account's life, and it carries no
+ * unsubscribe because there is no preference behind it. `createProfile`
+ * refuses a second profile, so "once" is enforced by the thing that already
+ * enforced it rather than by a ledger row.
+ *
+ * Deliberately not awaited by its caller — see the call site. An address that
+ * is somehow unverified gets nothing: onboarding is behind
+ * `requireVerifiedEmail`, so that case is a contradiction rather than a
+ * scenario, and the check costs one comparison.
+ */
+export async function sendWelcome(
+  app: FastifyInstance,
+  userId: string,
+  name: string,
+  handle: string,
+): Promise<void> {
+  const address = await emailFor(app.mongo.db, userId)
+  if (!address?.verified) return
+  const locale = await localeFor(app.mongo.db, userId)
+  await app.email.send({ to: address.email, ...welcomeEmail(locale, { name, handle }) })
+}

--- a/apps/api/src/routes/billing.test.ts
+++ b/apps/api/src/routes/billing.test.ts
@@ -106,6 +106,9 @@ describe('Faz 7 — billing', () => {
       storage,
       translation,
       revenueCat: fakeRevenueCat,
+      // The webhook writes to people now: a failed payment and an ended plan
+      // both send mail, and the console sender would swallow them.
+      email: emailSender,
     })
     await app.ready()
 
@@ -145,6 +148,91 @@ describe('Faz 7 — billing', () => {
         payload: { event: { id: 'e2', type: 'INITIAL_PURCHASE', app_user_id: 'someone' } },
       })
       expect(response.statusCode).toBe(401)
+    })
+
+    /**
+     * The two events billing says out loud. Neither asks a preference: this
+     * is money, and the alternative to hearing about a failed card is finding
+     * out when the plan stops.
+     */
+    it('writes to somebody whose payment failed, without changing anything', async () => {
+      const user = await newUser('billing-issue@example.com')
+      await app.inject({
+        method: 'POST',
+        url: '/webhooks/revenuecat',
+        headers: { authorization: WEBHOOK_SECRET },
+        payload: {
+          event: {
+            id: 'evt-grant-issue',
+            type: 'INITIAL_PURCHASE',
+            app_user_id: user.userId,
+            store: 'app_store',
+            expiration_at_ms: Date.now() + 1_000_000,
+          },
+        },
+      })
+      emailSender.messages.length = 0
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/webhooks/revenuecat',
+        headers: { authorization: WEBHOOK_SECRET },
+        payload: {
+          event: { id: 'evt-issue-1', type: 'BILLING_ISSUE', app_user_id: user.userId },
+        },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+
+      // Turkish, because that is the native language the fixture onboards
+      // with — `localeFor` reads it, not the request's headers.
+      const mail = emailSender.messages.at(-1)
+      expect(mail?.subject).toContain('ödemen alınamadı')
+      expect(mail?.html).toContain('/settings/plan')
+      // Access is untouched — the store will retry.
+      const profile = await app.inject({
+        method: 'GET',
+        url: '/profiles/me',
+        headers: { cookie: user.cookie },
+      })
+      expect(profile.json()).toMatchObject({ entitlement: { tier: 'pro' } })
+    })
+
+    it('writes when the plan actually ends, naming the plan that ended', async () => {
+      const user = await newUser('billing-expired@example.com')
+      await app.inject({
+        method: 'POST',
+        url: '/webhooks/revenuecat',
+        headers: { authorization: WEBHOOK_SECRET },
+        payload: {
+          event: {
+            id: 'evt-grant-exp',
+            type: 'INITIAL_PURCHASE',
+            app_user_id: user.userId,
+            store: 'app_store',
+            expiration_at_ms: Date.now() + 1_000_000,
+          },
+        },
+      })
+      emailSender.messages.length = 0
+
+      await app.inject({
+        method: 'POST',
+        url: '/webhooks/revenuecat',
+        headers: { authorization: WEBHOOK_SECRET },
+        payload: {
+          event: {
+            id: 'evt-exp-1',
+            type: 'EXPIRATION',
+            app_user_id: user.userId,
+            store: 'app_store',
+          },
+        },
+      })
+
+      const mail = emailSender.messages.at(-1)
+      expect(mail?.subject).toContain('sona erdi')
+      // Read before the write, so it names what was lost rather than "free".
+      expect(mail?.html).toContain('pro')
     })
 
     it('grants Pro to the matching profile with the correct secret', async () => {

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -47,6 +47,7 @@ export const billingRoutes: FastifyPluginAsyncZod = async (app) => {
         app.mongo.db,
         request.body.event,
         app.revenueCat,
+        { email: app.email, push: app.push, logger: request.log },
       )
       return reply.send(result)
     },

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -9,7 +9,7 @@ import QRCode from 'qrcode'
 import { ObjectId } from 'mongodb'
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
 import type { FastifyInstance } from 'fastify'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { buildApp } from '../app'
 import { createAuth } from '../auth'
 import { connectToDatabase, type DbHandle } from '../db/client'
@@ -81,6 +81,9 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
       storage,
       translation,
       revenueCat,
+      // Onboarding sends a welcome mail now, and the console sender would
+      // swallow it.
+      email: emailSender,
     })
     await app.ready()
 
@@ -157,6 +160,30 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
       promotions: { push: false, email: true },
     })
     expect(profile?.promotionsConsent?.source).toBe('v1')
+  })
+
+  /** One mail, once in an account's life, the moment onboarding finishes. */
+  it('welcomes somebody the moment their profile exists', async () => {
+    const user = await newUser('welcome-mail@example.com')
+    emailSender.messages.length = 0
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/profiles',
+      headers: { cookie: user.cookie },
+      payload: onboardingBody({ handle: 'welcomed', displayName: 'Sofia R.' }),
+    })
+    expect(response.statusCode, response.body).toBe(201)
+
+    // Not awaited by the route, so give the send a tick to happen.
+    await vi.waitFor(() => {
+      expect(emailSender.messages.length).toBeGreaterThan(0)
+    })
+    const mail = emailSender.messages.at(-1)
+    expect(mail?.html).toContain('Sofia R.')
+    expect(mail?.html).toContain('welcomed')
+    // Transactional: it answers something they just did, so no unsubscribe.
+    expect(mail?.headers).toBeUndefined()
   })
 
   it('leaves promotional email off for somebody who signed up here', async () => {

--- a/apps/api/src/routes/profiles.ts
+++ b/apps/api/src/routes/profiles.ts
@@ -30,6 +30,7 @@ import {
   updateProfile,
 } from '../modules/profiles/profiles'
 import { deleteGuest } from '../modules/profiles/purgeGuests'
+import { sendWelcome } from '../modules/profiles/welcome'
 import { isEmailVerified } from '../modules/profiles/emailVerified'
 import { getSharedProfile } from '../modules/profiles/sharedProfile'
 import { readFollowState } from '../modules/social/follows'
@@ -54,6 +55,18 @@ export const profileRoutes: FastifyPluginAsyncZod = async (app) => {
         // Where the connection says they are. Beats whatever the form sent,
         // and is the reason the form no longer asks.
         countryFromHeaders(request.headers, app.env.EDGE_SECRET),
+      )
+      /*
+       * One mail, once in an account's life, and never awaited into the
+       * response: onboarding has already succeeded by the time this runs, and
+       * a mail provider having a bad minute must not turn a created profile
+       * into a 500. `createProfile` throws on a second attempt, so this
+       * cannot fire twice.
+       */
+      void sendWelcome(app, request.userId, profile.displayName, profile.handle).catch(
+        (error: unknown) => {
+          request.log.error({ err: error }, 'welcome email failed')
+        },
       )
       return reply.code(201).send(profile)
     },

--- a/apps/mobile/src/lib/notificationRoute.ts
+++ b/apps/mobile/src/lib/notificationRoute.ts
@@ -49,6 +49,9 @@ export function notificationRoute(data: unknown): Href | null {
       // The count is what the notification said; the names are behind the
       // paywall this screen draws. Landing here is the whole point of it.
       return '/viewers'
+    case 'billing':
+      // A failed payment and an ended plan are both fixed in one place.
+      return '/settings/plan'
     case 'security':
       // "Somebody signed in as you" has one useful next step, and it is the
       // screen that changes the password — which signs every other device out.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -67,6 +67,7 @@ during the window catches up on its next tick instead of skipping silently.
 | Account purge    | 1 hour   | Hard-deletes accounts past their 30-day grace period.                                                                                |
 | Streak reminder  | 30 min   | Sends the nudge at 20:00 in each user's own timezone, once per local day — as a push, or as email to somebody with no phone.         |
 | Notifications    | 30 min   | Three passes: the unread-message digest, the profile-visit round-up (daily push, weekly email) and the badge round-up at 18:00.      |
+| Verify reminder  | 30 min   | One more verification link, a day after an unverified sign-up. Exactly once per account, and never after a week.                     |
 | Campaign queue   | 30 min   | Drips a queued broadcast out on a warm-up ramp (`CAMPAIGN_WARMUP_PER_DAY`), 08–20 UTC only. `send-campaign.ts` enqueues, this sends. |
 
 Running several API instances is safe. The pool's `jobRuns` unique index means

--- a/packages/shared/src/push.ts
+++ b/packages/shared/src/push.ts
@@ -53,6 +53,12 @@ export const PUSH_KINDS = [
    * one kind with no row on the settings screen.
    */
   'security',
+  /**
+   * A payment that failed or a plan that ended. No preference gates it for
+   * the same reason `security` has none: this is money, and the alternative
+   * to hearing it is finding out when the plan stops.
+   */
+  'billing',
 ] as const
 export type PushKind = (typeof PUSH_KINDS)[number]
 


### PR DESCRIPTION
PR C of the email + push programme. **Stacked on #1264** — review that first; this PR's base retargets to `main` once #1264 merges.

## What changes

| Mail | Trigger | Kind |
| --- | --- | --- |
| **Welcome to LangX** | onboarding completes | transactional, once per account |
| **Confirm your email** (again) | unverified 24h after sign-up, never after a week | transactional, exactly once |
| **Payment did not go through** | RevenueCat `BILLING_ISSUE` — which until now was recorded and nothing else | transactional + push, no preference |
| **Your plan has ended** | the tier actually dropped to free after `EXPIRATION` | transactional + push, no preference |

## Details worth reading

- **The welcome mail is not awaited into the response.** Onboarding has already succeeded by then, and a mail provider having a bad minute must not turn a created profile into a 500. `createProfile` refuses a second profile, so "once" is enforced by the thing that already enforced it.
- **The reminder is worded as one.** `runVerifyReminderPass` claims `verifyReminder:<userId>:once` *before* asking Better Auth to send, and `sendVerificationEmail` reads that row to pick `verifyReminderEmail` over `verificationEmail` — the same trick the magic link already uses with `metadata.reason`. A reminder that repeated the first mail verbatim is the one a client stacks under "similar messages".
- **"Your plan has ended" only when something was lost.** An `EXPIRATION` on a Pro+ subscription whose plain Pro runs on ends nothing from the subscriber's point of view, and only `reconciled()` knows that — so the tier is read back after the write and compared with what it was before, rather than derived from the event.
- New push kind `billing`, routed to `/settings/plan`.
- Eight locales for all of it.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — green (api 92 files, mobile 93, shared 26).
- `verifyReminder.test.ts`: writes once and never again, waits a day, gives up after a week, ignores verified/guest/v1/no-address accounts, keeps the claim when the send fails.
- `billing.test.ts`: a failed payment writes without changing access; an expiry writes naming the plan that ended.
- `profiles.test.ts`: onboarding produces the welcome mail, with no unsubscribe header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)