### PR TITLE
Remarketing: six nudges, one pass, one at a time

### DIFF
--- a/apps/api/scripts/backfill-known-devices.ts
+++ b/apps/api/scripts/backfill-known-devices.ts
@@ -1,0 +1,98 @@
+/**
+ * Records the devices people are **already** signed in on, so switching the
+ * security notices on does not tell a hundred people their own phone is new.
+ *
+ * `knownDevices` starts empty. Without this, the first sign-in after the
+ * deploy is, by the only definition the code has, a sign-in from a device
+ * that has never been seen — and everybody who signs in that week gets a
+ * "new sign-in to your account" letter about the laptop they are reading it
+ * on. Which is the exact mail people learn to ignore, on the exact feature
+ * that has to be believed.
+ *
+ * `session` is the source: Better Auth stores the user agent on every row,
+ * and a live session *is* a device somebody is using. The rows expire in a
+ * week, so this covers the people who have signed in recently — which is the
+ * same set that would otherwise have been mailed. Anybody older gets one
+ * notice on their next sign-in, correctly.
+ *
+ * Idempotent: `claimNewDevice` upserts on `<userId>:<fingerprint>`, so
+ * running it twice writes nothing the second time. Run it **before**
+ * `fly deploy`, or in the same minute — the window between the deploy and
+ * this is the window the burst happens in.
+ *
+ * Usage:
+ *   pnpm --filter @langx/api exec tsx --env-file=../../.env --env-file=../../.env.prod \
+ *     scripts/backfill-known-devices.ts [--confirm]
+ */
+import { connectToDatabase } from '../src/db/client'
+import { COLLECTIONS } from '../src/db/collections'
+import { loadEnv } from '../src/env'
+import { deviceIdentity } from '../src/modules/security/deviceLabel'
+import { claimNewDevice } from '../src/modules/security/knownDevices'
+
+interface SessionRow {
+  userId: unknown
+  userAgent?: string
+  createdAt?: Date
+}
+
+async function main(): Promise<void> {
+  const confirm = process.argv.includes('--confirm')
+  const env = loadEnv()
+  const { db, close } = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
+
+  try {
+    const sessions = await db
+      .collection<SessionRow>(COLLECTIONS.session)
+      .find({}, { projection: { userId: 1, userAgent: 1, createdAt: 1 } })
+      .toArray()
+
+    // One row per person per device family, oldest first, so `firstSeenAt`
+    // ends up as close to the truth as the sessions can say.
+    const pairs = new Map<string, { userId: string; fingerprint: string; at: Date }>()
+    let noAgent = 0
+    for (const session of sessions) {
+      if (!session.userAgent) {
+        noAgent++
+        continue
+      }
+      const userId = String(session.userId)
+      const { fingerprint } = deviceIdentity(session.userAgent)
+      const key = `${userId}:${fingerprint}`
+      const at = session.createdAt ?? new Date()
+      const existing = pairs.get(key)
+      if (!existing || at < existing.at) pairs.set(key, { userId, fingerprint, at })
+    }
+
+    const byFingerprint = new Map<string, number>()
+    for (const { fingerprint } of pairs.values()) {
+      byFingerprint.set(fingerprint, (byFingerprint.get(fingerprint) ?? 0) + 1)
+    }
+
+    console.log(`known devices from ${sessions.length} sessions on ${env.MONGODB_DB}`)
+    console.log(`  device rows to write: ${pairs.size}`)
+    console.log(`  people covered: ${new Set([...pairs.values()].map((p) => p.userId)).size}`)
+    console.log(`  sessions with no user agent: ${noAgent}`)
+    for (const [fingerprint, count] of [...byFingerprint].sort((a, b) => b[1] - a[1])) {
+      console.log(`    ${fingerprint}: ${count}`)
+    }
+
+    if (!confirm) {
+      console.log('\n(dry run — re-run with --confirm to write)')
+      return
+    }
+
+    let written = 0
+    for (const { userId, fingerprint, at } of pairs.values()) {
+      if (await claimNewDevice(db, userId, fingerprint, { at })) written++
+    }
+    console.log(`\nwrote ${written} (the rest were already recorded)`)
+  } finally {
+    await close()
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -442,6 +442,61 @@ export function billingEmail(
   }
 }
 
+/** The six nudges `modules/notifications/promotions.ts` offers, in its order. */
+export type PromotionScenario =
+  'addPhoto' | 'streakBroke' | 'away' | 'awayLong' | 'tokensWaiting' | 'inviteFriend'
+
+/**
+ * One nudge, worded from the catalogue rather than assembled here.
+ *
+ * `notificationEmail`, so it carries the footer that says why it arrived and
+ * how to stop — which for this class of mail is not a nicety but the thing
+ * that keeps a mailbox provider delivering the verification links.
+ *
+ * The scenario decides the strings *and* the destination; a nudge whose
+ * button goes somewhere unrelated to its sentence is the kind that gets
+ * marked as spam by somebody who meant to act on it.
+ */
+export function promotionEmail(
+  locale: Locale,
+  scenario: PromotionScenario,
+  input: { count?: number; unsubscribe: string },
+): Email {
+  const t = translator(locale)
+  const params = input.count === undefined ? {} : { count: input.count }
+  const subject = t(`email.promo.${scenario}Subject` as never, params)
+  const body = t(`email.promo.${scenario}Body` as never, params)
+  const cta = {
+    url: PROMOTION_DESTINATIONS[scenario],
+    label: t(`email.promo.${scenario}Button` as never),
+  }
+  return {
+    subject,
+    html: notificationEmail(locale, {
+      preheader: body,
+      bodyHtml: `<p><strong style="font-family:${TITLE_FONT}; font-size:20px; line-height:26px;">${subject}</strong></p><p>${body}</p>`,
+      cta,
+      unsubscribeUrl: input.unsubscribe,
+      manageUrl: webUrl('/settings'),
+    }).html,
+    text: notificationText(locale, [subject, '', body, '', cta.url], input.unsubscribe),
+  }
+}
+
+/**
+ * Where each nudge lands. Beside the copy rather than beside the trigger,
+ * because the sentence and the button have to agree and they are written
+ * together.
+ */
+const PROMOTION_DESTINATIONS: Record<PromotionScenario, string> = {
+  addPhoto: webUrl('/me/edit'),
+  streakBroke: webUrl('/wallet'),
+  away: webUrl('/discover'),
+  awayLong: webUrl('/discover'),
+  tokensWaiting: webUrl('/wallet'),
+  inviteFriend: webUrl('/settings/share'),
+}
+
 /** The four things this app tells somebody about their own account. */
 export type SecurityEvent = 'newSignIn' | 'passwordChanged' | 'methodLinked' | 'methodUnlinked'
 

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -29,6 +29,25 @@ export const ar: Localized<ServerMessages> = {
       other: '{count} رمز مقابل بلاغك 🎉',
     },
     bountyBody: 'قرأنا ما أرسلته، وقد كان يستحق.',
+    /** The same nudges on the phone, under the same switches. */
+    promo: {
+      addPhotoTitle: 'أضف صورة',
+      addPhotoBody: 'الملفات التي تحمل وجهاً تتلقى ردوداً أكثر.',
+      streakBrokeTitle: {
+        one: 'انقطعت سلسلتك البالغة {count} يوم',
+        other: 'انقطعت سلسلتك البالغة {count} يوماً',
+      },
+      streakBrokeBody: 'الإصلاح يعيد يوم أمس.',
+      awayTitle: 'الناس ما زالوا هنا',
+      awayBody: 'أشخاص جدد للتدرب معهم.',
+      awayLongTitle: 'نحن هنا متى أردت',
+      awayLongBody: 'سلسلتك ورموزك في الانتظار.',
+      tokensWaitingTitle: { one: '{count} رمز في الانتظار', other: '{count} رمزاً في الانتظار' },
+      tokensWaitingBody: 'افتح محفظتك.',
+      inviteFriendTitle: 'ادعُ صديقاً',
+      inviteFriendBody: 'ستحصلان كلاكما على رموز.',
+    },
+
     /** Security, which no preference can switch off. */
     /** Billing, which no preference gates either. */
     billingFailedTitle: 'لم تتم عملية الدفع',
@@ -140,6 +159,62 @@ export const ar: Localized<ServerMessages> = {
     unsubscribedTitle: 'تم — لن تصلك بعد الآن.',
     unsubscribedBody: 'يمكنك تشغيلها متى شئت من LangX في الإعدادات ← الإشعارات.',
     unsubscribeInvalid: 'هذا الرابط غير صالح. افتح LangX وغيّره من الإعدادات ← الإشعارات.',
+
+    /**
+
+     * The nudges in `modules/notifications/promotions.ts`, in its order.
+
+     * Every one of them is behind a switch and carries a way out.
+
+     */
+
+    promo: {
+      addPhotoSubject: 'أضف صورة ليعثر عليك الآخرون',
+
+      addPhotoBody:
+        'الملفات التي تحمل وجهاً تتلقى ردوداً أكثر بكثير. يستغرق الأمر عشر ثوانٍ ويمكنك تغييرها متى شئت.',
+
+      addPhotoButton: 'أضف صورتي',
+
+      streakBrokeSubject: {
+        one: 'انقطعت سلسلتك البالغة {count} يوم',
+        other: 'انقطعت سلسلتك البالغة {count} يوماً',
+      },
+
+      streakBrokeBody: 'فاتك يوم أمس. إصلاح من المتجر يعيد اليوم وتستمر السلسلة.',
+
+      streakBrokeButton: 'أصلح يوم أمس',
+
+      awaySubject: 'الناس ما زالوا يتدربون من دونك',
+
+      awayBody: 'مضى أسبوع. هناك أشخاص جدد للحديث معهم، ولغاتك لم تتغير.',
+
+      awayButton: 'انظر من هنا',
+
+      awayLongSubject: 'لن نراسلك بعد هذه',
+
+      awayLongBody:
+        'الشهر مدة طويلة. حسابك وسلسلتك ورموزك ما زالت هنا إن أردتها — وهذه آخر رسالة عن الأمر.',
+
+      awayLongButton: 'افتح LangX',
+
+      tokensWaitingSubject: {
+        one: 'لديك {count} رمز في الانتظار',
+        other: 'لديك {count} رمزاً في الانتظار',
+      },
+
+      tokensWaitingBody:
+        'الرموز تشتري تجميد السلسلة وإصلاح الأيام والإطارات والألقاب. رموزك لم تُستخدم منذ أسبوعين.',
+
+      tokensWaitingButton: 'افتح محفظتي',
+
+      inviteFriendSubject: 'التدرب مع شخص تعرفه أفضل',
+
+      inviteFriendBody:
+        'ادعُ صديقاً وستحصلان كلاكما على رموز عند انضمامه. رابط الدعوة في الإعدادات.',
+
+      inviteFriendButton: 'احصل على رابط الدعوة',
+    },
 
     /** Onboarding finished: one mail, once in an account's life. */
 

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -23,6 +23,25 @@ export const de: Localized<ServerMessages> = {
       other: '{count} Token für deinen Hinweis 🎉',
     },
     bountyBody: 'Wir haben gelesen, was du geschickt hast – es hat sich gelohnt.',
+    /** The same nudges on the phone, under the same switches. */
+    promo: {
+      addPhotoTitle: 'Füge ein Foto hinzu',
+      addPhotoBody: 'Profile mit Gesicht bekommen mehr Antworten.',
+      streakBrokeTitle: {
+        one: 'Deine {count}-Tage-Serie ist gerissen',
+        other: 'Deine {count}-Tage-Serie ist gerissen',
+      },
+      streakBrokeBody: 'Eine Reparatur holt gestern zurück.',
+      awayTitle: 'Die Leute sind noch da',
+      awayBody: 'Neue Leute zum Üben.',
+      awayLongTitle: 'Wir sind da, wenn du willst',
+      awayLongBody: 'Deine Serie und deine Token warten.',
+      tokensWaitingTitle: { one: '{count} Token wartet', other: '{count} Token warten' },
+      tokensWaitingBody: 'Öffne dein Wallet.',
+      inviteFriendTitle: 'Lade jemanden ein',
+      inviteFriendBody: 'Ihr bekommt beide Token.',
+    },
+
     /** Security, which no preference can switch off. */
     /** Billing, which no preference gates either. */
     billingFailedTitle: 'Deine Zahlung ist fehlgeschlagen',
@@ -142,6 +161,64 @@ export const de: Localized<ServerMessages> = {
       'Du kannst sie jederzeit in LangX unter Einstellungen → Mitteilungen wieder einschalten.',
     unsubscribeInvalid:
       'Dieser Link ist ungültig. Öffne LangX und ändere es unter Einstellungen → Mitteilungen.',
+
+    /**
+
+     * The nudges in `modules/notifications/promotions.ts`, in its order.
+
+     * Every one of them is behind a switch and carries a way out.
+
+     */
+
+    promo: {
+      addPhotoSubject: 'Füge ein Foto hinzu, damit man dich findet',
+
+      addPhotoBody:
+        'Profile mit Gesicht bekommen deutlich mehr Antworten. Es dauert zehn Sekunden und du kannst es jederzeit ändern.',
+
+      addPhotoButton: 'Foto hinzufügen',
+
+      streakBrokeSubject: {
+        one: 'Deine {count}-Tage-Serie ist gerissen',
+        other: 'Deine {count}-Tage-Serie ist gerissen',
+      },
+
+      streakBrokeBody:
+        'Gestern hat gefehlt. Eine Reparatur aus dem Store setzt den Tag zurück und die Serie läuft weiter.',
+
+      streakBrokeButton: 'Gestern reparieren',
+
+      awaySubject: 'Es wird weiter geübt, auch ohne dich',
+
+      awayBody:
+        'Eine Woche ist vergangen. Es gibt neue Leute zum Reden, und deine Sprachen sind dieselben.',
+
+      awayButton: 'Schauen, wer da ist',
+
+      awayLongSubject: 'Danach schreiben wir nicht mehr',
+
+      awayLongBody:
+        'Ein Monat ist lang. Dein Konto, deine Serie und deine Token sind noch da, falls du sie willst — und das ist das Letzte, was wir dazu sagen.',
+
+      awayLongButton: 'LangX öffnen',
+
+      tokensWaitingSubject: {
+        one: '{count} Token wartet auf dich',
+        other: '{count} Token warten auf dich',
+      },
+
+      tokensWaitingBody:
+        'Token kaufen Streak-Freezes, Tagesreparaturen, Rahmen und Titel. Deine liegen seit zwei Wochen da.',
+
+      tokensWaitingButton: 'Wallet öffnen',
+
+      inviteFriendSubject: 'Zu zweit übt es sich besser',
+
+      inviteFriendBody:
+        'Lade jemanden ein — ihr bekommt beide Token, wenn er dazukommt. Dein Einladungslink steht in den Einstellungen.',
+
+      inviteFriendButton: 'Einladungslink holen',
+    },
 
     /** Onboarding finished: one mail, once in an account's life. */
 

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -27,6 +27,25 @@ export const en = {
       other: '{count} tokens for your report 🎉',
     },
     bountyBody: 'We read what you sent, and it was worth it.',
+    /** The same nudges on the phone, under the same switches. */
+    promo: {
+      addPhotoTitle: 'Add a photo',
+      addPhotoBody: 'Profiles with a face get far more replies.',
+      streakBrokeTitle: {
+        one: 'Your {count}-day streak broke',
+        other: 'Your {count}-day streak broke',
+      },
+      streakBrokeBody: 'A repair puts yesterday back.',
+      awayTitle: 'People are still here',
+      awayBody: 'New people to practise with.',
+      awayLongTitle: 'Still here when you are',
+      awayLongBody: 'Your streak and tokens are waiting.',
+      tokensWaitingTitle: { one: '{count} token waiting', other: '{count} tokens waiting' },
+      tokensWaitingBody: 'Open your wallet.',
+      inviteFriendTitle: 'Invite a friend',
+      inviteFriendBody: 'You both get tokens when they join.',
+    },
+
     /** Security, which no preference can switch off. */
     /** Billing, which no preference gates either. */
     billingFailedTitle: 'Your payment did not go through',
@@ -147,6 +166,64 @@ export const en = {
     unsubscribedBody: 'You can turn them back on any time in LangX under Settings → Notifications.',
     unsubscribeInvalid:
       'This link is not valid. Open LangX and change it under Settings → Notifications.',
+
+    /**
+
+     * The nudges in `modules/notifications/promotions.ts`, in its order.
+
+     * Every one of them is behind a switch and carries a way out.
+
+     */
+
+    promo: {
+      addPhotoSubject: 'Add a photo, and people will find you',
+
+      addPhotoBody:
+        'Profiles with a face get far more replies. It takes ten seconds and you can change it whenever you like.',
+
+      addPhotoButton: 'Add my photo',
+
+      streakBrokeSubject: {
+        one: 'Your {count}-day streak broke',
+        other: 'Your {count}-day streak broke',
+      },
+
+      streakBrokeBody:
+        'You missed yesterday. A repair from the store puts the day back and the streak carries on.',
+
+      streakBrokeButton: 'Repair yesterday',
+
+      awaySubject: 'People are still practising without you',
+
+      awayBody:
+        'It has been a week. There are new people to talk to, and your languages have not changed.',
+
+      awayButton: 'See who is here',
+
+      awayLongSubject: 'We will stop writing after this',
+
+      awayLongBody:
+        'A month is a long time. Your account, your streak and your tokens are all still here if you want them — and this is the last we will say about it.',
+
+      awayLongButton: 'Open LangX',
+
+      tokensWaitingSubject: {
+        one: 'You have {count} token waiting',
+        other: 'You have {count} tokens waiting',
+      },
+
+      tokensWaitingBody:
+        'Tokens buy streak freezes, day repairs, frames and titles. Yours have been sitting there a fortnight.',
+
+      tokensWaitingButton: 'Open my wallet',
+
+      inviteFriendSubject: 'Practising is better with someone you know',
+
+      inviteFriendBody:
+        'Invite a friend and you both get tokens when they join. Your invite link is in Settings.',
+
+      inviteFriendButton: 'Get my invite link',
+    },
 
     /** Onboarding finished: one mail, once in an account's life. */
 

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -23,6 +23,25 @@ export const es: Localized<ServerMessages> = {
       other: '{count} fichas por tu aviso 🎉',
     },
     bountyBody: 'Leímos lo que nos enviaste y valió la pena.',
+    /** The same nudges on the phone, under the same switches. */
+    promo: {
+      addPhotoTitle: 'Añade una foto',
+      addPhotoBody: 'Los perfiles con cara reciben más respuestas.',
+      streakBrokeTitle: {
+        one: 'Tu racha de {count} día se ha roto',
+        other: 'Tu racha de {count} días se ha roto',
+      },
+      streakBrokeBody: 'Una reparación devuelve el día.',
+      awayTitle: 'La gente sigue aquí',
+      awayBody: 'Gente nueva con quien practicar.',
+      awayLongTitle: 'Aquí cuando quieras',
+      awayLongBody: 'Tu racha y tus tokens te esperan.',
+      tokensWaitingTitle: { one: '{count} token esperando', other: '{count} tokens esperando' },
+      tokensWaitingBody: 'Abre tu cartera.',
+      inviteFriendTitle: 'Invita a alguien',
+      inviteFriendBody: 'Los dos ganáis tokens.',
+    },
+
     /** Security, which no preference can switch off. */
     /** Billing, which no preference gates either. */
     billingFailedTitle: 'Tu pago no se pudo procesar',
@@ -141,6 +160,64 @@ export const es: Localized<ServerMessages> = {
       'Puedes volver a activarlos cuando quieras en LangX, en Ajustes → Notificaciones.',
     unsubscribeInvalid:
       'Este enlace no es válido. Abre LangX y cámbialo en Ajustes → Notificaciones.',
+
+    /**
+
+     * The nudges in `modules/notifications/promotions.ts`, in its order.
+
+     * Every one of them is behind a switch and carries a way out.
+
+     */
+
+    promo: {
+      addPhotoSubject: 'Añade una foto y te encontrarán',
+
+      addPhotoBody:
+        'Los perfiles con cara reciben muchas más respuestas. Tarda diez segundos y puedes cambiarla cuando quieras.',
+
+      addPhotoButton: 'Añadir mi foto',
+
+      streakBrokeSubject: {
+        one: 'Tu racha de {count} día se ha roto',
+        other: 'Tu racha de {count} días se ha roto',
+      },
+
+      streakBrokeBody:
+        'Te faltó ayer. Una reparación de la tienda devuelve el día y la racha continúa.',
+
+      streakBrokeButton: 'Reparar ayer',
+
+      awaySubject: 'La gente sigue practicando sin ti',
+
+      awayBody:
+        'Ha pasado una semana. Hay gente nueva con quien hablar, y tus idiomas no han cambiado.',
+
+      awayButton: 'Ver quién está',
+
+      awayLongSubject: 'Después de esto dejaremos de escribir',
+
+      awayLongBody:
+        'Un mes es mucho tiempo. Tu cuenta, tu racha y tus tokens siguen aquí si los quieres, y esto es lo último que diremos.',
+
+      awayLongButton: 'Abrir LangX',
+
+      tokensWaitingSubject: {
+        one: 'Tienes {count} token esperando',
+        other: 'Tienes {count} tokens esperando',
+      },
+
+      tokensWaitingBody:
+        'Los tokens compran congelaciones de racha, reparaciones, marcos y títulos. Los tuyos llevan quince días ahí.',
+
+      tokensWaitingButton: 'Abrir mi cartera',
+
+      inviteFriendSubject: 'Practicar es mejor con alguien conocido',
+
+      inviteFriendBody:
+        'Invita a alguien y los dos ganáis tokens cuando entre. Tu enlace está en Ajustes.',
+
+      inviteFriendButton: 'Ver mi enlace',
+    },
 
     /** Onboarding finished: one mail, once in an account's life. */
 

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -23,6 +23,28 @@ export const fr: Localized<ServerMessages> = {
       other: '{count} jetons pour ton signalement 🎉',
     },
     bountyBody: 'On a lu ce que tu nous as envoyé, et ça valait le coup.',
+    /** The same nudges on the phone, under the same switches. */
+    promo: {
+      addPhotoTitle: 'Ajoutez une photo',
+      addPhotoBody: 'Les profils avec un visage reçoivent plus de réponses.',
+      streakBrokeTitle: {
+        one: 'Votre série de {count} jour est rompue',
+        other: 'Votre série de {count} jours est rompue',
+      },
+      streakBrokeBody: 'Une réparation remet hier.',
+      awayTitle: 'Les gens sont toujours là',
+      awayBody: 'De nouvelles personnes pour pratiquer.',
+      awayLongTitle: 'Nous serons là quand vous voudrez',
+      awayLongBody: 'Votre série et vos jetons attendent.',
+      tokensWaitingTitle: {
+        one: '{count} jeton vous attend',
+        other: '{count} jetons vous attendent',
+      },
+      tokensWaitingBody: 'Ouvrez votre portefeuille.',
+      inviteFriendTitle: 'Invitez quelqu’un',
+      inviteFriendBody: 'Vous gagnez tous les deux des jetons.',
+    },
+
     /** Security, which no preference can switch off. */
     /** Billing, which no preference gates either. */
     billingFailedTitle: 'Votre paiement n’a pas abouti',
@@ -143,6 +165,64 @@ export const fr: Localized<ServerMessages> = {
       'Vous pouvez les réactiver à tout moment dans LangX, sous Réglages → Notifications.',
     unsubscribeInvalid:
       'Ce lien n’est pas valide. Ouvrez LangX et modifiez-le dans Réglages → Notifications.',
+
+    /**
+
+     * The nudges in `modules/notifications/promotions.ts`, in its order.
+
+     * Every one of them is behind a switch and carries a way out.
+
+     */
+
+    promo: {
+      addPhotoSubject: 'Ajoutez une photo, on vous trouvera',
+
+      addPhotoBody:
+        'Les profils avec un visage reçoivent bien plus de réponses. Dix secondes, et vous pouvez la changer quand vous voulez.',
+
+      addPhotoButton: 'Ajouter ma photo',
+
+      streakBrokeSubject: {
+        one: 'Votre série de {count} jour est rompue',
+        other: 'Votre série de {count} jours est rompue',
+      },
+
+      streakBrokeBody:
+        'Hier a manqué. Une réparation depuis la boutique remet la journée et la série continue.',
+
+      streakBrokeButton: 'Réparer hier',
+
+      awaySubject: 'On continue à pratiquer sans vous',
+
+      awayBody:
+        'Une semaine a passé. Il y a de nouvelles personnes à qui parler, et vos langues n’ont pas changé.',
+
+      awayButton: 'Voir qui est là',
+
+      awayLongSubject: 'Après cela, nous n’écrirons plus',
+
+      awayLongBody:
+        'Un mois, c’est long. Votre compte, votre série et vos jetons sont toujours là si vous les voulez — et c’est la dernière fois que nous en parlons.',
+
+      awayLongButton: 'Ouvrir LangX',
+
+      tokensWaitingSubject: {
+        one: '{count} jeton vous attend',
+        other: '{count} jetons vous attendent',
+      },
+
+      tokensWaitingBody:
+        'Les jetons achètent des gels de série, des réparations, des cadres et des titres. Les vôtres dorment depuis quinze jours.',
+
+      tokensWaitingButton: 'Ouvrir mon portefeuille',
+
+      inviteFriendSubject: 'On pratique mieux à deux',
+
+      inviteFriendBody:
+        'Invitez quelqu’un : vous gagnez tous les deux des jetons quand il arrive. Votre lien est dans les Réglages.',
+
+      inviteFriendButton: 'Voir mon lien',
+    },
 
     /** Onboarding finished: one mail, once in an account's life. */
 

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -23,6 +23,25 @@ export const ptBR: Localized<ServerMessages> = {
       other: '{count} fichas pelo seu aviso 🎉',
     },
     bountyBody: 'Lemos o que você enviou, e valeu a pena.',
+    /** The same nudges on the phone, under the same switches. */
+    promo: {
+      addPhotoTitle: 'Coloque uma foto',
+      addPhotoBody: 'Perfis com rosto recebem mais respostas.',
+      streakBrokeTitle: {
+        one: 'Sua sequência de {count} dia acabou',
+        other: 'Sua sequência de {count} dias acabou',
+      },
+      streakBrokeBody: 'Um reparo devolve ontem.',
+      awayTitle: 'As pessoas continuam aqui',
+      awayBody: 'Gente nova para praticar.',
+      awayLongTitle: 'Estaremos aqui quando você voltar',
+      awayLongBody: 'Sua sequência e seus tokens esperam.',
+      tokensWaitingTitle: { one: '{count} token esperando', other: '{count} tokens esperando' },
+      tokensWaitingBody: 'Abra sua carteira.',
+      inviteFriendTitle: 'Convide alguém',
+      inviteFriendBody: 'Vocês dois ganham tokens.',
+    },
+
     /** Security, which no preference can switch off. */
     /** Billing, which no preference gates either. */
     billingFailedTitle: 'Seu pagamento não foi concluído',
@@ -138,6 +157,63 @@ export const ptBR: Localized<ServerMessages> = {
     unsubscribedBody: 'Você pode reativar quando quiser no LangX, em Configurações → Notificações.',
     unsubscribeInvalid:
       'Este link não é válido. Abra o LangX e altere em Configurações → Notificações.',
+
+    /**
+
+     * The nudges in `modules/notifications/promotions.ts`, in its order.
+
+     * Every one of them is behind a switch and carries a way out.
+
+     */
+
+    promo: {
+      addPhotoSubject: 'Coloque uma foto e vão te encontrar',
+
+      addPhotoBody:
+        'Perfis com rosto recebem muito mais respostas. Leva dez segundos e você pode trocar quando quiser.',
+
+      addPhotoButton: 'Adicionar minha foto',
+
+      streakBrokeSubject: {
+        one: 'Sua sequência de {count} dia acabou',
+        other: 'Sua sequência de {count} dias acabou',
+      },
+
+      streakBrokeBody: 'Faltou ontem. Um reparo da loja devolve o dia e a sequência continua.',
+
+      streakBrokeButton: 'Reparar ontem',
+
+      awaySubject: 'As pessoas continuam praticando sem você',
+
+      awayBody:
+        'Já faz uma semana. Tem gente nova para conversar, e seus idiomas continuam os mesmos.',
+
+      awayButton: 'Ver quem está aqui',
+
+      awayLongSubject: 'Depois desta, paramos de escrever',
+
+      awayLongBody:
+        'Um mês é muito tempo. Sua conta, sua sequência e seus tokens continuam aqui, se você quiser — e esta é a última vez que falamos disso.',
+
+      awayLongButton: 'Abrir o LangX',
+
+      tokensWaitingSubject: {
+        one: 'Você tem {count} token esperando',
+        other: 'Você tem {count} tokens esperando',
+      },
+
+      tokensWaitingBody:
+        'Tokens compram congelamentos, reparos de dia, molduras e títulos. Os seus estão parados há quinze dias.',
+
+      tokensWaitingButton: 'Abrir minha carteira',
+
+      inviteFriendSubject: 'Praticar é melhor com alguém conhecido',
+
+      inviteFriendBody:
+        'Convide alguém e vocês dois ganham tokens quando ela entrar. Seu link está nas Configurações.',
+
+      inviteFriendButton: 'Pegar meu link',
+    },
 
     /** Onboarding finished: one mail, once in an account's life. */
 

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -35,6 +35,25 @@ export const ru: Localized<ServerMessages> = {
       other: '{count} жетона за твоё сообщение 🎉',
     },
     bountyBody: 'Мы прочитали то, что ты прислал, — это того стоило.',
+    /** The same nudges on the phone, under the same switches. */
+    promo: {
+      addPhotoTitle: 'Добавьте фото',
+      addPhotoBody: 'Профили с лицом получают больше ответов.',
+      streakBrokeTitle: {
+        one: 'Серия из {count} дня прервалась',
+        other: 'Серия из {count} дней прервалась',
+      },
+      streakBrokeBody: 'Починка вернёт вчерашний день.',
+      awayTitle: 'Люди всё ещё здесь',
+      awayBody: 'Новые собеседники.',
+      awayLongTitle: 'Мы здесь, когда захотите',
+      awayLongBody: 'Серия и токены ждут.',
+      tokensWaitingTitle: { one: 'Ждёт {count} токен', other: 'Ждут {count} токенов' },
+      tokensWaitingBody: 'Откройте кошелёк.',
+      inviteFriendTitle: 'Пригласите знакомого',
+      inviteFriendBody: 'Токены получите оба.',
+    },
+
     /** Security, which no preference can switch off. */
     /** Billing, which no preference gates either. */
     billingFailedTitle: 'Платёж не прошёл',
@@ -152,6 +171,59 @@ export const ru: Localized<ServerMessages> = {
     unsubscribedBody: 'Включить обратно можно в любой момент в LangX: Настройки → Уведомления.',
     unsubscribeInvalid:
       'Ссылка недействительна. Откройте LangX и измените это в Настройках → Уведомления.',
+
+    /**
+
+     * The nudges in `modules/notifications/promotions.ts`, in its order.
+
+     * Every one of them is behind a switch and carries a way out.
+
+     */
+
+    promo: {
+      addPhotoSubject: 'Добавьте фото — и вас найдут',
+
+      addPhotoBody:
+        'Профили с лицом получают заметно больше ответов. Это десять секунд, и фото можно поменять когда угодно.',
+
+      addPhotoButton: 'Добавить фото',
+
+      streakBrokeSubject: {
+        one: 'Серия из {count} дня прервалась',
+        other: 'Серия из {count} дней прервалась',
+      },
+
+      streakBrokeBody: 'Вчера пропущено. Починка из магазина вернёт день, и серия продолжится.',
+
+      streakBrokeButton: 'Починить вчера',
+
+      awaySubject: 'Здесь продолжают заниматься и без вас',
+
+      awayBody: 'Прошла неделя. Появились новые собеседники, а ваши языки те же.',
+
+      awayButton: 'Посмотреть, кто здесь',
+
+      awayLongSubject: 'После этого письма мы замолчим',
+
+      awayLongBody:
+        'Месяц — долгий срок. Ваш аккаунт, серия и токены на месте, если они вам нужны, и это последнее, что мы об этом скажем.',
+
+      awayLongButton: 'Открыть LangX',
+
+      tokensWaitingSubject: { one: 'Вас ждёт {count} токен', other: 'Вас ждут {count} токенов' },
+
+      tokensWaitingBody:
+        'За токены покупают заморозки серии, починку дней, рамки и титулы. Ваши лежат уже две недели.',
+
+      tokensWaitingButton: 'Открыть кошелёк',
+
+      inviteFriendSubject: 'Вдвоём заниматься лучше',
+
+      inviteFriendBody:
+        'Пригласите знакомого — токены получите оба, когда он придёт. Ссылка в настройках.',
+
+      inviteFriendButton: 'Взять ссылку',
+    },
 
     /** Onboarding finished: one mail, once in an account's life. */
 

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -17,6 +17,25 @@ export const tr: Localized<ServerMessages> = {
       other: 'Bildirimin için {count} jeton 🎉',
     },
     bountyBody: 'Yazdıklarını okuduk, değdi.',
+    /** The same nudges on the phone, under the same switches. */
+    promo: {
+      addPhotoTitle: 'Bir fotoğraf ekle',
+      addPhotoBody: 'Yüzü olan profiller çok daha fazla cevap alıyor.',
+      streakBrokeTitle: {
+        one: '{count} günlük serin bozuldu',
+        other: '{count} günlük serin bozuldu',
+      },
+      streakBrokeBody: 'Onarım dünü geri koyar.',
+      awayTitle: 'İnsanlar hâlâ burada',
+      awayBody: 'Pratik yapacak yeni insanlar var.',
+      awayLongTitle: 'Sen gelene kadar buradayız',
+      awayLongBody: 'Serin ve token’ların bekliyor.',
+      tokensWaitingTitle: { one: '{count} token bekliyor', other: '{count} token bekliyor' },
+      tokensWaitingBody: 'Cüzdanını aç.',
+      inviteFriendTitle: 'Bir arkadaşını davet et',
+      inviteFriendBody: 'O katılınca ikiniz de token kazanırsınız.',
+    },
+
     /** Security, which no preference can switch off. */
     /** Billing, which no preference gates either. */
     billingFailedTitle: 'Ödemen alınamadı',
@@ -127,6 +146,62 @@ export const tr: Localized<ServerMessages> = {
     unsubscribedBody: 'İstediğin zaman LangX’te Ayarlar → Bildirimler’den geri açabilirsin.',
     unsubscribeInvalid:
       'Bu bağlantı geçerli değil. LangX’i açıp Ayarlar → Bildirimler’den değiştir.',
+
+    /**
+
+     * The nudges in `modules/notifications/promotions.ts`, in its order.
+
+     * Every one of them is behind a switch and carries a way out.
+
+     */
+
+    promo: {
+      addPhotoSubject: 'Bir fotoğraf ekle, seni bulsunlar',
+
+      addPhotoBody:
+        'Yüzü olan profiller çok daha fazla cevap alıyor. On saniye sürer, istediğin zaman değiştirebilirsin.',
+
+      addPhotoButton: 'Fotoğrafımı ekle',
+
+      streakBrokeSubject: {
+        one: '{count} günlük serin bozuldu',
+        other: '{count} günlük serin bozuldu',
+      },
+
+      streakBrokeBody: 'Dünü kaçırdın. Mağazadan bir onarım günü geri koyar ve seri devam eder.',
+
+      streakBrokeButton: 'Dünü onar',
+
+      awaySubject: 'İnsanlar sensiz de pratik yapıyor',
+
+      awayBody: 'Bir hafta oldu. Konuşacak yeni insanlar var ve dillerin değişmedi.',
+
+      awayButton: 'Kimler var, bak',
+
+      awayLongSubject: 'Bundan sonra yazmayacağız',
+
+      awayLongBody:
+        'Bir ay uzun bir süre. Hesabın, serin ve token’ların hâlâ burada — istersen diye. Bu konuda son yazışımız.',
+
+      awayLongButton: 'LangX’i aç',
+
+      tokensWaitingSubject: {
+        one: '{count} token’ın bekliyor',
+        other: '{count} token’ın bekliyor',
+      },
+
+      tokensWaitingBody:
+        'Token’lar seri dondurma, gün onarımı, çerçeve ve unvan alır. Seninkiler iki haftadır duruyor.',
+
+      tokensWaitingButton: 'Cüzdanımı aç',
+
+      inviteFriendSubject: 'Tanıdığınla pratik daha iyi',
+
+      inviteFriendBody:
+        'Bir arkadaşını davet et, o katılınca ikiniz de token kazanın. Davet bağlantın Ayarlar’da.',
+
+      inviteFriendButton: 'Davet bağlantımı al',
+    },
 
     /** Onboarding finished: one mail, once in an account's life. */
 

--- a/apps/api/src/modules/notifications/promotions.test.ts
+++ b/apps/api/src/modules/notifications/promotions.test.ts
@@ -1,0 +1,249 @@
+import { ObjectId } from 'mongodb'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import { ensureIndexes } from '../../db/indexes'
+import type { NotificationEmailContext } from '../../email/notify'
+import { authId } from '../../lib/authId'
+import { CapturingEmailSender } from '../../testSupport/authFlow'
+import { LoggingPushSender } from '../push/devices'
+import { claimCampaignRecipients } from './campaign'
+import { runPromotionsPass } from './promotions'
+
+const SECRET = 'p'.repeat(40)
+const DAY = 24 * 60 * 60 * 1000
+/** 12:00 UTC, so UTC is inside the reader's waking hours. */
+const NOW = new Date('2026-09-14T12:00:00Z')
+
+describe('the nudges that need permission', () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+  let email: CapturingEmailSender
+  let push: LoggingPushSender
+  let senders: { email: NotificationEmailContext; push: LoggingPushSender }
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'promotions_test')
+    await ensureIndexes(handle.db)
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    for (const name of [
+      COLLECTIONS.profiles,
+      COLLECTIONS.user,
+      COLLECTIONS.devices,
+      COLLECTIONS.notificationLedger,
+      COLLECTIONS.emailCampaigns,
+      COLLECTIONS.referrals,
+      COLLECTIONS.tokenLedger,
+      COLLECTIONS.tokenAggregates,
+    ]) {
+      await handle.db.collection(name).deleteMany({})
+    }
+    email = new CapturingEmailSender()
+    push = new LoggingPushSender()
+    senders = {
+      email: { sender: email, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api.langx.io' },
+      push,
+    }
+  })
+
+  async function newProfile(
+    opts: {
+      avatar?: boolean
+      createdDaysAgo?: number
+      activeDaysAgo?: number
+      notifications?: unknown
+      streak?: { current: number; lastQualifiedDay: string | null }
+      earned?: number
+      spent?: number
+      timezone?: string
+      device?: boolean
+      /** Kills the invite nudge, which every long-standing account qualifies for. */
+      invited?: boolean
+    } = {},
+  ): Promise<string> {
+    const userId = new ObjectId().toHexString()
+    await handle.db.collection(COLLECTIONS.profiles).insertOne({
+      _id: userId,
+      handle: `h${userId.slice(-10)}`,
+      displayName: 'Sofia R.',
+      timezone: opts.timezone ?? 'UTC',
+      ...(opts.avatar ? { avatarUrl: 'https://media.langx.io/a.png' } : {}),
+      settings: {
+        discoverable: true,
+        notifications: opts.notifications ?? { promotions: { push: true, email: true } },
+      },
+      nativeLanguages: [{ code: 'en' }],
+      streak: opts.streak ?? { current: 0, longest: 0, lastQualifiedDay: null },
+      stats: {
+        lastActiveAt: new Date(NOW.getTime() - (opts.activeDaysAgo ?? 0) * DAY),
+        messagesSent: 1,
+      },
+      ...(opts.spent ? { tokenSpent: opts.spent } : {}),
+      createdAt: new Date(NOW.getTime() - (opts.createdDaysAgo ?? 40) * DAY),
+    } as never)
+    await handle.db.collection(COLLECTIONS.user).insertOne({
+      _id: authId(userId),
+      email: `${userId}@example.com`,
+      emailVerified: true,
+    })
+    if (opts.earned) {
+      await handle.db.collection(COLLECTIONS.tokenAggregates).insertOne({
+        _id: `${userId}:all:all`,
+        userId,
+        periodType: 'all',
+        periodKey: 'all',
+        tokens: opts.earned,
+        updatedAt: NOW,
+      } as never)
+    }
+    if (opts.invited) {
+      await handle.db
+        .collection(COLLECTIONS.referrals)
+        .insertOne({ _id: `invitee-${userId}`, referrerId: userId, createdAt: NOW } as never)
+    }
+    if (opts.device) {
+      await handle.db.collection(COLLECTIONS.devices).insertOne({
+        userId,
+        pushToken: `ExponentPushToken[${userId.slice(-12)}]`,
+        platform: 'ios',
+        locale: 'en',
+        createdAt: NOW,
+        updatedAt: NOW,
+      })
+    }
+    return userId
+  }
+
+  const subjects = () => email.messages.map((message) => message.subject)
+
+  it('asks for a photo from an account two days old that has none', async () => {
+    await newProfile({ createdDaysAgo: 3 })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 1 })
+    expect(subjects()[0]).toContain('photo')
+  })
+
+  it('says nothing to somebody who never asked for promotions', async () => {
+    await newProfile({ createdDaysAgo: 3, notifications: {} })
+    await newProfile({ createdDaysAgo: 3, notifications: false })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
+  })
+
+  /** One thing at a time; the cap keeps the next one a week away. */
+  it('sends one nudge to somebody eligible for several', async () => {
+    await newProfile({ createdDaysAgo: 3, activeDaysAgo: 7 })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 1 })
+    expect(email.messages).toHaveLength(1)
+    // And the same tick again finds them inside the gap.
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
+  })
+
+  it('respects the marketing gap a campaign already used up', async () => {
+    const userId = await newProfile({ createdDaysAgo: 3 })
+    await claimCampaignRecipients(handle.db, 'launch', [userId], new Date(NOW.getTime() - 2 * DAY))
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
+  })
+
+  it('waits for waking hours on the reader’s own clock', async () => {
+    // 12:00 UTC is 03:00 in Anchorage, which is not a time to be nudged.
+    await newProfile({ createdDaysAgo: 3, timezone: 'America/Anchorage' })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
+  })
+
+  it('offers the repair the day after a real streak broke, and only then', async () => {
+    await newProfile({
+      avatar: true,
+      streak: { current: 9, lastQualifiedDay: '2026-09-13' },
+      notifications: { streak: { push: true, email: true } },
+    })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 1 })
+    expect(subjects()[0]).toContain('9')
+
+    // A streak of two is not worth a letter, and neither is one that broke a
+    // week ago.
+    email.messages.length = 0
+    await handle.db.collection(COLLECTIONS.notificationLedger).deleteMany({})
+    await handle.db.collection(COLLECTIONS.profiles).deleteMany({})
+    await newProfile({
+      avatar: true,
+      invited: true,
+      streak: { current: 2, lastQualifiedDay: '2026-09-13' },
+    })
+    await newProfile({
+      avatar: true,
+      invited: true,
+      streak: { current: 9, lastQualifiedDay: '2026-09-01' },
+    })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
+  })
+
+  it('writes about tokens nobody has spent, and not about a small balance', async () => {
+    await newProfile({ avatar: true, invited: true, earned: 900, spent: 100 })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 1 })
+    expect(subjects()[0]).toContain('800')
+
+    email.messages.length = 0
+    await handle.db.collection(COLLECTIONS.profiles).deleteMany({})
+    await handle.db.collection(COLLECTIONS.notificationLedger).deleteMany({})
+    await newProfile({ avatar: true, invited: true, earned: 150 })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
+  })
+
+  it('does not write about tokens somebody just spent', async () => {
+    const userId = await newProfile({ avatar: true, invited: true, earned: 900 })
+    await handle.db.collection(COLLECTIONS.tokenLedger).insertOne({
+      userId,
+      kind: 'spend',
+      amount: -50,
+      day: '2026-09-13',
+      week: '2026-W37',
+      month: '2026-09',
+      createdAt: new Date(NOW.getTime() - 2 * DAY),
+    })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
+  })
+
+  it('asks for an invite from somebody who stayed and has invited nobody', async () => {
+    const userId = await newProfile({ avatar: true })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 1 })
+    expect(subjects()[0]).toContain('Practising')
+
+    email.messages.length = 0
+    await handle.db.collection(COLLECTIONS.notificationLedger).deleteMany({})
+    await handle.db.collection(COLLECTIONS.referrals).insertOne({
+      _id: 'someone-else',
+      referrerId: userId,
+      createdAt: NOW,
+    } as never)
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
+  })
+
+  it('buzzes the phone too, under the same switch', async () => {
+    await newProfile({ createdDaysAgo: 3, device: true })
+    await runPromotionsPass(handle.db, senders, NOW)
+    expect(push.sent).toHaveLength(1)
+    expect(push.sent[0]?.data.kind).toBe('promotion')
+
+    // Email on, push off: the mail goes, the phone stays quiet.
+    email.messages.length = 0
+    push.sent.length = 0
+    await handle.db.collection(COLLECTIONS.profiles).deleteMany({})
+    await handle.db.collection(COLLECTIONS.notificationLedger).deleteMany({})
+    await newProfile({
+      createdDaysAgo: 3,
+      device: true,
+      notifications: { promotions: { push: false, email: true } },
+    })
+    await runPromotionsPass(handle.db, senders, NOW)
+    expect(email.messages).toHaveLength(1)
+    expect(push.sent).toHaveLength(0)
+  })
+})

--- a/apps/api/src/modules/notifications/promotions.ts
+++ b/apps/api/src/modules/notifications/promotions.ts
@@ -1,0 +1,253 @@
+import { NOTIFICATION_EMAIL_LOCAL_HOURS, localHour, notificationsAllowed } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { sendNotificationEmail, type NotificationEmailContext } from '../../email/notify'
+import { promotionEmail, type PromotionScenario } from '../../email/templates'
+import { translator } from '../../i18n'
+import type { Profile } from '../profiles/profiles'
+import { sendPush, tokensByLocale, type PushSender } from '../push/devices'
+import { claimOnce } from './ledger'
+import { recentlyMarketed } from './marketing'
+import { readAggregates } from '../tokens/ledger'
+
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+/**
+ * The nudges that need somebody's permission, in the order they are offered.
+ *
+ * One pass rather than one per scenario, and one **scan** rather than one
+ * query each: the candidates are the same people every time — everybody with
+ * `promotions.email` on — and the difference between the scenarios is a
+ * couple of fields on a profile that has already been read. Six passes would
+ * have been six collection scans every half hour to send, on most ticks,
+ * nothing at all.
+ *
+ * The order is the priority. At most one of these is sent to one person on
+ * one tick, and `MARKETING_MIN_GAP_DAYS` then keeps the next one a week
+ * away — so a person who qualifies for three hears the first, and hears the
+ * others only if they still qualify next week. Which is the point: the list
+ * is a queue of things worth saying, not a list of things to say at once.
+ *
+ * Every one of them is gated on `promotions.email` being exactly true. The
+ * streak repair is the exception and it is deliberate — see its entry.
+ */
+
+export interface PromotionCandidate {
+  profile: Profile
+  now: Date
+  db: Db
+}
+
+interface Promotion {
+  /** Ledger job; the `promo.` prefix is what `recentlyMarketed` scans for. */
+  job: `promo.${string}`
+  scenario: PromotionScenario
+  /**
+   * `streak` for the repair, `promotions` for the rest. The switch a person
+   * reads has to match what the mail is about, not where it came from.
+   */
+  type: 'promotions' | 'streak'
+  /** Same answer for the same state, so a claim can be keyed on it. */
+  periodKey: (input: PromotionCandidate) => string
+  eligible: (input: PromotionCandidate) => Promise<boolean> | boolean
+  /** Filled into the body; scenario-specific and usually a number. */
+  detail?: (input: PromotionCandidate) => Promise<Record<string, number>> | Record<string, number>
+}
+
+/** Long enough to have finished onboarding and looked around. */
+const PHOTO_AFTER_HOURS = 48
+const AWAY_SHORT_DAYS = 7
+const AWAY_LONG_DAYS = 30
+/** Below this a "you have tokens waiting" mail is about nothing. */
+const IDLE_TOKENS_MIN = 200
+const IDLE_TOKENS_DAYS = 14
+const INVITE_AFTER_DAYS = 14
+
+function daysAgo(date: Date | undefined, now: Date): number {
+  return date ? (now.getTime() - new Date(date).getTime()) / DAY_MS : Number.POSITIVE_INFINITY
+}
+
+export const PROMOTIONS: Promotion[] = [
+  {
+    /*
+     * First, because it is the one whose absence costs somebody everything
+     * else: `discoverProfiles` shows a face, and an account with none is
+     * scrolled past. Two days in, so it is not asked of somebody who is still
+     * in the app finishing their profile.
+     */
+    job: 'promo.photo',
+    scenario: 'addPhoto',
+    type: 'promotions',
+    periodKey: () => 'once',
+    eligible: ({ profile, now }) =>
+      !profile.avatarUrl && daysAgo(profile.createdAt, now) * 24 >= PHOTO_AFTER_HOURS,
+  },
+  {
+    /*
+     * A streak that broke yesterday, and only one that was worth keeping.
+     * Under `streak` rather than `promotions`: it is about the streak, the
+     * repair is one sentence, and somebody who asked for streak reminders has
+     * asked for exactly this. The store sells the repair, which is why it is
+     * in this file rather than beside the evening nudge.
+     */
+    job: 'promo.streakRepair',
+    scenario: 'streakBroke',
+    type: 'streak',
+    periodKey: ({ profile }) => profile.streak?.lastQualifiedDay ?? 'none',
+    eligible: ({ profile, now }) => {
+      const last = profile.streak?.lastQualifiedDay
+      if (!last || (profile.streak?.current ?? 0) < 3) return false
+      const missed = daysAgo(new Date(`${last}T12:00:00Z`), now)
+      // Yesterday, not today (still savable by simply showing up) and not the
+      // day before (by then it is a cold fact rather than a repair).
+      return missed >= 1 && missed < 2
+    },
+    detail: ({ profile }) => ({ count: profile.streak?.current ?? 0 }),
+  },
+  {
+    job: 'promo.away7',
+    scenario: 'away',
+    type: 'promotions',
+    // `lastActiveAt` does not move while somebody is away, so this key is one
+    // absence — the same trick the unread digest uses to stay a single mail.
+    periodKey: ({ profile }) => `away:${profile.stats?.lastActiveAt?.toISOString() ?? 'never'}`,
+    eligible: ({ profile, now }) => {
+      const away = daysAgo(profile.stats?.lastActiveAt, now)
+      return away >= AWAY_SHORT_DAYS && away < AWAY_SHORT_DAYS + 1
+    },
+  },
+  {
+    /** The second and last touch. After this, silence. */
+    job: 'promo.away30',
+    scenario: 'awayLong',
+    type: 'promotions',
+    periodKey: ({ profile }) => `away30:${profile.stats?.lastActiveAt?.toISOString() ?? 'never'}`,
+    eligible: ({ profile, now }) => {
+      const away = daysAgo(profile.stats?.lastActiveAt, now)
+      return away >= AWAY_LONG_DAYS && away < AWAY_LONG_DAYS + 1
+    },
+  },
+  {
+    /*
+     * Tokens earned and never spent. A wallet nobody opens is a feature
+     * nobody found, and the number in the mail is the argument.
+     */
+    job: 'promo.idleTokens',
+    scenario: 'tokensWaiting',
+    type: 'promotions',
+    periodKey: ({ now }) => now.toISOString().slice(0, 7),
+    eligible: async ({ profile, now, db }) => {
+      if (daysAgo(profile.stats?.lastActiveAt, now) > AWAY_SHORT_DAYS) return false
+      const balance = (await readAggregates(db, profile._id)).all - (profile.tokenSpent ?? 0)
+      if (balance < IDLE_TOKENS_MIN) return false
+      const spentRecently = await db.collection(COLLECTIONS.tokenLedger).findOne({
+        userId: profile._id,
+        amount: { $lt: 0 },
+        createdAt: { $gte: new Date(now.getTime() - IDLE_TOKENS_DAYS * DAY_MS) },
+      })
+      return spentRecently === null
+    },
+    detail: async ({ profile, db }) => ({
+      count: (await readAggregates(db, profile._id)).all - (profile.tokenSpent ?? 0),
+    }),
+  },
+  {
+    /*
+     * Last, because it asks for something rather than offering it, and it is
+     * only worth asking of somebody who has stayed.
+     */
+    job: 'promo.invite',
+    scenario: 'inviteFriend',
+    type: 'promotions',
+    periodKey: () => 'once',
+    eligible: async ({ profile, now, db }) => {
+      if (daysAgo(profile.createdAt, now) < INVITE_AFTER_DAYS) return false
+      if (daysAgo(profile.stats?.lastActiveAt, now) > AWAY_SHORT_DAYS) return false
+      const invited = await db
+        .collection(COLLECTIONS.referrals)
+        .findOne({ referrerId: profile._id }, { projection: { _id: 1 } })
+      return invited === null
+    },
+  },
+]
+
+/**
+ * One tick: everybody eligible for something hears the first thing they are
+ * eligible for.
+ *
+ * Quiet hours are the reader's, not the server's — a promotional mail landing
+ * at 3am is the same buzz as a push, and this is the class of mail people are
+ * least forgiving about.
+ */
+export async function runPromotionsPass(
+  db: Db,
+  senders: { email: NotificationEmailContext; push: PushSender },
+  now: Date = new Date(),
+): Promise<{ sent: number }> {
+  const profiles = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .find({
+      deletedAt: { $exists: false },
+      guest: { $exists: false },
+      // Bounds the scan only; `notificationsAllowed` decides. Two of the three
+      // stored shapes are objects this cannot read into.
+      'settings.notifications': { $ne: false },
+    })
+    .toArray()
+
+  let sent = 0
+  for (const profile of profiles) {
+    const hour = localHour(now, profile.timezone ?? 'UTC')
+    if (hour < NOTIFICATION_EMAIL_LOCAL_HOURS.earliest) continue
+    if (hour > NOTIFICATION_EMAIL_LOCAL_HOURS.latest) continue
+    if (await recentlyMarketed(db, profile._id, now)) continue
+
+    const candidate: PromotionCandidate = { profile, now, db }
+    for (const promotion of PROMOTIONS) {
+      if (!notificationsAllowed(profile.settings?.notifications, promotion.type, 'email')) continue
+      if (!(await promotion.eligible(candidate))) continue
+      if (!(await claimOnce(db, promotion.job, profile._id, promotion.periodKey(candidate)))) break
+
+      const detail = promotion.detail ? await promotion.detail(candidate) : {}
+      const outcome = await sendNotificationEmail(db, senders.email, {
+        userId: profile._id,
+        type: promotion.type,
+        build: (locale, unsubscribe) =>
+          promotionEmail(locale, promotion.scenario, { ...detail, unsubscribe }),
+      })
+      if (outcome === 'sent') sent++
+      await pushIt(db, senders.push, profile, promotion, detail)
+      // One thing at a time. The cap keeps the next one a week away.
+      break
+    }
+  }
+
+  return { sent }
+}
+
+/**
+ * The same nudge on the phone, when the same switch allows it on that
+ * channel. Not a fallback for the mail and not gated on it: somebody with the
+ * app installed and promotions on has asked for both, and the mail may be the
+ * one that is never opened.
+ */
+async function pushIt(
+  db: Db,
+  sender: PushSender,
+  profile: Profile,
+  promotion: Promotion,
+  detail: Record<string, number>,
+): Promise<void> {
+  if (!notificationsAllowed(profile.settings?.notifications, promotion.type, 'push')) return
+  for (const [locale, tokens] of await tokensByLocale(db, profile._id)) {
+    if (tokens.length === 0) continue
+    const t = translator(locale)
+    await sendPush(db, sender, {
+      to: tokens,
+      title: t(`push.promo.${promotion.scenario}Title` as never, detail),
+      body: t(`push.promo.${promotion.scenario}Body` as never, detail),
+      data: { kind: promotion.type === 'streak' ? 'streakReminder' : 'promotion' },
+    })
+  }
+}

--- a/apps/api/src/modules/notifications/scheduler.ts
+++ b/apps/api/src/modules/notifications/scheduler.ts
@@ -5,6 +5,7 @@ import type { SchedulerLogger } from '../tokens/poolScheduler'
 import { runBadgeRoundUpPass } from './badges'
 import { runCampaignQueuePass } from './campaignQueue'
 import { runProfileVisitsEmailPass, runProfileVisitsPushPass } from './profileVisits'
+import { runPromotionsPass } from './promotions'
 import { runUnreadDigestPass } from './unreadDigest'
 import { runVerifyReminderPass } from './verifyReminder'
 
@@ -67,6 +68,7 @@ export function startNotificationScheduler(
               ),
             ]
           : []),
+        run('promotions', () => runPromotionsPass(db, senders, now)),
         run('campaign queue', () =>
           runCampaignQueuePass(db, senders.email, now, {
             tickMinutes: intervalMs / 60_000,

--- a/apps/api/src/modules/security/deviceLabel.test.ts
+++ b/apps/api/src/modules/security/deviceLabel.test.ts
@@ -15,6 +15,9 @@ const AGENTS = {
     'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Mobile Safari/537.36',
   edge: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36 Edg/152.0.0.0',
   expoIos: 'LangX/2.2 CFNetwork/1568.100.1 Darwin/24.0.0',
+  /** What React Native actually sends, taken off `session` in production. */
+  bareIos: 'CFNetwork/1568.100.1 Darwin/24.0.0',
+  bareAndroid: 'okhttp/4.12.0',
   curl: 'curl/8.5.0',
 }
 
@@ -55,6 +58,26 @@ describe('naming the device somebody signed in from', () => {
     const now = deviceIdentity(AGENTS.windowsChrome).fingerprint
     const later = deviceIdentity(AGENTS.windowsChrome.replace('152.0.0.0', '191.0.3.7')).fingerprint
     expect(later).toBe(now)
+  })
+
+  /**
+   * React Native sends no browser user agent at all. Fifty-three production
+   * sessions carried `okhttp/4.12.0`, and reading those literally told people
+   * they had signed in from "okhttp".
+   */
+  it('knows the app by the library it speaks through', () => {
+    expect(deviceIdentity(AGENTS.bareAndroid)).toEqual({
+      fingerprint: 'android-app',
+      label: 'the LangX app on Android',
+    })
+    expect(deviceIdentity(AGENTS.bareIos)).toEqual({
+      fingerprint: 'ios-app',
+      label: 'the LangX app on iPhone',
+    })
+    // And the two ways in from one phone are one device, not two.
+    expect(deviceIdentity(AGENTS.expoIos).fingerprint).toBe(
+      deviceIdentity(AGENTS.bareIos).fingerprint,
+    )
   })
 
   it('names a script by what it called itself, and an absent agent not at all', () => {

--- a/apps/api/src/modules/security/deviceLabel.ts
+++ b/apps/api/src/modules/security/deviceLabel.ts
@@ -21,17 +21,29 @@ export interface DeviceIdentity {
 
 const UNKNOWN: DeviceIdentity = { fingerprint: 'unknown', label: 'an unrecognised device' }
 
-/** Ours first: the app's own requests should not read as "Safari on iPhone". */
+/**
+ * Ours first: the app's own requests should not read as "Safari on iPhone",
+ * and they must not read as the HTTP library either.
+ *
+ * React Native does not send a browser user agent. On Android it sends
+ * `okhttp/4.x` and nothing else, and on iOS `CFNetwork/… Darwin/…` — which
+ * a run against production turned into fifty-three people being told they had
+ * signed in from "okhttp". Nothing else in this app's traffic uses either
+ * library, so both are read as the app.
+ */
 function appIdentity(userAgent: string): DeviceIdentity | null {
-  if (/\bExpo\b|LangX/i.test(userAgent)) {
-    if (/\bAndroid\b/i.test(userAgent))
-      return { fingerprint: 'android-app', label: 'the LangX app on Android' }
-    if (/\biPhone|iPad|iOS|CFNetwork\b/i.test(userAgent)) {
-      return { fingerprint: 'ios-app', label: 'the LangX app on iPhone' }
-    }
-    return { fingerprint: 'app', label: 'the LangX app' }
+  const named = /\bExpo\b|LangX/i.test(userAgent)
+  if (named ? /\bAndroid\b/i.test(userAgent) : /^okhttp\//i.test(userAgent)) {
+    return { fingerprint: 'android-app', label: 'the LangX app on Android' }
   }
-  return null
+  if (
+    named
+      ? /\biPhone|iPad|iOS|CFNetwork\b/i.test(userAgent)
+      : /\bCFNetwork\b/i.test(userAgent) && /\bDarwin\b/i.test(userAgent)
+  ) {
+    return { fingerprint: 'ios-app', label: 'the LangX app on iPhone' }
+  }
+  return named ? { fingerprint: 'app', label: 'the LangX app' } : null
 }
 
 function platformOf(userAgent: string): { key: string; name: string } {

--- a/apps/mobile/src/lib/notificationRoute.ts
+++ b/apps/mobile/src/lib/notificationRoute.ts
@@ -49,6 +49,11 @@ export function notificationRoute(data: unknown): Href | null {
       // The count is what the notification said; the names are behind the
       // paywall this screen draws. Landing here is the whole point of it.
       return '/viewers'
+    case 'promotion':
+      // Every nudge that is not about the streak points at the same place:
+      // people to talk to. The mail carries the specific destination; a push
+      // that lands days later should not.
+      return '/discover'
     case 'billing':
       // A failed payment and an ended plan are both fixed in one place.
       return '/settings/plan'

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3683,3 +3683,32 @@ sign-up is excluded: being told you signed in seconds after creating the
 account is noise. Nothing thrown inside is allowed to reach the caller —
 these fire on the response to a correct password, and a mail provider having
 a bad minute must not turn that into an error page.
+
+## Six nudges, one pass, one at a time
+
+The remarketing scenarios could each have been a pass, the way the digest and
+the visit round-up are. They are not, and the reason is arithmetic: the
+candidates are the same people every time — everybody with `promotions.email`
+on — and what separates the scenarios is two or three fields on a profile
+that has already been read. Six passes would have been six collection scans
+every half hour in order to send, on most ticks, nothing.
+
+So `promotions.ts` is a **table**, walked in order for each candidate, and
+the order is the priority: photo, streak repair, 7 days away, 30 days away,
+idle tokens, invite. The first one that matches is sent and the loop breaks.
+`MARKETING_MIN_GAP_DAYS` then keeps the next one a week off, so somebody who
+qualifies for three hears one, and hears the second only if it is still true
+next week. The list is a queue of things worth saying, not a list of things
+to say at once.
+
+Two choices inside it are worth naming. The **streak repair sits under the
+`streak` switch, not `promotions`** — it is about the streak, the repair is
+one sentence, and somebody who asked for streak reminders asked for exactly
+this; putting it behind the marketing switch would have hidden it from the
+people it is for. And the **away nudges key on `stats.lastActiveAt`**, which
+does not move while somebody is away — the same trick the unread digest uses,
+and what makes "we miss you" one letter rather than a daily one.
+
+The push half is not a fallback for the mail and not gated on it. Somebody
+with the app installed and promotions on asked for both, and the mail is
+often the one that is never opened.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -61,14 +61,15 @@ Four schedulers start with the API. None of them is a cron expression — each
 asks "is there unfinished work?" on an interval, so a process that was down
 during the window catches up on its next tick instead of skipping silently.
 
-| Scheduler        | Interval | What it does                                                                                                                         |
-| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| Daily token pool | 15 min   | Distributes a closed day's token pool. Idempotent twice over: a `jobRuns` lock, and the ledger's unique index. Catches up 7 days.    |
-| Account purge    | 1 hour   | Hard-deletes accounts past their 30-day grace period.                                                                                |
-| Streak reminder  | 30 min   | Sends the nudge at 20:00 in each user's own timezone, once per local day — as a push, or as email to somebody with no phone.         |
-| Notifications    | 30 min   | Three passes: the unread-message digest, the profile-visit round-up (daily push, weekly email) and the badge round-up at 18:00.      |
-| Verify reminder  | 30 min   | One more verification link, a day after an unverified sign-up. Exactly once per account, and never after a week.                     |
-| Campaign queue   | 30 min   | Drips a queued broadcast out on a warm-up ramp (`CAMPAIGN_WARMUP_PER_DAY`), 08–20 UTC only. `send-campaign.ts` enqueues, this sends. |
+| Scheduler        | Interval | What it does                                                                                                                                                                       |
+| ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Daily token pool | 15 min   | Distributes a closed day's token pool. Idempotent twice over: a `jobRuns` lock, and the ledger's unique index. Catches up 7 days.                                                  |
+| Account purge    | 1 hour   | Hard-deletes accounts past their 30-day grace period.                                                                                                                              |
+| Streak reminder  | 30 min   | Sends the nudge at 20:00 in each user's own timezone, once per local day — as a push, or as email to somebody with no phone.                                                       |
+| Notifications    | 30 min   | Three passes: the unread-message digest, the profile-visit round-up (daily push, weekly email) and the badge round-up at 18:00.                                                    |
+| Promotions       | 30 min   | Six nudges — add a photo, repair a broken streak, come back at 7 and 30 days, spend idle tokens, invite a friend. One per person per tick, then `MARKETING_MIN_GAP_DAYS` of quiet. |
+| Verify reminder  | 30 min   | One more verification link, a day after an unverified sign-up. Exactly once per account, and never after a week.                                                                   |
+| Campaign queue   | 30 min   | Drips a queued broadcast out on a warm-up ramp (`CAMPAIGN_WARMUP_PER_DAY`), 08–20 UTC only. `send-campaign.ts` enqueues, this sends.                                               |
 
 Running several API instances is safe. The pool's `jobRuns` unique index means
 only one instance can own a given day, every notification pass claims a row

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -82,7 +82,10 @@ a changed password, and a sign-in method connected or disconnected. They go
 by mail _and_ push, carry no unsubscribe, and reach an account whose owner
 switched every other notification off — a switch whose honest label is "do
 not tell me when somebody signs in as me" is not one to offer. `knownDevices`
-is what makes "a device we have not seen" answerable; it has no TTL.
+is what makes "a device we have not seen" answerable; it has no TTL — and it
+starts empty, so `scripts/backfill-known-devices.ts` has to run before the
+first deploy that carries this, or everybody's next sign-in is a "new device"
+letter about the phone they are holding.
 
 Nothing is sent to an address on `emailSuppressions`, service mail included:
 a permanent bounce or a spam complaint reported by Resend's webhook

--- a/packages/shared/src/push.ts
+++ b/packages/shared/src/push.ts
@@ -59,6 +59,12 @@ export const PUSH_KINDS = [
    * to hearing it is finding out when the plan stops.
    */
   'billing',
+  /**
+   * A nudge from `modules/notifications/promotions.ts` — add a photo, come
+   * back, spend your tokens. The only kind here gated on `promotions`, which
+   * is off until somebody turns it on.
+   */
+  'promotion',
 ] as const
 export type PushKind = (typeof PUSH_KINDS)[number]
 


### PR DESCRIPTION
PR D of the email + push programme. **Stacked on #1265** (which is stacked on #1264) — the base retargets as each merges.

## The six, in the order they are offered

| # | Nudge | Trigger | Switch |
| --- | --- | --- | --- |
| 1 | Add a photo | no `avatarUrl`, account > 48h | promotions |
| 2 | Your streak broke — repair it | streak ≥ 3 that lapsed *yesterday* | **streak** |
| 3 | People are still practising without you | `lastActiveAt` 7–8 days ago | promotions |
| 4 | We will stop writing after this | `lastActiveAt` 30–31 days ago | promotions |
| 5 | You have N tokens waiting | balance ≥ 200, nothing spent in a fortnight | promotions |
| 6 | Invite a friend | 14 days old, active, has invited nobody | promotions |

Both channels, under the same switch per channel. The mail's button and its sentence are chosen together, in the template, so they cannot disagree.

## Why one table and not six passes

The candidates are the same people every time — everybody with `promotions.email` on — and what separates the scenarios is two or three fields on a profile that has already been read. Six passes would have been six collection scans every half hour in order to send, on most ticks, nothing.

The order is the priority: the first match is sent, the loop breaks, and `MARKETING_MIN_GAP_DAYS` keeps the next one a week off. Somebody who qualifies for three hears one, and hears the second only if it is still true next week.

## Two judgement calls

- **The streak repair sits under the `streak` switch**, not `promotions`. It is about the streak, the repair is one sentence, and somebody who asked for streak reminders asked for exactly this — putting it behind the marketing switch would hide it from the people it is for.
- **The away nudges key on `stats.lastActiveAt`**, which does not move while somebody is away. Same trick as the unread digest; it is what makes "we miss you" one letter rather than a daily one.

New push kind `promotion`, routed to `/discover`. Eight locales throughout.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — green (api 93 files, mobile 93, shared 26).
- `promotions.test.ts`: each scenario fires on its trigger and not otherwise, one nudge per person per tick, the campaign cap is respected, quiet hours are the reader's own clock, and push follows its own half of the switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)