### PR TITLE
Send with the return key on a Mac

### DIFF
--- a/apps/mobile/src/components/ChatComposer.tsx
+++ b/apps/mobile/src/components/ChatComposer.tsx
@@ -1,5 +1,6 @@
 import Feather from '@expo/vector-icons/Feather'
 import { TOKEN_RULES } from '@langx/shared'
+import * as Device from 'expo-device'
 import { useState, type ReactNode } from 'react'
 import {
   Platform,
@@ -11,9 +12,17 @@ import {
   type TextInputKeyPressEventData,
 } from 'react-native'
 import { useT } from '../i18n'
-import { shouldSubmitOnEnter } from '../lib/submitOnEnter'
+import { enterSendsOnNative, shouldSubmitOnEnter } from '../lib/submitOnEnter'
 import { makeStyles, useTheme } from '../lib/theme'
 import { ComposerHint } from './ComposerHint'
+
+/**
+ * A Mac, either as a Catalyst app or as the iPad binary running on Apple
+ * Silicon — `expo-device` reports both as `DESKTOP`, which is the only signal
+ * that tells one of those apart from a real iPad. Read once: it cannot change
+ * while the app is running.
+ */
+const IS_DESKTOP = Device.deviceType === Device.DeviceType.DESKTOP
 
 interface ChatComposerProps {
   value: string
@@ -83,10 +92,19 @@ export function ChatComposer({
           autoFocus={autoFocus}
           multiline
           /**
-           * Web only, and it has to be a key handler: `multiline` is a
+           * Two ways to send with the return key, because the two platforms
+           * offer different handles on it.
+           *
+           * On the web it has to be a key handler: `multiline` is a
            * `<textarea>` in the browser, where `onSubmitEditing` never fires.
-           * On native the return key inserts a newline and the send button is
-           * the way to send, which is what people expect there.
+           *
+           * On a native desktop it has to be `submitBehavior`, because that is
+           * the only thing that stops the newline — a key handler cannot, there
+           * being nothing to `preventDefault` on. `'submit'` rather than
+           * `'blurAndSubmit'` keeps the field focused for the next sentence.
+           *
+           * On a phone or a tablet neither is set and the return key inserts a
+           * newline, which is what people expect with a keyboard on the glass.
            */
           {...(Platform.OS === 'web'
             ? {
@@ -100,7 +118,9 @@ export function ChatComposer({
                   onSend()
                 },
               }
-            : {})}
+            : enterSendsOnNative(Platform.OS, IS_DESKTOP)
+              ? { submitBehavior: 'submit' as const, onSubmitEditing: onSend }
+              : {})}
         />
         {/* The send button appears only when there is something to send; the
           resting state to its right (a microphone, in a thread) is the

--- a/apps/mobile/src/lib/submitOnEnter.test.ts
+++ b/apps/mobile/src/lib/submitOnEnter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { shouldSubmitOnEnter } from './submitOnEnter'
+import { enterSendsOnNative, shouldSubmitOnEnter } from './submitOnEnter'
 
 describe('shouldSubmitOnEnter', () => {
   it('sends on a bare Enter', () => {
@@ -15,5 +15,22 @@ describe('shouldSubmitOnEnter', () => {
     for (const key of ['a', ' ', 'Escape', 'Tab', 'NumpadEnter', '']) {
       expect(shouldSubmitOnEnter(key, false)).toBe(false)
     }
+  })
+})
+
+describe('enterSendsOnNative', () => {
+  /** The Mac build: no on-screen keyboard, so the return key has to send. */
+  it('sends on a native desktop', () => {
+    expect(enterSendsOnNative('ios', true)).toBe(true)
+  })
+
+  it('leaves the return key alone on a phone or a tablet', () => {
+    expect(enterSendsOnNative('ios', false)).toBe(false)
+    expect(enterSendsOnNative('android', false)).toBe(false)
+  })
+
+  /** A desktop browser has the key handler above, which tells the Enters apart. */
+  it('stays out of the way on web', () => {
+    expect(enterSendsOnNative('web', true)).toBe(false)
   })
 })

--- a/apps/mobile/src/lib/submitOnEnter.ts
+++ b/apps/mobile/src/lib/submitOnEnter.ts
@@ -14,3 +14,24 @@
 export function shouldSubmitOnEnter(key: string, shiftKey: boolean): boolean {
   return key === 'Enter' && !shiftKey
 }
+
+/**
+ * Whether the return key should send on a native build rather than open a line.
+ *
+ * True only on a desktop: the app also ships as a "Designed for iPad" binary
+ * that runs on Apple Silicon Macs, where there is no on-screen keyboard at all
+ * and the return key is the only one a person reaches for. On a phone or a
+ * tablet it stays a newline — the send button is right there, and a thumb has
+ * no way to say "not that Enter".
+ *
+ * The rule cannot be `shouldSubmitOnEnter`'s on native, because iOS hands the
+ * text view a bare "\n" with no modifier state attached: Shift+Enter and Enter
+ * are the same event. So on a Mac every return sends, and a second line is
+ * written by pasting one.
+ *
+ * Web is excluded even on a desktop, because there the key handler above is
+ * both available and better — it can tell the two Enters apart.
+ */
+export function enterSendsOnNative(platform: string, isDesktop: boolean): boolean {
+  return platform !== 'web' && isDesktop
+}


### PR DESCRIPTION
## The problem

The app also ships as the "Designed for iPad" binary that runs on Apple Silicon Macs. There is no on-screen keyboard there, so the return key is the only one a person reaches for — and it opened a line, leaving the mouse as the only way to send a message.

## The fix

The Enter-sends rule already existed in `ChatComposer`, but behind a `Platform.OS === 'web'` guard. That guard is right about the *handle*, not about the rule: a key handler is web-only, because `multiline` is a `<textarea>` there and `onSubmitEditing` never fires.

On native the handle is `submitBehavior`, which is also the only thing that can suppress the newline — there is nothing to `preventDefault` on. `'submit'` rather than `'blurAndSubmit'`, so the field keeps focus for the next sentence.

Desktop only. `expo-device` returns `DESKTOP` for exactly the two cases that are one machine — Mac Catalyst and the iPad binary on Apple Silicon (`ProcessInfo.isiOSAppOnMac`) — which is the signal that tells a Mac from the iPad it is pretending to be. On a phone or a tablet nothing is set and the return key still opens a line.

## The trade-off

The rule cannot be the web's on native: iOS hands the text view a bare `"\n"` with no modifier state attached, so Shift+Enter and Enter are the same event. On a Mac every return sends, and a second line is written by pasting one. Deliberate, and agreed before the change.

## Verified

- `pnpm test` (758 mobile tests), `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` — all green. The typecheck is what confirms `submitBehavior: 'submit'` is a real `TextInputProps` value on RN 0.86.
- `pnpm build:web` exports and prerenders every route, so the new module-scope `expo-device` read does not break the Node prerender (its web implementation guards on `Platform.isDOMAvailable`).
- The native return-key behaviour was verified by reading RN 0.86's own implementation on both architectures — `RCTBaseTextInputView.mm` `textInputShouldSubmitOnReturn` and `RCTTextInputComponentView.mm` — rather than on a device: no dev client is installed on any simulator here, and `Device.deviceType` never reports `DESKTOP` on a simulator anyway. **The Mac itself still wants one confirmation from a TestFlight or local build.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)