### PR TITLE
The monthly newsletter, and a place for the note that goes in it

### DIFF
--- a/apps/api/scripts/backfill-known-devices.ts
+++ b/apps/api/scripts/backfill-known-devices.ts
@@ -1,0 +1,98 @@
+/**
+ * Records the devices people are **already** signed in on, so switching the
+ * security notices on does not tell a hundred people their own phone is new.
+ *
+ * `knownDevices` starts empty. Without this, the first sign-in after the
+ * deploy is, by the only definition the code has, a sign-in from a device
+ * that has never been seen — and everybody who signs in that week gets a
+ * "new sign-in to your account" letter about the laptop they are reading it
+ * on. Which is the exact mail people learn to ignore, on the exact feature
+ * that has to be believed.
+ *
+ * `session` is the source: Better Auth stores the user agent on every row,
+ * and a live session *is* a device somebody is using. The rows expire in a
+ * week, so this covers the people who have signed in recently — which is the
+ * same set that would otherwise have been mailed. Anybody older gets one
+ * notice on their next sign-in, correctly.
+ *
+ * Idempotent: `claimNewDevice` upserts on `<userId>:<fingerprint>`, so
+ * running it twice writes nothing the second time. Run it **before**
+ * `fly deploy`, or in the same minute — the window between the deploy and
+ * this is the window the burst happens in.
+ *
+ * Usage:
+ *   pnpm --filter @langx/api exec tsx --env-file=../../.env --env-file=../../.env.prod \
+ *     scripts/backfill-known-devices.ts [--confirm]
+ */
+import { connectToDatabase } from '../src/db/client'
+import { COLLECTIONS } from '../src/db/collections'
+import { loadEnv } from '../src/env'
+import { deviceIdentity } from '../src/modules/security/deviceLabel'
+import { claimNewDevice } from '../src/modules/security/knownDevices'
+
+interface SessionRow {
+  userId: unknown
+  userAgent?: string
+  createdAt?: Date
+}
+
+async function main(): Promise<void> {
+  const confirm = process.argv.includes('--confirm')
+  const env = loadEnv()
+  const { db, close } = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
+
+  try {
+    const sessions = await db
+      .collection<SessionRow>(COLLECTIONS.session)
+      .find({}, { projection: { userId: 1, userAgent: 1, createdAt: 1 } })
+      .toArray()
+
+    // One row per person per device family, oldest first, so `firstSeenAt`
+    // ends up as close to the truth as the sessions can say.
+    const pairs = new Map<string, { userId: string; fingerprint: string; at: Date }>()
+    let noAgent = 0
+    for (const session of sessions) {
+      if (!session.userAgent) {
+        noAgent++
+        continue
+      }
+      const userId = String(session.userId)
+      const { fingerprint } = deviceIdentity(session.userAgent)
+      const key = `${userId}:${fingerprint}`
+      const at = session.createdAt ?? new Date()
+      const existing = pairs.get(key)
+      if (!existing || at < existing.at) pairs.set(key, { userId, fingerprint, at })
+    }
+
+    const byFingerprint = new Map<string, number>()
+    for (const { fingerprint } of pairs.values()) {
+      byFingerprint.set(fingerprint, (byFingerprint.get(fingerprint) ?? 0) + 1)
+    }
+
+    console.log(`known devices from ${sessions.length} sessions on ${env.MONGODB_DB}`)
+    console.log(`  device rows to write: ${pairs.size}`)
+    console.log(`  people covered: ${new Set([...pairs.values()].map((p) => p.userId)).size}`)
+    console.log(`  sessions with no user agent: ${noAgent}`)
+    for (const [fingerprint, count] of [...byFingerprint].sort((a, b) => b[1] - a[1])) {
+      console.log(`    ${fingerprint}: ${count}`)
+    }
+
+    if (!confirm) {
+      console.log('\n(dry run — re-run with --confirm to write)')
+      return
+    }
+
+    let written = 0
+    for (const { userId, fingerprint, at } of pairs.values()) {
+      if (await claimNewDevice(db, userId, fingerprint, { at })) written++
+    }
+    console.log(`\nwrote ${written} (the rest were already recorded)`)
+  } finally {
+    await close()
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/api/src/email/newsletters/README.md
+++ b/apps/api/src/email/newsletters/README.md
@@ -1,0 +1,47 @@
+# Newsletter notes
+
+The editorial half of the monthly recap — what shipped, in the writer's own
+words. One file per month, `YYYY-MM.ts`, registered in `index.ts`.
+
+The numbers in the recap are computed per reader and always sent. This is the
+part somebody writes, and a month with no file simply has no editorial block.
+
+## How a month's note gets here
+
+1. **Drafted.** A scheduled routine runs on the 27th: it reads
+   `git log --merges` since the last note, the GitHub releases in the window
+   and the `docs/decisions.md` entries added that month, writes
+   `YYYY-MM.ts` in English, translates it into the other seven, registers it
+   in `index.ts`, and opens a pull request called `Newsletter 2026-10` whose
+   body carries the rendered English.
+2. **Reviewed.** The PR notification is the ping; the rendering is in the body.
+   Edit the English in the PR — the routine re-translates from whatever the
+   English ends up being, because the typed catalogue will not compile
+   otherwise.
+3. **Approved by merging.** No merge, no note. Nothing is ever sent on
+   anybody's behalf by the routine.
+4. **Deployed.** `fly deploy -a langx-api`, as always. The pass sends on the
+   first of the month at 10:00 on each reader's own clock, or any of the six
+   days after — so a deploy that slips does not skip a month.
+
+## Writing one by hand
+
+```ts
+// apps/api/src/email/newsletters/2026-10.ts
+import type { LocalizedNote } from './index'
+
+export const note: LocalizedNote = {
+  en: {
+    headline: 'What shipped in October',
+    items: [{ title: 'Sign in with Apple', body: 'Two taps, no password.' }],
+    note: 'Reply to this email if something feels off — it reaches a human.',
+  },
+  tr: { headline: 'Ekimde neler çıktı', items: [/* … */] },
+}
+```
+
+Then add it to `NOTES` in `index.ts`. English is required; every other
+language falls back to it, which is what makes a half-translated month
+harmless rather than a compile error.
+
+Keep it to three or four items. This is the part people skim.

--- a/apps/api/src/email/newsletters/index.ts
+++ b/apps/api/src/email/newsletters/index.ts
@@ -1,0 +1,38 @@
+import type { Locale } from '@langx/shared'
+
+/**
+ * The editorial half of the monthly recap: what shipped, in the writer's own
+ * words, in eight languages.
+ *
+ * One file per month, `YYYY-MM.ts`, drafted from the repository's own history
+ * by a scheduled routine, opened as a pull request, edited by a person and
+ * **merged** — the merge is the approval, and no merge means no editorial
+ * block that month. The recap still goes out: the numbers are the part that
+ * is always true.
+ *
+ * A registry rather than a directory read at runtime, because the API ships
+ * as one bundled `dist/index.js` with no files beside it — the same reason
+ * the images are inlined.
+ */
+export interface NewsletterNote {
+  headline: string
+  items: { title: string; body: string }[]
+  /** An optional closing line from whoever wrote it. */
+  note?: string
+}
+
+export type LocalizedNote = Partial<Record<Locale, NewsletterNote>> & { en: NewsletterNote }
+
+/** Every month that has a note. Add the import and the entry together. */
+const NOTES: Record<string, LocalizedNote> = {}
+
+/**
+ * The note for a month in the reader's language, falling back to English —
+ * which is the one language every note has, because the routine writes it
+ * first and translates from it.
+ */
+export function noteFor(month: string, locale: Locale): NewsletterNote | null {
+  const note = NOTES[month]
+  if (!note) return null
+  return note[locale] ?? note.en
+}

--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -11,6 +11,8 @@ import { translator } from '../i18n'
 import { facesRow, type AvatarFace } from './avatars'
 import type { InlineAsset } from './inlineAssets'
 import { inlineSrc, LOGO_SRC } from './logo'
+import type { NewsletterNote } from './newsletters'
+import type { MonthlyRecap } from '../modules/notifications/newsletter'
 
 /**
  * The site's display voice — `--font--title` in `website/src/lib/scss/_variables.scss`,
@@ -439,6 +441,126 @@ export function billingEmail(
        <p style="margin:24px 0 0;">${button(url, t(`email.billing.${event}Button` as never))}</p>`,
     ),
     text: [title, '', t(`email.billing.${event}Body` as never), '', url].join('\n'),
+  }
+}
+
+/**
+ * "Your month on LangX": four numbers that are yours, three that are
+ * everybody's, and whatever shipped.
+ *
+ * The two halves are deliberate. A personal recap alone is thin in a quiet
+ * month and reads as an accusation; the community numbers say the place is
+ * alive whether or not the reader was there, which is the argument for coming
+ * back. A **quiet month** swaps the personal half for one sentence rather
+ * than printing three zeroes at somebody.
+ *
+ * The editorial block is optional and comes from `email/newsletters/` —
+ * written by a routine, reviewed as a pull request, merged. No note, no
+ * block; the numbers are the part that is always true.
+ */
+export function newsletterEmail(
+  locale: Locale,
+  recap: MonthlyRecap,
+  note: NewsletterNote | null,
+  unsubscribe: string,
+): Email {
+  const t = translator(locale)
+  const monthName = monthLabel(locale, recap.month)
+  const subject = t('email.newsletterSubject', { month: monthName })
+
+  const stat = (label: string, value: number): string =>
+    `<tr><td style="padding:6px 16px 6px 0; font-size:15px; line-height:23px; color:#62676d;">${label}</td><td style="padding:6px 0; font-size:15px; line-height:23px; color:#17191c;"><strong>${value.toLocaleString(locale)}</strong></td></tr>`
+
+  const yours = recap.quiet
+    ? `<p style="color:#62676d;">${t('email.newsletterQuiet')}</p>`
+    : `<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:12px 0 0;">
+        ${[
+          stat(t('email.newsletterMessages'), recap.personal.messages),
+          stat(t('email.newsletterCorrections'), recap.personal.corrections),
+          stat(t('email.newsletterTokens'), recap.personal.tokens),
+          stat(t('email.newsletterStreak'), recap.personal.streak),
+        ].join('\n        ')}
+      </table>`
+
+  const everybody = `<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:12px 0 0;">
+        ${[
+          stat(t('email.newsletterNewMembers'), recap.community.members),
+          stat(t('email.newsletterMessagesSent'), recap.community.messages),
+          stat(t('email.newsletterCorrectionsMade'), recap.community.corrections),
+        ].join('\n        ')}
+      </table>`
+
+  const editorial = note
+    ? `<h2 style="font-family:${TITLE_FONT}; font-size:18px; line-height:24px; font-weight:800; color:#17191c; margin:32px 0 0;">${escapeHtml(note.headline)}</h2>
+       ${note.items
+         .map(
+           (item) =>
+             `<p style="margin:12px 0 0;"><strong>${escapeHtml(item.title)}</strong><br /><span style="color:#62676d;">${escapeHtml(item.body)}</span></p>`,
+         )
+         .join('\n       ')}
+       ${note.note ? `<p style="margin:16px 0 0; color:#62676d;">${escapeHtml(note.note)}</p>` : ''}`
+    : ''
+
+  const cta = { url: webUrl('/discover'), label: t('email.newsletterButton') }
+  return {
+    subject,
+    html: notificationEmail(locale, {
+      preheader: t('email.newsletterPreheader'),
+      bodyHtml: `<p><strong style="font-family:${TITLE_FONT}; font-size:20px; line-height:26px;">${subject}</strong></p>
+       <h2 style="font-family:${TITLE_FONT}; font-size:18px; line-height:24px; font-weight:800; color:#17191c; margin:24px 0 0;">${t('email.newsletterYours')}</h2>
+       ${yours}
+       <h2 style="font-family:${TITLE_FONT}; font-size:18px; line-height:24px; font-weight:800; color:#17191c; margin:32px 0 0;">${t('email.newsletterEverybody')}</h2>
+       ${everybody}
+       ${editorial}`,
+      cta,
+      unsubscribeUrl: unsubscribe,
+      manageUrl: webUrl('/settings'),
+    }).html,
+    text: notificationText(
+      locale,
+      [
+        subject,
+        '',
+        t('email.newsletterYours'),
+        ...(recap.quiet
+          ? [t('email.newsletterQuiet')]
+          : [
+              `${t('email.newsletterMessages')}: ${recap.personal.messages}`,
+              `${t('email.newsletterCorrections')}: ${recap.personal.corrections}`,
+              `${t('email.newsletterTokens')}: ${recap.personal.tokens}`,
+              `${t('email.newsletterStreak')}: ${recap.personal.streak}`,
+            ]),
+        '',
+        t('email.newsletterEverybody'),
+        `${t('email.newsletterNewMembers')}: ${recap.community.members}`,
+        `${t('email.newsletterMessagesSent')}: ${recap.community.messages}`,
+        `${t('email.newsletterCorrectionsMade')}: ${recap.community.corrections}`,
+        ...(note
+          ? [
+              '',
+              note.headline,
+              ...note.items.map((item) => `- ${item.title}: ${item.body}`),
+              ...(note.note ? [note.note] : []),
+            ]
+          : []),
+        '',
+        cta.url,
+      ],
+      unsubscribe,
+    ),
+  }
+}
+
+/** "September 2026", in the reader's language, falling back to the key. */
+function monthLabel(locale: Locale, month: string): string {
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      month: 'long',
+      year: 'numeric',
+      timeZone: 'UTC',
+    }).format(new Date(`${month}-01T00:00:00Z`))
+  } catch {
+    return month
   }
 }
 

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -160,6 +160,35 @@ export const ar: Localized<ServerMessages> = {
     unsubscribedBody: 'يمكنك تشغيلها متى شئت من LangX في الإعدادات ← الإشعارات.',
     unsubscribeInvalid: 'هذا الرابط غير صالح. افتح LangX وغيّره من الإعدادات ← الإشعارات.',
 
+    /** The monthly recap. Two halves: the reader's numbers and everybody's. */
+
+    newsletterSubject: '{month} في LangX',
+
+    newsletterPreheader: 'الشهر بالأرقام: أرقامك وأرقام الجميع',
+
+    newsletterYours: 'شهرك',
+
+    newsletterEverybody: 'شهر الجميع',
+
+    newsletterQuiet:
+      'كنت هادئاً هذا الشهر — لا رسائل ولا تصحيحات. من في الأسفل لم يكونوا كذلك، وما زالوا هنا.',
+
+    newsletterMessages: 'الرسائل المُرسَلة',
+
+    newsletterCorrections: 'التصحيحات المُقدَّمة',
+
+    newsletterTokens: 'الرموز المكتسبة',
+
+    newsletterStreak: 'السلسلة اليوم',
+
+    newsletterNewMembers: 'أعضاء جدد',
+
+    newsletterMessagesSent: 'الرسائل المُرسَلة',
+
+    newsletterCorrectionsMade: 'التصحيحات المُنجَزة',
+
+    newsletterButton: 'افتح LangX',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -162,6 +162,35 @@ export const de: Localized<ServerMessages> = {
     unsubscribeInvalid:
       'Dieser Link ist ungültig. Öffne LangX und ändere es unter Einstellungen → Mitteilungen.',
 
+    /** The monthly recap. Two halves: the reader's numbers and everybody's. */
+
+    newsletterSubject: 'Dein {month} bei LangX',
+
+    newsletterPreheader: 'Der Monat in Zahlen — deine und die aller',
+
+    newsletterYours: 'Dein Monat',
+
+    newsletterEverybody: 'Der Monat aller',
+
+    newsletterQuiet:
+      'Du warst diesen Monat still — keine Nachrichten, keine Korrekturen. Die Leute unten waren es nicht, und sie sind noch da.',
+
+    newsletterMessages: 'Gesendete Nachrichten',
+
+    newsletterCorrections: 'Gegebene Korrekturen',
+
+    newsletterTokens: 'Verdiente Token',
+
+    newsletterStreak: 'Serie heute',
+
+    newsletterNewMembers: 'Neue Mitglieder',
+
+    newsletterMessagesSent: 'Gesendete Nachrichten',
+
+    newsletterCorrectionsMade: 'Gemachte Korrekturen',
+
+    newsletterButton: 'LangX öffnen',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -167,6 +167,35 @@ export const en = {
     unsubscribeInvalid:
       'This link is not valid. Open LangX and change it under Settings → Notifications.',
 
+    /** The monthly recap. Two halves: the reader's numbers and everybody's. */
+
+    newsletterSubject: 'Your {month} on LangX',
+
+    newsletterPreheader: 'The month in numbers, yours and everybody’s',
+
+    newsletterYours: 'Your month',
+
+    newsletterEverybody: 'Everybody’s month',
+
+    newsletterQuiet:
+      'You were quiet this month — no messages, no corrections. The people below were not, and they are still here.',
+
+    newsletterMessages: 'Messages sent',
+
+    newsletterCorrections: 'Corrections given',
+
+    newsletterTokens: 'Tokens earned',
+
+    newsletterStreak: 'Streak today',
+
+    newsletterNewMembers: 'New members',
+
+    newsletterMessagesSent: 'Messages sent',
+
+    newsletterCorrectionsMade: 'Corrections made',
+
+    newsletterButton: 'Open LangX',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -161,6 +161,35 @@ export const es: Localized<ServerMessages> = {
     unsubscribeInvalid:
       'Este enlace no es válido. Abre LangX y cámbialo en Ajustes → Notificaciones.',
 
+    /** The monthly recap. Two halves: the reader's numbers and everybody's. */
+
+    newsletterSubject: 'Tu {month} en LangX',
+
+    newsletterPreheader: 'El mes en números, el tuyo y el de todos',
+
+    newsletterYours: 'Tu mes',
+
+    newsletterEverybody: 'El mes de todos',
+
+    newsletterQuiet:
+      'Este mes estuviste en silencio: ni mensajes ni correcciones. La gente de abajo no lo estuvo, y sigue aquí.',
+
+    newsletterMessages: 'Mensajes enviados',
+
+    newsletterCorrections: 'Correcciones hechas',
+
+    newsletterTokens: 'Tokens ganados',
+
+    newsletterStreak: 'Racha hoy',
+
+    newsletterNewMembers: 'Nuevos miembros',
+
+    newsletterMessagesSent: 'Mensajes enviados',
+
+    newsletterCorrectionsMade: 'Correcciones hechas',
+
+    newsletterButton: 'Abrir LangX',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -166,6 +166,35 @@ export const fr: Localized<ServerMessages> = {
     unsubscribeInvalid:
       'Ce lien n’est pas valide. Ouvrez LangX et modifiez-le dans Réglages → Notifications.',
 
+    /** The monthly recap. Two halves: the reader's numbers and everybody's. */
+
+    newsletterSubject: 'Votre {month} sur LangX',
+
+    newsletterPreheader: 'Le mois en chiffres, le vôtre et celui de tous',
+
+    newsletterYours: 'Votre mois',
+
+    newsletterEverybody: 'Le mois de tous',
+
+    newsletterQuiet:
+      'Vous avez été silencieux ce mois-ci : aucun message, aucune correction. Les personnes ci-dessous ne l’ont pas été, et elles sont toujours là.',
+
+    newsletterMessages: 'Messages envoyés',
+
+    newsletterCorrections: 'Corrections données',
+
+    newsletterTokens: 'Jetons gagnés',
+
+    newsletterStreak: 'Série aujourd’hui',
+
+    newsletterNewMembers: 'Nouveaux membres',
+
+    newsletterMessagesSent: 'Messages envoyés',
+
+    newsletterCorrectionsMade: 'Corrections faites',
+
+    newsletterButton: 'Ouvrir LangX',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -158,6 +158,35 @@ export const ptBR: Localized<ServerMessages> = {
     unsubscribeInvalid:
       'Este link não é válido. Abra o LangX e altere em Configurações → Notificações.',
 
+    /** The monthly recap. Two halves: the reader's numbers and everybody's. */
+
+    newsletterSubject: 'Seu {month} no LangX',
+
+    newsletterPreheader: 'O mês em números, o seu e o de todos',
+
+    newsletterYours: 'Seu mês',
+
+    newsletterEverybody: 'O mês de todos',
+
+    newsletterQuiet:
+      'Você ficou quieto este mês — nenhuma mensagem, nenhuma correção. As pessoas abaixo não ficaram, e continuam aqui.',
+
+    newsletterMessages: 'Mensagens enviadas',
+
+    newsletterCorrections: 'Correções feitas',
+
+    newsletterTokens: 'Tokens ganhos',
+
+    newsletterStreak: 'Sequência hoje',
+
+    newsletterNewMembers: 'Novos membros',
+
+    newsletterMessagesSent: 'Mensagens enviadas',
+
+    newsletterCorrectionsMade: 'Correções feitas',
+
+    newsletterButton: 'Abrir o LangX',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -172,6 +172,35 @@ export const ru: Localized<ServerMessages> = {
     unsubscribeInvalid:
       'Ссылка недействительна. Откройте LangX и измените это в Настройках → Уведомления.',
 
+    /** The monthly recap. Two halves: the reader's numbers and everybody's. */
+
+    newsletterSubject: 'Ваш {month} в LangX',
+
+    newsletterPreheader: 'Месяц в цифрах — ваших и общих',
+
+    newsletterYours: 'Ваш месяц',
+
+    newsletterEverybody: 'Месяц всех',
+
+    newsletterQuiet:
+      'В этом месяце вы молчали — ни сообщений, ни исправлений. Те, кто ниже, — нет, и они всё ещё здесь.',
+
+    newsletterMessages: 'Отправлено сообщений',
+
+    newsletterCorrections: 'Сделано исправлений',
+
+    newsletterTokens: 'Заработано токенов',
+
+    newsletterStreak: 'Серия сегодня',
+
+    newsletterNewMembers: 'Новых участников',
+
+    newsletterMessagesSent: 'Отправлено сообщений',
+
+    newsletterCorrectionsMade: 'Сделано исправлений',
+
+    newsletterButton: 'Открыть LangX',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -147,6 +147,35 @@ export const tr: Localized<ServerMessages> = {
     unsubscribeInvalid:
       'Bu bağlantı geçerli değil. LangX’i açıp Ayarlar → Bildirimler’den değiştir.',
 
+    /** The monthly recap. Two halves: the reader's numbers and everybody's. */
+
+    newsletterSubject: 'LangX’te {month} ayın',
+
+    newsletterPreheader: 'Ay, rakamlarla: senin ve herkesin',
+
+    newsletterYours: 'Senin ayın',
+
+    newsletterEverybody: 'Herkesin ayı',
+
+    newsletterQuiet:
+      'Bu ay sessizdin — mesaj yok, düzeltme yok. Aşağıdakiler sessiz değildi ve hâlâ buradalar.',
+
+    newsletterMessages: 'Gönderilen mesaj',
+
+    newsletterCorrections: 'Yapılan düzeltme',
+
+    newsletterTokens: 'Kazanılan token',
+
+    newsletterStreak: 'Bugünkü seri',
+
+    newsletterNewMembers: 'Yeni üye',
+
+    newsletterMessagesSent: 'Gönderilen mesaj',
+
+    newsletterCorrectionsMade: 'Yapılan düzeltme',
+
+    newsletterButton: 'LangX’i aç',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/modules/notifications/newsletter.test.ts
+++ b/apps/api/src/modules/notifications/newsletter.test.ts
@@ -1,0 +1,181 @@
+import { ObjectId } from 'mongodb'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import { ensureIndexes } from '../../db/indexes'
+import type { NotificationEmailContext } from '../../email/notify'
+import { authId } from '../../lib/authId'
+import { CapturingEmailSender } from '../../testSupport/authFlow'
+import { lastMonthKey, runNewsletterPass } from './newsletter'
+
+const SECRET = 'n'.repeat(40)
+/** The first of October at noon UTC: the recap is about September. */
+const FIRST = new Date('2026-10-01T12:00:00Z')
+
+describe('the monthly recap', () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+  let sender: CapturingEmailSender
+  let ctx: NotificationEmailContext
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'newsletter_test')
+    await ensureIndexes(handle.db)
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    for (const name of [
+      COLLECTIONS.profiles,
+      COLLECTIONS.user,
+      COLLECTIONS.notificationLedger,
+      COLLECTIONS.emailCampaigns,
+      COLLECTIONS.dailyActivity,
+      COLLECTIONS.tokenAggregates,
+      COLLECTIONS.messages,
+      COLLECTIONS.postCorrections,
+    ]) {
+      await handle.db.collection(name).deleteMany({})
+    }
+    sender = new CapturingEmailSender()
+    ctx = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api.langx.io' }
+  })
+
+  async function newProfile(
+    opts: { timezone?: string; optedIn?: boolean; streak?: number; createdAt?: Date } = {},
+  ): Promise<string> {
+    const userId = new ObjectId().toHexString()
+    await handle.db.collection(COLLECTIONS.profiles).insertOne({
+      _id: userId,
+      handle: `h${userId.slice(-10)}`,
+      displayName: 'Sofia R.',
+      timezone: opts.timezone ?? 'UTC',
+      settings: {
+        discoverable: true,
+        notifications: opts.optedIn === false ? {} : { promotions: { push: false, email: true } },
+      },
+      nativeLanguages: [{ code: 'en' }],
+      streak: { current: opts.streak ?? 0, longest: 0, lastQualifiedDay: null },
+      stats: { lastActiveAt: FIRST, messagesSent: 0 },
+      createdAt: opts.createdAt ?? new Date('2026-01-01T00:00:00Z'),
+    } as never)
+    await handle.db.collection(COLLECTIONS.user).insertOne({
+      _id: authId(userId),
+      email: `${userId}@example.com`,
+      emailVerified: true,
+    })
+    return userId
+  }
+
+  async function activity(userId: string, day: string, messages: number, corrections: number) {
+    await handle.db.collection(COLLECTIONS.dailyActivity).insertOne({
+      _id: `${userId}:${day}`,
+      userId,
+      day,
+      messages,
+      corrections,
+      mutualConversations: 0,
+      partners: [],
+      perPartner: {},
+      updatedAt: FIRST,
+    } as never)
+  }
+
+  it('names last month, not this one', () => {
+    expect(lastMonthKey(FIRST)).toBe('2026-09')
+    expect(lastMonthKey(new Date('2026-01-03T00:00:00Z'))).toBe('2025-12')
+  })
+
+  it('adds up the month from what is already counted', async () => {
+    const userId = await newProfile({ streak: 4 })
+    await activity(userId, '2026-09-02', 12, 3)
+    await activity(userId, '2026-09-19', 8, 1)
+    // A day in the month before must not leak in.
+    await activity(userId, '2026-08-30', 99, 99)
+    await handle.db.collection(COLLECTIONS.tokenAggregates).insertOne({
+      _id: `${userId}:month:2026-09`,
+      userId,
+      periodType: 'month',
+      periodKey: '2026-09',
+      tokens: 640,
+      updatedAt: FIRST,
+    } as never)
+
+    expect(await runNewsletterPass(handle.db, ctx, FIRST)).toEqual({ sent: 1 })
+    const html = sender.messages[0]?.html ?? ''
+    expect(sender.messages[0]?.subject).toContain('September 2026')
+    expect(html).toContain('>20<')
+    expect(html).toContain('>4<')
+    expect(html).toContain('640')
+  })
+
+  /** Three zeroes at somebody is not a summary; one sentence is. */
+  it('writes a different letter for a month somebody sat out', async () => {
+    await newProfile()
+    await runNewsletterPass(handle.db, ctx, FIRST)
+    expect(sender.messages[0]?.html).toContain('You were quiet this month')
+  })
+
+  it('counts the community once and tells everybody the same numbers', async () => {
+    await newProfile()
+    await newProfile()
+    await handle.db.collection(COLLECTIONS.messages).insertMany([
+      { createdAt: new Date('2026-09-04T10:00:00Z') },
+      { createdAt: new Date('2026-09-24T10:00:00Z') },
+      // October: outside the month being summed.
+      { createdAt: new Date('2026-10-01T01:00:00Z') },
+    ] as never[])
+
+    expect(await runNewsletterPass(handle.db, ctx, FIRST)).toEqual({ sent: 2 })
+    for (const message of sender.messages) expect(message.html).toContain('>2<')
+  })
+
+  it('goes once a month, whatever the tick', async () => {
+    await newProfile()
+    expect(await runNewsletterPass(handle.db, ctx, FIRST)).toEqual({ sent: 1 })
+    expect(await runNewsletterPass(handle.db, ctx, FIRST)).toEqual({ sent: 0 })
+    // A day later is still the same month's recap.
+    expect(await runNewsletterPass(handle.db, ctx, new Date('2026-10-03T12:00:00Z'))).toEqual({
+      sent: 0,
+    })
+  })
+
+  /** A deploy on the third must not skip the month; the claim stops the double. */
+  it('catches up within the first week', async () => {
+    await newProfile()
+    expect(await runNewsletterPass(handle.db, ctx, new Date('2026-10-05T12:00:00Z'))).toEqual({
+      sent: 1,
+    })
+    // And after the window it waits for the next month rather than arriving late.
+    await handle.db.collection(COLLECTIONS.notificationLedger).deleteMany({})
+    expect(await runNewsletterPass(handle.db, ctx, new Date('2026-10-20T12:00:00Z'))).toEqual({
+      sent: 0,
+    })
+  })
+
+  it('waits for ten in the morning, on the reader’s own clock', async () => {
+    await newProfile({ timezone: 'Asia/Tokyo' })
+    // Noon UTC is 21:00 in Tokyo on the 1st — past ten, so it goes.
+    expect(await runNewsletterPass(handle.db, ctx, FIRST)).toEqual({ sent: 1 })
+
+    await handle.db.collection(COLLECTIONS.profiles).deleteMany({})
+    await handle.db.collection(COLLECTIONS.notificationLedger).deleteMany({})
+    sender.messages.length = 0
+    await newProfile({ timezone: 'America/Los_Angeles' })
+    // 03:00 in Los Angeles is not ten in the morning anywhere.
+    expect(await runNewsletterPass(handle.db, ctx, new Date('2026-10-01T10:00:00Z'))).toEqual({
+      sent: 0,
+    })
+  })
+
+  it('goes only to somebody who asked for promotional mail', async () => {
+    await newProfile({ optedIn: false })
+    expect(await runNewsletterPass(handle.db, ctx, FIRST)).toEqual({ sent: 0 })
+  })
+})

--- a/apps/api/src/modules/notifications/newsletter.ts
+++ b/apps/api/src/modules/notifications/newsletter.ts
@@ -1,0 +1,164 @@
+import { NEWSLETTER_LOCAL_HOUR, localDayKey, localHour, notificationsAllowed } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { sendNotificationEmail, type NotificationEmailContext } from '../../email/notify'
+import { newsletterEmail } from '../../email/templates'
+import { noteFor } from '../../email/newsletters'
+import type { Profile } from '../profiles/profiles'
+import { claimOnce } from './ledger'
+import { recentlyMarketed } from './marketing'
+
+/** What a month looked like for one person, and for everybody. */
+export interface MonthlyRecap {
+  month: string
+  personal: { messages: number; corrections: number; tokens: number; streak: number }
+  community: { members: number; messages: number; corrections: number }
+  /** True when the personal half is all zeroes — a different letter. */
+  quiet: boolean
+}
+
+/** The month before the one `now` is in, as `YYYY-MM`. */
+export function lastMonthKey(now: Date): string {
+  const first = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+  const previous = new Date(first.getTime() - 24 * 60 * 60 * 1000)
+  return previous.toISOString().slice(0, 7)
+}
+
+/**
+ * The community numbers, computed once per tick rather than once per reader.
+ *
+ * Three counts over a month of rows. On a database this size that is
+ * milliseconds; if it ever is not, the answer is a `jobRuns` row holding the
+ * month's totals rather than a cache here, since every instance would want
+ * the same three numbers.
+ */
+export async function communityMonth(db: Db, month: string): Promise<MonthlyRecap['community']> {
+  const from = new Date(`${month}-01T00:00:00.000Z`)
+  const to = new Date(Date.UTC(from.getUTCFullYear(), from.getUTCMonth() + 1, 1))
+  const range = { $gte: from, $lt: to }
+  const [members, messages, corrections] = await Promise.all([
+    db
+      .collection(COLLECTIONS.profiles)
+      .countDocuments({ createdAt: range, guest: { $exists: false } }),
+    db.collection(COLLECTIONS.messages).countDocuments({ createdAt: range }),
+    db.collection(COLLECTIONS.postCorrections).countDocuments({ createdAt: range }),
+  ])
+  return { members, messages, corrections }
+}
+
+/**
+ * One person's month, read from what the token ledger already aggregates and
+ * what `dailyActivity` already counts.
+ *
+ * Nothing new is stored for this. `dailyActivity` exists to cap the daily
+ * pool and holds a row per person per day with exactly the two numbers a
+ * recap wants; summing thirty of them is cheaper than keeping a second
+ * running total that could disagree with the first.
+ */
+export async function personalMonth(
+  db: Db,
+  userId: string,
+  month: string,
+): Promise<MonthlyRecap['personal']> {
+  const days = await db
+    .collection<{ messages?: number; corrections?: number }>(COLLECTIONS.dailyActivity)
+    .find({ userId, day: { $gte: `${month}-01`, $lte: `${month}-31` } })
+    .toArray()
+  const tokens =
+    (
+      await db
+        .collection<{ tokens: number }>(COLLECTIONS.tokenAggregates)
+        .findOne({ _id: `${userId}:month:${month}` as never })
+    )?.tokens ?? 0
+  const profile = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .findOne({ _id: userId }, { projection: { streak: 1 } })
+  return {
+    messages: days.reduce((total, day) => total + (day.messages ?? 0), 0),
+    corrections: days.reduce((total, day) => total + (day.corrections ?? 0), 0),
+    tokens,
+    streak: profile?.streak?.current ?? 0,
+  }
+}
+
+/**
+ * "Your month on LangX" — the one piece of mail here that is the same shape
+ * every time and still worth reading, because the numbers in it are yours.
+ *
+ * **Monthly rather than weekly**, and the reason is the numbers themselves: a
+ * week of a language exchange is three conversations and a correction, which
+ * reads as an accusation rather than a summary. Switching it is
+ * `NEWSLETTER_LOCAL_HOUR`'s neighbours in `packages/shared`, not a rewrite.
+ *
+ * **"On or after the first", not "on the first."** A deploy on the third
+ * would otherwise skip the month silently, and the claim is what stops it
+ * being sent twice — so the condition can afford to be generous.
+ *
+ * The editorial half — what shipped this month — comes from
+ * `email/newsletters/`, which is written by a scheduled routine, reviewed as
+ * a pull request and merged. No note for the month, no editorial block; the
+ * recap still goes, because the numbers are the part that is always true.
+ */
+export async function runNewsletterPass(
+  db: Db,
+  ctx: NotificationEmailContext,
+  now: Date = new Date(),
+): Promise<{ sent: number }> {
+  const month = lastMonthKey(now)
+  const profiles = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .find({
+      deletedAt: { $exists: false },
+      guest: { $exists: false },
+      'settings.notifications': { $ne: false },
+    })
+    .toArray()
+
+  let community: MonthlyRecap['community'] | null = null
+  let sent = 0
+
+  for (const profile of profiles) {
+    if (!notificationsAllowed(profile.settings?.notifications, 'promotions', 'email')) continue
+    const zone = profile.timezone ?? 'UTC'
+    // Their first of the month — or one of the six days after it, so a
+    // deploy that slipped does not skip a month — and any hour from ten
+    // onwards, since a tick missed at ten is not a month skipped either.
+    if (!isSendingDay(localDayKey(now, zone))) continue
+    if (localHour(now, zone) < NEWSLETTER_LOCAL_HOUR) continue
+    if (await recentlyMarketed(db, profile._id, now)) continue
+
+    // Computed on the first tick that needs it, then reused for the rest.
+    community ??= await communityMonth(db, month)
+    const personal = await personalMonth(db, profile._id, month)
+    const recap: MonthlyRecap = {
+      month,
+      personal,
+      community,
+      quiet: personal.messages === 0 && personal.corrections === 0 && personal.tokens === 0,
+    }
+
+    if (!(await claimOnce(db, 'promo.newsletter', profile._id, month))) continue
+    const outcome = await sendNotificationEmail(db, ctx, {
+      userId: profile._id,
+      type: 'promotions',
+      build: (locale, unsubscribe) =>
+        newsletterEmail(locale, recap, noteFor(month, locale), unsubscribe),
+    })
+    if (outcome === 'sent') sent++
+  }
+
+  return { sent }
+}
+
+/**
+ * The days that still count as "this month's newsletter".
+ *
+ * The first, plus the six after it: long enough to cover a deploy that
+ * slipped or an instance that was down, short enough that a recap of last
+ * month does not arrive when last month is a fortnight gone. The claim is
+ * what stops it going twice, so this can afford to be generous.
+ */
+function isSendingDay(localDay: string): boolean {
+  const dayOfMonth = Number(localDay.slice(8, 10))
+  return dayOfMonth >= 1 && dayOfMonth <= 7
+}

--- a/apps/api/src/modules/notifications/scheduler.ts
+++ b/apps/api/src/modules/notifications/scheduler.ts
@@ -5,6 +5,7 @@ import type { SchedulerLogger } from '../tokens/poolScheduler'
 import { runBadgeRoundUpPass } from './badges'
 import { runCampaignQueuePass } from './campaignQueue'
 import { runProfileVisitsEmailPass, runProfileVisitsPushPass } from './profileVisits'
+import { runNewsletterPass } from './newsletter'
 import { runPromotionsPass } from './promotions'
 import { runUnreadDigestPass } from './unreadDigest'
 import { runVerifyReminderPass } from './verifyReminder'
@@ -68,6 +69,9 @@ export function startNotificationScheduler(
               ),
             ]
           : []),
+        // Before the nudges: on the first of a month the recap is the thing
+        // worth saying, and the cap would otherwise let a nudge take its place.
+        run('newsletter', () => runNewsletterPass(db, senders.email, now)),
         run('promotions', () => runPromotionsPass(db, senders, now)),
         run('campaign queue', () =>
           runCampaignQueuePass(db, senders.email, now, {

--- a/apps/api/src/modules/security/deviceLabel.test.ts
+++ b/apps/api/src/modules/security/deviceLabel.test.ts
@@ -15,6 +15,9 @@ const AGENTS = {
     'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Mobile Safari/537.36',
   edge: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36 Edg/152.0.0.0',
   expoIos: 'LangX/2.2 CFNetwork/1568.100.1 Darwin/24.0.0',
+  /** What React Native actually sends, taken off `session` in production. */
+  bareIos: 'CFNetwork/1568.100.1 Darwin/24.0.0',
+  bareAndroid: 'okhttp/4.12.0',
   curl: 'curl/8.5.0',
 }
 
@@ -55,6 +58,26 @@ describe('naming the device somebody signed in from', () => {
     const now = deviceIdentity(AGENTS.windowsChrome).fingerprint
     const later = deviceIdentity(AGENTS.windowsChrome.replace('152.0.0.0', '191.0.3.7')).fingerprint
     expect(later).toBe(now)
+  })
+
+  /**
+   * React Native sends no browser user agent at all. Fifty-three production
+   * sessions carried `okhttp/4.12.0`, and reading those literally told people
+   * they had signed in from "okhttp".
+   */
+  it('knows the app by the library it speaks through', () => {
+    expect(deviceIdentity(AGENTS.bareAndroid)).toEqual({
+      fingerprint: 'android-app',
+      label: 'the LangX app on Android',
+    })
+    expect(deviceIdentity(AGENTS.bareIos)).toEqual({
+      fingerprint: 'ios-app',
+      label: 'the LangX app on iPhone',
+    })
+    // And the two ways in from one phone are one device, not two.
+    expect(deviceIdentity(AGENTS.expoIos).fingerprint).toBe(
+      deviceIdentity(AGENTS.bareIos).fingerprint,
+    )
   })
 
   it('names a script by what it called itself, and an absent agent not at all', () => {

--- a/apps/api/src/modules/security/deviceLabel.ts
+++ b/apps/api/src/modules/security/deviceLabel.ts
@@ -21,17 +21,29 @@ export interface DeviceIdentity {
 
 const UNKNOWN: DeviceIdentity = { fingerprint: 'unknown', label: 'an unrecognised device' }
 
-/** Ours first: the app's own requests should not read as "Safari on iPhone". */
+/**
+ * Ours first: the app's own requests should not read as "Safari on iPhone",
+ * and they must not read as the HTTP library either.
+ *
+ * React Native does not send a browser user agent. On Android it sends
+ * `okhttp/4.x` and nothing else, and on iOS `CFNetwork/… Darwin/…` — which
+ * a run against production turned into fifty-three people being told they had
+ * signed in from "okhttp". Nothing else in this app's traffic uses either
+ * library, so both are read as the app.
+ */
 function appIdentity(userAgent: string): DeviceIdentity | null {
-  if (/\bExpo\b|LangX/i.test(userAgent)) {
-    if (/\bAndroid\b/i.test(userAgent))
-      return { fingerprint: 'android-app', label: 'the LangX app on Android' }
-    if (/\biPhone|iPad|iOS|CFNetwork\b/i.test(userAgent)) {
-      return { fingerprint: 'ios-app', label: 'the LangX app on iPhone' }
-    }
-    return { fingerprint: 'app', label: 'the LangX app' }
+  const named = /\bExpo\b|LangX/i.test(userAgent)
+  if (named ? /\bAndroid\b/i.test(userAgent) : /^okhttp\//i.test(userAgent)) {
+    return { fingerprint: 'android-app', label: 'the LangX app on Android' }
   }
-  return null
+  if (
+    named
+      ? /\biPhone|iPad|iOS|CFNetwork\b/i.test(userAgent)
+      : /\bCFNetwork\b/i.test(userAgent) && /\bDarwin\b/i.test(userAgent)
+  ) {
+    return { fingerprint: 'ios-app', label: 'the LangX app on iPhone' }
+  }
+  return named ? { fingerprint: 'app', label: 'the LangX app' } : null
 }
 
 function platformOf(userAgent: string): { key: string; name: string } {

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3712,3 +3712,32 @@ and what makes "we miss you" one letter rather than a daily one.
 The push half is not a fallback for the mail and not gated on it. Somebody
 with the app installed and promotions on asked for both, and the mail is
 often the one that is never opened.
+
+## The newsletter is monthly, and its editorial half is a pull request
+
+A weekly recap was the obvious cadence and the numbers rule it out: a week of
+a language exchange is three conversations and a correction, which reads as
+an accusation rather than a summary. Monthly, at ten in the morning on the
+reader's own clock — and on **any of the first seven days**, not only the
+first, because a deploy that slipped would otherwise skip a month silently
+and the ledger claim already makes a second send impossible.
+
+Two halves, and both are load-bearing. The personal numbers are the reason to
+open it; the community numbers are the reason to come back, because they are
+true whether or not the reader was there. A month somebody sat out swaps the
+personal half for a single sentence rather than printing three zeroes at
+them.
+
+Nothing new is stored to compute any of it. `dailyActivity` already holds a
+row per person per day with the two numbers a recap wants — it exists to cap
+the daily pool — and `tokenAggregates` already has the month's tokens.
+Summing thirty small rows is cheaper than a second running total that could
+disagree with the first.
+
+**The editorial half is written by a scheduled routine and approved by
+merging its pull request.** The alternative — an admin screen, or a note
+typed into a database — would have put the one piece of user-facing copy this
+app sends outside review, outside git, and outside the eight-language
+catalogue that every other string lives in. A month with no merged note still
+gets its recap; the numbers are the part that is always true. See
+`src/email/newsletters/README.md`.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -67,6 +67,7 @@ during the window catches up on its next tick instead of skipping silently.
 | Account purge    | 1 hour   | Hard-deletes accounts past their 30-day grace period.                                                                                                                              |
 | Streak reminder  | 30 min   | Sends the nudge at 20:00 in each user's own timezone, once per local day — as a push, or as email to somebody with no phone.                                                       |
 | Notifications    | 30 min   | Three passes: the unread-message digest, the profile-visit round-up (daily push, weekly email) and the badge round-up at 18:00.                                                    |
+| Newsletter       | 30 min   | "Your month on LangX" on the first of the month at 10:00 local, or any of the six days after. Once per reader per month.                                                           |
 | Promotions       | 30 min   | Six nudges — add a photo, repair a broken streak, come back at 7 and 30 days, spend idle tokens, invite a friend. One per person per tick, then `MARKETING_MIN_GAP_DAYS` of quiet. |
 | Verify reminder  | 30 min   | One more verification link, a day after an unverified sign-up. Exactly once per account, and never after a week.                                                                   |
 | Campaign queue   | 30 min   | Drips a queued broadcast out on a warm-up ramp (`CAMPAIGN_WARMUP_PER_DAY`), 08–20 UTC only. `send-campaign.ts` enqueues, this sends.                                               |

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -83,7 +83,10 @@ a changed password, and a sign-in method connected or disconnected. They go
 by mail _and_ push, carry no unsubscribe, and reach an account whose owner
 switched every other notification off — a switch whose honest label is "do
 not tell me when somebody signs in as me" is not one to offer. `knownDevices`
-is what makes "a device we have not seen" answerable; it has no TTL.
+is what makes "a device we have not seen" answerable; it has no TTL — and it
+starts empty, so `scripts/backfill-known-devices.ts` has to run before the
+first deploy that carries this, or everybody's next sign-in is a "new device"
+letter about the phone they are holding.
 
 Nothing is sent to an address on `emailSuppressions`, service mail included:
 a permanent bounce or a spam complaint reported by Resend's webhook

--- a/packages/shared/src/notifications.ts
+++ b/packages/shared/src/notifications.ts
@@ -321,3 +321,18 @@ export const UNREAD_DIGEST_MAX_SENDERS = 3
  * fired the moment the condition is met.
  */
 export const NOTIFICATION_EMAIL_LOCAL_HOURS = { earliest: 9, latest: 21 } as const
+
+/**
+ * When the monthly recap goes out, on the reader's own clock.
+ *
+ * Ten in the morning: late enough not to be the first thing on a phone,
+ * early enough to be read the day it arrives. It is sent on the first of the
+ * month or any of the six days after — see `runNewsletterPass` for why the
+ * window is wider than the day.
+ *
+ * **Monthly rather than weekly**, and the numbers are the reason: a week of a
+ * language exchange is three conversations and a correction, which reads as
+ * an accusation rather than a summary. A weekly cadence is this constant plus
+ * a different period key, not a rewrite.
+ */
+export const NEWSLETTER_LOCAL_HOUR = 10


### PR DESCRIPTION
PR E of the email + push programme. **Stacked on #1266** (→ #1265 → #1264); each base retargets as the one under it merges.

## What it sends

"Your **September 2026** on LangX", once a month, to anybody with `promotions.email` on:

- **Your month** — messages sent, corrections given, tokens earned, streak today. A month somebody sat out swaps all four for one sentence rather than printing three zeroes at them.
- **Everybody's month** — new members, messages, corrections. Computed once per tick, not once per reader.
- **What shipped** — optional, from `src/email/newsletters/YYYY-MM.ts`. No note for the month, no block; the recap still goes.

## Decisions

- **Monthly, not weekly.** A week of a language exchange is three conversations and a correction, which reads as an accusation rather than a summary. Weekly is `NEWSLETTER_LOCAL_HOUR`'s neighbours plus a different period key, not a rewrite.
- **Any of the first seven days**, at 10:00 on the reader's own clock. A deploy that slipped would otherwise skip a month silently, and the ledger claim already makes a second send impossible — so the window can afford to be generous.
- **Nothing new is stored.** `dailyActivity` already holds a row per person per day with the two numbers a recap wants, and `tokenAggregates` has the month's tokens. Summing thirty small rows beats a second running total that could disagree with the first.
- It runs **before** the promotions pass in the same tick: on the first of a month the recap is the thing worth saying, and the marketing cap would otherwise let a nudge take its place.

## The editorial half is a pull request

A scheduled routine drafts `YYYY-MM.ts` on the 27th from `git log --merges`, the month's releases and the new `docs/decisions.md` entries, in English plus seven translations, and opens a PR whose body carries the rendering. **Approval is the merge.** Nothing is ever sent on anybody's behalf.

The alternative — an admin screen or a note in a database — would have put the one piece of user-facing copy this app writes outside review, outside git, and outside the eight-language catalogue every other string lives in. `src/email/newsletters/README.md` has the whole workflow, including how to write one by hand.

**Not created yet:** the routine itself lives in Behic's scheduled agents, not in this repo. Say the word and I'll set it up.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — green (api 94 files, mobile 93, shared 26).
- `newsletter.test.ts`: the month is summed from what is already counted and August does not leak in, the quiet variant fires, the community numbers are counted once and are the same for everybody, it goes once a month whatever the tick, it catches up within the week and not after, it waits for ten on the reader's own clock, and it only goes to somebody who asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)