### PR TITLE
Say how big a share was, and who is in tonight's pool

### DIFF
--- a/apps/mobile/app/(app)/wallet/pool.tsx
+++ b/apps/mobile/app/(app)/wallet/pool.tsx
@@ -43,6 +43,19 @@ export default function PoolScreen() {
   const today = xp.data?.today
 
   /*
+   * The share against the pool it came out of. A backward-looking fact like
+   * the amount itself, and the one that gives the amount a size: +500 says
+   * nothing on its own, "5% of the daily pool" says how big a night that was.
+   * A fraction digit because a share of a ten-thousand pool is often under 1%.
+   */
+  const shareOfPool =
+    lastPayout &&
+    (lastPayout.amount / TOKEN_RULES.pool.total).toLocaleString(locale, {
+      style: 'percent',
+      maximumFractionDigits: 1,
+    })
+
+  /*
    * When the next share can land, for somebody who has never had one.
    *
    * Not a projected amount — the note on `tokenSummarySchema.pool` explains
@@ -85,6 +98,12 @@ export default function PoolScreen() {
               <Text style={styles.shareValue}>
                 {t('tokens.shareAmount', { count: lastPayout.amount })}
               </Text>
+              {/* How big a night that was, against the pool it came out of. */}
+              {shareOfPool ? (
+                <Text style={styles.meta}>
+                  {t('tokens.poolShareOfPool', { percent: shareOfPool })}
+                </Text>
+              ) : null}
               {/* Who the share was split with; absent from an API that does not say. */}
               {lastPayout.participants !== undefined ? (
                 <Text style={styles.meta}>
@@ -132,6 +151,20 @@ export default function PoolScreen() {
             })}{' '}
             {t('tokens.poolCap', { cap: shareCap })}
           </Text>
+          {/*
+            Who you are splitting tonight's pool with. The count the API has
+            always sent and the screen has never drawn — and the other half of
+            what makes today legible: your own score means nothing without the
+            number of people it will be divided among.
+          */}
+          {pool ? (
+            <Text style={styles.meta}>
+              {t('tokens.poolActiveToday', {
+                count: pool.activeToday,
+                n: pool.activeToday.toLocaleString(locale),
+              })}
+            </Text>
+          ) : null}
         </View>
       ) : null}
 

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -1471,6 +1471,15 @@ export const ar: Localized<EnMessages> = {
       many: '{n} شخصًا كانوا نشطين ذلك اليوم',
       other: '{n} شخص كانوا نشطين ذلك اليوم',
     },
+    poolShareOfPool: '{percent} من التجمّع اليومي',
+    poolActiveToday: {
+      zero: 'لا أحد نشط اليوم',
+      one: 'شخص واحد نشط اليوم',
+      two: 'شخصان نشطان اليوم',
+      few: '{n} أشخاص نشطون اليوم',
+      many: '{n} شخصًا نشطون اليوم',
+      other: '{n} شخص نشطون اليوم',
+    },
   },
 
   invite: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -1293,6 +1293,8 @@ export const de: Localized<EnMessages> = {
     activityScore: { one: '{count} Aktivität', other: '{count} Aktivität' },
     todayBreakdown: '{messages} Nachrichten, {corrections} Korrekturen, {partners} Personen.',
     poolParticipants: { one: '{n} aktiv an dem Tag', other: '{n} aktiv an dem Tag' },
+    poolShareOfPool: '{percent} des täglichen Pools',
+    poolActiveToday: { one: '{n} heute aktiv', other: '{n} heute aktiv' },
   },
 
   invite: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -1313,6 +1313,8 @@ export const en = {
     activityScore: { one: '{count} activity', other: '{count} activity' },
     todayBreakdown: '{messages} messages, {corrections} corrections, {partners} people.',
     poolParticipants: { one: '{n} active that day', other: '{n} active that day' },
+    poolShareOfPool: '{percent} of the daily pool',
+    poolActiveToday: { one: '{n} active today', other: '{n} active today' },
   },
 
   /** One per `TOKEN_KINDS`; `kindKey()` builds the key from the kind itself. */

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -1262,6 +1262,8 @@ export const es: Localized<EnMessages> = {
     activityScore: { one: '{count} de actividad', other: '{count} de actividad' },
     todayBreakdown: '{messages} mensajes, {corrections} correcciones, {partners} personas.',
     poolParticipants: { one: '{n} activo ese día', other: '{n} activos ese día' },
+    poolShareOfPool: '{percent} del bote diario',
+    poolActiveToday: { one: '{n} activo hoy', other: '{n} activos hoy' },
   },
 
   invite: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -1273,6 +1273,8 @@ export const fr: Localized<EnMessages> = {
     activityScore: { one: '{count} d’activité', other: '{count} d’activité' },
     todayBreakdown: '{messages} messages, {corrections} corrections, {partners} personnes.',
     poolParticipants: { one: '{n} actif ce jour-là', other: '{n} actifs ce jour-là' },
+    poolShareOfPool: '{percent} de la cagnotte du jour',
+    poolActiveToday: { one: '{n} actif aujourd’hui', other: '{n} actifs aujourd’hui' },
   },
 
   invite: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -1259,6 +1259,8 @@ export const ptBR: Localized<EnMessages> = {
     activityScore: { one: '{count} de atividade', other: '{count} de atividade' },
     todayBreakdown: '{messages} mensagens, {corrections} correções, {partners} pessoas.',
     poolParticipants: { one: '{n} ativo naquele dia', other: '{n} ativos naquele dia' },
+    poolShareOfPool: '{percent} do bolo diário',
+    poolActiveToday: { one: '{n} ativo hoje', other: '{n} ativos hoje' },
   },
 
   invite: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -1406,6 +1406,13 @@ export const ru: Localized<EnMessages> = {
       many: '{n} активных в тот день',
       other: '{n} активных в тот день',
     },
+    poolShareOfPool: '{percent} ежедневного пула',
+    poolActiveToday: {
+      one: '{n} активный сегодня',
+      few: '{n} активных сегодня',
+      many: '{n} активных сегодня',
+      other: '{n} активных сегодня',
+    },
   },
 
   invite: {

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -1269,6 +1269,8 @@ export const tr: Localized<EnMessages> = {
     activityScore: { one: '{count} aktivite', other: '{count} aktivite' },
     todayBreakdown: '{messages} mesaj, {corrections} düzeltme, {partners} kişi.',
     poolParticipants: { one: 'O gün {n} kişi aktifti', other: 'O gün {n} kişi aktifti' },
+    poolShareOfPool: 'Günlük havuzun {percent} kadarı',
+    poolActiveToday: { one: 'Bugün {n} kişi aktif', other: 'Bugün {n} kişi aktif' },
   },
 
   invite: {


### PR DESCRIPTION
## Why

The pool screen showed a number with nothing to measure it against. `+377` is not a size — it becomes one next to the pool it came out of. Both new lines are backward- or presently-true facts, so neither crosses the line the screen's own doc comment draws against a *projected* share.

## What

**The share as a fraction of the pool.** `lastPayout.amount / TOKEN_RULES.pool.total`, both already on the client — no API change. One fraction digit, because a share of a ten-thousand pool is often under 1%.

**`pool.activeToday`.** The API has sent this since the token summary existed and the app has never drawn it. Today's own score means very little without the number of people it will be divided among — and it is the only live thing on the page for someone who has no share yet, where "No share yet" and "the pool is broken" otherwise read identically.

Two new i18n keys across all eight locales; the count uses a plural entry, not a ternary.

## Not in this PR

Diagnosed while writing it, deliberately left alone: with fewer than 20 active users a day, everyone's proportional share exceeds `maxShareOfPool`, so every participant is paid exactly the 500 cap regardless of effort and ~80% of the pool goes undistributed (prod, 2026-09-09: 4 active, 4 paid, 2 000 of 10 000). The rule stops binding on its own past 20 active users. Changing it is a token-economy decision with website and GitBook copies to keep in step, so it is not smuggled into a presentation PR.

## Verified

Ran against a seeded `langx_dev` — ten backdated test accounts, uneven activity, and a real `runDailyPool` for 2026-09-09 (10 paid, 4 792 of 10 000 distributed, one account under the cap at 377):

- **Paid account, English**: "+377" / "3.8% of the daily pool" / "10 active that day" / "10 active today".
- **Turkish**: "Günlük havuzun %3,8 kadarı" / "Bugün 10 kişi aktif" — the percent formats per locale (`%3,8`), which is why it goes through `toLocaleString` rather than a template.
- **No share yet**: empty state unchanged ("Your first share lands …"), and the new active-today line renders there too.
- `pnpm test` (755 mobile tests), `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` — all green. The typecheck is what proves all eight locales carry both keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)