### PR TITLE
Promotional email becomes opt-out, and the published copy moves with it

### DIFF
--- a/apps/api/scripts/backfill-known-devices.ts
+++ b/apps/api/scripts/backfill-known-devices.ts
@@ -1,0 +1,98 @@
+/**
+ * Records the devices people are **already** signed in on, so switching the
+ * security notices on does not tell a hundred people their own phone is new.
+ *
+ * `knownDevices` starts empty. Without this, the first sign-in after the
+ * deploy is, by the only definition the code has, a sign-in from a device
+ * that has never been seen — and everybody who signs in that week gets a
+ * "new sign-in to your account" letter about the laptop they are reading it
+ * on. Which is the exact mail people learn to ignore, on the exact feature
+ * that has to be believed.
+ *
+ * `session` is the source: Better Auth stores the user agent on every row,
+ * and a live session *is* a device somebody is using. The rows expire in a
+ * week, so this covers the people who have signed in recently — which is the
+ * same set that would otherwise have been mailed. Anybody older gets one
+ * notice on their next sign-in, correctly.
+ *
+ * Idempotent: `claimNewDevice` upserts on `<userId>:<fingerprint>`, so
+ * running it twice writes nothing the second time. Run it **before**
+ * `fly deploy`, or in the same minute — the window between the deploy and
+ * this is the window the burst happens in.
+ *
+ * Usage:
+ *   pnpm --filter @langx/api exec tsx --env-file=../../.env --env-file=../../.env.prod \
+ *     scripts/backfill-known-devices.ts [--confirm]
+ */
+import { connectToDatabase } from '../src/db/client'
+import { COLLECTIONS } from '../src/db/collections'
+import { loadEnv } from '../src/env'
+import { deviceIdentity } from '../src/modules/security/deviceLabel'
+import { claimNewDevice } from '../src/modules/security/knownDevices'
+
+interface SessionRow {
+  userId: unknown
+  userAgent?: string
+  createdAt?: Date
+}
+
+async function main(): Promise<void> {
+  const confirm = process.argv.includes('--confirm')
+  const env = loadEnv()
+  const { db, close } = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
+
+  try {
+    const sessions = await db
+      .collection<SessionRow>(COLLECTIONS.session)
+      .find({}, { projection: { userId: 1, userAgent: 1, createdAt: 1 } })
+      .toArray()
+
+    // One row per person per device family, oldest first, so `firstSeenAt`
+    // ends up as close to the truth as the sessions can say.
+    const pairs = new Map<string, { userId: string; fingerprint: string; at: Date }>()
+    let noAgent = 0
+    for (const session of sessions) {
+      if (!session.userAgent) {
+        noAgent++
+        continue
+      }
+      const userId = String(session.userId)
+      const { fingerprint } = deviceIdentity(session.userAgent)
+      const key = `${userId}:${fingerprint}`
+      const at = session.createdAt ?? new Date()
+      const existing = pairs.get(key)
+      if (!existing || at < existing.at) pairs.set(key, { userId, fingerprint, at })
+    }
+
+    const byFingerprint = new Map<string, number>()
+    for (const { fingerprint } of pairs.values()) {
+      byFingerprint.set(fingerprint, (byFingerprint.get(fingerprint) ?? 0) + 1)
+    }
+
+    console.log(`known devices from ${sessions.length} sessions on ${env.MONGODB_DB}`)
+    console.log(`  device rows to write: ${pairs.size}`)
+    console.log(`  people covered: ${new Set([...pairs.values()].map((p) => p.userId)).size}`)
+    console.log(`  sessions with no user agent: ${noAgent}`)
+    for (const [fingerprint, count] of [...byFingerprint].sort((a, b) => b[1] - a[1])) {
+      console.log(`    ${fingerprint}: ${count}`)
+    }
+
+    if (!confirm) {
+      console.log('\n(dry run — re-run with --confirm to write)')
+      return
+    }
+
+    let written = 0
+    for (const { userId, fingerprint, at } of pairs.values()) {
+      if (await claimNewDevice(db, userId, fingerprint, { at })) written++
+    }
+    console.log(`\nwrote ${written} (the rest were already recorded)`)
+  } finally {
+    await close()
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/api/scripts/opt-in-everyone.ts
+++ b/apps/api/scripts/opt-in-everyone.ts
@@ -1,0 +1,128 @@
+/**
+ * Puts every live profile that has never touched its notification settings
+ * onto the mailing list.
+ *
+ * The one-off half of the reversal `DEFAULT_NOTIFICATION_PREFS` describes:
+ * the default now opts new accounts in, and this is what does the same for
+ * the accounts that already existed.
+ *
+ * **An explicit refusal stays a refusal.** `notificationsUntouched` knows
+ * every shape this codebase has ever written on somebody's behalf, and only
+ * those are changed — a profile whose owner opened Settings and left
+ * promotions off has already answered, and re-adding them is the one thing
+ * worse than never having asked. So is a suppressed address: somebody who
+ * pressed an unsubscribe link is skipped whatever their profile says.
+ *
+ * `promotionsConsent` records where the yes came from, the way
+ * `adopt-v1-consent.ts` does, so a row can still answer "who decided this"
+ * a year from now.
+ *
+ * Usage:
+ *   pnpm --filter @langx/api exec tsx --env-file=../../.env --env-file=../../.env.prod \
+ *     scripts/opt-in-everyone.ts [--limit 50] [--confirm]
+ *
+ * Without `--confirm` it counts and prints and writes nothing.
+ */
+import { notificationsUntouched, resolveNotificationPrefs } from '@langx/shared'
+import { connectToDatabase } from '../src/db/client'
+import { COLLECTIONS } from '../src/db/collections'
+import { loadEnv } from '../src/env'
+import { suppressedAmong } from '../src/modules/notifications/suppressions'
+import { emailFor } from '../src/modules/profiles/emailFor'
+import type { Profile } from '../src/modules/profiles/profiles'
+
+function flag(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`)
+  return index === -1 ? undefined : process.argv[index + 1]
+}
+
+async function main(): Promise<void> {
+  const limit = flag('limit') ? Number(flag('limit')) : undefined
+  const confirm = process.argv.includes('--confirm')
+
+  const env = loadEnv()
+  const { db, close } = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
+
+  try {
+    const profiles = await db
+      .collection<Profile>(COLLECTIONS.profiles)
+      .find({ deletedAt: { $exists: false }, guest: { $exists: false } })
+      .toArray()
+
+    const counts = { touched: 0, alreadyOn: 0, suppressed: 0, noEmail: 0, wouldOptIn: 0 }
+    const targets: string[] = []
+
+    // One query rather than one per profile: the list is small, and this is
+    // the only lookup that is not already in memory.
+    const addresses = new Map<string, string>()
+    for (const profile of profiles) {
+      const address = await emailFor(db, profile._id)
+      if (address) addresses.set(profile._id, address.email)
+    }
+    const suppressed = await suppressedAmong(db, [...addresses.values()])
+
+    for (const profile of profiles) {
+      const prefs = profile.settings?.notifications
+      if (resolveNotificationPrefs(prefs).promotions.email) {
+        counts.alreadyOn++
+        continue
+      }
+      if (!notificationsUntouched(prefs)) {
+        counts.touched++
+        continue
+      }
+      const email = addresses.get(profile._id)
+      if (!email) {
+        counts.noEmail++
+        continue
+      }
+      if (suppressed.has(email.toLowerCase())) {
+        counts.suppressed++
+        continue
+      }
+      counts.wouldOptIn++
+      targets.push(profile._id)
+      if (limit && targets.length >= limit) break
+    }
+
+    console.log(`opt-in on ${env.MONGODB_DB}`)
+    console.log(`  live profiles: ${profiles.length}`)
+    console.log(`  would opt in: ${counts.wouldOptIn}`)
+    console.log(`  skipped: ${JSON.stringify(counts)}`)
+
+    if (!confirm) {
+      console.log('\n(dry run — re-run with --confirm to write)')
+      return
+    }
+
+    const now = new Date()
+    let written = 0
+    for (const userId of targets) {
+      const profile = profiles.find((candidate) => candidate._id === userId)
+      if (!profile) continue
+      const resolved = resolveNotificationPrefs(profile.settings?.notifications)
+      await db.collection<Profile>(COLLECTIONS.profiles).updateOne(
+        { _id: userId },
+        {
+          $set: {
+            // Whole, for the reason `setEmailNotifications` writes whole: a
+            // dotted path one level deeper cannot enter the bare boolean the
+            // oldest profiles still carry.
+            'settings.notifications.promotions': { ...resolved.promotions, email: true },
+            promotionsConsent: { source: 'default-optin', at: now },
+            updatedAt: now,
+          },
+        },
+      )
+      written++
+    }
+    console.log(`\nopted in ${written}`)
+  } finally {
+    await close()
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/api/src/email/notify.test.ts
+++ b/apps/api/src/email/notify.test.ts
@@ -179,20 +179,24 @@ describe('sendNotificationEmail', () => {
     expect(sender.messages).toHaveLength(0)
   })
 
-  it('never sends promotions to somebody who did not ask', async () => {
+  /**
+   * Reversed on 10 September 2026: silence is now yes on this channel, and a
+   * refusal is what stops it. Push did not move.
+   */
+  it('sends promotions to somebody who has not said no, and never after they do', async () => {
     await seed(u1)
     expect(
       await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'promotions', build }),
-    ).toBe('opted-out')
+    ).toBe('sent')
     await handle.db
       .collection(COLLECTIONS.profiles)
       .updateOne(
         { _id: u1 as never },
-        { $set: { 'settings.notifications.promotions': { push: false, email: true } } },
+        { $set: { 'settings.notifications.promotions': { push: false, email: false } } },
       )
     expect(
       await sendNotificationEmail(handle.db, ctx, { userId: u1, type: 'promotions', build }),
-    ).toBe('sent')
+    ).toBe('opted-out')
   })
 
   it('refuses an address nobody has proved', async () => {

--- a/apps/api/src/modules/notifications/adoptConsent.test.ts
+++ b/apps/api/src/modules/notifications/adoptConsent.test.ts
@@ -40,7 +40,17 @@ describe('recording a consent given at v1 sign-up', () => {
         handle: `h${userId.slice(-12)}`,
         settings: {
           discoverable: true,
-          notifications: opts.notifications ?? DEFAULT_NOTIFICATION_PREFS,
+          /*
+           * The pre-flip default, written out. Since 10 September 2026 the
+           * shipped default already opts people in — see
+           * `DEFAULT_NOTIFICATION_PREFS` — so a fixture using it would be
+           * testing nothing. This script exists for accounts written before
+           * that, and this is what they carry.
+           */
+          notifications: opts.notifications ?? {
+            ...DEFAULT_NOTIFICATION_PREFS,
+            promotions: { push: false, email: false },
+          },
         },
       } as never)
     }
@@ -88,7 +98,11 @@ describe('recording a consent given at v1 sign-up', () => {
   it('never overwrites a refusal', async () => {
     const said = await newAccount({
       fromV1: true,
-      notifications: { ...DEFAULT_NOTIFICATION_PREFS, messages: { push: false, email: false } },
+      notifications: {
+        ...DEFAULT_NOTIFICATION_PREFS,
+        messages: { push: false, email: false },
+        promotions: { push: false, email: false },
+      },
     })
 
     const outcome = await adoptPromotionsConsent(handle.db, 'v1', { apply: true })

--- a/apps/api/src/modules/notifications/audience.test.ts
+++ b/apps/api/src/modules/notifications/audience.test.ts
@@ -63,23 +63,38 @@ describe('what a Resend audience should contain', () => {
 
   const optedIn = { promotions: { push: false, email: true } }
 
-  it('takes only a recorded yes when that is all that is claimed', async () => {
+  /**
+   * Since the reversal, "consented" is everybody the default put on the list
+   * as well as everybody who chose it — the `notificationsAllowed` answer,
+   * which is the only definition a sender uses.
+   */
+  it('takes everybody the reader says may be mailed', async () => {
     const yes = await newAccount({ notifications: optedIn })
-    await newAccount()
-    await newAccount({ fromV1: true })
+    const unanswered = await newAccount()
+    const fromV1 = await newAccount({ fromV1: true })
 
     const plan = await audiencePlan(handle.db, 'consented')
-    expect(plan.contacts.map((contact) => contact.userId)).toEqual([yes])
-    expect(plan.skipped.noConsent).toBe(2)
+    expect(new Set(plan.contacts.map((contact) => contact.userId))).toEqual(
+      new Set([yes, unanswered, fromV1]),
+    )
+    expect(plan.skipped.noConsent).toBe(0)
   })
 
-  it('adds the v1 accounts that never answered, under the v1 source', async () => {
+  /**
+   * The sources have converged since the reversal: an unanswered account is
+   * on the list under all three, because the default put it there. What
+   * `--source v1` still buys is the pre-created rows that have no profile at
+   * all — see the case further down.
+   */
+  it('takes an unanswered account under every source', async () => {
     const yes = await newAccount({ notifications: optedIn })
     const v1 = await newAccount({ fromV1: true })
-    await newAccount()
+    const neither = await newAccount()
 
     const plan = await audiencePlan(handle.db, 'v1')
-    expect(new Set(plan.contacts.map((contact) => contact.userId))).toEqual(new Set([yes, v1]))
+    expect(new Set(plan.contacts.map((contact) => contact.userId))).toEqual(
+      new Set([yes, v1, neither]),
+    )
   })
 
   /**
@@ -124,6 +139,10 @@ describe('what a Resend audience should contain', () => {
       notifications: {
         ...DEFAULT_NOTIFICATION_PREFS,
         messages: { push: false, email: false },
+        // The refusal itself. Since the default opts in, this cell has to be
+        // off explicitly to mean no — which is exactly what the settings
+        // screen writes when somebody turns the row off.
+        promotions: { push: false, email: false },
       },
     })
 
@@ -169,10 +188,17 @@ describe('what a Resend audience should contain', () => {
 describe('audienceAction', () => {
   const account = { deleted: false, fromV1: false, prefs: undefined }
 
-  it('reads a bare boolean per kind as silence, not as consent to mail', () => {
-    expect(audienceAction('consented', { ...account, prefs: { promotions: true } })).toBeNull()
-    expect(audienceAction('v1', { ...account, fromV1: true, prefs: { promotions: true } })).toBe(
+  /**
+   * The bare boolean says nothing about mail — but the default it falls
+   * through to now says yes, so the answer is `subscribe` for a reason that
+   * has nothing to do with what v1 wrote.
+   */
+  it('lets the default answer for a shape that could not', () => {
+    expect(audienceAction('consented', { ...account, prefs: { promotions: true } })).toBe(
       'subscribe',
+    )
+    expect(audienceAction('consented', { ...account, prefs: { promotions: false } })).toBe(
+      'unsubscribe',
     )
   })
 

--- a/apps/api/src/modules/notifications/campaign.test.ts
+++ b/apps/api/src/modules/notifications/campaign.test.ts
@@ -73,26 +73,28 @@ describe('who a campaign may be sent to', () => {
 
   const optedIn = { promotions: { push: false, email: true } }
 
-  it('includes only people who said yes', async () => {
+  it('includes everybody who has not said no', async () => {
     const yes = await newProfile({ notifications: optedIn })
-    await newProfile()
+    const unanswered = await newProfile()
     await newProfile({ notifications: { promotions: { email: false } } })
 
     const audience = await campaignRecipients(handle.db, CAMPAIGN)
-    expect(audience.recipients.map((r) => r.userId)).toEqual([yes])
-    expect(audience.skipped.optedOut).toBe(2)
+    expect(audience.recipients.map((r) => r.userId).sort()).toEqual([yes, unanswered].sort())
+    expect(audience.skipped.optedOut).toBe(1)
   })
 
   /**
-   * The one cell that is never inferred. Every other kind falls back to a
-   * default when nobody has said; consent to be marketed at has to be given.
+   * Since the reversal, an unanswered account is on the list — that is the
+   * whole of it. A refusal is what still takes somebody off.
    */
-  it('never infers consent from an older stored shape', async () => {
+  it('reads silence as yes and a refusal as no', async () => {
     await newProfile({ notifications: true })
     await newProfile({ notifications: { promotions: true } })
+    await newProfile({ notifications: { promotions: { email: false } } })
 
     const audience = await campaignRecipients(handle.db, CAMPAIGN)
-    expect(audience.recipients).toHaveLength(0)
+    expect(audience.recipients).toHaveLength(2)
+    expect(audience.skipped.optedOut).toBe(1)
   })
 
   it('excludes an unverified address and one that does not exist', async () => {

--- a/apps/api/src/modules/notifications/campaign.ts
+++ b/apps/api/src/modules/notifications/campaign.ts
@@ -63,9 +63,12 @@ export interface CampaignAudience {
  * every account deletion and every toggle synchronised into it, and the day
  * the two disagree is a complaint rather than a bug.
  *
- * `promotions.email` must be exactly true. Every other kind falls back to a
- * default when nobody has said; this one never does — consent to be marketed
- * at has to have been given.
+ * `notificationsAllowed` decides, as everywhere else. Since 10 September 2026
+ * its default for promotional **email** is yes and for promotional **push**
+ * is no, so "nobody has said" now means the mail may go — see
+ * `DEFAULT_NOTIFICATION_PREFS` for whose decision that was and what it does
+ * not change. A refusal is still a refusal, and a suppressed address is
+ * skipped whatever the profile says.
  */
 export async function campaignRecipients(
   db: Db,

--- a/apps/api/src/modules/notifications/campaignQueue.test.ts
+++ b/apps/api/src/modules/notifications/campaignQueue.test.ts
@@ -263,7 +263,6 @@ describe('the campaign queue', () => {
   describe('who a source reaches', () => {
     it('v1: pre-created rows with no profile, greeted by the name the row carries', async () => {
       const bare = await newAccount({ profile: false, fromV1: true, name: 'Behlül' })
-      await newAccount({ profile: false }) // never v1, nobody said yes
       const audience = await resolveCampaignAudience(handle.db, {
         _id: 'x',
         source: 'v1',

--- a/apps/api/src/modules/notifications/newsletter.test.ts
+++ b/apps/api/src/modules/notifications/newsletter.test.ts
@@ -58,7 +58,10 @@ describe('the monthly recap', () => {
       timezone: opts.timezone ?? 'UTC',
       settings: {
         discoverable: true,
-        notifications: opts.optedIn === false ? {} : { promotions: { push: false, email: true } },
+        notifications:
+          opts.optedIn === false
+            ? { promotions: { push: false, email: false } }
+            : { promotions: { push: false, email: true } },
       },
       nativeLanguages: [{ code: 'en' }],
       streak: { current: opts.streak ?? 0, longest: 0, lastQualifiedDay: null },
@@ -174,7 +177,7 @@ describe('the monthly recap', () => {
     })
   })
 
-  it('goes only to somebody who asked for promotional mail', async () => {
+  it('goes to everybody except the people who turned promotional mail off', async () => {
     await newProfile({ optedIn: false })
     expect(await runNewsletterPass(handle.db, ctx, FIRST)).toEqual({ sent: 0 })
   })

--- a/apps/api/src/modules/notifications/promotions.test.ts
+++ b/apps/api/src/modules/notifications/promotions.test.ts
@@ -131,8 +131,13 @@ describe('the nudges that need permission', () => {
     expect(subjects()[0]).toContain('photo')
   })
 
-  it('says nothing to somebody who never asked for promotions', async () => {
-    await newProfile({ createdDaysAgo: 3, notifications: {} })
+  /**
+   * Since the default opts people in, "no" has to be said — and when it is,
+   * it is final. The bare `false` is the oldest shape and still means
+   * silence everywhere.
+   */
+  it('says nothing to somebody who turned promotions off', async () => {
+    await newProfile({ createdDaysAgo: 3, notifications: { promotions: { email: false } } })
     await newProfile({ createdDaysAgo: 3, notifications: false })
     expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
   })

--- a/apps/api/src/modules/security/deviceLabel.test.ts
+++ b/apps/api/src/modules/security/deviceLabel.test.ts
@@ -15,6 +15,9 @@ const AGENTS = {
     'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Mobile Safari/537.36',
   edge: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36 Edg/152.0.0.0',
   expoIos: 'LangX/2.2 CFNetwork/1568.100.1 Darwin/24.0.0',
+  /** What React Native actually sends, taken off `session` in production. */
+  bareIos: 'CFNetwork/1568.100.1 Darwin/24.0.0',
+  bareAndroid: 'okhttp/4.12.0',
   curl: 'curl/8.5.0',
 }
 
@@ -55,6 +58,26 @@ describe('naming the device somebody signed in from', () => {
     const now = deviceIdentity(AGENTS.windowsChrome).fingerprint
     const later = deviceIdentity(AGENTS.windowsChrome.replace('152.0.0.0', '191.0.3.7')).fingerprint
     expect(later).toBe(now)
+  })
+
+  /**
+   * React Native sends no browser user agent at all. Fifty-three production
+   * sessions carried `okhttp/4.12.0`, and reading those literally told people
+   * they had signed in from "okhttp".
+   */
+  it('knows the app by the library it speaks through', () => {
+    expect(deviceIdentity(AGENTS.bareAndroid)).toEqual({
+      fingerprint: 'android-app',
+      label: 'the LangX app on Android',
+    })
+    expect(deviceIdentity(AGENTS.bareIos)).toEqual({
+      fingerprint: 'ios-app',
+      label: 'the LangX app on iPhone',
+    })
+    // And the two ways in from one phone are one device, not two.
+    expect(deviceIdentity(AGENTS.expoIos).fingerprint).toBe(
+      deviceIdentity(AGENTS.bareIos).fingerprint,
+    )
   })
 
   it('names a script by what it called itself, and an absent agent not at all', () => {

--- a/apps/api/src/modules/security/deviceLabel.ts
+++ b/apps/api/src/modules/security/deviceLabel.ts
@@ -21,17 +21,29 @@ export interface DeviceIdentity {
 
 const UNKNOWN: DeviceIdentity = { fingerprint: 'unknown', label: 'an unrecognised device' }
 
-/** Ours first: the app's own requests should not read as "Safari on iPhone". */
+/**
+ * Ours first: the app's own requests should not read as "Safari on iPhone",
+ * and they must not read as the HTTP library either.
+ *
+ * React Native does not send a browser user agent. On Android it sends
+ * `okhttp/4.x` and nothing else, and on iOS `CFNetwork/… Darwin/…` — which
+ * a run against production turned into fifty-three people being told they had
+ * signed in from "okhttp". Nothing else in this app's traffic uses either
+ * library, so both are read as the app.
+ */
 function appIdentity(userAgent: string): DeviceIdentity | null {
-  if (/\bExpo\b|LangX/i.test(userAgent)) {
-    if (/\bAndroid\b/i.test(userAgent))
-      return { fingerprint: 'android-app', label: 'the LangX app on Android' }
-    if (/\biPhone|iPad|iOS|CFNetwork\b/i.test(userAgent)) {
-      return { fingerprint: 'ios-app', label: 'the LangX app on iPhone' }
-    }
-    return { fingerprint: 'app', label: 'the LangX app' }
+  const named = /\bExpo\b|LangX/i.test(userAgent)
+  if (named ? /\bAndroid\b/i.test(userAgent) : /^okhttp\//i.test(userAgent)) {
+    return { fingerprint: 'android-app', label: 'the LangX app on Android' }
   }
-  return null
+  if (
+    named
+      ? /\biPhone|iPad|iOS|CFNetwork\b/i.test(userAgent)
+      : /\bCFNetwork\b/i.test(userAgent) && /\bDarwin\b/i.test(userAgent)
+  ) {
+    return { fingerprint: 'ios-app', label: 'the LangX app on iPhone' }
+  }
+  return named ? { fingerprint: 'app', label: 'the LangX app' } : null
 }
 
 function platformOf(userAgent: string): { key: string; name: string } {

--- a/apps/api/src/routes/email.test.ts
+++ b/apps/api/src/routes/email.test.ts
@@ -282,10 +282,14 @@ describe('unsubscribing from a link in an email', () => {
     const profile = await handle.db
       .collection<Profile>(COLLECTIONS.profiles)
       .findOne({ _id: stranger.userId })
-    expect(profile?.settings.notifications).toMatchObject({
-      promotions: { push: false, email: false },
-    })
+    /*
+     * The default opts people in, so this is the case that has to keep
+     * working: somebody who pressed unsubscribe before they had a profile is
+     * on `emailSuppressions`, and every sender reads it — the cell below says
+     * yes and nothing goes to them anyway.
+     */
     expect(profile?.promotionsConsent).toBeUndefined()
+    expect(await isEmailSuppressed(handle.db, stranger.email)).toBe(true)
   })
 
   /**

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -186,7 +186,7 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
     expect(mail?.headers).toBeUndefined()
   })
 
-  it('leaves promotional email off for somebody who signed up here', async () => {
+  it('puts somebody who signed up here on the mailing list, and not on push', async () => {
     const user = await newUser('fresh-consent@example.com')
     await app.inject({
       method: 'POST',
@@ -198,8 +198,11 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
     const profile = await handle.db
       .collection<Profile>(COLLECTIONS.profiles)
       .findOne({ _id: user.userId })
+    // Reversed on 10 September 2026 — see `DEFAULT_NOTIFICATION_PREFS`. The
+    // consent record stays for the v1 case alone: this one is the default,
+    // not a decision anybody made.
     expect(profile?.settings.notifications).toMatchObject({
-      promotions: { push: false, email: false },
+      promotions: { push: false, email: true },
     })
     expect(profile?.promotionsConsent).toBeUndefined()
   })
@@ -502,7 +505,7 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
     // The other half of the kind that moved is written back, not dropped.
     expect(settings.notifications.streak).toEqual({ push: true, email: false })
     expect(settings.notifications.messages).toEqual({ push: true, email: true })
-    expect(settings.notifications.promotions).toEqual({ push: false, email: false })
+    expect(settings.notifications.promotions).toEqual({ push: false, email: true })
     expect(settings.discoverable).toBe(true)
   })
 

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -529,7 +529,7 @@ export const ar: Localized<EnMessages> = {
     meetings: 'المواعيد',
     meetingsBody: 'قبل ساعة من مكالمة اتفقتما عليها. إشعار فقط.',
     promotions: 'الأخبار والعروض',
-    promotionsBody: 'بين حين وآخر عن الجديد. مغلق ما لم تطلبه.',
+    promotionsBody: 'بين حين وآخر عن الجديد. نقرة واحدة توقفه.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
     channel: { push: 'إشعار فوري', email: 'البريد' },
     emailUnverified: 'وثّق عنوان بريدك لتفعيل هذا.',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -468,7 +468,7 @@ export const de: Localized<EnMessages> = {
     meetings: 'Termine',
     meetingsBody: 'Eine Stunde vor einem Gespräch, dem ihr beide zugestimmt habt. Nur Push.',
     promotions: 'Neues und Angebote',
-    promotionsBody: 'Gelegentlich, was es Neues gibt. Aus, sofern du es nicht willst.',
+    promotionsBody: 'Gelegentlich, was es Neues gibt. Ein Tipp beendet es.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
     channel: { push: 'Push', email: 'E-Mail' },
     emailUnverified: 'Bestätige deine E-Mail-Adresse, um das einzuschalten.',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -505,7 +505,7 @@ export const en = {
     meetings: 'Meetings',
     meetingsBody: 'An hour before a call you both agreed to. Push only.',
     promotions: 'News and offers',
-    promotionsBody: 'Occasional word about what is new. Off unless you ask.',
+    promotionsBody: 'Occasional word about what is new. One tap to stop.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
     channel: { push: 'Push', email: 'Email' },
     emailUnverified: 'Verify your email address to turn this on.',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -461,7 +461,7 @@ export const es: Localized<EnMessages> = {
     meetings: 'Citas',
     meetingsBody: 'Una hora antes de una llamada que ambos aceptasteis. Solo push.',
     promotions: 'Novedades y ofertas',
-    promotionsBody: 'De vez en cuando, lo nuevo. Apagado salvo que lo pidas.',
+    promotionsBody: 'De vez en cuando, lo nuevo. Un toque para parar.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
     channel: { push: 'Push', email: 'Correo' },
     emailUnverified: 'Verifica tu dirección de correo para activarlo.',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -467,7 +467,7 @@ export const fr: Localized<EnMessages> = {
     meetings: 'Rendez-vous',
     meetingsBody: 'Une heure avant un appel que vous avez accepté tous les deux. Push uniquement.',
     promotions: 'Actualités et offres',
-    promotionsBody: 'De temps en temps, les nouveautés. Désactivé sauf demande.',
+    promotionsBody: 'De temps en temps, les nouveautés. Un geste pour arrêter.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
     channel: { push: 'Push', email: 'E-mail' },
     emailUnverified: 'Vérifiez votre adresse e-mail pour l’activer.',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -458,7 +458,7 @@ export const ptBR: Localized<EnMessages> = {
     meetings: 'Encontros',
     meetingsBody: 'Uma hora antes de uma chamada que vocês dois aceitaram. Só push.',
     promotions: 'Novidades e ofertas',
-    promotionsBody: 'De vez em quando, o que há de novo. Desligado a não ser que você peça.',
+    promotionsBody: 'De vez em quando, o que há de novo. Um toque para parar.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
     channel: { push: 'Push', email: 'E-mail' },
     emailUnverified: 'Verifique seu endereço de e-mail para ativar isto.',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -510,7 +510,7 @@ export const ru: Localized<EnMessages> = {
     meetings: 'Встречи',
     meetingsBody: 'За час до звонка, на который вы оба согласились. Только пуш.',
     promotions: 'Новости и предложения',
-    promotionsBody: 'Изредка о новом. Выключено, пока не включите.',
+    promotionsBody: 'Изредка о новом. Одно касание — и всё прекратится.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
     channel: { push: 'Пуш', email: 'Почта' },
     emailUnverified: 'Подтвердите адрес почты, чтобы включить это.',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -465,7 +465,7 @@ export const tr: Localized<EnMessages> = {
     meetings: 'Randevular',
     meetingsBody: 'İkinizin de kabul ettiği bir görüşmeden bir saat önce. Sadece bildirim.',
     promotions: 'Haberler ve kampanyalar',
-    promotionsBody: 'Arada yeniliklerden haber. İstemedikçe kapalı.',
+    promotionsBody: 'Arada yeniliklerden haber. Tek dokunuşla durur.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
     channel: { push: 'Anlık bildirim', email: 'E-posta' },
     emailUnverified: 'Bunu açmak için e-posta adresini doğrula.',

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3741,3 +3741,40 @@ app sends outside review, outside git, and outside the eight-language
 catalogue that every other string lives in. A month with no merged note still
 gets its recap; the numbers are the part that is always true. See
 `src/email/newsletters/README.md`.
+
+## Promotional email is opt-out now, and the published copy moved with it
+
+This reverses a decision recorded above. Promotions used to be off on both
+channels, with the argument that consent to be marketed at has to be given
+rather than withdrawn. On 10 September 2026 the owner decided otherwise:
+everybody is on the mailing list, and the unsubscribe in every message is the
+way out. Three profiles had promotional email on at the time, so the
+alternative was building a remarketing programme and a newsletter for three
+people.
+
+I raised the objection and it is worth keeping written down: a pre-ticked box
+is not consent under GDPR, CASL asks for consent too, and the practical risk
+is not a regulator but deliverability — spam complaints land on the domain
+that also carries the verification links. Behic reaffirmed it. What the
+decision bought in exchange is that the list is real; what it cost is that
+the app now has to be _very_ good at the unsubscribe, which is the rest of
+this entry.
+
+Three things did not move:
+
+- **Push stays off.** Nobody asked to be buzzed at by marketing, and it is
+  the intrusive channel.
+- **An explicit refusal wins over everything.** `opt-in-everyone.ts` changes
+  only profiles that `notificationsUntouched` recognises — every set of
+  preferences this codebase has ever written on somebody's behalf, which now
+  includes the pre-flip default. Somebody who opened Settings and left
+  promotions off had already answered; re-adding them is the one thing worse
+  than never having asked.
+- **A suppressed address gets nothing**, whatever its profile says. That is
+  what makes an unsubscribe pressed before onboarding survive the account
+  being created afterwards.
+
+And the published copy had to change **before** the script could run, because
+a default-on list under text that says "off unless you ask" is a false claim
+rather than a stale one: the Settings row in eight locales, and
+`docs/legal/promise-change.md`, which describes the default out loud.

--- a/docs/legal/promise-change.md
+++ b/docs/legal/promise-change.md
@@ -128,10 +128,13 @@ the store forms and the GitBook copy still need them.
   only thing that can change it afterwards is a location fix from the device.
   This has to be said out loud: "we do not build a profile from your IP" stays
   true, and would be misleading next to a stored country if it stood alone.
-- **Notification preferences are four kinds by two channels**, and promotions
-  are **off** until somebody turns them on. Consent to be marketed at has to be
-  given rather than withdrawn; the email column exists and nothing sends to it
-  yet.
+- **Notification preferences are six kinds by two channels.** Promotional
+  **email is on by default** and promotional **push is off** — reversed on
+  10 September 2026, and worth stating plainly because the earlier text here
+  said the opposite. Every promotional message carries a one-click
+  unsubscribe, a refusal is permanent, and nothing else moved: the service
+  kinds are on because the app was installed, and marketing never reaches a
+  phone unless somebody switches it on.
 
 One more that is a promise rather than a disclosure: **passwords are 6 to 64
 characters, with no composition rule**. Anything published that describes the

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -83,7 +83,10 @@ a changed password, and a sign-in method connected or disconnected. They go
 by mail _and_ push, carry no unsubscribe, and reach an account whose owner
 switched every other notification off — a switch whose honest label is "do
 not tell me when somebody signs in as me" is not one to offer. `knownDevices`
-is what makes "a device we have not seen" answerable; it has no TTL.
+is what makes "a device we have not seen" answerable; it has no TTL — and it
+starts empty, so `scripts/backfill-known-devices.ts` has to run before the
+first deploy that carries this, or everybody's next sign-in is a "new device"
+letter about the phone they are holding.
 
 Nothing is sent to an address on `emailSuppressions`, service mail included:
 a permanent bounce or a spam complaint reported by Resend's webhook

--- a/packages/shared/src/notifications.test.ts
+++ b/packages/shared/src/notifications.test.ts
@@ -13,12 +13,12 @@ import {
 
 describe('notification defaults', () => {
   /**
-   * Not a taste: consent to be marketed at has to be given rather than
-   * withdrawn, so a new account is opted out of promotions — and out of both
-   * channels, because an unsolicited email is the half with a regulator.
+   * Reversed on 10 September 2026, by the owner: everybody is on the mailing
+   * list and the unsubscribe is the way out. Push did not move — nobody asked
+   * to be buzzed at by marketing.
    */
-  it('opts nobody into promotions, on either channel', () => {
-    expect(DEFAULT_NOTIFICATION_PREFS.promotions).toEqual({ push: false, email: false })
+  it('puts everybody on the mailing list and nobody on promotional push', () => {
+    expect(DEFAULT_NOTIFICATION_PREFS.promotions).toEqual({ push: false, email: true })
   })
 
   it('is on for what the app already does', () => {
@@ -47,7 +47,8 @@ describe('notificationsAllowed', () => {
     expect(notificationsAllowed({}, 'messages', 'push')).toBe(true)
     expect(notificationsAllowed(undefined, 'streak', 'email')).toBe(true)
     expect(notificationsAllowed({}, 'promotions', 'push')).toBe(false)
-    expect(notificationsAllowed({}, 'promotions', 'email')).toBe(false)
+    // The one that reversed: unsaid is now yes on mail, no on push.
+    expect(notificationsAllowed({}, 'promotions', 'email')).toBe(true)
   })
 
   /**
@@ -64,7 +65,7 @@ describe('notificationsAllowed', () => {
     expect(notificationsAllowed(true, 'messages', 'push')).toBe(true)
     expect(notificationsAllowed(true, 'messages', 'email')).toBe(true)
     expect(notificationsAllowed(true, 'promotions', 'push')).toBe(false)
-    expect(notificationsAllowed(true, 'promotions', 'email')).toBe(false)
+    expect(notificationsAllowed(true, 'promotions', 'email')).toBe(true)
   })
 
   describe('the bare boolean per kind, written while there was no channel axis', () => {
@@ -85,7 +86,11 @@ describe('notificationsAllowed', () => {
      */
     it('never lets it consent to email that was never offered', () => {
       expect(notificationsAllowed({ messages: true }, 'messages', 'email')).toBe(true)
-      expect(notificationsAllowed({ promotions: true }, 'promotions', 'email')).toBe(false)
+      // A bare `true` from v1 says nothing about mail — but the default it
+      // falls through to now says yes, which is the same answer for a
+      // different reason.
+      expect(notificationsAllowed({ promotions: true }, 'promotions', 'email')).toBe(true)
+      expect(notificationsAllowed({ promotions: false }, 'promotions', 'email')).toBe(false)
     })
   })
 
@@ -102,14 +107,13 @@ describe('notificationsAllowed', () => {
     it('fills a half nobody named with the default', () => {
       expect(notificationsAllowed({ messages: { email: false } }, 'messages', 'push')).toBe(true)
       expect(notificationsAllowed({ streak: { push: false } }, 'streak', 'email')).toBe(true)
-      expect(notificationsAllowed({ promotions: { push: true } }, 'promotions', 'email')).toBe(
-        false,
-      )
+      expect(notificationsAllowed({ promotions: { push: true } }, 'promotions', 'email')).toBe(true)
     })
 
     it('falls back to the default for an empty object', () => {
       expect(notificationsAllowed({ streak: {} }, 'streak', 'push')).toBe(true)
-      expect(notificationsAllowed({ promotions: {} }, 'promotions', 'email')).toBe(false)
+      expect(notificationsAllowed({ promotions: {} }, 'promotions', 'email')).toBe(true)
+      expect(notificationsAllowed({ promotions: {} }, 'promotions', 'push')).toBe(false)
     })
   })
 })
@@ -136,7 +140,7 @@ describe('resolveNotificationPrefs', () => {
     const stored = { messages: { push: false }, promotions: true }
     const resolved = resolveNotificationPrefs(stored)
     expect(resolved.messages).toEqual({ push: false, email: true })
-    expect(resolved.promotions).toEqual({ push: true, email: false })
+    expect(resolved.promotions).toEqual({ push: true, email: true })
   })
 })
 

--- a/packages/shared/src/notifications.ts
+++ b/packages/shared/src/notifications.ts
@@ -61,12 +61,26 @@ export type StoredNotificationPrefs = Partial<
 >
 
 /**
- * On for everything the app already does; **promotions off on both channels**.
+ * On for everything the app already does, and — since 10 September 2026 —
+ * **promotional email on, promotional push off**.
  *
- * The last one is not a taste. Consent to be marketed at has to be given, not
- * withdrawn — GDPR calls a pre-ticked box no consent at all, and CAN-SPAM's
- * unsubscribe is the floor rather than the rule. So a new account is opted out
- * of promotions and opted in to the things it asked for by installing the app.
+ * This is a reversal, and it is the owner's decision rather than a technical
+ * one. It used to read: consent to be marketed at has to be given, not
+ * withdrawn. What replaces it is the ordinary newsletter bargain — everybody
+ * is on the list, the unsubscribe is one tap and is in every message, and a
+ * refusal is permanent (`emailSuppressions`, and a profile that has been
+ * touched is never re-opted-in by the backfill).
+ *
+ * Two things did not change with it. **Push stays off**: nobody asked to be
+ * buzzed at by marketing, and it is the intrusive channel. And **an explicit
+ * refusal wins over everything** — the day this flipped, `opt-in-everyone.ts`
+ * skipped every profile whose owner had opened Settings and left promotions
+ * off, because re-adding somebody who already said no is the one thing worse
+ * than never having asked.
+ *
+ * If this is ever reverted, the published copy has to move with it: the
+ * Settings row in eight locales and `docs/legal/promise-change.md` both
+ * describe the default out loud.
  */
 export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
   messages: { push: true, email: true },
@@ -87,7 +101,7 @@ export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
    * push that already worked.
    */
   meetings: { push: true, email: false },
-  promotions: { push: false, email: false },
+  promotions: { push: false, email: true },
 }
 
 /**
@@ -208,6 +222,14 @@ export function notificationsAllowed(
  */
 const SYSTEM_WRITTEN_DEFAULTS: StoredNotificationPrefs[] = [
   DEFAULT_NOTIFICATION_PREFS,
+  /*
+   * Today's shape with yesterday's promotions cell. Every profile written
+   * before 10 September 2026 carries this, and leaving it out would have made
+   * all of them read as "touched" — so `opt-in-everyone.ts` would have found
+   * nobody to opt in, and `audience.ts` would have read a default nobody
+   * chose as a refusal.
+   */
+  { ...DEFAULT_NOTIFICATION_PREFS, promotions: { push: false, email: false } },
   // The bare boolean per kind — no `badges`, which did not exist yet.
   { messages: true, streak: true, profileVisits: true, promotions: false },
   // The retired matrix, in the shape it was written in.


### PR DESCRIPTION
PR G of the email + push programme. **Stacked on #1268** (→ #1266 → #1265 → #1264). **This is the one that decides whether D and E reach anybody**: three profiles have promotional email on today.

## What changes

- `DEFAULT_NOTIFICATION_PREFS.promotions` → `{ push: false, email: true }`. **Push does not move** — nobody asked to be buzzed at by marketing.
- `scripts/opt-in-everyone.ts` — the same thing for accounts that already exist. Dry run by default.
- The **Settings copy in eight locales** ("Off unless you ask" → "One tap to stop") and `docs/legal/promise-change.md`, which described the old default out loud.
- The comments and tests that argued the old policy now argue this one, including `campaign.ts`'s header and `audience.ts`'s source semantics.

## The objection, for the record

I raised it and it is in `docs/decisions.md` beside the decision: a pre-ticked box is not consent under GDPR, CASL asks for consent too, and the practical risk is not a regulator but deliverability — spam complaints land on the domain that also carries the verification links. You reaffirmed it; this implements it, with the guards below.

## The three guards

1. **An explicit refusal wins.** `opt-in-everyone.ts` only touches profiles `notificationsUntouched` recognises — every preference set this codebase has written on somebody's behalf, and the **pre-flip default is now one of those shapes** (without that, every existing profile would read as "touched" and the script would find nobody).
2. **A suppressed address gets nothing**, whatever its profile says. An unsubscribe pressed before onboarding survives the account being created afterwards — tested end to end.
3. **The copy moved first.** A default-on list under text that says "off unless you ask" is a false claim, not a stale one.

## Running it

```bash
pnpm --filter @langx/api exec tsx --env-file=../../.env --env-file=../../.env.prod \
  scripts/opt-in-everyone.ts
```

Prints the counts and writes nothing; add `--confirm` when the numbers look right. Expect ~78 of the 81 live profiles.

## Still yours to check

The website and GitBook may carry their own copy of the old promise — `docs/repo-map.md` says which values are copied by hand. Grep those repos for "off unless" before the script runs.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — green (api 94 files, mobile 93, shared 26).
- `notifications.test.ts` in shared now asserts the reversed default and that push stayed off; `audience.test.ts` covers the converged sources and the refusal that still wins; `email.test.ts` proves the profile-less unsubscribe survives onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)