### PR TITLE
Boosted profiles strip, Boost toggle, account suspension, three-letter handles

### DIFF
--- a/apps/api/src/modules/discovery/discovery.ts
+++ b/apps/api/src/modules/discovery/discovery.ts
@@ -9,10 +9,16 @@ import {
   DISCOVERY_CURSOR_MAX_AGE_MS,
   ONLINE_WINDOW_MS,
   isOnlineAt,
+  DISCOVERY_BOOSTED_LIMIT,
+  DISCOVERY_BOOSTED_TIERS,
+  type BoostedProfile,
+  type BoostedProfilesPage,
+  type BoostedTier,
   type LanguageLevel,
   type DiscoveryItem,
   type DiscoveryPage,
   type DiscoveryQuery,
+  type PlanTier,
 } from '@langx/shared'
 import type { Db, Document } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
@@ -135,11 +141,31 @@ function scopedTo(
   return [...requested]
 }
 
-export async function discoverProfiles(
+interface DiscoveryScope {
+  viewer: Profile
+  tier: PlanTier
+  /** Everyone this viewer may be shown, before any sort. */
+  match: Document
+  myNativeCodes: string[]
+  myLearningCodes: string[]
+}
+
+/**
+ * Who the viewer is allowed to see: the viewer's own languages narrowed to the
+ * request, the mutual-fit `$match`, blocks, the exclusions that keep guests
+ * and deleted accounts out, and every filter the request carries.
+ *
+ * Shared by the list and the boosted strip so that the two can never
+ * disagree about who is discoverable — the strip is the list's own candidates
+ * with a plan attached, not a second definition of "visible". Sort-specific
+ * checks (`nearby`'s entitlement and location) stay with the list, since the
+ * strip has no sort.
+ */
+async function resolveDiscoveryScope(
   db: Db,
   viewerId: string,
   query: DiscoveryQuery,
-): Promise<DiscoveryPage> {
+): Promise<DiscoveryScope> {
   const profiles = db.collection<Profile>(COLLECTIONS.profiles)
   const viewer = await profiles.findOne({ _id: viewerId })
   if (!viewer) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Complete onboarding first')
@@ -151,23 +177,6 @@ export async function discoverProfiles(
     throw new ApiError(ERROR_CODES.UPGRADE_REQUIRED, 'Advanced filters require Pro', {
       feature: 'advancedFilters',
     })
-  }
-
-  if (query.sort === 'nearby') {
-    if (!hasFeature(tier, 'nearby')) {
-      throw new ApiError(ERROR_CODES.UPGRADE_REQUIRED, 'Nearby requires Pro+', {
-        feature: 'nearby',
-      })
-    }
-    // Checked before the query rather than left to return nothing: an empty
-    // list would be indistinguishable from "nobody is near you", and the user
-    // would go looking for people instead of for the setting.
-    if (!viewer.location) {
-      throw new ApiError(
-        ERROR_CODES.LOCATION_REQUIRED,
-        'Share your own location to sort by distance',
-      )
-    }
   }
 
   // Which of the viewer's own languages this search is made with: all of them
@@ -248,6 +257,73 @@ export async function discoverProfiles(
     if (query.ageMin !== undefined) birthDate.$lt = `${currentYear - query.ageMin + 1}-01-01`
     if (query.ageMax !== undefined) birthDate.$gte = `${currentYear - query.ageMax}-01-01`
     match.birthDate = birthDate
+  }
+
+  return { viewer, tier, match, myNativeCodes, myLearningCodes }
+}
+
+/**
+ * What one candidate becomes on the wire. Shared by the list and the strip:
+ * the strip adds a tier on top, and nothing else about a person may differ
+ * between the two places they appear.
+ */
+function toDiscoveryItem(
+  doc: Profile & { score?: number; distanceMeters?: number },
+  now: Date,
+): DiscoveryItem {
+  const item: DiscoveryItem = {
+    _id: doc._id,
+    handle: doc.handle,
+    displayName: doc.displayName,
+    gender: doc.gender,
+    age: ageFromBirthDate(doc.birthDate, now),
+    // Stored values were already validated against languageCodeSchema/cefrLevelSchema
+    // at write time (createProfile/updateProfile) — Profile's own DB-facing
+    // interface just doesn't carry those branded types.
+    nativeLanguages: doc.nativeLanguages as DiscoveryItem['nativeLanguages'],
+    learning: doc.learning as DiscoveryItem['learning'],
+    // Same rule as `toPublicProfile`, and it was missing here: a hidden
+    // profile still drew a green dot in the discovery list, which is the
+    // one place most people would have seen it.
+    isOnline: hidesOnlineStatus(doc) ? false : isOnlineAt(doc.stats.lastActiveAt, now),
+    streak: { current: doc.streak.current },
+  }
+  if (doc.avatarUrl !== undefined) item.avatarUrl = doc.avatarUrl
+  if (doc.bio !== undefined) item.bio = doc.bio
+  if (doc.country !== undefined) item.country = doc.country
+  // Bucketed, never the measured value — `bucketDistanceKm` explains what
+  // reporting the real one would give away.
+  if (doc.distanceMeters !== undefined) item.distanceKm = bucketDistanceKm(doc.distanceMeters)
+  return item
+}
+
+export async function discoverProfiles(
+  db: Db,
+  viewerId: string,
+  query: DiscoveryQuery,
+): Promise<DiscoveryPage> {
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  const { viewer, tier, match, myNativeCodes, myLearningCodes } = await resolveDiscoveryScope(
+    db,
+    viewerId,
+    query,
+  )
+
+  if (query.sort === 'nearby') {
+    if (!hasFeature(tier, 'nearby')) {
+      throw new ApiError(ERROR_CODES.UPGRADE_REQUIRED, 'Nearby requires Pro+', {
+        feature: 'nearby',
+      })
+    }
+    // Checked before the query rather than left to return nothing: an empty
+    // list would be indistinguishable from "nobody is near you", and the user
+    // would go looking for people instead of for the setting.
+    if (!viewer.location) {
+      throw new ApiError(
+        ERROR_CODES.LOCATION_REQUIRED,
+        'Share your own location to sort by distance',
+      )
+    }
   }
 
   /**
@@ -421,32 +497,7 @@ export async function discoverProfiles(
   const hasMore = docs.length > query.limit
   const page = hasMore ? docs.slice(0, query.limit) : docs
 
-  const items: DiscoveryItem[] = page.map((doc) => {
-    const item: DiscoveryItem = {
-      _id: doc._id,
-      handle: doc.handle,
-      displayName: doc.displayName,
-      gender: doc.gender,
-      age: ageFromBirthDate(doc.birthDate, now),
-      // Stored values were already validated against languageCodeSchema/cefrLevelSchema
-      // at write time (createProfile/updateProfile) — Profile's own DB-facing
-      // interface just doesn't carry those branded types.
-      nativeLanguages: doc.nativeLanguages as DiscoveryItem['nativeLanguages'],
-      learning: doc.learning as DiscoveryItem['learning'],
-      // Same rule as `toPublicProfile`, and it was missing here: a hidden
-      // profile still drew a green dot in the discovery list, which is the
-      // one place most people would have seen it.
-      isOnline: hidesOnlineStatus(doc) ? false : isOnlineAt(doc.stats.lastActiveAt, now),
-      streak: { current: doc.streak.current },
-    }
-    if (doc.avatarUrl !== undefined) item.avatarUrl = doc.avatarUrl
-    if (doc.bio !== undefined) item.bio = doc.bio
-    if (doc.country !== undefined) item.country = doc.country
-    // Bucketed, never the measured value — `bucketDistanceKm` explains what
-    // reporting the real one would give away.
-    if (doc.distanceMeters !== undefined) item.distanceKm = bucketDistanceKm(doc.distanceMeters)
-    return item
-  })
+  const items: DiscoveryItem[] = page.map((doc) => toDiscoveryItem(doc, now))
 
   let nextCursor: string | null = null
   if (hasMore) {
@@ -465,4 +516,62 @@ export async function discoverProfiles(
   }
 
   return { items, nextCursor }
+}
+
+/**
+ * The strip above the list: the same candidates the list would show, kept to
+ * those on a paid plan, most expensive plan first and most recently active
+ * within it.
+ *
+ * `settings.boosted` is read as *absent means on*. The flag is only ever
+ * written when somebody turns the toggle off (or back on), so a new
+ * subscriber is in the strip the moment the entitlement lands, with no
+ * billing-side hook, and an explicit "off" survives a lapse and a
+ * re-subscribe the way every other setting a person chose does.
+ *
+ * The tier is checked here in the query rather than through `hasFeature`
+ * because the question is "who", over many documents, not "may this viewer".
+ * The expiry clause mirrors `effectivePlanTier`: a lapsed subscription whose
+ * webhook is late stops being boosted on its own. `null` matches both a
+ * missing and a null `expiresAt`, and the "unparseable date" branch there
+ * cannot happen on a BSON Date.
+ *
+ * `boostedRank` is computed, so the sort is in memory — over the paying
+ * members inside one language fit, which is a handful. The `$match` is still
+ * served by the two discovery indexes.
+ */
+export async function boostedProfiles(
+  db: Db,
+  viewerId: string,
+  query: DiscoveryQuery,
+): Promise<BoostedProfilesPage> {
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  const { match } = await resolveDiscoveryScope(db, viewerId, query)
+  const now = new Date()
+
+  const pipeline: Document[] = [
+    {
+      $match: {
+        ...match,
+        'entitlement.tier': { $in: [...DISCOVERY_BOOSTED_TIERS] },
+        'settings.boosted': { $ne: false },
+        $or: [{ 'entitlement.expiresAt': null }, { 'entitlement.expiresAt': { $gt: now } }],
+      },
+    },
+    {
+      $addFields: {
+        boostedRank: { $indexOfArray: [[...DISCOVERY_BOOSTED_TIERS], '$entitlement.tier'] },
+      },
+    },
+    { $sort: { boostedRank: 1, 'stats.lastActiveAt': -1, _id: 1 } },
+    { $limit: DISCOVERY_BOOSTED_LIMIT },
+  ]
+
+  const docs = await profiles.aggregate<Profile>(pipeline).toArray()
+  const items: BoostedProfile[] = docs.map((doc) => ({
+    ...toDiscoveryItem(doc, now),
+    // Narrowed by the `$match` above; the cast only tells TypeScript so.
+    tier: doc.entitlement.tier as BoostedTier,
+  }))
+  return { items }
 }

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -115,6 +115,11 @@ export interface Profile {
   interests: string[]
   settings: {
     discoverable: boolean
+    /**
+     * The strip above Discover, for paid tiers only. Absent means on — see
+     * `boostedProfiles`; only the toggle ever writes it.
+     */
+    boosted?: boolean
     /** A native language code, or absent for "the first native language". See `translateTargetFor`. */
     translateTo?: string
     /**
@@ -728,6 +733,7 @@ export async function updateProfile(
     privacy?: Record<string, boolean>
     settings?: {
       discoverable?: boolean
+      boosted?: boolean
       translateTo?: string | null
       notifications?: NotificationPrefsInput
     }
@@ -757,6 +763,7 @@ export async function updateProfile(
   const settingsUnset: Record<string, ''> = {}
   if (settings?.discoverable !== undefined)
     settingsPaths['settings.discoverable'] = settings.discoverable
+  if (settings?.boosted !== undefined) settingsPaths['settings.boosted'] = settings.boosted
   /*
    * The translation target has to be one of the person's *native* languages
    * — the schema cannot see the profile, so the check is here, against the

--- a/apps/api/src/routes/discovery.test.ts
+++ b/apps/api/src/routes/discovery.test.ts
@@ -1,6 +1,7 @@
 import {
   DISCOVERY_CURSOR_MAX_AGE_MS,
   DISTANCE_BUCKETS_KM,
+  type BoostedProfilesPage,
   type DiscoveryPage,
   type HandleSearchPage,
 } from '@langx/shared'
@@ -70,6 +71,27 @@ describe('Faz 3 — discovery aggregation', () => {
       url: `/discovery${qs ? `?${qs}` : ''}`,
       headers: { cookie: user.cookie },
     })
+  }
+
+  async function boosted(user: SignedUpUser, qs = '') {
+    return app.inject({
+      method: 'GET',
+      url: `/discovery/boosted${qs ? `?${qs}` : ''}`,
+      headers: { cookie: user.cookie },
+    })
+  }
+
+  /** Straight onto the document — a subscription in these tests is a fact, not a purchase. */
+  async function setTier(userId: string, tier: Profile['entitlement']['tier'], expiresAt?: Date) {
+    await handle.db.collection<Profile>(COLLECTIONS.profiles).updateOne(
+      { _id: userId },
+      {
+        $set: {
+          'entitlement.tier': tier,
+          ...(expiresAt ? { 'entitlement.expiresAt': expiresAt } : {}),
+        },
+      },
+    )
   }
 
   beforeAll(async () => {
@@ -955,12 +977,6 @@ describe('Faz 3 — discovery aggregation', () => {
     const ANOTHER_CITY = { lat: 40.19, lng: 29.06 } //  ~91 km  (Bursa)
     const FAR_AWAY = { lat: 39.93, lng: 32.86 } //     ~350 km  (Ankara)
 
-    async function setTier(userId: string, tier: Profile['entitlement']['tier']) {
-      await handle.db
-        .collection<Profile>(COLLECTIONS.profiles)
-        .updateOne({ _id: userId }, { $set: { 'entitlement.tier': tier } })
-    }
-
     // Generic so it hands back exactly what it was given — `newUser` returns a
     // `SignedUpUser` *plus* the handle, and every assertion below needs it.
     async function share<T extends SignedUpUser>(
@@ -1250,5 +1266,124 @@ describe('Faz 3 — discovery aggregation', () => {
      * of someone offline in the next street, which is a recommended list with
      * a radius rather than a nearby list.
      */
+  })
+
+  /**
+   * The strip above the list. One rule worth stating up front: it is the
+   * list's own candidates with a plan attached, so everything that keeps
+   * somebody out of `/discovery` keeps them out of here too.
+   */
+  describe('GET /discovery/boosted', () => {
+    const fits = {
+      nativeLanguages: [{ code: 'en' }],
+      learning: [{ code: 'tr', level: 'beginner', priority: 1 }],
+    }
+    const boostedHandles = async (user: SignedUpUser, qs = '') => {
+      const response = await boosted(user, qs)
+      expect(response.statusCode).toBe(200)
+      return response.json<BoostedProfilesPage>().items
+    }
+
+    it('lists paying members only, Polyglot first, then Fluent, each by last active', async () => {
+      const viewer = await newUser('boost-viewer@example.com')
+      const proPlusOld = await newUser('boost-pp-old@example.com', fits)
+      const proPlusNew = await newUser('boost-pp-new@example.com', fits)
+      const proOld = await newUser('boost-pro-old@example.com', fits)
+      const proNew = await newUser('boost-pro-new@example.com', fits)
+      const free = await newUser('boost-free@example.com', fits)
+
+      await setTier(proPlusOld.userId, 'pro_plus')
+      await setTier(proPlusNew.userId, 'pro_plus')
+      await setTier(proOld.userId, 'pro')
+      await setTier(proNew.userId, 'pro')
+      await setLastActiveAt(proPlusOld.userId, new Date('2026-01-01T00:00:00Z'))
+      await setLastActiveAt(proPlusNew.userId, new Date('2026-06-01T00:00:00Z'))
+      await setLastActiveAt(proOld.userId, new Date('2026-01-01T00:00:00Z'))
+      await setLastActiveAt(proNew.userId, new Date('2026-06-01T00:00:00Z'))
+
+      const items = await boostedHandles(viewer)
+      expect(items.map((i) => i.handle)).toEqual([
+        proPlusNew.handle,
+        proPlusOld.handle,
+        proNew.handle,
+        proOld.handle,
+      ])
+      expect(items.map((i) => i.tier)).toEqual(['pro_plus', 'pro_plus', 'pro', 'pro'])
+      expect(items.map((i) => i.handle)).not.toContain(free.handle)
+    })
+
+    it('drops a lapsed subscription and keeps a live one', async () => {
+      const viewer = await newUser('boost-exp-viewer@example.com')
+      const lapsed = await newUser('boost-lapsed@example.com', fits)
+      const live = await newUser('boost-live@example.com', fits)
+      await setTier(lapsed.userId, 'pro', new Date(Date.now() - 60_000))
+      await setTier(live.userId, 'pro', new Date(Date.now() + 60_000))
+
+      const handles = (await boostedHandles(viewer)).map((i) => i.handle)
+      expect(handles).toContain(live.handle)
+      expect(handles).not.toContain(lapsed.handle)
+    })
+
+    it("keeps the list's own exclusions: no language fit, blocked", async () => {
+      const viewer = await newUser('boost-excl-viewer@example.com')
+      const noFit = await newUser('boost-nofit@example.com', {
+        nativeLanguages: [{ code: 'de' }],
+        learning: [{ code: 'fr', level: 'beginner', priority: 1 }],
+      })
+      const blocked = await newUser('boost-blocked@example.com', fits)
+      await setTier(noFit.userId, 'pro_plus')
+      await setTier(blocked.userId, 'pro_plus')
+      const block = await app.inject({
+        method: 'POST',
+        url: '/blocks',
+        headers: { cookie: viewer.cookie },
+        payload: { userId: blocked.userId },
+      })
+      expect(block.statusCode).toBe(201)
+
+      const handles = (await boostedHandles(viewer)).map((i) => i.handle)
+      expect(handles).not.toContain(noFit.handle)
+      expect(handles).not.toContain(blocked.handle)
+    })
+
+    it('is empty, not an error, when nobody around is paying', async () => {
+      const viewer = await newUser('boost-empty-viewer@example.com')
+      await newUser('boost-empty-free@example.com', fits)
+      expect(await boostedHandles(viewer)).toEqual([])
+    })
+
+    it('honours the filters and ignores the sort', async () => {
+      const viewer = await newUser('boost-filter-viewer@example.com')
+      const here = await newUser('boost-filter-here@example.com', { ...fits, country: 'TR' })
+      const there = await newUser('boost-filter-there@example.com', { ...fits, country: 'DE' })
+      await setTier(here.userId, 'pro')
+      await setTier(there.userId, 'pro')
+
+      const filtered = (await boostedHandles(viewer, 'country=TR')).map((i) => i.handle)
+      expect(filtered).toContain(here.handle)
+      expect(filtered).not.toContain(there.handle)
+
+      // A free viewer asking the list for `nearby` is refused; the strip has
+      // no sort, so the same querystring must not be.
+      const sorted = await boosted(viewer, 'sort=nearby')
+      expect(sorted.statusCode).toBe(200)
+    })
+
+    it('respects the toggle: off is out, absent is in, and a free flag buys nothing', async () => {
+      const viewer = await newUser('boost-toggle-viewer@example.com')
+      const optedOut = await newUser('boost-optout@example.com', fits)
+      const untouched = await newUser('boost-untouched@example.com', fits)
+      const freeFlag = await newUser('boost-freeflag@example.com', fits)
+      await setTier(optedOut.userId, 'pro')
+      await setTier(untouched.userId, 'pro')
+      const profiles = handle.db.collection<Profile>(COLLECTIONS.profiles)
+      await profiles.updateOne({ _id: optedOut.userId }, { $set: { 'settings.boosted': false } })
+      await profiles.updateOne({ _id: freeFlag.userId }, { $set: { 'settings.boosted': true } })
+
+      const handles = (await boostedHandles(viewer)).map((i) => i.handle)
+      expect(handles).toContain(untouched.handle)
+      expect(handles).not.toContain(optedOut.handle)
+      expect(handles).not.toContain(freeFlag.handle)
+    })
   })
 })

--- a/apps/api/src/routes/discovery.ts
+++ b/apps/api/src/routes/discovery.ts
@@ -1,7 +1,7 @@
 import { discoveryQuerySchema, handleSearchQuerySchema } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { requireAuth } from '../middleware/requireAuth'
-import { discoverProfiles } from '../modules/discovery/discovery'
+import { boostedProfiles, discoverProfiles } from '../modules/discovery/discovery'
 import { searchHandles } from '../modules/discovery/handleSearch'
 
 // eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
@@ -12,6 +12,21 @@ export const discoveryRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request, reply) => {
       const page = await discoverProfiles(app.mongo.db, request.userId, request.query)
       return reply.send(page)
+    },
+  )
+
+  /*
+   * The strip above the list. Takes the same querystring as `/discovery` so
+   * the client can send the filters it already has; `sort`, `cursor`, `limit`
+   * and `radiusKm` are accepted and ignored — the strip has one order and no
+   * pages, and a second schema for three ignored fields is not worth the
+   * drift (the base schema is refined, so it cannot be extended anyway).
+   */
+  app.get(
+    '/discovery/boosted',
+    { preHandler: requireAuth, schema: { querystring: discoveryQuerySchema } },
+    async (request, reply) => {
+      return reply.send(await boostedProfiles(app.mongo.db, request.userId, request.query))
     },
   )
 

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -1683,6 +1683,35 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
       expect(later?.privacy).toMatchObject({ incognito: false, hideOnlineStatus: true })
     })
 
+    /**
+     * The Boosted toggle writes one key. It must not disturb its siblings —
+     * `discoverable` in particular, which is the switch that hides a whole
+     * account — and a free account may write it without a refusal, since the
+     * strip decides by tier at read time (see `boostedProfiles`).
+     */
+    it('stores settings.boosted on its own and leaves the other settings alone', async () => {
+      const user = await onboarded('boost-off@example.com', 'boostoff')
+      const patch = (settings: Record<string, boolean>) =>
+        app.inject({
+          method: 'PATCH',
+          url: '/profiles/me',
+          headers: { cookie: user.cookie },
+          payload: { settings },
+        })
+
+      expect((await patch({ boosted: false })).statusCode).toBe(200)
+      const after = await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .findOne({ _id: user.userId })
+      expect(after?.settings).toMatchObject({ discoverable: true, boosted: false })
+
+      expect((await patch({ boosted: true })).statusCode).toBe(200)
+      const later = await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .findOne({ _id: user.userId })
+      expect(later?.settings).toMatchObject({ discoverable: true, boosted: true })
+    })
+
     /** The two flags are independent; incognito never touched presence. */
     it('leaves online status alone when only incognito is on', async () => {
       const hider = await onboarded('incog-only@example.com', 'incogonly')

--- a/packages/shared/src/discovery.ts
+++ b/packages/shared/src/discovery.ts
@@ -39,6 +39,20 @@ export const ONLINE_WINDOW_MS = 5 * 60 * 1000
  */
 export const DISCOVERY_CURSOR_MAX_AGE_MS = 60 * 60 * 1000
 
+/**
+ * The strip above the discovery list, most expensive plan first.
+ *
+ * A presentation order like `tierUnlocking`, not a guard — see the note on
+ * `PLAN_TIERS` for why no guard may compare tiers. Which tiers belong here at
+ * all is decided by `PLAN_LIMITS[tier].boostedProfile`; `rules.test.ts` pins
+ * the two together so a tier cannot buy the benefit and miss the strip.
+ */
+export const DISCOVERY_BOOSTED_TIERS = ['pro_plus', 'pro'] as const
+export type BoostedTier = (typeof DISCOVERY_BOOSTED_TIERS)[number]
+
+/** How many profiles the strip shows. It is a shelf, not a second list. */
+export const DISCOVERY_BOOSTED_LIMIT = 12
+
 /** How often a connected client tells the server it is still there. */
 export const PRESENCE_HEARTBEAT_MS = 60_000
 
@@ -238,6 +252,19 @@ export const discoveryPageSchema = z.object({
   nextCursor: z.string().nullable(),
 })
 export type DiscoveryPage = z.infer<typeof discoveryPageSchema>
+
+/**
+ * A discovery item plus the plan that put it in the strip, which the card
+ * draws as a chip. Only ever a paid tier: a free profile is never boosted.
+ */
+export const boostedProfileSchema = discoveryItemSchema.extend({
+  tier: z.enum(DISCOVERY_BOOSTED_TIERS),
+})
+export type BoostedProfile = z.infer<typeof boostedProfileSchema>
+
+/** No cursor: the strip is capped at `DISCOVERY_BOOSTED_LIMIT` and never pages. */
+export const boostedProfilesPageSchema = z.object({ items: z.array(boostedProfileSchema) })
+export type BoostedProfilesPage = z.infer<typeof boostedProfilesPageSchema>
 
 /** How many results a handle search returns. Small on purpose: it is a
  *  jump-to, not a browse — the list below is what browsing is for. */

--- a/packages/shared/src/limits.ts
+++ b/packages/shared/src/limits.ts
@@ -153,6 +153,17 @@ export interface PlanLimits {
    */
   copilot: boolean
   /**
+   * The strip above Discover — "Boosted profiles" — that shows paying members
+   * ahead of the list, most expensive plan first.
+   *
+   * On for both paid tiers. The flag on the profile is `settings.boosted`,
+   * read as absent-means-on, so a new subscriber is in the strip the moment
+   * the entitlement lands and only somebody who turned it off is out. Which
+   * tiers lead the strip is `DISCOVERY_BOOSTED_TIERS`; the rules test keeps it
+   * equal to the tiers that are `true` here.
+   */
+  boostedProfile: boolean
+  /**
    * Photos on a profile, avatar excluded.
    *
    * A ladder, and it was not always one: every tier had six until the gallery
@@ -198,6 +209,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     incognito: false,
     nearby: false,
     copilot: false,
+    boostedProfile: false,
     maxPhotos: 5,
     maxLearningLanguages: 1,
     maxNativeLanguages: 1,
@@ -214,6 +226,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     incognito: false,
     nearby: false,
     copilot: false,
+    boostedProfile: true,
     maxPhotos: 10,
     maxLearningLanguages: 2,
     maxNativeLanguages: 2,
@@ -236,6 +249,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     incognito: true,
     nearby: true,
     copilot: true,
+    boostedProfile: true,
     maxPhotos: 10,
     maxLearningLanguages: 5,
     maxNativeLanguages: 5,
@@ -293,7 +307,7 @@ export function quotaLimit(tier: PlanTier, kind: QuotaKind): Limit {
  * `403 UPGRADE_REQUIRED` payload. `hasFeature` reads these directly off
  * `PLAN_LIMITS`, so this list cannot drift from what the server enforces.
  */
-export const PRO_FEATURES = ['advancedFilters'] as const
+export const PRO_FEATURES = ['advancedFilters', 'boostedProfile'] as const
 export type ProFeature = (typeof PRO_FEATURES)[number]
 
 /**

--- a/packages/shared/src/profile.ts
+++ b/packages/shared/src/profile.ts
@@ -291,6 +291,13 @@ export const updateProfileSchema = z
       .object({
         discoverable: z.boolean(),
         /**
+         * The Boosted strip on Discover. Absent means on; only the toggle
+         * writes it. Not tier-checked here, and not in `updateProfile` either:
+         * the strip re-reads the tier on every request, so a free account
+         * writing `true` gains nothing (see `boostedProfiles`).
+         */
+        boosted: z.boolean(),
+        /**
          * Which native language a translated message is shown in. Must be
          * one of the profile's native languages — checked in `updateProfile`,
          * which can see the profile — and `null` clears it back to the first

--- a/packages/shared/src/rules.test.ts
+++ b/packages/shared/src/rules.test.ts
@@ -8,6 +8,7 @@ import {
   LANGUAGES,
   languageCodeSchema,
 } from './languages'
+import { DISCOVERY_BOOSTED_TIERS } from './discovery'
 import { translateRequestSchema } from './translation'
 import { PACKAGES, packageDefinition, tierFromEntitlementIds } from './billing'
 import {
@@ -480,5 +481,15 @@ describe('the two feature lists', () => {
       expect(PRO_PLUS_FEATURES as readonly string[]).not.toContain(feature)
     }
     expect([...PLAN_FEATURES].sort()).toEqual([...PRO_FEATURES, ...PRO_PLUS_FEATURES].sort())
+  })
+
+  /**
+   * The strip's order is a presentation list, the capability is a table row.
+   * A tier that buys `boostedProfile` and is missing from the strip would be
+   * a benefit sold and never delivered, so the two are pinned together.
+   */
+  it('boosts exactly the tiers that buy boostedProfile', () => {
+    const buying = PLAN_TIERS.filter((tier) => PLAN_LIMITS[tier].boostedProfile)
+    expect([...DISCOVERY_BOOSTED_TIERS].sort()).toEqual([...buying].sort())
   })
 })


### PR DESCRIPTION
Work in progress. Landed so far:

## Boosted profiles strip (API)

- `GET /discovery/boosted`: paying members who match the viewer, Polyglot first then Fluent, each by last activity, capped at `DISCOVERY_BOOSTED_LIMIT`, no cursor.
- `discoverProfiles` now builds its scope through `resolveDiscoveryScope` and maps items through `toDiscoveryItem`; `boostedProfiles` reuses both, so the strip can never disagree with the list about who is visible.
- `settings.boosted` on the profile, read as absent-means-on. A new subscriber is boosted the moment the entitlement lands; only the toggle ever writes the flag, and an explicit "off" survives a lapse and a re-subscribe.
- `boostedProfile` joins `PlanLimits` (free: no, Fluent and Polyglot: yes) and `PRO_FEATURES`. A rules test pins `DISCOVERY_BOOSTED_TIERS` to the tiers that buy it.
- Tests: ordering, lapsed subscription, no language fit, blocked, empty, filters honoured and sort ignored, toggle off/absent/free flag; PATCH of `settings.boosted` leaves the other settings alone.

## Still to come on this branch

- Mobile: the strip component on Discover, the "Boost my profile" row in Settings → Privacy (locked with a FLUENT chip on free, opens the paywall), paywall and Settings benefit copy in eight locales.
- Account suspension: signed review link in the report email (days / permanent / dismiss), `ACCOUNT_SUSPENDED` enforcement in `requireAuth` and the socket, the suspended page with a single appeal, status tags on suspended and deleting profiles.
- Three-letter usernames (`HANDLE_MIN_LENGTH = 3`, `pro` reserved).
- A companion PR on `langx/website` for the plan cards, the Terms suspension clause and the privacy wording; `CURRENT_TERMS_VERSION` bump.

## Notes for review

- The API integration tests could not run in the authoring environment (the MongoDB binary download is blocked by egress policy); typecheck, lint, format and the shared unit tests pass. CI is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD9DkMcvqRXnMhSSR6yUZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01MD9DkMcvqRXnMhSSR6yUZR)_