### PR TITLE
Make --source v1 mean v1 again

### DIFF
--- a/apps/api/src/modules/notifications/audience.test.ts
+++ b/apps/api/src/modules/notifications/audience.test.ts
@@ -86,15 +86,32 @@ describe('what a Resend audience should contain', () => {
    * `--source v1` still buys is the pre-created rows that have no profile at
    * all — see the case further down.
    */
-  it('takes an unanswered account under every source', async () => {
+  it('takes an unanswered account under consented and all', async () => {
     const yes = await newAccount({ notifications: optedIn })
     const v1 = await newAccount({ fromV1: true })
     const neither = await newAccount()
 
-    const plan = await audiencePlan(handle.db, 'v1')
+    const plan = await audiencePlan(handle.db, 'all')
     expect(new Set(plan.contacts.map((contact) => contact.userId))).toEqual(
       new Set([yes, v1, neither]),
     )
+  })
+
+  /**
+   * `--source v1` names a population, not a consent, and the difference
+   * stopped being free when promotional email became opt-out: without it, a
+   * campaign asking for v1 accounts is handed every verified address there
+   * is — which for the launch letter means telling somebody who signed up
+   * last week that their streak is waiting.
+   */
+  it('takes only accounts that actually came from v1 under the v1 source', async () => {
+    const v1 = await newAccount({ fromV1: true })
+    await newAccount({ notifications: optedIn })
+    await newAccount()
+
+    const plan = await audiencePlan(handle.db, 'v1')
+    expect(plan.contacts.map((contact) => contact.userId)).toEqual([v1])
+    expect(plan.skipped.noConsent).toBe(2)
   })
 
   /**

--- a/apps/api/src/modules/notifications/audience.ts
+++ b/apps/api/src/modules/notifications/audience.ts
@@ -25,7 +25,10 @@ import { suppressedAmong } from './suppressions'
 export type AudienceSource =
   /** `promotions.email` is true in this database. The only self-evident case. */
   | 'consented'
-  /** Consent given at v1's sign-up: every `precreatedFromV1` row, unless v2 refused. */
+  /**
+   * The pre-created v1 rows and nobody else — a population rather than a
+   * consent, which is what the win-back letters are addressed to.
+   */
   | 'v1'
   /** Both, plus everybody else with a verified address. Widest, and the least defensible. */
   | 'all'
@@ -159,10 +162,25 @@ export async function audiencePlan(
     }
 
     const userId = String(user._id)
+    const fromV1 = user.precreatedFromV1 !== undefined && user.precreatedFromV1 !== null
+    /*
+     * `--source v1` names *who*, not what they consented to, and that
+     * distinction stopped being free when promotional email became opt-out:
+     * `audienceAction` now answers `subscribe` for anybody whose switch
+     * allows it, which is everybody untouched — so without this line a
+     * campaign asking for v1 accounts was handed every verified address in
+     * the database. Caught by a dry run of the launch mail, which offered to
+     * tell twenty-five people who signed up last week that their streak was
+     * waiting for them.
+     */
+    if (source === 'v1' && !fromV1) {
+      skipped.noConsent++
+      continue
+    }
     const profile = profiles.get(userId)
     const decided = audienceAction(source, {
       deleted: profile?.deletedAt !== undefined,
-      fromV1: user.precreatedFromV1 !== undefined && user.precreatedFromV1 !== null,
+      fromV1,
       prefs: profile?.settings?.notifications,
     })
     const action =

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -166,12 +166,12 @@ month.
 `apps/api/campaigns/README.md` for the commands and
 [`release-runbook.md`](release-runbook.md) for the rules.
 
-| Source      | Who                                                             |
-| ----------- | --------------------------------------------------------------- |
-| `consented` | `promotions.email` allows it                                    |
-| `v1`        | plus every pre-created v1 row that has not said no              |
-| `all`       | plus every verified address                                     |
-| `v1deleted` | the addresses v1's deleted accounts left in `v1DeletedContacts` |
+| Source      | Who                                                                       |
+| ----------- | ------------------------------------------------------------------------- |
+| `consented` | `promotions.email` allows it                                              |
+| `v1`        | the pre-created v1 rows **and nobody else** — a population, not a consent |
+| `all`       | plus every verified address                                               |
+| `v1deleted` | the addresses v1's deleted accounts left in `v1DeletedContacts`           |
 
 `--exclude-returned` drops anybody who has since onboarded. Warm-up ramp:
 250 / 500 / 1000 / 2000 / 4000 a day, 08–20 UTC. `--pause` stops the next


### PR DESCRIPTION
Found by dry-running the launch letter against production before queueing it: the campaign offered to send to **3,905** people. There are **3,901** v1 accounts.

## What was wrong

`audienceAction` answers the *consent* question, and its first line is "does the switch allow it". Since promotional email became opt-out (#1270) that is **yes for everybody who has not touched their settings** — so the `switch (source)` below it was never reached, and `--source v1` was handed every verified address in the database.

Twenty-five of them are people who signed up this month. The launch letter tells its reader that their username, tokens and streak are waiting for them.

## The fix

The source names *who*, so the filter belongs where the population is read — one guard in `audiencePlan` — rather than inside the consent decision. `audienceAction` is unchanged.

```
3,905 → 3,899   (3,901 v1 rows, minus the 2 who came back)
skipped: { returned: 1, upstream: { unverified: 1, guest: 92, noConsent: 29 } }
```

## Verification

- Re-ran the dry run against production: 3,899, the number the raw counts predict.
- New test: `--source v1` takes only accounts that actually came from v1, and the other two sources are unchanged.
- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — green (api 96, mobile 93, shared 26).
- `docs/notifications.md`'s source table corrected: `v1` is a population, not a consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)