### PR TITLE
Send the Play screenshots with supply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,8 +56,9 @@ GoogleService-Info.plist
 # screenshots written by the tools/ext-lab scripts
 tools/ext-lab/shots/
 
-# Assembled from the branding checkout by collect-store-screenshots.mjs; the
-# images themselves live in langx/branding, not here.
+# Assembled from the branding checkout by collect-store-screenshots.mjs and
+# collect-play-screenshots.mjs; the images themselves live in langx/branding,
+# not here.
 apps/mobile/fastlane/screenshots/
 apps/mobile/fastlane/metadata/
 apps/mobile/fastlane/README.md

--- a/apps/mobile/fastlane/Fastfile
+++ b/apps/mobile/fastlane/Fastfile
@@ -39,3 +39,53 @@ platform :ios do
     )
   end
 end
+
+# The Play half. Same shape as the App Store one: a collect script lays the
+# branding repo out the way the tool wants, the tool sends it, and a person
+# presses the button.
+#
+#   node scripts/collect-play-screenshots.mjs
+#   export SUPPLY_JSON_KEY=~/path/to/eas-submit-service-account.json
+#   fastlane android play
+#
+# The platform prefix is not optional: `default_platform` above is :ios, so a
+# bare `fastlane play` looks for `ios play` and fails.
+#
+# There is no by-hand fallback for this one. The Play Console keeps no
+# `<input type=file>` in its page, so "Add assets" opens the operating
+# system's file picker and nothing but a person can drive it — 192 times,
+# across eight languages and three device sizes.
+#
+# The key is the `eas-submit@` service account, the one EAS already submits
+# Android builds with, so it has the Android Publisher access supply needs.
+# Like the .p8 above, it stays where it is and fastlane reads it.
+platform :android do
+  desc 'Put the Play screenshots up, in every language, in order'
+  # `fastlane android play submit:true` sends the listing for review as well as
+  # uploading. Without it the images land as pending changes and a person
+  # presses Send for review, which is the default for the same reason the iOS
+  # lane does not submit.
+  lane :play do |options|
+    # Screenshots only. The copy, the feature graphic, the icon and the binary
+    # are all skipped, and `collect-play-screenshots.mjs` writes nothing but
+    # images — so there is no metadata on disk for supply to send even if one
+    # of these flags were wrong.
+    #
+    # Unlike the App Store, this really is images-only: a Play listing is
+    # reviewed on its own, without the binary riding along.
+    supply(
+      package_name: 'tech.newchapter.languageXchange',
+      json_key: File.expand_path(ENV.fetch('SUPPLY_JSON_KEY')),
+      metadata_path: './fastlane/metadata/android',
+      skip_upload_aab: true,
+      skip_upload_apk: true,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      # `images` is the icon and the feature graphic; `screenshots` is the set
+      # this lane exists for. Two separate flags.
+      skip_upload_images: true,
+      skip_upload_screenshots: false,
+      changes_not_sent_for_review: !options[:submit],
+    )
+  end
+end

--- a/apps/mobile/scripts/collect-play-screenshots.mjs
+++ b/apps/mobile/scripts/collect-play-screenshots.mjs
@@ -25,10 +25,26 @@ import { fileURLToPath } from 'node:url'
 const HERE = path.dirname(fileURLToPath(import.meta.url))
 const MOBILE = path.resolve(HERE, '..')
 
+/**
+ * Every read is built through here and has to land inside the directory it
+ * was given. `BRANDING_DIR` is a developer's own env var rather than anything
+ * hostile, but it is still the one value in this script that comes from
+ * outside it — so the containment check is written down instead of assumed,
+ * and `..` in a name cannot walk out of the tree being copied.
+ */
+function within(root, ...parts) {
+  const resolved = path.resolve(root, ...parts)
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    console.error(`Refusing ${resolved}: outside ${root}`)
+    process.exit(1)
+  }
+  return resolved
+}
+
 /** Same resolution rule as the App Store script beside this one. */
 function brandingRoot() {
   const root = path.resolve(HERE, '..', process.env.BRANDING_DIR ?? '../../../branding')
-  if (!fs.existsSync(path.join(root, '2.x'))) {
+  if (!fs.existsSync(within(root, '2.x'))) {
     console.error(
       `No 2.x in ${root}. Check out langx/branding next to this repo, or set BRANDING_DIR.`,
     )
@@ -38,7 +54,7 @@ function brandingRoot() {
 }
 
 const BRANDING = brandingRoot()
-const OUT = path.join(MOBILE, 'fastlane/metadata/android')
+const OUT = within(MOBILE, 'fastlane/metadata/android')
 
 /**
  * Our folder name to Play's locale code. These are not Apple's: Play wants a
@@ -83,19 +99,22 @@ fs.rmSync(OUT, { recursive: true, force: true })
 let copied = 0
 for (const [ours, play] of Object.entries(LOCALES)) {
   for (const [size, supplyDir] of Object.entries(SIZES)) {
-    const from = path.join(BRANDING, '2.x', ours, 'android', size)
+    const from = within(BRANDING, '2.x', ours, 'android', size)
     if (!fs.existsSync(from)) {
       console.error(`Missing ${from}`)
       process.exit(1)
     }
-    const to = path.join(OUT, play, 'images', supplyDir)
+    const to = within(OUT, play, 'images', supplyDir)
     fs.mkdirSync(to, { recursive: true })
-    for (const file of fs
+    for (const entry of fs
       .readdirSync(from)
       .filter((f) => f.endsWith('.png'))
       .sort()) {
+      // `basename` twice: once to keep a name from readdir from being a path
+      // at all, once to drop the extension for the numeric prefix.
+      const file = path.basename(entry)
       const n = path.basename(file, '.png').padStart(2, '0')
-      fs.copyFileSync(path.join(from, file), path.join(to, `${n}.png`))
+      fs.copyFileSync(within(from, file), within(to, `${n}.png`))
       copied++
     }
   }

--- a/apps/mobile/scripts/collect-play-screenshots.mjs
+++ b/apps/mobile/scripts/collect-play-screenshots.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/* global console */
+/**
+ * Lays the store screenshots out the way `fastlane supply` expects, so all
+ * eight languages go up in one command instead of 192 drags through the Play
+ * Console.
+ *
+ * 192 is not an exaggeration and the drags are not optional: the Play Console
+ * keeps no `<input type=file>` in its page, so "Add assets" opens the
+ * operating system's own file picker. Nothing can drive that but a person,
+ * which is why this script and the `play` lane exist at all.
+ *
+ * The images live in the sibling `branding` checkout (see docs/repo-map.md),
+ * one folder per language per device size. supply wants
+ * `<locale>/images/<size>Screenshots/` and sorts by filename, so this only has
+ * to copy and rename — the numeric prefix is what keeps the order.
+ *
+ *   node apps/mobile/scripts/collect-play-screenshots.mjs
+ *   cd apps/mobile && fastlane play
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const MOBILE = path.resolve(HERE, '..')
+
+/** Same resolution rule as the App Store script beside this one. */
+function brandingRoot() {
+  const root = path.resolve(HERE, '..', process.env.BRANDING_DIR ?? '../../../branding')
+  if (!fs.existsSync(path.join(root, '2.x'))) {
+    console.error(
+      `No 2.x in ${root}. Check out langx/branding next to this repo, or set BRANDING_DIR.`,
+    )
+    process.exit(1)
+  }
+  return root
+}
+
+const BRANDING = brandingRoot()
+const OUT = path.join(MOBILE, 'fastlane/metadata/android')
+
+/**
+ * Our folder name to Play's locale code. These are not Apple's: Play wants a
+ * region on most of them (`tr-TR`, not `tr`) and the listing's default is
+ * British rather than American English.
+ *
+ * **Six, not the eight the branding repo holds.** The API refuses a locale
+ * that is not already a translation on the listing, and Play's thirteen are
+ * `de-DE en-GB es-419 es-ES fr-FR id it-IT ja-JP ko-KR pt-BR th tr-TR zh-CN`
+ * — no Russian and no Arabic. Both have artwork sitting ready in
+ * `branding/2.x`; adding either needs a title and a description first, which
+ * is a copy decision rather than this script's.
+ *
+ * The seven Play locales we have no artwork for keep falling back to `en-GB`,
+ * which is where the set that everyone actually sees lives: before this
+ * script ran the first time, `en-GB` was the *only* locale on the listing
+ * with screenshots at all.
+ *
+ * Check it with `fastlane supply init` into a scratch path before adding a
+ * row here.
+ */
+const LOCALES = {
+  en: 'en-GB',
+  tr: 'tr-TR',
+  es: 'es-ES',
+  fr: 'fr-FR',
+  de: 'de-DE',
+  'pt-BR': 'pt-BR',
+}
+
+/** Our folder name to supply's directory name. */
+const SIZES = {
+  phone: 'phoneScreenshots',
+  '7tablet': 'sevenInchScreenshots',
+  '10tablet': 'tenInchScreenshots',
+}
+
+// Only the screenshots are rewritten here. Leaving the rest of
+// `metadata/android` absent is what keeps supply from touching the listing
+// copy, the feature graphic or the icon — see the `play` lane.
+fs.rmSync(OUT, { recursive: true, force: true })
+let copied = 0
+for (const [ours, play] of Object.entries(LOCALES)) {
+  for (const [size, supplyDir] of Object.entries(SIZES)) {
+    const from = path.join(BRANDING, '2.x', ours, 'android', size)
+    if (!fs.existsSync(from)) {
+      console.error(`Missing ${from}`)
+      process.exit(1)
+    }
+    const to = path.join(OUT, play, 'images', supplyDir)
+    fs.mkdirSync(to, { recursive: true })
+    for (const file of fs
+      .readdirSync(from)
+      .filter((f) => f.endsWith('.png'))
+      .sort()) {
+      const n = path.basename(file, '.png').padStart(2, '0')
+      fs.copyFileSync(path.join(from, file), path.join(to, `${n}.png`))
+      copied++
+    }
+  }
+  console.log(`${play}: ${Object.keys(SIZES).length * 8} screenshots`)
+}
+console.log(`\n${copied} files in ${OUT}`)
+console.log('Next: cd apps/mobile && fastlane android play')


### PR DESCRIPTION
## Summary

Play had no upload path at all — no Supplyfile, no android lane, no collect script — so the listing still carried v1 artwork while the App Store had already moved to 2.0.

- `apps/mobile/scripts/collect-play-screenshots.mjs` — lays `branding/2.x/<lang>/android/` out as `<locale>/images/{phone,sevenInch,tenInch}Screenshots/`, numbered so supply's filename sort keeps the order.
- `fastlane android play` — sends it. `submit:true` also sends the listing for review; without it the images land as pending changes and a person presses the button, same as the iOS lane.

## Why a lane and not just doing it by hand

Because by hand is not actually available. The Play Console keeps **no `<input type=file>` in its page** — "Add assets" opens the operating system's file picker, which nothing but a person can drive. That is 192 drags across the languages and device sizes. (Deleting works fine, which is the worst possible half to have: it can clear the old set and not place the new one.)

## Six locales, not eight

Play's thirteen are `de-DE en-GB es-419 es-ES fr-FR id it-IT ja-JP ko-KR pt-BR th tr-TR zh-CN` — **no Russian and no Arabic**, and the API refuses a locale that is not already a translation. Both have artwork sitting ready in `branding/2.x`; adding either needs a title and a description first, which is a copy decision.

The seven we have no artwork for keep falling back to `en-GB`. That matters more than it sounds: `fastlane supply init` shows `en-GB` was the **only** locale on the listing with any screenshots at all, so that one set is what every language was showing.

## Notes for the reviewer

- Screenshots only. The copy, feature graphic, icon and binary are all skipped, and the collect script writes nothing but images — so there is no metadata on disk for supply to send even if one of those flags were wrong.
- `skip_upload_images` (icon + feature graphic) and `skip_upload_screenshots` are separate flags; only the second is off.
- Auth is the `eas-submit@` service account, the one EAS already submits Android builds with, so it has the Android Publisher access supply needs. Path comes from `SUPPLY_JSON_KEY`; the key stays where it is, same as the `.p8`.
- The platform prefix is required — `default_platform` is `:ios`, so a bare `fastlane play` looks for `ios play` and fails. Noted in the file.
- Run against the live listing: 144 images across the six locales, uploaded clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)