### PR TITLE
Open the app with the mark coming apart

### DIFF
--- a/apps/mobile/src/components/AppSplash.tsx
+++ b/apps/mobile/src/components/AppSplash.tsx
@@ -1,14 +1,22 @@
 import * as SplashScreen from 'expo-splash-screen'
 import { usePathname } from 'expo-router'
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
-import { ActivityIndicator, Animated, Easing, Image, StyleSheet, View } from 'react-native'
+import {
+  ActivityIndicator,
+  Animated,
+  Easing,
+  Image,
+  StyleSheet,
+  View,
+  useWindowDimensions,
+} from 'react-native'
 import darkBadge from '../../assets/splash/badge-dark.png'
 import defaultBadge from '../../assets/splash/badge.png'
 import { useT } from '../i18n'
 import { useAppReady } from '../hooks/useAppReady'
 import { useReduceMotion } from '../hooks/useReduceMotion'
 import { markAppReady } from '../lib/appReady'
-import { SPLASH_TIMING, msUntilExitAllowed } from '../lib/splashTiming'
+import { SPLASH_TIMING, floodDiameter, msUntilExitAllowed } from '../lib/splashTiming'
 import { OVERLAY_LAYER } from '../lib/overlayLayers'
 import { makeStyles, useTheme } from '../lib/theme'
 
@@ -31,6 +39,94 @@ const TILE_GROUND = { light: '#ffc409', dark: '#121318' } as const
 const BADGES = { light: defaultBadge, dark: darkBadge } as const
 
 /**
+ * The bloom: the mark's own geometry, taken apart.
+ *
+ * The badge is two arcs curling into one another, so the opening is four more
+ * of them at four radii, turning at four speeds in alternating directions.
+ * Nothing here is a shape the logo does not already contain.
+ *
+ * An arc is a circular `View` with two of its four borders coloured and the
+ * other two transparent; `sweep` says which two. Two adjacent sides is a
+ * half-turn of ring, and picking a different pair per ring is what keeps the
+ * gaps from lining up into a symmetry.
+ *
+ * `offset` is what stops this being a target. Each arc is pushed off centre by
+ * that many points and then swung around it, so the four are eccentric to one
+ * another and their paths cross — arcs cutting through arcs, which is the
+ * effect, rather than four rings nested tidily inside one another. It is
+ * applied after the rotation, so it is an orbit and not a lean.
+ *
+ * `scale` is a multiple of `TILE_SIZE`: the innermost sits just outside the
+ * badge and the outermost is twice the width of a phone, so its arc leaves the
+ * screen entirely and comes back — that one is the yellow reaching the corners.
+ * Opacity falls with radius because at those widths an arc is a stripe across
+ * the whole display, and a stripe at full strength is a barrier, not a bloom.
+ */
+const BLOOM_RINGS = [
+  {
+    scale: 1.45,
+    thickness: 10,
+    opacity: 0.95,
+    offset: 16,
+    spinMs: 9000,
+    reverse: false,
+    sweep: 'ne',
+  },
+  {
+    scale: 2.3,
+    thickness: 14,
+    opacity: 0.7,
+    offset: 30,
+    spinMs: 13000,
+    reverse: true,
+    sweep: 'sw',
+  },
+  {
+    scale: 3.4,
+    thickness: 20,
+    opacity: 0.42,
+    offset: 48,
+    spinMs: 19000,
+    reverse: false,
+    sweep: 'nw',
+  },
+  {
+    scale: 4.8,
+    thickness: 30,
+    opacity: 0.24,
+    offset: 66,
+    spinMs: 27000,
+    reverse: true,
+    sweep: 'se',
+  },
+] as const
+
+type Sweep = (typeof BLOOM_RINGS)[number]['sweep']
+
+/** The two lit borders of an arc, and the two that are not. */
+function arcSides(sweep: Sweep, color: string) {
+  const transparent = 'transparent'
+  return {
+    borderTopColor: sweep === 'ne' || sweep === 'nw' ? color : transparent,
+    borderRightColor: sweep === 'ne' || sweep === 'se' ? color : transparent,
+    borderBottomColor: sweep === 'sw' || sweep === 'se' ? color : transparent,
+    borderLeftColor: sweep === 'sw' || sweep === 'nw' ? color : transparent,
+  }
+}
+
+/**
+ * What the screen fills with on the way out.
+ *
+ * Yellow in light, where yellow is the brand's ground and a warm wash is the
+ * point. Not in dark: `#ffc409` across a whole display is where the app is
+ * most likely to be opened in an unlit room, and the badge's dark variant says
+ * what the answer is — after dark the yellow is a line, not a field. So the
+ * flood there is the same hue burnt almost to black, which reads as the dark
+ * ground warming rather than as a lamp being switched on.
+ */
+const FLOOD = { light: '#ffc409', dark: '#33290c' } as const
+
+/**
  * The opening.
  *
  * Mounted on `RootShell`'s first render and *outside* the readiness branch, so
@@ -42,6 +138,11 @@ const BADGES = { light: defaultBadge, dark: darkBadge } as const
  * because it sits above the navigator rather than inside a screen. Before
  * this, a cold start was a blank window, then a spinner, then a second
  * spinner, then something to look at.
+ *
+ * Everything animated here is a transform or an opacity, so all of it is on
+ * the native driver. That is not a micro-optimisation on this screen: the JS
+ * thread during a cold start is the busiest it will ever be, and an animation
+ * driven from it would stutter precisely while it is the only thing visible.
  */
 export function AppSplash() {
   const styles = useStyles()
@@ -50,6 +151,7 @@ export function AppSplash() {
   const ready = useAppReady()
   const reduceMotion = useReduceMotion()
   const pathname = usePathname()
+  const { width, height } = useWindowDimensions()
 
   const [visible, setVisible] = useState(true)
   const mountedAt = useRef(Date.now())
@@ -60,7 +162,22 @@ export function AppSplash() {
   const opacity = useRef(new Animated.Value(1)).current
   const scale = useRef(new Animated.Value(SPLASH_TIMING.ENTRY_FROM_SCALE)).current
   const pulse = useRef(new Animated.Value(0)).current
-  const loop = useRef<Animated.CompositeAnimation | null>(null)
+  const flood = useRef(new Animated.Value(0)).current
+  /**
+   * The table above, with each ring's two drivers hung off it: how far it has
+   * opened, and how far round it has turned. Carried together rather than as
+   * parallel arrays so nothing here has to index one list by a position in
+   * another.
+   */
+  const rings = useRef(
+    BLOOM_RINGS.map((ring) => ({
+      ...ring,
+      size: TILE_SIZE * ring.scale,
+      bloom: new Animated.Value(0),
+      spin: new Animated.Value(0),
+    })),
+  ).current
+  const loops = useRef<Animated.CompositeAnimation[]>([])
   const exiting = useRef(false)
 
   /** Nothing signalled. One-way, so it can only ever be early, never wrong. */
@@ -107,17 +224,46 @@ export function AppSplash() {
         }),
       ]),
     )
-    loop.current = breathing
-    breathing.start()
-    return () => breathing.stop()
-  }, [reduceMotion, pulse, scale])
+
+    const opening = rings.map((ring, index) =>
+      Animated.sequence([
+        Animated.delay(index * SPLASH_TIMING.BLOOM_STAGGER_MS),
+        Animated.spring(ring.bloom, {
+          toValue: 1,
+          speed: SPLASH_TIMING.BLOOM_SPEED,
+          bounciness: SPLASH_TIMING.BLOOM_BOUNCINESS,
+          useNativeDriver: true,
+        }),
+      ]),
+    )
+    // Linear and never reversed: an eased rotation reads as a thing being
+    // pushed, and these should look like they were already turning.
+    const turning = rings.map((ring) =>
+      Animated.loop(
+        Animated.timing(ring.spin, {
+          toValue: 1,
+          duration: ring.spinMs,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+      ),
+    )
+
+    loops.current = [breathing, ...turning]
+    Animated.parallel([breathing, ...opening, ...turning]).start()
+    return () => {
+      for (const animation of loops.current) animation.stop()
+      loops.current = []
+    }
+  }, [reduceMotion, pulse, scale, rings])
 
   useEffect(() => {
     if (!ready || exiting.current) return
     exiting.current = true
     const wait = msUntilExitAllowed(mountedAt.current, Date.now())
     const timer = setTimeout(() => {
-      loop.current?.stop()
+      for (const animation of loops.current) animation.stop()
+      loops.current = []
       Animated.parallel([
         // Settled rather than snapped: `pulse.setValue(0)` mid-breath is a
         // visible jump on the first frame of the exit.
@@ -127,24 +273,35 @@ export function AppSplash() {
           easing: Easing.out(Easing.quad),
           useNativeDriver: true,
         }),
+        // The yellow leaving the badge and taking the screen. Skipped under
+        // reduce motion, where a colour crossing the whole display is the
+        // single most objectionable thing on this screen.
+        Animated.timing(flood, {
+          toValue: reduceMotion ? 0 : 1,
+          duration: SPLASH_TIMING.EXIT_FLOOD_MS,
+          easing: Easing.out(Easing.cubic),
+          useNativeDriver: true,
+        }),
         Animated.timing(scale, {
           toValue: reduceMotion ? 1 : SPLASH_TIMING.EXIT_TILE_SCALE,
           duration: SPLASH_TIMING.EXIT_TILE_MS,
+          delay: reduceMotion ? 0 : SPLASH_TIMING.EXIT_TILE_DELAY_MS,
           easing: Easing.in(Easing.quad),
           useNativeDriver: true,
         }),
         Animated.timing(opacity, {
           toValue: 0,
           duration: SPLASH_TIMING.EXIT_TILE_MS,
+          delay: reduceMotion ? 0 : SPLASH_TIMING.EXIT_TILE_DELAY_MS,
           easing: Easing.in(Easing.quad),
           useNativeDriver: true,
         }),
         // The ground leaves last, so the screen underneath is not revealed
-        // before the badge has finished going.
+        // before the flood has finished crossing it.
         Animated.timing(ground, {
           toValue: 0,
           duration: SPLASH_TIMING.EXIT_GROUND_MS,
-          delay: SPLASH_TIMING.EXIT_GROUND_DELAY_MS,
+          delay: reduceMotion ? 0 : SPLASH_TIMING.EXIT_GROUND_DELAY_MS,
           easing: Easing.in(Easing.quad),
           useNativeDriver: true,
         }),
@@ -153,7 +310,7 @@ export function AppSplash() {
       })
     }, wait)
     return () => clearTimeout(timer)
-  }, [ready, reduceMotion, ground, opacity, pulse, scale])
+  }, [ready, reduceMotion, ground, opacity, pulse, scale, flood])
 
   /**
    * The one place the native splash is allowed to go: after this layer has been
@@ -165,6 +322,15 @@ export function AppSplash() {
       void SplashScreen.hideAsync().catch(() => undefined)
     })
   }, [])
+
+  /**
+   * The flood starts out exactly the size of the badge and ends covering the
+   * corners, so the gesture is the tile's own yellow spreading rather than a
+   * second yellow arriving from somewhere. Both ends are derived from the
+   * screen, which is why this is a ratio rather than a constant.
+   */
+  const spread = floodDiameter(width, height)
+  const floodFrom = spread > 0 ? TILE_SIZE / spread : 1
 
   if (!visible) return null
 
@@ -190,6 +356,69 @@ export function AppSplash() {
         { backgroundColor: colors.bg, opacity: ground },
       ]}
     >
+      {!reduceMotion && (
+        <View pointerEvents="none" style={[StyleSheet.absoluteFill, styles.centred]}>
+          {rings.map((ring) => (
+            <Animated.View
+              key={ring.sweep}
+              style={[
+                styles.ring,
+                {
+                  width: ring.size,
+                  height: ring.size,
+                  borderRadius: ring.size / 2,
+                  borderWidth: ring.thickness,
+                  ...arcSides(ring.sweep, colors.primary),
+                  opacity: ring.bloom.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [0, ring.opacity],
+                  }),
+                  transform: [
+                    {
+                      scale: ring.bloom.interpolate({
+                        inputRange: [0, 1],
+                        outputRange: [SPLASH_TIMING.BLOOM_FROM_SCALE, 1],
+                      }),
+                    },
+                    {
+                      rotate: ring.spin.interpolate({
+                        inputRange: [0, 1],
+                        outputRange: ['0deg', ring.reverse ? '-360deg' : '360deg'],
+                      }),
+                    },
+                    // After the rotation, so the arc orbits the centre rather
+                    // than sitting off it at a fixed angle. See `offset`.
+                    { translateX: ring.offset },
+                  ],
+                },
+              ]}
+            />
+          ))}
+        </View>
+      )}
+
+      {!reduceMotion && spread > 0 && (
+        <Animated.View
+          pointerEvents="none"
+          style={[
+            styles.flood,
+            {
+              width: spread,
+              height: spread,
+              borderRadius: spread / 2,
+              backgroundColor: FLOOD[scheme],
+              // Nothing on screen until the exit starts, and fully there well
+              // before it stops growing — a disc that fades in as it travels
+              // shows its edge as a soft ring instead of a front.
+              opacity: flood.interpolate({ inputRange: [0, 0.25, 1], outputRange: [0, 1, 1] }),
+              transform: [
+                { scale: flood.interpolate({ inputRange: [0, 1], outputRange: [floodFrom, 1] }) },
+              ],
+            },
+          ]}
+        />
+      )}
+
       <Animated.View
         style={[
           styles.tile,
@@ -235,8 +464,12 @@ const useStyles = makeStyles(({ colors }) => ({
     alignItems: 'center',
     elevation: OVERLAY_LAYER.splash,
     justifyContent: 'center',
+    overflow: 'hidden',
     zIndex: OVERLAY_LAYER.splash,
   },
+  centred: { alignItems: 'center', justifyContent: 'center' },
+  ring: { position: 'absolute' },
+  flood: { position: 'absolute' },
   fill: {
     alignItems: 'center',
     backgroundColor: colors.bg,

--- a/apps/mobile/src/lib/splashTiming.test.ts
+++ b/apps/mobile/src/lib/splashTiming.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { SPLASH_TIMING, msUntilExitAllowed } from './splashTiming'
+import { SPLASH_TIMING, floodDiameter, msUntilExitAllowed } from './splashTiming'
 
 const { MIN_VISIBLE_MS } = SPLASH_TIMING
 
@@ -24,5 +24,27 @@ describe('msUntilExitAllowed', () => {
    */
   it('treats a clock that went backwards as the start of the floor', () => {
     expect(msUntilExitAllowed(5000, 1000)).toBe(MIN_VISIBLE_MS)
+  })
+})
+
+describe('floodDiameter', () => {
+  /**
+   * The failure this exists to catch: sizing the disc by the *width* leaves
+   * the four corners of a tall screen uncovered for the whole exit.
+   */
+  it('reaches past the corners of a phone', () => {
+    const [width, height] = [390, 844]
+    expect(floodDiameter(width, height) / 2).toBeGreaterThan(Math.hypot(width, height) / 2)
+    expect(floodDiameter(width, height)).toBeGreaterThan(height)
+  })
+
+  it('covers a landscape tablet the same way round', () => {
+    expect(floodDiameter(1366, 1024)).toBeGreaterThan(1366)
+  })
+
+  /** A frame of 0x0, which the web reports during the static export's prerender. */
+  it('asks for nothing when there is no window yet', () => {
+    expect(floodDiameter(0, 0)).toBe(0)
+    expect(floodDiameter(Number.NaN, 100)).toBe(0)
   })
 })

--- a/apps/mobile/src/lib/splashTiming.ts
+++ b/apps/mobile/src/lib/splashTiming.ts
@@ -13,8 +13,13 @@ export const SPLASH_TIMING = {
    * A warm start resolves the session from a cached cookie almost immediately,
    * and without a floor the logo would appear and vanish inside about eighty
    * milliseconds — read as a flicker, not as an opening.
+   *
+   * Raised from 700 when the arcs arrived: the last of the four is still
+   * springing open at ~800ms, and a floor that lets the exit start before the
+   * bloom has finished shows the reader an animation being interrupted rather
+   * than one being played.
    */
-  MIN_VISIBLE_MS: 700,
+  MIN_VISIBLE_MS: 900,
   /**
    * Nothing signalled. Not "the app is fine" — just "stop hiding it": whatever
    * is slow, the reader is better off seeing the screen behind this and its
@@ -28,11 +33,33 @@ export const SPLASH_TIMING = {
   LOOP_HALF_MS: 900,
   LOOP_SCALE: 1.045,
   LOOP_OPACITY: 0.9,
+  /**
+   * The arcs open one after another rather than together, smallest first, so
+   * the bloom reads as coming *out of* the badge instead of appearing around
+   * it. Below about 60ms the four stop being distinguishable.
+   */
+  BLOOM_STAGGER_MS: 90,
+  /**
+   * Looser than the badge's own spring — these are meant to overshoot — but
+   * not so loose that the outermost is still settling when `MIN_VISIBLE_MS`
+   * is up and the exit wants to start.
+   */
+  BLOOM_SPEED: 9,
+  BLOOM_BOUNCINESS: 6,
+  BLOOM_FROM_SCALE: 0.22,
   EXIT_SETTLE_MS: 180,
+  /** The yellow leaving the badge and taking the screen. The whole exit hangs off it. */
+  EXIT_FLOOD_MS: 460,
+  /**
+   * The badge waits a beat before dissolving, so there is a moment of it
+   * sitting *on* the flood rather than being overtaken by it.
+   */
+  EXIT_TILE_DELAY_MS: 160,
   EXIT_TILE_MS: 320,
   EXIT_TILE_SCALE: 1.1,
-  EXIT_GROUND_MS: 320,
-  EXIT_GROUND_DELAY_MS: 60,
+  /** Only once the flood has actually covered the screen — see `EXIT_FLOOD_MS`. */
+  EXIT_GROUND_MS: 360,
+  EXIT_GROUND_DELAY_MS: 380,
 } as const
 
 /**
@@ -46,4 +73,23 @@ export function msUntilExitAllowed(mountedAtMs: number, nowMs: number): number {
   const elapsed = nowMs - mountedAtMs
   if (!Number.isFinite(elapsed) || elapsed < 0) return SPLASH_TIMING.MIN_VISIBLE_MS
   return Math.max(0, SPLASH_TIMING.MIN_VISIBLE_MS - elapsed)
+}
+
+/**
+ * The width of the disc that has to cover the screen on the way out.
+ *
+ * It grows from the centre, so what it must clear is the distance to a
+ * *corner*, not to an edge — a disc as wide as the screen leaves four wedges
+ * of the app showing through before the ground has faded. The corner is half
+ * a diagonal away, so the diagonal is the diameter, plus a few percent for the
+ * rounding at the very last frame.
+ *
+ * Guards a zero: `useWindowDimensions` can report 0×0 for a frame on the web
+ * during the static export's prerender, and a diameter of zero would make the
+ * exit a hard cut.
+ */
+export function floodDiameter(width: number, height: number): number {
+  const diagonal = Math.hypot(width, height)
+  if (!Number.isFinite(diagonal) || diagonal <= 0) return 0
+  return diagonal * 1.06
 }


### PR DESCRIPTION
The splash was a badge that pulsed and faded. This gives it the animation the mark was already asking for.

## What it does

The logo is two arcs curling into one another, so the opening is four more of them at four radii, turning at four speeds in alternating directions. Each is pushed off centre by a few points and then swung around it, so the four are eccentric to one another and their paths cross — arcs cutting through arcs, rather than four rings nested tidily. The outermost is twice the width of a phone, so its arc leaves the screen and comes back: that one is the yellow reaching the corners.

On the way out, the badge's own yellow grows into a disc sized by the screen *diagonal* (a disc as wide as the screen leaves four wedges of the app showing) until it covers everything, and then the whole layer lifts.

## Why not three.js

That was the obvious answer and it is the wrong one here. `expo-gl` is a native module, so this change could no longer ship over the air, and three.js puts roughly half a megabyte of parse cost on exactly the cold start this screen exists to cover — a splash animation that makes the splash longer.

An arc is instead a circular `View` with two of its four borders coloured and the other two transparent. Everything animated is a transform or an opacity, so all of it runs on the native driver, and the diff adds no dependency.

## Cost

About **560ms** on a cold start: `MIN_VISIBLE_MS` moves 700 → 900 so the bloom is not interrupted mid-spring, and the exit grows from ~380ms to ~740ms. Every number is in `splashTiming.ts` if that turns out to be too much.

## Edges

- **Reduce motion** gets neither the arcs nor the flood — the old, plain behaviour.
- **Dark mode** gets the arcs at full strength, which is where the yellow lives after dark, but floods to a burnt amber rather than `#ffc409`: a full display of brand yellow at night is a lamp, not a brand.
- `floodDiameter` is covered by tests, including the 0×0 window the web reports during the static export's prerender.

## Verified

Browser (light and dark) and an iPhone 17 Pro simulator, through a real cold start. typecheck, tests (791), lint and format all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)