### PR TITLE
Store the two cells the trial and churn letters needed

### DIFF
--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -566,7 +566,14 @@ function monthLabel(locale: Locale, month: string): string {
 
 /** The six nudges `modules/notifications/promotions.ts` offers, in its order. */
 export type PromotionScenario =
-  'addPhoto' | 'streakBroke' | 'away' | 'awayLong' | 'tokensWaiting' | 'inviteFriend'
+  | 'addPhoto'
+  | 'streakBroke'
+  | 'away'
+  | 'awayLong'
+  | 'trialEnding'
+  | 'winBack'
+  | 'tokensWaiting'
+  | 'inviteFriend'
 
 /**
  * One nudge, worded from the catalogue rather than assembled here.
@@ -615,6 +622,8 @@ const PROMOTION_DESTINATIONS: Record<PromotionScenario, string> = {
   streakBroke: webUrl('/wallet'),
   away: webUrl('/discover'),
   awayLong: webUrl('/discover'),
+  trialEnding: webUrl('/settings/plan'),
+  winBack: webUrl('/settings/plan'),
   tokensWaiting: webUrl('/wallet'),
   inviteFriend: webUrl('/settings/share'),
 }

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -42,6 +42,10 @@ export const ar: Localized<ServerMessages> = {
       awayBody: 'أشخاص جدد للتدرب معهم.',
       awayLongTitle: 'نحن هنا متى أردت',
       awayLongBody: 'سلسلتك ورموزك في الانتظار.',
+      trialEndingTitle: 'تنتهي أسبوعك المجاني بعد يومين',
+      trialEndingBody: 'الاحتفاظ بها نقرة واحدة.',
+      winBackTitle: 'انتهت خطتك',
+      winBackBody: 'كل ما أنشأته ما زال هنا.',
       tokensWaitingTitle: { one: '{count} رمز في الانتظار', other: '{count} رمزاً في الانتظار' },
       tokensWaitingBody: 'افتح محفظتك.',
       inviteFriendTitle: 'ادعُ صديقاً',
@@ -262,6 +266,20 @@ export const ar: Localized<ServerMessages> = {
         'الشهر مدة طويلة. حسابك وسلسلتك ورموزك ما زالت هنا إن أردتها — وهذه آخر رسالة عن الأمر.',
 
       awayLongButton: 'افتح LangX',
+
+      trialEndingSubject: 'تنتهي أسبوعك المجاني بعد يومين',
+
+      trialEndingBody:
+        'بعدها يعود حسابك إلى الخطة المجانية. كل ما أنشأته يبقى، لكن الحدود تعود. الاحتفاظ بالخطة نقرة واحدة.',
+
+      trialEndingButton: 'احتفظ بخطتي',
+
+      winBackSubject: 'انتهت خطتك قبل أسبوع',
+
+      winBackBody:
+        'لم يُؤخذ منك شيء — سلسلتك ورموزك وكل ما كتبته في مكانه. ما توقف هو حدود الخطة المدفوعة.',
+
+      winBackButton: 'اطّلع على الخطط',
 
       tokensWaitingSubject: {
         one: 'لديك {count} رمز في الانتظار',

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -36,6 +36,10 @@ export const de: Localized<ServerMessages> = {
       awayBody: 'Neue Leute zum Üben.',
       awayLongTitle: 'Wir sind da, wenn du willst',
       awayLongBody: 'Deine Serie und deine Token warten.',
+      trialEndingTitle: 'Deine Gratiswoche endet in zwei Tagen',
+      trialEndingBody: 'Behalten ist ein Tipp.',
+      winBackTitle: 'Dein Tarif ist ausgelaufen',
+      winBackBody: 'Alles, was du erstellt hast, ist noch da.',
       tokensWaitingTitle: { one: '{count} Token wartet', other: '{count} Token warten' },
       tokensWaitingBody: 'Öffne dein Wallet.',
       inviteFriendTitle: 'Lade jemanden ein',
@@ -269,6 +273,20 @@ export const de: Localized<ServerMessages> = {
         'Ein Monat ist lang. Dein Konto, deine Serie und deine Token sind noch da, falls du sie willst — und das ist das Letzte, was wir dazu sagen.',
 
       awayLongButton: 'LangX öffnen',
+
+      trialEndingSubject: 'Deine Gratiswoche endet in zwei Tagen',
+
+      trialEndingBody:
+        'Danach fällt dein Konto auf den kostenlosen Tarif zurück. Alles, was du erstellt hast, bleibt; die Limits kommen wieder. Behalten ist ein Tipp.',
+
+      trialEndingButton: 'Tarif behalten',
+
+      winBackSubject: 'Dein Tarif ist vor einer Woche ausgelaufen',
+
+      winBackBody:
+        'Nichts wurde weggenommen — deine Serie, deine Token und alles Geschriebene liegen, wo du sie gelassen hast. Aufgehört haben nur die bezahlten Limits.',
+
+      winBackButton: 'Tarife ansehen',
 
       tokensWaitingSubject: {
         one: '{count} Token wartet auf dich',

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -40,6 +40,10 @@ export const en = {
       awayBody: 'New people to practise with.',
       awayLongTitle: 'Still here when you are',
       awayLongBody: 'Your streak and tokens are waiting.',
+      trialEndingTitle: 'Your free week ends in two days',
+      trialEndingBody: 'Keeping your plan takes one tap.',
+      winBackTitle: 'Your plan ended a week ago',
+      winBackBody: 'Everything you made is still here.',
       tokensWaitingTitle: { one: '{count} token waiting', other: '{count} tokens waiting' },
       tokensWaitingBody: 'Open your wallet.',
       inviteFriendTitle: 'Invite a friend',
@@ -274,6 +278,20 @@ export const en = {
         'A month is a long time. Your account, your streak and your tokens are all still here if you want them — and this is the last we will say about it.',
 
       awayLongButton: 'Open LangX',
+
+      trialEndingSubject: 'Your free week ends in two days',
+
+      trialEndingBody:
+        'After that your account goes back to the free plan. Everything you made stays; the limits come back. Keeping it is one tap.',
+
+      trialEndingButton: 'Keep my plan',
+
+      winBackSubject: 'Your plan ended a week ago',
+
+      winBackBody:
+        'Nothing was taken away — your streak, your tokens and everything you wrote are where you left them. The paid limits are what stopped.',
+
+      winBackButton: 'See the plans',
 
       tokensWaitingSubject: {
         one: 'You have {count} token waiting',

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -36,6 +36,10 @@ export const es: Localized<ServerMessages> = {
       awayBody: 'Gente nueva con quien practicar.',
       awayLongTitle: 'Aquí cuando quieras',
       awayLongBody: 'Tu racha y tus tokens te esperan.',
+      trialEndingTitle: 'Tu semana gratis termina en dos días',
+      trialEndingBody: 'Mantenerlo es un toque.',
+      winBackTitle: 'Tu plan terminó',
+      winBackBody: 'Todo lo que creaste sigue aquí.',
       tokensWaitingTitle: { one: '{count} token esperando', other: '{count} tokens esperando' },
       tokensWaitingBody: 'Abre tu cartera.',
       inviteFriendTitle: 'Invita a alguien',
@@ -271,6 +275,20 @@ export const es: Localized<ServerMessages> = {
         'Un mes es mucho tiempo. Tu cuenta, tu racha y tus tokens siguen aquí si los quieres, y esto es lo último que diremos.',
 
       awayLongButton: 'Abrir LangX',
+
+      trialEndingSubject: 'Tu semana gratis termina en dos días',
+
+      trialEndingBody:
+        'Después tu cuenta vuelve al plan gratuito. Todo lo que creaste se queda; los límites regresan. Mantenerlo es un toque.',
+
+      trialEndingButton: 'Mantener mi plan',
+
+      winBackSubject: 'Tu plan terminó hace una semana',
+
+      winBackBody:
+        'No se quitó nada: tu racha, tus tokens y todo lo que escribiste siguen donde los dejaste. Lo que se detuvo son los límites de pago.',
+
+      winBackButton: 'Ver los planes',
 
       tokensWaitingSubject: {
         one: 'Tienes {count} token esperando',

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -36,6 +36,10 @@ export const fr: Localized<ServerMessages> = {
       awayBody: 'De nouvelles personnes pour pratiquer.',
       awayLongTitle: 'Nous serons là quand vous voudrez',
       awayLongBody: 'Votre série et vos jetons attendent.',
+      trialEndingTitle: 'Votre semaine gratuite se termine dans deux jours',
+      trialEndingBody: 'La garder tient en un geste.',
+      winBackTitle: 'Votre formule a pris fin',
+      winBackBody: 'Tout ce que vous avez créé est toujours là.',
       tokensWaitingTitle: {
         one: '{count} jeton vous attend',
         other: '{count} jetons vous attendent',
@@ -276,6 +280,20 @@ export const fr: Localized<ServerMessages> = {
         'Un mois, c’est long. Votre compte, votre série et vos jetons sont toujours là si vous les voulez — et c’est la dernière fois que nous en parlons.',
 
       awayLongButton: 'Ouvrir LangX',
+
+      trialEndingSubject: 'Votre semaine gratuite se termine dans deux jours',
+
+      trialEndingBody:
+        'Ensuite, votre compte revient à la formule gratuite. Tout ce que vous avez créé reste ; les limites reviennent. La garder tient en un geste.',
+
+      trialEndingButton: 'Garder ma formule',
+
+      winBackSubject: 'Votre formule a pris fin il y a une semaine',
+
+      winBackBody:
+        'Rien n’a été retiré : votre série, vos jetons et tout ce que vous avez écrit sont là où vous les avez laissés. Ce sont les limites payantes qui se sont arrêtées.',
+
+      winBackButton: 'Voir les formules',
 
       tokensWaitingSubject: {
         one: '{count} jeton vous attend',

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -36,6 +36,10 @@ export const ptBR: Localized<ServerMessages> = {
       awayBody: 'Gente nova para praticar.',
       awayLongTitle: 'Estaremos aqui quando você voltar',
       awayLongBody: 'Sua sequência e seus tokens esperam.',
+      trialEndingTitle: 'Sua semana grátis termina em dois dias',
+      trialEndingBody: 'Manter é um toque.',
+      winBackTitle: 'Seu plano terminou',
+      winBackBody: 'Tudo o que você criou continua aqui.',
       tokensWaitingTitle: { one: '{count} token esperando', other: '{count} tokens esperando' },
       tokensWaitingBody: 'Abra sua carteira.',
       inviteFriendTitle: 'Convide alguém',
@@ -267,6 +271,20 @@ export const ptBR: Localized<ServerMessages> = {
         'Um mês é muito tempo. Sua conta, sua sequência e seus tokens continuam aqui, se você quiser — e esta é a última vez que falamos disso.',
 
       awayLongButton: 'Abrir o LangX',
+
+      trialEndingSubject: 'Sua semana grátis termina em dois dias',
+
+      trialEndingBody:
+        'Depois disso sua conta volta ao plano gratuito. Tudo o que você criou fica; os limites voltam. Manter é um toque.',
+
+      trialEndingButton: 'Manter meu plano',
+
+      winBackSubject: 'Seu plano terminou há uma semana',
+
+      winBackBody:
+        'Nada foi tirado — sua sequência, seus tokens e tudo o que você escreveu continuam onde estavam. O que parou foram os limites pagos.',
+
+      winBackButton: 'Ver os planos',
 
       tokensWaitingSubject: {
         one: 'Você tem {count} token esperando',

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -48,6 +48,10 @@ export const ru: Localized<ServerMessages> = {
       awayBody: 'Новые собеседники.',
       awayLongTitle: 'Мы здесь, когда захотите',
       awayLongBody: 'Серия и токены ждут.',
+      trialEndingTitle: 'Бесплатная неделя заканчивается через два дня',
+      trialEndingBody: 'Продлить — одно касание.',
+      winBackTitle: 'Ваш тариф закончился',
+      winBackBody: 'Всё созданное на месте.',
       tokensWaitingTitle: { one: 'Ждёт {count} токен', other: 'Ждут {count} токенов' },
       tokensWaitingBody: 'Откройте кошелёк.',
       inviteFriendTitle: 'Пригласите знакомого',
@@ -277,6 +281,20 @@ export const ru: Localized<ServerMessages> = {
         'Месяц — долгий срок. Ваш аккаунт, серия и токены на месте, если они вам нужны, и это последнее, что мы об этом скажем.',
 
       awayLongButton: 'Открыть LangX',
+
+      trialEndingSubject: 'Бесплатная неделя заканчивается через два дня',
+
+      trialEndingBody:
+        'После этого аккаунт вернётся на бесплатный тариф. Всё созданное останется, но лимиты вернутся. Продлить — одно касание.',
+
+      trialEndingButton: 'Сохранить тариф',
+
+      winBackSubject: 'Ваш тариф закончился неделю назад',
+
+      winBackBody:
+        'Ничего не забрали — серия, токены и всё написанное на месте. Закончились только платные лимиты.',
+
+      winBackButton: 'Посмотреть тарифы',
 
       tokensWaitingSubject: { one: 'Вас ждёт {count} токен', other: 'Вас ждут {count} токенов' },
 

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -30,6 +30,10 @@ export const tr: Localized<ServerMessages> = {
       awayBody: 'Pratik yapacak yeni insanlar var.',
       awayLongTitle: 'Sen gelene kadar buradayız',
       awayLongBody: 'Serin ve token’ların bekliyor.',
+      trialEndingTitle: 'Ücretsiz haftan iki gün sonra bitiyor',
+      trialEndingBody: 'Sürdürmek tek dokunuş.',
+      winBackTitle: 'Planın bir hafta önce bitti',
+      winBackBody: 'Oluşturduğun her şey hâlâ burada.',
       tokensWaitingTitle: { one: '{count} token bekliyor', other: '{count} token bekliyor' },
       tokensWaitingBody: 'Cüzdanını aç.',
       inviteFriendTitle: 'Bir arkadaşını davet et',
@@ -252,6 +256,20 @@ export const tr: Localized<ServerMessages> = {
         'Bir ay uzun bir süre. Hesabın, serin ve token’ların hâlâ burada — istersen diye. Bu konuda son yazışımız.',
 
       awayLongButton: 'LangX’i aç',
+
+      trialEndingSubject: 'Ücretsiz haftan iki gün sonra bitiyor',
+
+      trialEndingBody:
+        'Sonrasında hesabın ücretsiz plana döner. Oluşturduğun her şey kalır; sınırlar geri gelir. Devam ettirmek tek dokunuş.',
+
+      trialEndingButton: 'Planımı sürdür',
+
+      winBackSubject: 'Planın bir hafta önce sona erdi',
+
+      winBackBody:
+        'Hiçbir şey alınmadı — serin, token’ların ve yazdığın her şey bıraktığın yerde. Duran şey ücretli sınırlar.',
+
+      winBackButton: 'Planlara bak',
 
       tokensWaitingSubject: {
         one: '{count} token’ın bekliyor',

--- a/apps/api/src/modules/billing/fakeRevenueCat.ts
+++ b/apps/api/src/modules/billing/fakeRevenueCat.ts
@@ -223,6 +223,7 @@ export function createFakeRevenueCat(): FakeRevenueCat {
             // The harness has tracked this since it was written; it simply was
             // not reported, because `refreshEntitlement` overwrote it with `true`.
             willRenew: subscription.willRenew,
+            periodType: null,
           })
         }
         if (record.promotional.includes(id)) {
@@ -232,6 +233,7 @@ export function createFakeRevenueCat(): FakeRevenueCat {
             productId: promoProductId(id),
             store: 'promotional',
             willRenew: false,
+            periodType: null,
           })
         }
       }

--- a/apps/api/src/modules/billing/refresh.ts
+++ b/apps/api/src/modules/billing/refresh.ts
@@ -60,6 +60,7 @@ async function applyEntitlement(
         willRenew: entitlement.willRenew,
         store: entitlement.store,
         updatedAt: now,
+        ...(entitlement.periodType ? { periodType: entitlement.periodType } : {}),
       }
     : { tier: 'free', willRenew: false, updatedAt: now }
   if (entitlement?.expiresAt) next.expiresAt = entitlement.expiresAt

--- a/apps/api/src/modules/billing/revenueCatClient.test.ts
+++ b/apps/api/src/modules/billing/revenueCatClient.test.ts
@@ -194,6 +194,8 @@ describe('createRevenueCatClient', () => {
       expiresAt: null,
       productId: 'rc_promo_pro_plus_lifetime',
       store: 'promotional',
+      // Nothing renews, so there is no period to be in.
+      periodType: null,
       willRenew: false,
     })
   })

--- a/apps/api/src/modules/billing/revenueCatClient.ts
+++ b/apps/api/src/modules/billing/revenueCatClient.ts
@@ -1,4 +1,10 @@
-import { ENTITLEMENT_PRECEDENCE, ENTITLEMENT_TIERS, type PlanTier } from '@langx/shared'
+import {
+  ENTITLEMENT_PRECEDENCE,
+  ENTITLEMENT_TIERS,
+  periodTypeOf,
+  type BillingPeriodType,
+  type PlanTier,
+} from '@langx/shared'
 
 /**
  * One *active* entitlement, already resolved to the tier it grants.
@@ -13,6 +19,11 @@ export interface SubscriberEntitlement {
   expiresAt: Date | null
   productId: string
   store: string
+  /**
+   * Whether they are paying yet. `null` for a lifetime grant and for anything
+   * RevenueCat did not label — see `BillingPeriodType`.
+   */
+  periodType: BillingPeriodType | null
   /**
    * Whether it renews at `expiresAt`, or simply ends there.
    *
@@ -67,7 +78,10 @@ export interface RevenueCatClient {
 interface RevenueCatSubscriberResponse {
   subscriber: {
     entitlements: Record<string, { expires_date: string | null; product_identifier: string }>
-    subscriptions?: Record<string, { store?: string; unsubscribe_detected_at?: string | null }>
+    subscriptions?: Record<
+      string,
+      { store?: string; unsubscribe_detected_at?: string | null; period_type?: string | null }
+    >
     non_subscriptions?: Record<string, { store?: string }[]>
   }
 }
@@ -163,6 +177,11 @@ export function createRevenueCatClient(secretApiKey: string): RevenueCatClient {
           willRenew: lifetime
             ? false
             : willRenewProduct(body.subscriber, entitlement.product_identifier),
+          periodType: lifetime
+            ? null
+            : periodTypeOf(
+                body.subscriber.subscriptions?.[entitlement.product_identifier]?.period_type,
+              ),
         }
       }
       return null

--- a/apps/api/src/modules/billing/webhook.test.ts
+++ b/apps/api/src/modules/billing/webhook.test.ts
@@ -168,6 +168,7 @@ describe('processRevenueCatWebhook', () => {
           productId: 'rc_promo_pro_plus_lifetime',
           store: 'promotional',
           willRenew: false,
+          periodType: null,
         }),
       grantLifetimeEntitlement: () => Promise.resolve(),
     }
@@ -208,6 +209,9 @@ describe('processRevenueCatWebhook', () => {
         willRenew: false,
         store: 'promotional',
       })
+      // Absence, not `null`: a promotional grant is in no period, and the
+      // cell is written only when RevenueCat says which one.
+      expect(profile?.entitlement.periodType).toBeUndefined()
       expect(profile?.entitlement.expiresAt).toBeUndefined()
     })
 

--- a/apps/api/src/modules/billing/webhook.ts
+++ b/apps/api/src/modules/billing/webhook.ts
@@ -1,4 +1,5 @@
 import {
+  periodTypeOf,
   ENTITLEMENT_CANCEL_EVENTS,
   ENTITLEMENT_GRANT_EVENTS,
   ENTITLEMENT_REVOKE_EVENTS,
@@ -112,7 +113,26 @@ export async function processRevenueCatWebhook(
      * says something was just bought or given, so an empty answer is a record
      * that has not caught up with its own webhook, and the event decides.
      */
-    if (client && (await reconciledIfHeld(db, client, userId))) return { processed: true }
+    /*
+     * Whether they are paying yet, and the only place a webhook can say so.
+     * Written on both branches below — the reconciled one has already put the
+     * entitlement in place and only this cell is missing from it.
+     *
+     * Only when RevenueCat said. Absence means "not known", and a nudge about
+     * a trial ending has to fire on a positive answer or it goes to
+     * subscribers.
+     */
+    const periodType = periodTypeOf(event.period_type)
+
+    if (client && (await reconciledIfHeld(db, client, userId))) {
+      if (periodType) {
+        await profiles.updateOne(
+          { _id: userId },
+          { $set: { 'entitlement.periodType': periodType } },
+        )
+      }
+      return { processed: true }
+    }
 
     const tier = tierFromEntitlementIds(event.entitlement_ids)
 
@@ -127,6 +147,7 @@ export async function processRevenueCatWebhook(
       willRenew: true,
       store: record.store,
       updatedAt: now,
+      ...(periodType ? { periodType } : {}),
     }
     if (record.expiresAt) entitlement.expiresAt = record.expiresAt
     await profiles.updateOne({ _id: userId }, { $set: { entitlement, updatedAt: now } })
@@ -173,6 +194,18 @@ export async function processRevenueCatWebhook(
      * Pro+ subscription whose plain Pro runs on ends nothing from the
      * subscriber's point of view, and `reconciled` is what knows that.
      */
+    /*
+     * What was lost, and when — written only on the fall, and never cleared
+     * by the upgrade it is meant to cause. `entitlement.updatedAt` cannot
+     * answer "how long ago did they churn": an ordinary `/billing/refresh`
+     * moves it.
+     */
+    if (previousTier !== 'free') {
+      await profiles.updateOne(
+        { _id: userId },
+        { $set: { churnedFrom: { tier: previousTier, at: now } } },
+      )
+    }
     if (notify && previousTier !== 'free') {
       const left = await profiles.findOne({ _id: userId }, { projection: { entitlement: 1 } })
       if ((left?.entitlement?.tier ?? 'free') === 'free') {

--- a/apps/api/src/modules/handles/legacyLifetimeGrant.test.ts
+++ b/apps/api/src/modules/handles/legacyLifetimeGrant.test.ts
@@ -42,6 +42,7 @@ class RecordingBilling implements RevenueCatClient {
       productId: `rc_promo_${id}_lifetime`,
       store: 'promotional',
       willRenew: false,
+      periodType: null,
     })
   }
 
@@ -225,6 +226,9 @@ describe('v1 loyalty lifetime grant', () => {
       willRenew: false,
       store: 'promotional',
     })
+    // A lifetime is in no period, and the cell is written only when
+    // RevenueCat names one.
+    expect(stored?.entitlement.periodType).toBeUndefined()
   })
 
   it('leaves the tier at free when no rung is earned', async () => {

--- a/apps/api/src/modules/notifications/promotions.test.ts
+++ b/apps/api/src/modules/notifications/promotions.test.ts
@@ -66,6 +66,8 @@ describe('the nudges that need permission', () => {
       spent?: number
       timezone?: string
       device?: boolean
+      entitlement?: Record<string, unknown>
+      churnedFrom?: { tier: string; at: Date }
       /** Kills the invite nudge, which every long-standing account qualifies for. */
       invited?: boolean
     } = {},
@@ -88,6 +90,8 @@ describe('the nudges that need permission', () => {
         messagesSent: 1,
       },
       ...(opts.spent ? { tokenSpent: opts.spent } : {}),
+      ...(opts.entitlement ? { entitlement: opts.entitlement } : {}),
+      ...(opts.churnedFrom ? { churnedFrom: opts.churnedFrom } : {}),
       createdAt: new Date(NOW.getTime() - (opts.createdDaysAgo ?? 40) * DAY),
     } as never)
     await handle.db.collection(COLLECTIONS.user).insertOne({
@@ -212,6 +216,95 @@ describe('the nudges that need permission', () => {
       week: '2026-W37',
       month: '2026-09',
       createdAt: new Date(NOW.getTime() - 2 * DAY),
+    })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
+  })
+
+  /**
+   * The cell that made this letter writable at all: a trial ending and a
+   * subscription ending are otherwise the same three fields, and before
+   * `periodType` existed this would have gone to paying subscribers.
+   */
+  it('warns about a trial that ends in two days, and nobody else', async () => {
+    await newProfile({
+      avatar: true,
+      invited: true,
+      entitlement: {
+        tier: 'pro',
+        periodType: 'trial',
+        willRenew: false,
+        expiresAt: new Date(NOW.getTime() + 1.5 * DAY),
+        updatedAt: NOW,
+      },
+    })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 1 })
+    expect(subjects()[0]).toContain('free week')
+
+    email.messages.length = 0
+    await handle.db.collection(COLLECTIONS.profiles).deleteMany({})
+    await handle.db.collection(COLLECTIONS.notificationLedger).deleteMany({})
+    // A paying subscriber whose plan ends on the same day.
+    await newProfile({
+      avatar: true,
+      invited: true,
+      entitlement: {
+        tier: 'pro',
+        periodType: 'normal',
+        willRenew: false,
+        expiresAt: new Date(NOW.getTime() + 1.5 * DAY),
+        updatedAt: NOW,
+      },
+    })
+    // A trial that converts on its own — the store will charge the card, and
+    // saying so is the store's job.
+    await newProfile({
+      avatar: true,
+      invited: true,
+      entitlement: {
+        tier: 'pro',
+        periodType: 'trial',
+        willRenew: true,
+        expiresAt: new Date(NOW.getTime() + 1.5 * DAY),
+        updatedAt: NOW,
+      },
+    })
+    // And one RevenueCat never labelled: silence is the right answer to a
+    // question nobody can answer.
+    await newProfile({
+      avatar: true,
+      invited: true,
+      entitlement: {
+        tier: 'pro',
+        willRenew: false,
+        expiresAt: new Date(NOW.getTime() + 1.5 * DAY),
+        updatedAt: NOW,
+      },
+    })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
+  })
+
+  it('asks somebody back a week after their plan ended, once', async () => {
+    await newProfile({
+      avatar: true,
+      invited: true,
+      churnedFrom: { tier: 'pro', at: new Date(NOW.getTime() - 7.5 * DAY) },
+    })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 1 })
+    expect(subjects()[0]).toContain('ended')
+
+    // The same person tomorrow is outside the window, and the claim holds
+    // besides.
+    expect(await runPromotionsPass(handle.db, senders, new Date(NOW.getTime() + DAY))).toEqual({
+      sent: 0,
+    })
+  })
+
+  it('says nothing to somebody who churned and came back', async () => {
+    await newProfile({
+      avatar: true,
+      invited: true,
+      churnedFrom: { tier: 'pro', at: new Date(NOW.getTime() - 7.5 * DAY) },
+      entitlement: { tier: 'pro', willRenew: true, updatedAt: NOW },
     })
     expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
   })

--- a/apps/api/src/modules/notifications/promotions.ts
+++ b/apps/api/src/modules/notifications/promotions.ts
@@ -63,6 +63,10 @@ const AWAY_LONG_DAYS = 30
 const IDLE_TOKENS_MIN = 200
 const IDLE_TOKENS_DAYS = 14
 const INVITE_AFTER_DAYS = 14
+/** How long before a trial ends it is worth saying so. */
+const TRIAL_WARNING_DAYS = 2
+/** And how long after a plan ended before asking somebody to come back. */
+const WIN_BACK_DAYS = 7
 
 function daysAgo(date: Date | undefined, now: Date): number {
   return date ? (now.getTime() - new Date(date).getTime()) / DAY_MS : Number.POSITIVE_INFINITY
@@ -151,6 +155,59 @@ export const PROMOTIONS: Promotion[] = [
     detail: async ({ profile, db }) => ({
       count: (await readAggregates(db, profile._id)).all - (profile.tokenSpent ?? 0),
     }),
+  },
+  {
+    /*
+     * The free week ending, and the one nudge here with a deadline in it.
+     *
+     * `periodType === 'trial'` is what makes it honest: a trial ending and a
+     * subscription ending are the same three fields on a profile, and before
+     * that cell existed this letter could not be written without sending it
+     * to paying subscribers. Absence is not "normal" — a grant RevenueCat
+     * never labelled says nothing either way, and silence is the right answer
+     * to a question nobody can answer.
+     *
+     * `willRenew: false` narrows it further: a trial that converts on its own
+     * needs no letter, and telling somebody their card is about to be charged
+     * is the store's job.
+     */
+    job: 'promo.trialEnding',
+    scenario: 'trialEnding',
+    type: 'promotions',
+    periodKey: ({ profile }) => profile.entitlement?.expiresAt?.toISOString() ?? 'none',
+    eligible: ({ profile, now }) => {
+      const { entitlement } = profile
+      if (entitlement?.periodType !== 'trial') return false
+      if (entitlement.willRenew !== false) return false
+      const endsIn = entitlement.expiresAt
+        ? (new Date(entitlement.expiresAt).getTime() - now.getTime()) / DAY_MS
+        : Number.POSITIVE_INFINITY
+      // Two days out, and never after it has already ended — by then the
+      // letter to write is the one `billingEmail` already sent.
+      return endsIn > 0 && endsIn <= TRIAL_WARNING_DAYS
+    },
+  },
+  {
+    /*
+     * Somebody who paid and stopped. A week later, because the first days
+     * after a plan ends are when the decision still feels fresh and a letter
+     * reads as an argument with it.
+     *
+     * `churnedFrom` is written on the fall and never cleared by the upgrade
+     * it is meant to cause, which is what lets this ask "how long ago" at
+     * all: `entitlement.updatedAt` moves on an ordinary `/billing/refresh`.
+     */
+    job: 'promo.winBack',
+    scenario: 'winBack',
+    type: 'promotions',
+    periodKey: ({ profile }) => profile.churnedFrom?.at.toISOString() ?? 'none',
+    eligible: ({ profile, now }) => {
+      if (!profile.churnedFrom) return false
+      // Still free: somebody who resubscribed has answered already.
+      if ((profile.entitlement?.tier ?? 'free') !== 'free') return false
+      const since = daysAgo(profile.churnedFrom.at, now)
+      return since >= WIN_BACK_DAYS && since < WIN_BACK_DAYS + 1
+    },
   },
   {
     /*

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -1,4 +1,5 @@
 import {
+  type BillingPeriodType,
   DEFAULT_NOTIFICATION_PREFS,
   ERROR_CODES,
   ageFromBirthDate,
@@ -153,8 +154,27 @@ export interface Profile {
     expiresAt?: Date
     willRenew?: boolean
     store?: string
+    /**
+     * Whether this is being paid for yet — `trial` while the free week runs.
+     *
+     * Absent on every entitlement written before 10 September 2026 and on
+     * every promotional grant, and absence means "not known" rather than
+     * "normal": a nudge about a trial ending must fire on a positive answer
+     * only, or it goes to subscribers.
+     */
+    periodType?: BillingPeriodType
     updatedAt: Date
   }
+  /**
+   * What was held before the account dropped to free, and when.
+   *
+   * Written only on the fall, and never cleared by a later upgrade — so a
+   * churn nudge can ask "did this person lose something, and how long ago"
+   * without the answer being erased by the resubscription it is trying to
+   * cause. `entitlement.updatedAt` cannot answer it: a plain
+   * `/billing/refresh` moves that.
+   */
+  churnedFrom?: { tier: PlanTier; at: Date }
   quota: { initiations: Date[]; translations: Date[]; media: Date[] }
   photos?: { url: string; createdAt: Date }[]
   /**

--- a/apps/api/src/routes/billing.test.ts
+++ b/apps/api/src/routes/billing.test.ts
@@ -336,6 +336,7 @@ describe('Faz 7 — billing', () => {
         productId: 'monthly',
         store: 'app_store',
         willRenew: true,
+        periodType: null,
       }
 
       await app.inject({
@@ -375,6 +376,7 @@ describe('Faz 7 — billing', () => {
         productId: 'pro_plus_monthly',
         store: 'app_store',
         willRenew: true,
+        periodType: null,
       }
 
       const response = await app.inject({
@@ -506,6 +508,7 @@ describe('Faz 7 — billing', () => {
         productId: 'monthly',
         store: 'play_store',
         willRenew: true,
+        periodType: null,
       }
 
       const response = await app.inject({
@@ -526,6 +529,7 @@ describe('Faz 7 — billing', () => {
         productId: 'pro_plus_yearly',
         store: 'play_store',
         willRenew: true,
+        periodType: null,
       }
 
       const response = await app.inject({
@@ -553,6 +557,7 @@ describe('Faz 7 — billing', () => {
         productId: 'monthly',
         store: 'app_store',
         willRenew: false,
+        periodType: null,
       }
 
       const response = await app.inject({

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -126,21 +126,27 @@ there is none. Each face links to `app.langx.io/<handle>`.
 
 ## 3. Promotions — `promotions.email` must allow it
 
-### The six nudges
+### The eight nudges
 
 `modules/notifications/promotions.ts` — a table walked in **priority order**
 for each candidate. The first match is sent, the loop breaks, and
 `MARKETING_MIN_GAP_DAYS` (7) keeps the next one a week off. Quiet hours are
 the reader's own clock.
 
-| #   | Nudge                                   | Trigger                                     | Kind       |
-| --- | --------------------------------------- | ------------------------------------------- | ---------- |
-| 1   | Add a photo, and people will find you   | no `avatarUrl`, account > 48 h              | promotions |
-| 2   | Your streak broke — repair it           | streak ≥ 3 that lapsed **yesterday**        | **streak** |
-| 3   | People are still practising without you | `lastActiveAt` 7–8 days ago                 | promotions |
-| 4   | We will stop writing after this         | `lastActiveAt` 30–31 days ago               | promotions |
-| 5   | You have N tokens waiting               | balance ≥ 200, nothing spent in a fortnight | promotions |
-| 6   | Invite a friend                         | 14 days old, active, has invited nobody     | promotions |
+| #   | Nudge                                   | Trigger                                               | Kind       |
+| --- | --------------------------------------- | ----------------------------------------------------- | ---------- |
+| 1   | Add a photo, and people will find you   | no `avatarUrl`, account > 48 h                        | promotions |
+| 2   | Your streak broke — repair it           | streak ≥ 3 that lapsed **yesterday**                  | **streak** |
+| 3   | People are still practising without you | `lastActiveAt` 7–8 days ago                           | promotions |
+| 4   | We will stop writing after this         | `lastActiveAt` 30–31 days ago                         | promotions |
+| 5   | Your free week ends in two days         | `periodType: trial`, not renewing, ends within 2 days | promotions |
+| 6   | Your plan ended a week ago              | `churnedFrom` 7–8 days ago, still on free             | promotions |
+| 7   | You have N tokens waiting               | balance ≥ 200, nothing spent in a fortnight           | promotions |
+| 8   | Invite a friend                         | 14 days old, active, has invited nobody               | promotions |
+
+`periodType` and `churnedFrom` are written from 10 September 2026 onward and
+**cannot be backfilled** — so nudges 5 and 6 reach only people whose trial
+began, or whose plan ended, after that deploy.
 
 The streak repair sits under the **streak** switch, not promotions: it is
 about the streak, and hiding it behind the marketing switch would hide it
@@ -225,13 +231,11 @@ Four mechanisms, and each is in the database rather than in a caller's care.
 
 Written down so the next person does not have to re-derive them.
 
-| Scenario                                | Blocked on                                                                               |
-| --------------------------------------- | ---------------------------------------------------------------------------------------- |
-| **Your trial ends in 2 days**           | `entitlement` stores no `periodType`; a trial cannot be told from an ending subscription |
-| **Come back to Pro** (churn win-back)   | no `previousTier` is kept when a tier drops                                              |
-| **You hit the free limit again**        | nothing counts a refused quota                                                           |
-| A daily email digest of corrections     | `social.email` has a switch and no sender                                                |
-| Editor's note as a standalone broadcast | the monthly note covers it                                                               |
+| Scenario                                | Blocked on                                |
+| --------------------------------------- | ----------------------------------------- |
+| **You hit the free limit again**        | nothing counts a refused quota            |
+| A daily email digest of corrections     | `social.email` has a switch and no sender |
+| Editor's note as a standalone broadcast | the monthly note covers it                |
 
 ## Every message is one format
 

--- a/packages/shared/src/billing.ts
+++ b/packages/shared/src/billing.ts
@@ -40,8 +40,34 @@ export const revenueCatEventSchema = z.object({
    * existed, or a test fixture, must still parse.
    */
   entitlement_ids: z.array(z.string()).nullable().optional(),
+  /**
+   * `TRIAL`, `INTRO` or `NORMAL` — whether the subscriber is paying yet.
+   *
+   * Read for one reason: a trial ending and a subscription ending are the
+   * same three fields on a profile (`expiresAt` soon, `willRenew` false), so
+   * without this there is no way to word a letter about the first without
+   * sending it to the second. RevenueCat has always sent it; nothing here
+   * looked.
+   *
+   * Optional and unconstrained, like every other field on this event: a
+   * payload from before it existed, or a fixture, must still parse.
+   */
+  period_type: z.string().nullable().optional(),
 })
 export type RevenueCatEvent = z.infer<typeof revenueCatEventSchema>
+
+/**
+ * Whether an entitlement is being paid for yet. `null` is not "no" — it is
+ * "RevenueCat did not say", which is what every event before this field was
+ * read looks like, and what a promotional grant looks like today.
+ */
+export type BillingPeriodType = 'trial' | 'intro' | 'normal'
+
+/** RevenueCat spells these in capitals, and only these three exist. */
+export function periodTypeOf(raw: string | null | undefined): BillingPeriodType | null {
+  const value = raw?.trim().toLowerCase()
+  return value === 'trial' || value === 'intro' || value === 'normal' ? value : null
+}
 
 export const revenueCatWebhookBodySchema = z.object({
   api_version: z.string().optional(),


### PR DESCRIPTION
The last two scenarios from the plan. They were left out of #1266 not for effort but because the database could not tell their stories apart from stories that are not true.

## The two problems

**A trial ending and a subscription ending are the same three fields.** `entitlement` held `tier`, `expiresAt`, `willRenew` — so "ends in two days, not renewing" describes somebody on a free week and somebody who cancelled their paid plan equally well. A letter about the first would have gone to the second.

**A churn has no timestamp.** `entitlement.updatedAt` looks like one and is not: an ordinary `POST /billing/refresh` moves it, so "they churned nine days ago" becomes "they refreshed this morning". And the tier that was lost is overwritten by the `free` that replaced it.

## What changes

| Field | Written from | Note |
| --- | --- | --- |
| `entitlement.periodType` | the webhook's `period_type` (RevenueCat has always sent it; nothing read it) and the subscriber record's per-subscription value | **Absence means "not known", not "normal"** — a promotional grant is in no period, and the nudge fires on a positive answer only |
| `churnedFrom: { tier, at }` | the `EXPIRATION` branch, on the fall | **Never cleared by the upgrade it is meant to cause** — clearing it would erase the evidence that the letter worked |

Then two entries join the promotions table, taking it from six nudges to eight:

- **Your free week ends in two days** — `periodType: 'trial'`, `willRenew: false`, ends within 2 days. The `willRenew` half matters: a trial that converts on its own needs no letter, and telling somebody their card is about to be charged is the store's job.
- **Your plan ended a week ago** — `churnedFrom` 7–8 days ago **and still on free**, so somebody who resubscribed hears nothing.

## Worth knowing

Neither field can be backfilled. They start accumulating the day this deploys, so the first trial nudge goes to somebody whose trial began after it — honest behaviour rather than a gap, and it is written in `docs/notifications.md` beside the nudges.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — green (api 96, mobile 94, shared 26).
- New cases in `promotions.test.ts`: the trial warning fires for a trial and **not** for a paying subscriber ending on the same day, not for a trial that renews, and not for a grant RevenueCat never labelled; the win-back fires once at seven days and never for somebody who came back.
- Existing billing tests updated to assert the cell is **absent** rather than null on a lifetime grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)