### PR TITLE
Stop the location guide dying on the way in

### DIFF
--- a/apps/mobile/app/(app)/settings/location.tsx
+++ b/apps/mobile/app/(app)/settings/location.tsx
@@ -48,7 +48,12 @@ export default function LocationPermissionScreen() {
   const [status, setStatus] = useState<LocationGuideStatus | null>(null)
 
   const read = useCallback(() => {
-    void readLocationGuideStatus().then(setStatus)
+    // A rejection here used to leave `status` at `null` for good, and a screen
+    // whose every branch is behind that check renders as a bare header — the
+    // shape this arrived in. Falling back to `blocked` is the honest answer to
+    // "we could not read it": it is the one state whose instructions are worth
+    // following whatever the truth turns out to be.
+    readLocationGuideStatus(Platform.OS).then(setStatus, () => setStatus('blocked'))
   }, [])
 
   /*

--- a/apps/mobile/src/lib/locationPermission.ts
+++ b/apps/mobile/src/lib/locationPermission.ts
@@ -31,13 +31,23 @@ export function locationGuideStatus(input: {
   return input.servicesEnabled ? 'granted' : 'servicesOff'
 }
 
-/** The same decision, made from what the OS currently says. */
-export async function readLocationGuideStatus(): Promise<LocationGuideStatus> {
-  const { Platform } = await import('react-native')
+/**
+ * The same decision, made from what the OS currently says.
+ *
+ * `platform` is a parameter rather than something this module reads, and that
+ * is not a style choice: a dynamic import of `react-native` compiles to Metro's
+ * `importAll`, which touches **every** named export on the barrel to build the
+ * namespace object — including the deprecated getters that exist only to throw
+ * (`PushNotificationIOS`). So the import rejected on device while resolving
+ * fine on the web, where the barrel is react-native-web's. The caller has
+ * `Platform` statically imported already; nothing here needs it. There is a
+ * test that keeps it that way — `noDynamicReactNativeImport.test.ts`.
+ */
+export async function readLocationGuideStatus(platform: string): Promise<LocationGuideStatus> {
   // Nothing to read in a browser, and `expo-location` is precisely what must
   // not be reached there. The pure function answers `web` before it looks at
   // anything else; this is that branch, taken early.
-  if (Platform.OS === 'web') return 'web'
+  if (platform === 'web') return 'web'
 
   const { locationPermissionState } = await import('./location')
   const Location = await import('expo-location')
@@ -47,5 +57,5 @@ export async function readLocationGuideStatus(): Promise<LocationGuideStatus> {
   // somebody who has simply never granted the app anything sends them to the
   // wrong screen entirely.
   const servicesEnabled = permission.granted ? await Location.hasServicesEnabledAsync() : false
-  return locationGuideStatus({ ...permission, servicesEnabled, platform: Platform.OS })
+  return locationGuideStatus({ ...permission, servicesEnabled, platform })
 }

--- a/apps/mobile/src/lib/noDynamicReactNativeImport.test.ts
+++ b/apps/mobile/src/lib/noDynamicReactNativeImport.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Nothing in the app may import `react-native` dynamically.
+ *
+ * A lazy import of an *expo* module is a normal thing to do here and half of
+ * `src/lib` does it — a module that reaches the platform is a module the mobile
+ * vitest setup cannot load, so the import moves inside the function. Doing the
+ * same to `react-native` looks identical and is not: Metro compiles a dynamic
+ * import into `importAll`, which builds the namespace object by reading **every**
+ * named export off the barrel. Several of those exist only to throw —
+ * `PushNotificationIOS` was extracted from core and its getter now blows up — so
+ * the promise rejects on a device while resolving perfectly in a browser, where
+ * the barrel is react-native-web's and has no such getter.
+ *
+ * That is not a hypothetical. `readLocationGuideStatus` did exactly this, and
+ * the rejection left the location guide screen at its `status === null` branch:
+ * a header and nothing else, forever, on both phones and nowhere on the web. In
+ * production the unhandled rejection took the app down instead.
+ *
+ * Nothing else catches it. Types are fine, lint is fine, every test passes, and
+ * the web build — the one thing a laptop can run — behaves. Hence a test that
+ * reads the source, in the manner of `routeLiterals.test.ts`, and over the AST
+ * rather than the text so that this very paragraph does not fail it.
+ *
+ * The fix is always the same: import `Platform` (or whatever it is) statically
+ * at the top of a file the tests do not load, and pass the value in.
+ */
+const MOBILE = path.join(__dirname, '..', '..')
+const ROOTS = ['src', 'app'].map((dir) => path.join(MOBILE, dir))
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) return entry.name === 'node_modules' ? [] : sourceFiles(full)
+    return /\.tsx?$/.test(entry.name) ? [full] : []
+  })
+}
+
+function importsReactNativeDynamically(file: string): boolean {
+  const source = ts.createSourceFile(
+    file,
+    readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  )
+
+  let found = false
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      const specifier = node.arguments[0]
+      if (specifier && ts.isStringLiteral(specifier) && specifier.text === 'react-native') {
+        found = true
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(source)
+  return found
+}
+
+describe('dynamic imports of react-native', () => {
+  it('appear nowhere in the app', () => {
+    const offenders = ROOTS.flatMap(sourceFiles)
+      .filter(importsReactNativeDynamically)
+      .map((file) => path.relative(MOBILE, file))
+
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
The location guide screen from #1276 opened to a bare header on a phone and stayed there. Reported as a crash, and on a production build that is what it is.

## What happened

`readLocationGuideStatus` began with `await import('react-native')`. Metro compiles a dynamic import into `importAll`, which builds the namespace object by reading **every** named export off the barrel — and several of those exist only to throw now that they have been extracted from core. `PushNotificationIOS` is one:

```
WARN  PushNotificationIOS has been extracted from react-native core ...
ERROR [Error: Uncaught (in promise, id: 0) TypeError: Cannot read property 'default' of undefined]
```

So the import rejected, `.then(setStatus)` never ran, `status` stayed `null`, and every branch of the screen sits behind that check. In dev that is a header and nothing else; in production the unhandled rejection takes the app down.

It resolved perfectly in a browser, where the barrel is react-native-web's and has no such getter — which is why the web verification on #1276 passed while both phones were broken.

## The fix

- `platform` is a parameter now. The screen has `Platform` statically imported already, so nothing in that module needs to reach for it.
- The read gets a rejection handler. A promise that never resolves must not be able to leave a screen looking like this again, and `blocked` is the honest answer to "we could not read it" — its instructions are worth following whatever the truth turns out to be.
- A test walks the AST of `src` and `app` for dynamic `react-native` imports. Confirmed it fails when the old line is put back.

Lazy-importing an *expo* module stays fine and half of `src/lib` does it; `react-native` itself is the one that cannot take it.

## Verified

- **iOS** — iPhone 16 Pro simulator, dev client on this branch's JS: before, a bare header and the rejection above in the Metro log; after, the `blocked` state draws its callout, three numbered steps and Open Settings. The granted path draws too.
- **Web** — `/settings/location` still renders the browser branch with no button, as before.
- **Android** — not run. Same barrel, same `importAll`, same missing getter, so the same fix covers it; nothing in the change is iOS-specific.
- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` (2,299 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)