### PR TITLE
Remember a refusal, and give the feed's email half a sender

### DIFF
--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -13,6 +13,7 @@ import type { InlineAsset } from './inlineAssets'
 import { inlineSrc, LOGO_SRC } from './logo'
 import type { NewsletterNote } from './newsletters'
 import type { MonthlyRecap } from '../modules/notifications/newsletter'
+import type { FeedDigestItem } from '../modules/notifications/feedDigest'
 
 /**
  * The site's display voice — `--font--title` in `website/src/lib/scss/_variables.scss`,
@@ -564,6 +565,69 @@ function monthLabel(locale: Locale, month: string): string {
   }
 }
 
+/**
+ * The day's replies to somebody's posts, in one letter.
+ *
+ * Counts and the opening words of their own sentence — never the correction
+ * itself. The same rule the unread digest follows, for a different reason:
+ * there the text is somebody else's private message, here it is the thing
+ * the reader is being asked to come and read. A mail that already contains
+ * the answer is a mail nobody clicks, and the correction is worth seeing
+ * beside the sentence it corrects.
+ */
+export function feedDigestEmail(
+  locale: Locale,
+  {
+    items,
+    morePosts,
+    unsubscribe,
+  }: { items: FeedDigestItem[]; morePosts: number; unsubscribe: string },
+): Email {
+  const t = translator(locale)
+  const total = items.reduce(
+    (sum, item) => sum + item.corrections + item.answers + item.comments,
+    0,
+  )
+  const subject = t('email.feedDigestSubject', { count: total })
+  const rows = items
+    .map((item) => {
+      const parts = [
+        item.corrections > 0 ? t('email.feedDigestCorrections', { count: item.corrections }) : '',
+        item.answers > 0 ? t('email.feedDigestAnswers', { count: item.answers }) : '',
+        item.comments > 0 ? t('email.feedDigestComments', { count: item.comments }) : '',
+      ].filter(Boolean)
+      return `<p style="margin:16px 0 0;"><a href="${postUrl(item.postId)}" style="color:#17191c; text-decoration:none;"><strong>&ldquo;${escapeHtml(item.excerpt)}&rdquo;</strong></a><br /><span style="color:#62676d;">${formatList(locale, parts)}</span></p>`
+    })
+    .join('\n       ')
+  const more = morePosts > 0 ? t('email.feedDigestMore', { count: morePosts }) : ''
+  const cta = { url: webUrl('/me'), label: t('email.feedDigestButton') }
+
+  return {
+    subject,
+    html: notificationEmail(locale, {
+      preheader: t('email.feedDigestPreheader'),
+      bodyHtml: `<p>${t('email.feedDigestBody', { count: total })}</p>
+       ${rows}
+       ${more ? `<p style="margin:16px 0 0; color:#62676d;">${more}</p>` : ''}`,
+      cta,
+      unsubscribeUrl: unsubscribe,
+      manageUrl: webUrl('/settings'),
+    }).html,
+    text: notificationText(
+      locale,
+      [
+        t('email.feedDigestBody', { count: total }),
+        '',
+        ...items.map((item) => `"${item.excerpt}" — ${postUrl(item.postId)}`),
+        ...(more ? ['', more] : []),
+        '',
+        cta.url,
+      ],
+      unsubscribe,
+    ),
+  }
+}
+
 /** The six nudges `modules/notifications/promotions.ts` offers, in its order. */
 export type PromotionScenario =
   | 'addPhoto'
@@ -571,6 +635,7 @@ export type PromotionScenario =
   | 'away'
   | 'awayLong'
   | 'trialEnding'
+  | 'limitReached'
   | 'winBack'
   | 'tokensWaiting'
   | 'inviteFriend'
@@ -623,6 +688,7 @@ const PROMOTION_DESTINATIONS: Record<PromotionScenario, string> = {
   away: webUrl('/discover'),
   awayLong: webUrl('/discover'),
   trialEnding: webUrl('/settings/plan'),
+  limitReached: webUrl('/settings/plan'),
   winBack: webUrl('/settings/plan'),
   tokensWaiting: webUrl('/wallet'),
   inviteFriend: webUrl('/settings/share'),

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -42,6 +42,8 @@ export const ar: Localized<ServerMessages> = {
       awayBody: 'أشخاص جدد للتدرب معهم.',
       awayLongTitle: 'نحن هنا متى أردت',
       awayLongBody: 'سلسلتك ورموزك في الانتظار.',
+      limitReachedTitle: 'تصطدم بالحدود باستمرار',
+      limitReachedBody: 'الخطة المدفوعة ترفعها.',
       trialEndingTitle: 'تنتهي أسبوعك المجاني بعد يومين',
       trialEndingBody: 'الاحتفاظ بها نقرة واحدة.',
       winBackTitle: 'انتهت خطتك',
@@ -229,6 +231,30 @@ export const ar: Localized<ServerMessages> = {
 
     newsletterButton: 'افتح LangX',
 
+    /** The day's replies to somebody's posts, in one letter. */
+
+    feedDigestSubject: {
+      one: 'رد واحد على ما كتبته اليوم',
+      other: '{count} ردود على ما كتبته اليوم',
+    },
+
+    feedDigestPreheader: 'ردّ الناس على ما نشرته',
+
+    feedDigestBody: {
+      one: 'ردّ أحدهم اليوم على جملة نشرتها.',
+      other: 'ردّ {count} أشخاص اليوم على جمل نشرتها.',
+    },
+
+    feedDigestCorrections: { one: 'تصحيح واحد', other: '{count} تصحيحات' },
+
+    feedDigestAnswers: { one: 'تسجيل واحد', other: '{count} تسجيلات' },
+
+    feedDigestComments: { one: 'تعليق واحد', other: '{count} تعليقات' },
+
+    feedDigestMore: { one: 'ومنشور واحد آخر.', other: 'و{count} منشورات أخرى.' },
+
+    feedDigestButton: 'اقرأ الردود',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.
@@ -266,6 +292,13 @@ export const ar: Localized<ServerMessages> = {
         'الشهر مدة طويلة. حسابك وسلسلتك ورموزك ما زالت هنا إن أردتها — وهذه آخر رسالة عن الأمر.',
 
       awayLongButton: 'افتح LangX',
+
+      limitReachedSubject: 'تصطدم بحدود الخطة المجانية',
+
+      limitReachedBody:
+        'بلغت الحد اليومي ثلاث مرات في الأيام الأخيرة. الخطة المدفوعة ترفع هذه الحدود — محادثات وترجمات ومرفقات أكثر كل يوم.',
+
+      limitReachedButton: 'اطّلع على الخطط',
 
       trialEndingSubject: 'تنتهي أسبوعك المجاني بعد يومين',
 

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -36,6 +36,8 @@ export const de: Localized<ServerMessages> = {
       awayBody: 'Neue Leute zum Üben.',
       awayLongTitle: 'Wir sind da, wenn du willst',
       awayLongBody: 'Deine Serie und deine Token warten.',
+      limitReachedTitle: 'Du stößt immer wieder an die Limits',
+      limitReachedBody: 'Ein Tarif hebt sie auf.',
       trialEndingTitle: 'Deine Gratiswoche endet in zwei Tagen',
       trialEndingBody: 'Behalten ist ein Tipp.',
       winBackTitle: 'Dein Tarif ist ausgelaufen',
@@ -234,6 +236,30 @@ export const de: Localized<ServerMessages> = {
 
     newsletterButton: 'LangX öffnen',
 
+    /** The day's replies to somebody's posts, in one letter. */
+
+    feedDigestSubject: {
+      one: '1 Antwort auf deinen Beitrag heute',
+      other: '{count} Antworten auf deine Beiträge heute',
+    },
+
+    feedDigestPreheader: 'Man hat auf deine Beiträge geantwortet',
+
+    feedDigestBody: {
+      one: 'Jemand hat heute auf einen deiner Sätze geantwortet.',
+      other: '{count} Leute haben heute auf deine Sätze geantwortet.',
+    },
+
+    feedDigestCorrections: { one: '1 Korrektur', other: '{count} Korrekturen' },
+
+    feedDigestAnswers: { one: '1 Aufnahme', other: '{count} Aufnahmen' },
+
+    feedDigestComments: { one: '1 Kommentar', other: '{count} Kommentare' },
+
+    feedDigestMore: { one: 'Und 1 weiterer Beitrag.', other: 'Und {count} weitere Beiträge.' },
+
+    feedDigestButton: 'Antworten lesen',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.
@@ -273,6 +299,13 @@ export const de: Localized<ServerMessages> = {
         'Ein Monat ist lang. Dein Konto, deine Serie und deine Token sind noch da, falls du sie willst — und das ist das Letzte, was wir dazu sagen.',
 
       awayLongButton: 'LangX öffnen',
+
+      limitReachedSubject: 'Du stößt an die kostenlosen Limits',
+
+      limitReachedBody:
+        'Du hast in den letzten Tagen dreimal ein Tageslimit erreicht. Ein Tarif hebt sie auf — mehr Gespräche, mehr Übersetzungen, mehr Anhänge, jeden Tag.',
+
+      limitReachedButton: 'Tarife ansehen',
 
       trialEndingSubject: 'Deine Gratiswoche endet in zwei Tagen',
 

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -40,6 +40,8 @@ export const en = {
       awayBody: 'New people to practise with.',
       awayLongTitle: 'Still here when you are',
       awayLongBody: 'Your streak and tokens are waiting.',
+      limitReachedTitle: 'You keep hitting the free limits',
+      limitReachedBody: 'A plan lifts them.',
       trialEndingTitle: 'Your free week ends in two days',
       trialEndingBody: 'Keeping your plan takes one tap.',
       winBackTitle: 'Your plan ended a week ago',
@@ -239,6 +241,30 @@ export const en = {
 
     newsletterButton: 'Open LangX',
 
+    /** The day's replies to somebody's posts, in one letter. */
+
+    feedDigestSubject: {
+      one: '1 reply to your writing today',
+      other: '{count} replies to your writing today',
+    },
+
+    feedDigestPreheader: 'People answered what you posted',
+
+    feedDigestBody: {
+      one: 'Somebody answered a sentence you posted today.',
+      other: '{count} people answered sentences you posted today.',
+    },
+
+    feedDigestCorrections: { one: '1 correction', other: '{count} corrections' },
+
+    feedDigestAnswers: { one: '1 recording', other: '{count} recordings' },
+
+    feedDigestComments: { one: '1 comment', other: '{count} comments' },
+
+    feedDigestMore: { one: 'And 1 more post.', other: 'And {count} more posts.' },
+
+    feedDigestButton: 'Read the replies',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.
@@ -278,6 +304,13 @@ export const en = {
         'A month is a long time. Your account, your streak and your tokens are all still here if you want them — and this is the last we will say about it.',
 
       awayLongButton: 'Open LangX',
+
+      limitReachedSubject: 'You are running into the free limits',
+
+      limitReachedBody:
+        'You have hit a daily limit three times in the last few days. A plan lifts them — more conversations, more translations, more attachments, every day.',
+
+      limitReachedButton: 'See the plans',
 
       trialEndingSubject: 'Your free week ends in two days',
 

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -36,6 +36,8 @@ export const es: Localized<ServerMessages> = {
       awayBody: 'Gente nueva con quien practicar.',
       awayLongTitle: 'Aquí cuando quieras',
       awayLongBody: 'Tu racha y tus tokens te esperan.',
+      limitReachedTitle: 'Sigues chocando con los límites',
+      limitReachedBody: 'Un plan los quita.',
       trialEndingTitle: 'Tu semana gratis termina en dos días',
       trialEndingBody: 'Mantenerlo es un toque.',
       winBackTitle: 'Tu plan terminó',
@@ -236,6 +238,30 @@ export const es: Localized<ServerMessages> = {
 
     newsletterButton: 'Abrir LangX',
 
+    /** The day's replies to somebody's posts, in one letter. */
+
+    feedDigestSubject: {
+      one: '1 respuesta a lo que escribiste hoy',
+      other: '{count} respuestas a lo que escribiste hoy',
+    },
+
+    feedDigestPreheader: 'Respondieron a lo que publicaste',
+
+    feedDigestBody: {
+      one: 'Alguien respondió a una frase que publicaste hoy.',
+      other: '{count} personas respondieron a frases que publicaste hoy.',
+    },
+
+    feedDigestCorrections: { one: '1 corrección', other: '{count} correcciones' },
+
+    feedDigestAnswers: { one: '1 grabación', other: '{count} grabaciones' },
+
+    feedDigestComments: { one: '1 comentario', other: '{count} comentarios' },
+
+    feedDigestMore: { one: 'Y 1 publicación más.', other: 'Y {count} publicaciones más.' },
+
+    feedDigestButton: 'Leer las respuestas',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.
@@ -275,6 +301,13 @@ export const es: Localized<ServerMessages> = {
         'Un mes es mucho tiempo. Tu cuenta, tu racha y tus tokens siguen aquí si los quieres, y esto es lo último que diremos.',
 
       awayLongButton: 'Abrir LangX',
+
+      limitReachedSubject: 'Estás chocando con los límites gratuitos',
+
+      limitReachedBody:
+        'Has alcanzado un límite diario tres veces en los últimos días. Un plan los quita: más conversaciones, más traducciones, más adjuntos, cada día.',
+
+      limitReachedButton: 'Ver los planes',
 
       trialEndingSubject: 'Tu semana gratis termina en dos días',
 

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -36,6 +36,8 @@ export const fr: Localized<ServerMessages> = {
       awayBody: 'De nouvelles personnes pour pratiquer.',
       awayLongTitle: 'Nous serons là quand vous voudrez',
       awayLongBody: 'Votre série et vos jetons attendent.',
+      limitReachedTitle: 'Vous butez souvent sur les limites',
+      limitReachedBody: 'Une formule les lève.',
       trialEndingTitle: 'Votre semaine gratuite se termine dans deux jours',
       trialEndingBody: 'La garder tient en un geste.',
       winBackTitle: 'Votre formule a pris fin',
@@ -241,6 +243,30 @@ export const fr: Localized<ServerMessages> = {
 
     newsletterButton: 'Ouvrir LangX',
 
+    /** The day's replies to somebody's posts, in one letter. */
+
+    feedDigestSubject: {
+      one: '1 réponse à ce que vous avez écrit aujourd’hui',
+      other: '{count} réponses à ce que vous avez écrit aujourd’hui',
+    },
+
+    feedDigestPreheader: 'On a répondu à vos publications',
+
+    feedDigestBody: {
+      one: 'Quelqu’un a répondu à une phrase que vous avez publiée aujourd’hui.',
+      other: '{count} personnes ont répondu à vos phrases publiées aujourd’hui.',
+    },
+
+    feedDigestCorrections: { one: '1 correction', other: '{count} corrections' },
+
+    feedDigestAnswers: { one: '1 enregistrement', other: '{count} enregistrements' },
+
+    feedDigestComments: { one: '1 commentaire', other: '{count} commentaires' },
+
+    feedDigestMore: { one: 'Et 1 autre publication.', other: 'Et {count} autres publications.' },
+
+    feedDigestButton: 'Lire les réponses',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.
@@ -280,6 +306,13 @@ export const fr: Localized<ServerMessages> = {
         'Un mois, c’est long. Votre compte, votre série et vos jetons sont toujours là si vous les voulez — et c’est la dernière fois que nous en parlons.',
 
       awayLongButton: 'Ouvrir LangX',
+
+      limitReachedSubject: 'Vous butez sur les limites gratuites',
+
+      limitReachedBody:
+        'Vous avez atteint une limite quotidienne trois fois ces derniers jours. Une formule les lève : plus de conversations, plus de traductions, plus de pièces jointes, chaque jour.',
+
+      limitReachedButton: 'Voir les formules',
 
       trialEndingSubject: 'Votre semaine gratuite se termine dans deux jours',
 

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -36,6 +36,8 @@ export const ptBR: Localized<ServerMessages> = {
       awayBody: 'Gente nova para praticar.',
       awayLongTitle: 'Estaremos aqui quando você voltar',
       awayLongBody: 'Sua sequência e seus tokens esperam.',
+      limitReachedTitle: 'Você continua esbarrando nos limites',
+      limitReachedBody: 'Um plano remove esses limites.',
       trialEndingTitle: 'Sua semana grátis termina em dois dias',
       trialEndingBody: 'Manter é um toque.',
       winBackTitle: 'Seu plano terminou',
@@ -233,6 +235,30 @@ export const ptBR: Localized<ServerMessages> = {
 
     newsletterButton: 'Abrir o LangX',
 
+    /** The day's replies to somebody's posts, in one letter. */
+
+    feedDigestSubject: {
+      one: '1 resposta ao que você escreveu hoje',
+      other: '{count} respostas ao que você escreveu hoje',
+    },
+
+    feedDigestPreheader: 'Responderam ao que você publicou',
+
+    feedDigestBody: {
+      one: 'Alguém respondeu a uma frase que você publicou hoje.',
+      other: '{count} pessoas responderam a frases que você publicou hoje.',
+    },
+
+    feedDigestCorrections: { one: '1 correção', other: '{count} correções' },
+
+    feedDigestAnswers: { one: '1 gravação', other: '{count} gravações' },
+
+    feedDigestComments: { one: '1 comentário', other: '{count} comentários' },
+
+    feedDigestMore: { one: 'E mais 1 publicação.', other: 'E mais {count} publicações.' },
+
+    feedDigestButton: 'Ler as respostas',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.
@@ -271,6 +297,13 @@ export const ptBR: Localized<ServerMessages> = {
         'Um mês é muito tempo. Sua conta, sua sequência e seus tokens continuam aqui, se você quiser — e esta é a última vez que falamos disso.',
 
       awayLongButton: 'Abrir o LangX',
+
+      limitReachedSubject: 'Você está esbarrando nos limites gratuitos',
+
+      limitReachedBody:
+        'Você atingiu um limite diário três vezes nos últimos dias. Um plano remove esses limites — mais conversas, mais traduções, mais anexos, todo dia.',
+
+      limitReachedButton: 'Ver os planos',
 
       trialEndingSubject: 'Sua semana grátis termina em dois dias',
 

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -48,6 +48,8 @@ export const ru: Localized<ServerMessages> = {
       awayBody: 'Новые собеседники.',
       awayLongTitle: 'Мы здесь, когда захотите',
       awayLongBody: 'Серия и токены ждут.',
+      limitReachedTitle: 'Вы часто упираетесь в лимиты',
+      limitReachedBody: 'Тариф снимает их.',
       trialEndingTitle: 'Бесплатная неделя заканчивается через два дня',
       trialEndingBody: 'Продлить — одно касание.',
       winBackTitle: 'Ваш тариф закончился',
@@ -244,6 +246,30 @@ export const ru: Localized<ServerMessages> = {
 
     newsletterButton: 'Открыть LangX',
 
+    /** The day's replies to somebody's posts, in one letter. */
+
+    feedDigestSubject: {
+      one: '1 ответ на ваш пост сегодня',
+      other: '{count} ответов на ваши посты сегодня',
+    },
+
+    feedDigestPreheader: 'На ваши посты ответили',
+
+    feedDigestBody: {
+      one: 'Сегодня кто-то ответил на вашу фразу.',
+      other: 'Сегодня на ваши фразы ответили {count} человек.',
+    },
+
+    feedDigestCorrections: { one: '1 исправление', other: '{count} исправлений' },
+
+    feedDigestAnswers: { one: '1 запись', other: '{count} записей' },
+
+    feedDigestComments: { one: '1 комментарий', other: '{count} комментариев' },
+
+    feedDigestMore: { one: 'И ещё 1 пост.', other: 'И ещё {count} постов.' },
+
+    feedDigestButton: 'Читать ответы',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.
@@ -281,6 +307,13 @@ export const ru: Localized<ServerMessages> = {
         'Месяц — долгий срок. Ваш аккаунт, серия и токены на месте, если они вам нужны, и это последнее, что мы об этом скажем.',
 
       awayLongButton: 'Открыть LangX',
+
+      limitReachedSubject: 'Вы упираетесь в бесплатные лимиты',
+
+      limitReachedBody:
+        'За последние дни вы трижды упёрлись в дневной лимит. Тариф снимает их — больше разговоров, больше переводов, больше вложений каждый день.',
+
+      limitReachedButton: 'Посмотреть тарифы',
 
       trialEndingSubject: 'Бесплатная неделя заканчивается через два дня',
 

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -30,6 +30,8 @@ export const tr: Localized<ServerMessages> = {
       awayBody: 'Pratik yapacak yeni insanlar var.',
       awayLongTitle: 'Sen gelene kadar buradayız',
       awayLongBody: 'Serin ve token’ların bekliyor.',
+      limitReachedTitle: 'Ücretsiz sınırlara takılıp duruyorsun',
+      limitReachedBody: 'Bir plan bunları kaldırır.',
       trialEndingTitle: 'Ücretsiz haftan iki gün sonra bitiyor',
       trialEndingBody: 'Sürdürmek tek dokunuş.',
       winBackTitle: 'Planın bir hafta önce bitti',
@@ -219,6 +221,30 @@ export const tr: Localized<ServerMessages> = {
 
     newsletterButton: 'LangX’i aç',
 
+    /** The day's replies to somebody's posts, in one letter. */
+
+    feedDigestSubject: {
+      one: 'Bugün yazdığına 1 yanıt geldi',
+      other: 'Bugün yazdığına {count} yanıt geldi',
+    },
+
+    feedDigestPreheader: 'Paylaştığın cümlelere cevap verdiler',
+
+    feedDigestBody: {
+      one: 'Bugün paylaştığın bir cümleye cevap verildi.',
+      other: 'Bugün paylaştığın cümlelere {count} kişi cevap verdi.',
+    },
+
+    feedDigestCorrections: { one: '1 düzeltme', other: '{count} düzeltme' },
+
+    feedDigestAnswers: { one: '1 seslendirme', other: '{count} seslendirme' },
+
+    feedDigestComments: { one: '1 yorum', other: '{count} yorum' },
+
+    feedDigestMore: { one: 'Ve 1 gönderi daha.', other: 'Ve {count} gönderi daha.' },
+
+    feedDigestButton: 'Yanıtları oku',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.
@@ -256,6 +282,13 @@ export const tr: Localized<ServerMessages> = {
         'Bir ay uzun bir süre. Hesabın, serin ve token’ların hâlâ burada — istersen diye. Bu konuda son yazışımız.',
 
       awayLongButton: 'LangX’i aç',
+
+      limitReachedSubject: 'Ücretsiz sınırlara takılıyorsun',
+
+      limitReachedBody:
+        'Son birkaç günde üç kez günlük sınıra takıldın. Bir plan bunları kaldırır — her gün daha fazla sohbet, daha fazla çeviri, daha fazla ek.',
+
+      limitReachedButton: 'Planlara bak',
 
       trialEndingSubject: 'Ücretsiz haftan iki gün sonra bitiyor',
 

--- a/apps/api/src/lib/quota.test.ts
+++ b/apps/api/src/lib/quota.test.ts
@@ -1,0 +1,93 @@
+import { quotaLimit } from '@langx/shared'
+import { ObjectId } from 'mongodb'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../db/client'
+import { COLLECTIONS } from '../db/collections'
+import type { Profile } from '../modules/profiles/profiles'
+import { consumeQuota, QUOTA_REFUSAL_WINDOW_MS } from './quota'
+
+const FREE_INITIATIONS = quotaLimit('free', 'initiations') ?? 0
+
+describe('what a refused quota leaves behind', () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'quota_refusal_test')
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    await handle.db.collection(COLLECTIONS.profiles).deleteMany({})
+  })
+
+  async function newProfile(refusals?: Date[]): Promise<string> {
+    const userId = new ObjectId().toHexString()
+    await handle.db.collection(COLLECTIONS.profiles).insertOne({
+      _id: userId,
+      handle: `h${userId.slice(-10)}`,
+      quota: { initiations: [], translations: [], media: [] },
+      ...(refusals ? { quotaRefusals: refusals } : {}),
+    } as never)
+    return userId
+  }
+
+  const refusalsOf = async (userId: string): Promise<Date[]> =>
+    (
+      await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .findOne({ _id: userId }, { projection: { quotaRefusals: 1 } })
+    )?.quotaRefusals ?? []
+
+  it('writes nothing while there is room', async () => {
+    const userId = await newProfile()
+    for (let index = 0; index < FREE_INITIATIONS; index++) {
+      expect(await consumeQuota(handle.db, userId, 'free', 'initiations')).toEqual({
+        consumed: true,
+      })
+    }
+    expect(await refusalsOf(userId)).toEqual([])
+  })
+
+  /** The counter the upsell nudge reads: once is Tuesday, three times is a pattern. */
+  it('remembers each refusal', async () => {
+    const userId = await newProfile()
+    for (let index = 0; index < FREE_INITIATIONS; index++) {
+      await consumeQuota(handle.db, userId, 'free', 'initiations')
+    }
+    const refused = await consumeQuota(handle.db, userId, 'free', 'initiations')
+    expect(refused.consumed).toBe(false)
+    await consumeQuota(handle.db, userId, 'free', 'initiations')
+    expect(await refusalsOf(userId)).toHaveLength(2)
+  })
+
+  it('drops the ones outside the window rather than growing forever', async () => {
+    const old = new Date(Date.now() - QUOTA_REFUSAL_WINDOW_MS - 60_000)
+    const userId = await newProfile([old, old])
+    for (let index = 0; index < FREE_INITIATIONS; index++) {
+      await consumeQuota(handle.db, userId, 'free', 'initiations')
+    }
+    await consumeQuota(handle.db, userId, 'free', 'initiations')
+
+    const kept = await refusalsOf(userId)
+    expect(kept).toHaveLength(1)
+    expect(kept[0]?.getTime()).toBeGreaterThan(old.getTime())
+  })
+
+  /** A paid tier has no limit to hit, so nothing is ever refused or recorded. */
+  it('never records anything for a tier with no limit', async () => {
+    const userId = await newProfile()
+    for (let index = 0; index < FREE_INITIATIONS + 5; index++) {
+      expect(await consumeQuota(handle.db, userId, 'pro', 'initiations')).toEqual({
+        consumed: true,
+      })
+    }
+    expect(await refusalsOf(userId)).toEqual([])
+  })
+})

--- a/apps/api/src/lib/quota.ts
+++ b/apps/api/src/lib/quota.ts
@@ -104,6 +104,52 @@ export async function consumeQuota(
 
   if (result) return { consumed: true }
 
+  await recordRefusal(db, userId, now)
   const status = await getQuotaStatus(db, userId, tier, kind)
   return { consumed: false, nextAvailableAt: status.nextAvailableAt }
+}
+
+/**
+ * How long a refusal is remembered. Three days: long enough that hitting the
+ * limit on two evenings running still reads as a pattern, short enough that
+ * a bad week in March is not an argument about a plan in June.
+ */
+export const QUOTA_REFUSAL_WINDOW_MS = 3 * 24 * 60 * 60 * 1000
+
+/**
+ * Remembers that somebody was refused, so a nudge can tell "hit the limit
+ * once" from "keeps hitting it".
+ *
+ * Here rather than at the three call sites, because here is the only place
+ * a refusal is decided — and the fourth caller, whenever it arrives, gets
+ * this for free rather than being the one that forgot.
+ *
+ * The same prune-and-append pipeline the quota itself uses, so the array
+ * cannot grow: everything outside the window is dropped on each write.
+ * Failure is swallowed — this is a counter for a marketing nudge, and
+ * nothing about it is worth turning a 429 into a 500.
+ */
+async function recordRefusal(db: Db, userId: string, now: Date): Promise<void> {
+  const since = new Date(now.getTime() - QUOTA_REFUSAL_WINDOW_MS)
+  try {
+    await db.collection<Profile>(COLLECTIONS.profiles).updateOne({ _id: userId }, [
+      {
+        $set: {
+          quotaRefusals: {
+            $concatArrays: [
+              {
+                $filter: {
+                  input: { $ifNull: ['$quotaRefusals', []] },
+                  cond: { $gte: ['$$this', since] },
+                },
+              },
+              [now],
+            ],
+          },
+        },
+      },
+    ])
+  } catch {
+    // A counter nobody is waiting on.
+  }
 }

--- a/apps/api/src/modules/notifications/feedDigest.test.ts
+++ b/apps/api/src/modules/notifications/feedDigest.test.ts
@@ -1,0 +1,161 @@
+import { ObjectId } from 'mongodb'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import type { NotificationEmailContext } from '../../email/notify'
+import { authId } from '../../lib/authId'
+import { CapturingEmailSender } from '../../testSupport/authFlow'
+import { FEED_DIGEST_LOCAL_HOUR, runFeedDigestPass } from './feedDigest'
+
+const SECRET = 'f'.repeat(40)
+const HOUR = 60 * 60 * 1000
+/** 19:00 UTC — the digest hour for a reader on UTC. */
+const EVENING = new Date(`2026-09-14T${String(FEED_DIGEST_LOCAL_HOUR).padStart(2, '0')}:00:00Z`)
+
+describe("the day's replies to somebody's posts", () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+  let sender: CapturingEmailSender
+  let ctx: NotificationEmailContext
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'feed_digest_test')
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    for (const name of [
+      COLLECTIONS.profiles,
+      COLLECTIONS.user,
+      COLLECTIONS.notificationLedger,
+      COLLECTIONS.posts,
+      COLLECTIONS.postCorrections,
+      COLLECTIONS.postComments,
+      COLLECTIONS.pronunciationAnswers,
+    ]) {
+      await handle.db.collection(name).deleteMany({})
+    }
+    sender = new CapturingEmailSender()
+    ctx = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api.langx.io' }
+  })
+
+  async function newProfile(
+    opts: { timezone?: string; notifications?: unknown } = {},
+  ): Promise<string> {
+    const userId = new ObjectId().toHexString()
+    await handle.db.collection(COLLECTIONS.profiles).insertOne({
+      _id: userId,
+      handle: `h${userId.slice(-10)}`,
+      displayName: 'Sofia R.',
+      timezone: opts.timezone ?? 'UTC',
+      settings: { discoverable: true, notifications: opts.notifications ?? {} },
+      nativeLanguages: [{ code: 'en' }],
+    } as never)
+    await handle.db.collection(COLLECTIONS.user).insertOne({
+      _id: authId(userId),
+      email: `${userId}@example.com`,
+      emailVerified: true,
+    })
+    return userId
+  }
+
+  async function newPost(authorId: string, body: string): Promise<ObjectId> {
+    const _id = new ObjectId()
+    await handle.db
+      .collection(COLLECTIONS.posts)
+      .insertOne({ _id, authorId, body, language: 'en', createdAt: EVENING })
+    return _id
+  }
+
+  async function reply(
+    collection: string,
+    postId: ObjectId,
+    when: Date = new Date(EVENING.getTime() - HOUR),
+  ) {
+    await handle.db.collection(collection).insertOne({
+      _id: new ObjectId(),
+      postId,
+      authorId: new ObjectId().toHexString(),
+      corrected: 'fixed',
+      createdAt: when,
+    })
+  }
+
+  it('counts the day into one letter and names the sentence', async () => {
+    const author = await newProfile()
+    const postId = await newPost(author, 'I go to the school yesterday')
+    await reply(COLLECTIONS.postCorrections, postId)
+    await reply(COLLECTIONS.postCorrections, postId)
+    await reply(COLLECTIONS.postComments, postId)
+    // Yesterday's replies belong to yesterday's digest.
+    await reply(COLLECTIONS.postCorrections, postId, new Date(EVENING.getTime() - 30 * HOUR))
+
+    expect(await runFeedDigestPass(handle.db, ctx, EVENING)).toEqual({ sent: 1 })
+    const mail = sender.messages[0]
+    expect(mail?.subject).toContain('3')
+    expect(mail?.html).toContain('I go to the school yesterday')
+    expect(mail?.html).toContain('2 corrections')
+    expect(mail?.html).toContain('1 comment')
+  })
+
+  /** The correction is the reason to open the app, not something to paste. */
+  it('carries no correction text, only the reader’s own sentence', async () => {
+    const author = await newProfile()
+    const postId = await newPost(author, 'my own words')
+    await handle.db.collection(COLLECTIONS.postCorrections).insertOne({
+      _id: new ObjectId(),
+      postId,
+      authorId: new ObjectId().toHexString(),
+      corrected: 'THE CORRECTED SENTENCE',
+      createdAt: new Date(EVENING.getTime() - HOUR),
+    })
+
+    await runFeedDigestPass(handle.db, ctx, EVENING)
+    expect(sender.messages[0]?.html).toContain('my own words')
+    expect(sender.messages[0]?.html).not.toContain('THE CORRECTED SENTENCE')
+    expect(sender.messages[0]?.text).not.toContain('THE CORRECTED SENTENCE')
+  })
+
+  it('goes once a day, and waits for the evening where the reader is', async () => {
+    const author = await newProfile()
+    await reply(COLLECTIONS.postCorrections, await newPost(author, 'hello'))
+
+    // Noon is not the evening.
+    expect(await runFeedDigestPass(handle.db, ctx, new Date('2026-09-14T12:00:00Z'))).toEqual({
+      sent: 0,
+    })
+    expect(await runFeedDigestPass(handle.db, ctx, EVENING)).toEqual({ sent: 1 })
+    // A reply landing after the letter waits for tomorrow's.
+    await reply(COLLECTIONS.postComments, await newPost(author, 'again'))
+    expect(await runFeedDigestPass(handle.db, ctx, new Date(EVENING.getTime() + HOUR))).toEqual({
+      sent: 0,
+    })
+  })
+
+  it('says nothing to somebody who turned the email half off', async () => {
+    const author = await newProfile({ notifications: { social: { push: true, email: false } } })
+    await reply(COLLECTIONS.postCorrections, await newPost(author, 'hello'))
+    expect(await runFeedDigestPass(handle.db, ctx, EVENING)).toEqual({ sent: 0 })
+  })
+
+  it('sends nothing on a day nobody answered anybody', async () => {
+    await newProfile()
+    expect(await runFeedDigestPass(handle.db, ctx, EVENING)).toEqual({ sent: 0 })
+    expect(sender.messages).toHaveLength(0)
+  })
+
+  it('names the busiest posts and counts the rest', async () => {
+    const author = await newProfile()
+    for (let index = 0; index < 5; index++) {
+      await reply(COLLECTIONS.postCorrections, await newPost(author, `sentence ${index}`))
+    }
+    expect(await runFeedDigestPass(handle.db, ctx, EVENING)).toEqual({ sent: 1 })
+    expect(sender.messages[0]?.html).toContain('2 more posts')
+  })
+})

--- a/apps/api/src/modules/notifications/feedDigest.ts
+++ b/apps/api/src/modules/notifications/feedDigest.ts
@@ -1,0 +1,150 @@
+import {
+  NOTIFICATION_EMAIL_LOCAL_HOURS,
+  localDayKey,
+  localHour,
+  notificationsAllowed,
+} from '@langx/shared'
+import { ObjectId, type Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { sendNotificationEmail, type NotificationEmailContext } from '../../email/notify'
+import { feedDigestEmail } from '../../email/templates'
+import type { Post } from '../feed/documents'
+import type { Profile } from '../profiles/profiles'
+import { claimOnce } from './ledger'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** The hour, on the reader's own clock, the day's corrections are worth reading. */
+export const FEED_DIGEST_LOCAL_HOUR = 19
+
+/** Named in the mail before it says "and N more". */
+export const FEED_DIGEST_MAX_POSTS = 3
+
+export interface FeedDigestItem {
+  /** The sentence that was answered, trimmed for a subject line. */
+  excerpt: string
+  postId: string
+  corrections: number
+  answers: number
+  comments: number
+}
+
+/**
+ * "Three people corrected your sentence" — the day's replies to somebody's
+ * posts, in one letter.
+ *
+ * The push half of `social` fires on the reply and is throttled to one an
+ * hour; this is the other half, and the two answer different questions. A
+ * push says *something happened, look now*; a digest says *here is what the
+ * day amounted to*, which is the one worth reading when the corrections are
+ * the reason somebody posted at all.
+ *
+ * Evening rather than morning: a sentence posted in the morning has had the
+ * day to be answered, and a correction is something people sit down with.
+ *
+ * One claim per local day. A reply that lands after the digest has gone waits
+ * for tomorrow's — the push already said it, and a second letter about the
+ * same post on the same day is how a digest becomes noise.
+ */
+export async function runFeedDigestPass(
+  db: Db,
+  ctx: NotificationEmailContext,
+  now: Date = new Date(),
+): Promise<{ sent: number }> {
+  const since = new Date(now.getTime() - DAY_MS)
+
+  // Driven from the replies rather than from the profiles: on any given day
+  // the people with something to read are a handful, and scanning every
+  // profile to find them would be a collection scan per tick.
+  const [corrections, answers, comments] = await Promise.all([
+    repliesSince(db, COLLECTIONS.postCorrections, since),
+    repliesSince(db, COLLECTIONS.pronunciationAnswers, since),
+    repliesSince(db, COLLECTIONS.postComments, since),
+  ])
+
+  const byPost = new Map<string, { corrections: number; answers: number; comments: number }>()
+  const bump = (
+    postId: ObjectId,
+    key: 'corrections' | 'answers' | 'comments',
+    authorId: string,
+  ) => {
+    const id = postId.toHexString()
+    const seen = byPost.get(id) ?? { corrections: 0, answers: 0, comments: 0 }
+    seen[key]++
+    byPost.set(id, seen)
+    return authorId
+  }
+  for (const row of corrections) bump(row.postId, 'corrections', row.authorId)
+  for (const row of answers) bump(row.postId, 'answers', row.authorId)
+  for (const row of comments) bump(row.postId, 'comments', row.authorId)
+  if (byPost.size === 0) return { sent: 0 }
+
+  const posts = await db
+    .collection<Post>(COLLECTIONS.posts)
+    .find(
+      // The keys came out of `ObjectId.toHexString`, so this cannot throw.
+      { _id: { $in: [...byPost.keys()].map((id) => new ObjectId(id)) } },
+      { projection: { authorId: 1, body: 1 } },
+    )
+    .toArray()
+
+  /** Each author's own posts, with what the day did to them. */
+  const perAuthor = new Map<string, FeedDigestItem[]>()
+  for (const post of posts) {
+    const counts = byPost.get(post._id.toHexString())
+    if (!counts) continue
+    const items = perAuthor.get(post.authorId) ?? []
+    items.push({
+      excerpt: post.body.trim().slice(0, 90),
+      postId: post._id.toHexString(),
+      ...counts,
+    })
+    perAuthor.set(post.authorId, items)
+  }
+
+  let sent = 0
+  for (const [authorId, items] of perAuthor) {
+    const profile = await db
+      .collection<Profile>(COLLECTIONS.profiles)
+      .findOne({ _id: authorId }, { projection: { settings: 1, timezone: 1, deletedAt: 1 } })
+    if (!profile || profile.deletedAt) continue
+    if (!notificationsAllowed(profile.settings?.notifications, 'social', 'email')) continue
+
+    const zone = profile.timezone ?? 'UTC'
+    const hour = localHour(now, zone)
+    if (hour < FEED_DIGEST_LOCAL_HOUR) continue
+    if (hour > NOTIFICATION_EMAIL_LOCAL_HOURS.latest) continue
+    if (!(await claimOnce(db, 'feedDigest', authorId, localDayKey(now, zone)))) continue
+
+    // Busiest first: the post with the most to read is the one worth naming.
+    const ranked = [...items].sort(
+      (a, b) => b.corrections + b.answers + b.comments - (a.corrections + a.answers + a.comments),
+    )
+    const named = ranked.slice(0, FEED_DIGEST_MAX_POSTS)
+    const outcome = await sendNotificationEmail(db, ctx, {
+      userId: authorId,
+      type: 'social',
+      build: (locale, unsubscribe) =>
+        feedDigestEmail(locale, {
+          items: named,
+          morePosts: ranked.length - named.length,
+          unsubscribe,
+        }),
+    })
+    if (outcome === 'sent') sent++
+  }
+
+  return { sent }
+}
+
+interface ReplyRow {
+  postId: ObjectId
+  authorId: string
+}
+
+async function repliesSince(db: Db, collection: string, since: Date): Promise<ReplyRow[]> {
+  return db
+    .collection<ReplyRow>(collection)
+    .find({ createdAt: { $gte: since } }, { projection: { postId: 1, authorId: 1 } })
+    .toArray()
+}

--- a/apps/api/src/modules/notifications/ledger.ts
+++ b/apps/api/src/modules/notifications/ledger.ts
@@ -8,6 +8,7 @@ export type NotificationJob =
   | 'profileVisitsEmail'
   | 'badgeEarned'
   | 'verifyReminder'
+  | 'feedDigest'
   /** The feed's own pushes: one per follower ever, one per post per hour. */
   | 'social.follow'
   | 'social.postReply'

--- a/apps/api/src/modules/notifications/promotions.test.ts
+++ b/apps/api/src/modules/notifications/promotions.test.ts
@@ -67,6 +67,7 @@ describe('the nudges that need permission', () => {
       timezone?: string
       device?: boolean
       entitlement?: Record<string, unknown>
+      refusals?: Date[]
       churnedFrom?: { tier: string; at: Date }
       /** Kills the invite nudge, which every long-standing account qualifies for. */
       invited?: boolean
@@ -91,6 +92,7 @@ describe('the nudges that need permission', () => {
       },
       ...(opts.spent ? { tokenSpent: opts.spent } : {}),
       ...(opts.entitlement ? { entitlement: opts.entitlement } : {}),
+      ...(opts.refusals ? { quotaRefusals: opts.refusals } : {}),
       ...(opts.churnedFrom ? { churnedFrom: opts.churnedFrom } : {}),
       createdAt: new Date(NOW.getTime() - (opts.createdDaysAgo ?? 40) * DAY),
     } as never)
@@ -304,6 +306,49 @@ describe('the nudges that need permission', () => {
       avatar: true,
       invited: true,
       churnedFrom: { tier: 'pro', at: new Date(NOW.getTime() - 7.5 * DAY) },
+      entitlement: { tier: 'pro', willRenew: true, updatedAt: NOW },
+    })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
+  })
+
+  /**
+   * The only nudge whose trigger is a refusal — which is why `consumeQuota`
+   * had to start remembering them. Once is Tuesday; three times in three days
+   * is a plan that no longer fits.
+   */
+  it('argues for a plan after three refusals, and not after two', async () => {
+    const recent = [
+      new Date(NOW.getTime() - 2 * DAY),
+      new Date(NOW.getTime() - DAY),
+      new Date(NOW.getTime() - 3600_000),
+    ]
+    await newProfile({ avatar: true, invited: true, refusals: recent })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 1 })
+    expect(subjects()[0]).toContain('free limits')
+
+    email.messages.length = 0
+    await handle.db.collection(COLLECTIONS.profiles).deleteMany({})
+    await handle.db.collection(COLLECTIONS.notificationLedger).deleteMany({})
+    await newProfile({ avatar: true, invited: true, refusals: recent.slice(0, 2) })
+    // And three refusals from a fortnight ago are a bad week in March, not an
+    // argument about a plan today.
+    await newProfile({
+      avatar: true,
+      invited: true,
+      refusals: recent.map((at) => new Date(at.getTime() - 14 * DAY)),
+    })
+    expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })
+  })
+
+  it('never sells a plan to somebody who already has one', async () => {
+    await newProfile({
+      avatar: true,
+      invited: true,
+      refusals: [
+        new Date(NOW.getTime() - 2 * DAY),
+        new Date(NOW.getTime() - DAY),
+        new Date(NOW.getTime() - 3600_000),
+      ],
       entitlement: { tier: 'pro', willRenew: true, updatedAt: NOW },
     })
     expect(await runPromotionsPass(handle.db, senders, NOW)).toEqual({ sent: 0 })

--- a/apps/api/src/modules/notifications/promotions.ts
+++ b/apps/api/src/modules/notifications/promotions.ts
@@ -6,6 +6,7 @@ import { promotionEmail, type PromotionScenario } from '../../email/templates'
 import { translator } from '../../i18n'
 import type { Profile } from '../profiles/profiles'
 import { sendPush, tokensByLocale, type PushSender } from '../push/devices'
+import { QUOTA_REFUSAL_WINDOW_MS } from '../../lib/quota'
 import { claimOnce } from './ledger'
 import { recentlyMarketed } from './marketing'
 import { readAggregates } from '../tokens/ledger'
@@ -67,6 +68,12 @@ const INVITE_AFTER_DAYS = 14
 const TRIAL_WARNING_DAYS = 2
 /** And how long after a plan ended before asking somebody to come back. */
 const WIN_BACK_DAYS = 7
+/**
+ * How many refusals inside `QUOTA_REFUSAL_WINDOW_MS` make a pattern. Three:
+ * once is Tuesday, twice is a coincidence, and three times in three days is
+ * a plan that no longer fits.
+ */
+const QUOTA_REFUSALS_BEFORE_NUDGE = 3
 
 function daysAgo(date: Date | undefined, now: Date): number {
   return date ? (now.getTime() - new Date(date).getTime()) / DAY_MS : Number.POSITIVE_INFINITY
@@ -207,6 +214,29 @@ export const PROMOTIONS: Promotion[] = [
       if ((profile.entitlement?.tier ?? 'free') !== 'free') return false
       const since = daysAgo(profile.churnedFrom.at, now)
       return since >= WIN_BACK_DAYS && since < WIN_BACK_DAYS + 1
+    },
+  },
+  {
+    /*
+     * Somebody who keeps running out. The only nudge here that is an argument
+     * for paying, and the only one whose trigger is a *refusal* — which is
+     * why `consumeQuota` had to start remembering them: one person hitting a
+     * limit once is Tuesday, and three times in three days is a plan that no
+     * longer fits.
+     *
+     * Free accounts only. A paid tier has no limit to hit, so the array can
+     * only be stale — somebody who upgraded yesterday must not be sold the
+     * thing they just bought.
+     */
+    job: 'promo.quotaHit',
+    scenario: 'limitReached',
+    type: 'promotions',
+    periodKey: ({ now }) => now.toISOString().slice(0, 7),
+    eligible: ({ profile, now }) => {
+      if ((profile.entitlement?.tier ?? 'free') !== 'free') return false
+      const since = now.getTime() - QUOTA_REFUSAL_WINDOW_MS
+      const recent = (profile.quotaRefusals ?? []).filter((at) => new Date(at).getTime() >= since)
+      return recent.length >= QUOTA_REFUSALS_BEFORE_NUDGE
     },
   },
   {

--- a/apps/api/src/modules/notifications/scheduler.ts
+++ b/apps/api/src/modules/notifications/scheduler.ts
@@ -5,6 +5,7 @@ import type { SchedulerLogger } from '../tokens/poolScheduler'
 import { runBadgeRoundUpPass } from './badges'
 import { runCampaignQueuePass } from './campaignQueue'
 import { runProfileVisitsEmailPass, runProfileVisitsPushPass } from './profileVisits'
+import { runFeedDigestPass } from './feedDigest'
 import { runNewsletterPass } from './newsletter'
 import { runLikesRoundUpPass } from './social'
 import { runPromotionsPass } from './promotions'
@@ -73,6 +74,7 @@ export function startNotificationScheduler(
           : []),
         // Before the nudges: on the first of a month the recap is the thing
         // worth saying, and the cap would otherwise let a nudge take its place.
+        run('feed digest', () => runFeedDigestPass(db, senders.email, now)),
         run('pool payout', () => runPoolPayoutPass(db, senders.push, now)),
         run('gift ready', () => runGiftReadyPass(db, senders.push, now)),
         run('likes round-up', () => runLikesRoundUpPass(db, senders.push, now)),

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -176,6 +176,15 @@ export interface Profile {
    */
   churnedFrom?: { tier: PlanTier; at: Date }
   quota: { initiations: Date[]; translations: Date[]; media: Date[] }
+  /**
+   * When this account was last told it had run out — a rolling window, kept
+   * by `consumeQuota` and read by nothing but the upsell nudge.
+   *
+   * Separate from `quota` because it is the opposite measurement: those
+   * arrays are what somebody *used*, this is what they were refused. Absent
+   * on everybody who has never hit a limit, which is most people.
+   */
+  quotaRefusals?: Date[]
   photos?: { url: string; createdAt: Date }[]
   /**
    * Where a `promotions.email: true` on this profile came from, when it was

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3874,3 +3874,38 @@ possible — `HANDLE_PATTERN` requires a letter first.
 The reading schema does not move, because it never could: v1 handles came
 across under a three-character rule, so a three-letter account has existed all
 along. What changed is that somebody can now be given one on purpose.
+
+## A refusal is worth remembering, and a correction is worth a digest
+
+The last two scenarios in the plan, and both were blocked on the same kind of
+thing: the code knew something momentarily and threw it away.
+
+**`consumeQuota` refused people and forgot.** "You keep hitting the free
+limits" is the one nudge here that is an argument for paying, and it needs to
+tell a person who ran out once from a person who runs out every evening —
+which nothing recorded. `quotaRefusals` is a rolling three-day array,
+written inside `consumeQuota` rather than at the three call sites that catch
+its `false`: that is where the refusal is _decided_, so the fourth caller,
+whenever it arrives, gets this for free rather than being the one that forgot.
+Three refusals in three days is the threshold — once is Tuesday, twice is a
+coincidence. Free tiers only: a paid tier has no limit to hit, so the array
+can only be stale, and somebody who upgraded yesterday must not be sold the
+thing they just bought.
+
+**`social.email` had a switch and nothing behind it.** The feed's push fires
+on the reply and is throttled to one an hour; the digest is the other half,
+and the two answer different questions. A push says _something happened, look
+now_. A digest says _here is what the day amounted to_ — which is the one
+worth reading when the corrections are the reason somebody posted at all. It
+goes in the evening, because a sentence posted in the morning has had the day
+to be answered and a correction is something people sit down with.
+
+The letter carries counts and the opening words of the reader's **own**
+sentence, never the correction itself. The unread digest withholds message
+text for privacy; this withholds it for a different reason — a mail that
+already contains the answer is a mail nobody clicks, and a correction is
+worth seeing beside the sentence it corrects.
+
+With a sender behind it, `social.email` now defaults **on**, like `messages`.
+A switch that was off because it did nothing should not stay off once it does
+the thing people joined for.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -29,7 +29,7 @@ two channels and both are real.
 | `badges`        | on      | off    | A badge earned                          |
 | `profileVisits` | on      | on     | Who looked at you                       |
 | `meetings`      | on      | off    | An hour before a call you agreed to     |
-| `social`        | on      | off    | The feed reacting to you                |
+| `social`        | on      | on     | The feed reacting to you                |
 | `wallet`        | on      | off    | Tokens arriving                         |
 | `promotions`    | **off** | **on** | Marketing, the newsletter, campaigns    |
 
@@ -106,6 +106,7 @@ every one claims a row in `notificationLedger` before it sends.
 | **Somebody followed you**                        | `social`        | push                          | on the follow                               | one per follower, **ever**                      |
 | **A correction, answer or comment on your post** | `social`        | push                          | on the reply                                | one per post per **hour**                       |
 | **Your posts' likes**                            | `social`        | push                          | daily batch                                 | UTC day                                         |
+| **The day's replies to your posts**              | `social`        | email                         | 19:00 local                                 | local day                                       |
 | **Yesterday's pool paid you N tokens**           | `wallet`        | push                          | 09:00 local                                 | pool day                                        |
 | **Your hourly gift is ready**                    | `wallet`        | push                          | waking hours                                | UTC day, and only if they have taken one before |
 
@@ -121,12 +122,14 @@ there is none. Each face links to `app.langx.io/<handle>`.
   anybody can do here.
 - **One follow notice per follower, ever.** Unfollowing and following again
   is not news.
+- **One digest per local day.** A reply landing after the letter has gone
+  waits for tomorrow's — the push already said it.
 
 ---
 
 ## 3. Promotions — `promotions.email` must allow it
 
-### The eight nudges
+### The nine nudges
 
 `modules/notifications/promotions.ts` — a table walked in **priority order**
 for each candidate. The first match is sent, the loop breaks, and
@@ -141,8 +144,9 @@ the reader's own clock.
 | 4   | We will stop writing after this         | `lastActiveAt` 30–31 days ago                         | promotions |
 | 5   | Your free week ends in two days         | `periodType: trial`, not renewing, ends within 2 days | promotions |
 | 6   | Your plan ended a week ago              | `churnedFrom` 7–8 days ago, still on free             | promotions |
-| 7   | You have N tokens waiting               | balance ≥ 200, nothing spent in a fortnight           | promotions |
-| 8   | Invite a friend                         | 14 days old, active, has invited nobody               | promotions |
+| 7   | You are running into the free limits    | refused 3 times in 3 days, still on free              | promotions |
+| 8   | You have N tokens waiting               | balance ≥ 200, nothing spent in a fortnight           | promotions |
+| 9   | Invite a friend                         | 14 days old, active, has invited nobody               | promotions |
 
 `periodType` and `churnedFrom` are written from 10 September 2026 onward and
 **cannot be backfilled** — so nudges 5 and 6 reach only people whose trial
@@ -231,11 +235,9 @@ Four mechanisms, and each is in the database rather than in a caller's care.
 
 Written down so the next person does not have to re-derive them.
 
-| Scenario                                | Blocked on                                |
-| --------------------------------------- | ----------------------------------------- |
-| **You hit the free limit again**        | nothing counts a refused quota            |
-| A daily email digest of corrections     | `social.email` has a switch and no sender |
-| Editor's note as a standalone broadcast | the monthly note covers it                |
+| Scenario                                | Blocked on                 |
+| --------------------------------------- | -------------------------- |
+| Editor's note as a standalone broadcast | the monthly note covers it |
 
 ## Every message is one format
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -70,6 +70,7 @@ during the window catches up on its next tick instead of skipping silently.
 | Account purge    | 1 hour   | Hard-deletes accounts past their 30-day grace period.                                                                                                                              |
 | Streak reminder  | 30 min   | Sends the nudge at 20:00 in each user's own timezone, once per local day — as a push, or as email to somebody with no phone.                                                       |
 | Notifications    | 30 min   | Three passes: the unread-message digest, the profile-visit round-up (daily push, weekly email) and the badge round-up at 18:00.                                                    |
+| Feed digest      | 30 min   | The day's corrections, answers and comments on somebody's posts, at 19:00 local. The email half of `social`.                                                                       |
 | Pool payout      | 30 min   | "Yesterday's pool paid you N tokens", at 09:00 on each reader's own clock. Push only.                                                                                              |
 | Gift ready       | 30 min   | "Your hourly gift is ready", at most once a day, and only for somebody who has taken one before.                                                                                   |
 | Likes round-up   | 30 min   | A day of likes on somebody's posts as one push, once a day.                                                                                                                        |

--- a/packages/shared/src/notifications.ts
+++ b/packages/shared/src/notifications.ts
@@ -120,12 +120,13 @@ export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
    */
   meetings: { push: true, email: false },
   /**
-   * Push on, email off. A follow is a small good thing; a daily letter about
-   * it is not. The corrections on a post are the half that would justify
-   * mail, and they are worth their own digest before they are worth turning
-   * this column on.
+   * Both on, like `messages`, and for the same reason: the email half is a
+   * **digest**, not a letter per event. A follow never earns one — the push
+   * is the whole of that — but the corrections on a sentence somebody posted
+   * are the thing they posted it for, and they arrive while that person is
+   * somewhere else.
    */
-  social: { push: true, email: false },
+  social: { push: true, email: true },
   wallet: { push: true, email: false },
   promotions: { push: false, email: true },
 }


### PR DESCRIPTION
The last two scenarios in the plan. Both were blocked on the same kind of thing: the code knew something momentarily and threw it away.

## 1. `consumeQuota` refused people and forgot

"You keep hitting the free limits" is the one nudge that is an argument for paying, and it has to tell somebody who ran out once from somebody who runs out every evening. Nothing recorded that.

`quotaRefusals` is a rolling three-day array, written **inside `consumeQuota`** rather than at the three call sites that catch its `false` — that is where the refusal is decided, so the fourth caller (whenever it arrives) gets this for free rather than being the one that forgot. Same prune-and-append pipeline the quota itself uses, so the array cannot grow. Failure is swallowed: a counter for a marketing nudge must not turn a 429 into a 500.

The nudge: **three refusals in three days**, free tier only. Once is Tuesday, twice is a coincidence. A paid tier has no limit to hit, so the array can only be stale — somebody who upgraded yesterday must not be sold what they just bought.

## 2. `social.email` had a switch and nothing behind it

The feed's push fires on the reply and is throttled to one an hour. The digest is the other half, and the two answer different questions: a push says *something happened, look now*; a digest says *here is what the day amounted to* — the one worth reading when the corrections are the reason somebody posted at all.

- **Evening** (19:00 local), because a sentence posted in the morning has had the day to be answered.
- **One per local day.** A reply landing after the letter waits for tomorrow's — the push already said it.
- Carries counts and the opening words of the reader's **own** sentence, never the correction. The unread digest withholds message text for privacy; this withholds it because a mail containing the answer is a mail nobody clicks.
- Driven from the replies, not from the profiles: on any given day the people with something to read are a handful, and scanning every profile would be a collection scan per tick.

With a sender behind it, **`social.email` now defaults on**, like `messages`. A switch that was off because it did nothing should not stay off once it does the thing people joined for.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — green (api 98 files, mobile 96, shared 26).
- `quota.test.ts` (new): nothing written while there is room, each refusal remembered, the window pruned rather than grown, and nothing at all recorded for a tier with no limit.
- `feedDigest.test.ts` (new): a day counted into one letter, the correction text **absent** from both parts, once a day and only in the evening, the switch honoured, and "and N more posts".
- `promotions.test.ts`: fires at three refusals and not at two, not for refusals a fortnight old, and never for somebody who already has a plan.

`docs/notifications.md`'s "Not built" table is down to one row, and that one is a judgement call rather than a gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)