### PR TITLE
Count a chat correction towards the review prompt

### DIFF
--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -58,6 +58,7 @@ import { Avatar } from '../../../src/components/ui/Avatar'
 import { Skeleton } from '../../../src/components/ui/Skeleton'
 import { Screen } from '../../../src/components/ui/Screen'
 import { useProfileCache, useProfileCacheStatus } from '../../../src/hooks/useProfileCache'
+import { useReviewPrompt } from '../../../src/hooks/useReviewPrompt'
 import { useVoiceRecorder } from '../../../src/hooks/useVoiceRecorder'
 import { chooseAlert, confirmAlert, showAlert } from '../../../src/lib/alert'
 import { emitWithAck, getSocket } from '../../../src/lib/socket'
@@ -184,6 +185,7 @@ export default function ChatScreen() {
   const conversation = useConversation(conversationId)
   const flags = useConversationFlags()
   const recorder = useVoiceRecorder()
+  const review = useReviewPrompt()
   /** Only for the pill's dress: white ground and accent ring while it has focus. */
   const [sendingMedia, setSendingMedia] = useState(false)
   /**
@@ -1037,6 +1039,7 @@ export default function ChatScreen() {
         corrected,
       })
       track({ name: 'message_sent', properties: { kind: 'correction', reply: false } })
+      review.request({ kind: 'correction' })
     } catch {
       setCorrecting(target)
       setDraft(corrected)


### PR DESCRIPTION
The feed and the post thread both fire `review.request({ kind: 'correction' })` when a correction lands. The chat's own correction — the same act, on a message rather than a post — did not, so the 3rd / 25th / 100th thresholds in `lib/reviewPrompt.ts` only ever counted the corrections written in the feed.

One call in `commitCorrection`, next to the existing `track()`. Everything else — the rationing, the version gate, the guest and web no-ops — is unchanged.

Typecheck, lint, prettier and `reviewPrompt.test.ts` (10 tests) pass.

Needs no new binary: `expo-store-review` has shipped since 2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)