### PR TITLE
Make the handle in the welcome mail open the profile

### DIFF
--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -368,13 +368,22 @@ export function welcomeEmail(locale: Locale, input: { name: string; handle: stri
   const t = translator(locale)
   const url = webUrl('/discover')
   const steps = [t('email.welcomeStep1'), t('email.welcomeStep2'), t('email.welcomeStep3')]
+  /*
+   * The handle is the link, `@` included — which is why the catalogue says
+   * `{handle}` rather than `@{handle}`: a link that starts one character
+   * after the thing it points at is a smaller target and reads as a typo.
+   * The text half gets the address written out instead, since a plain-text
+   * mail cannot hide a URL behind a word.
+   */
+  const profile = profileUrl(input.handle)
+  const handleLink = `<a href="${encodeURI(profile)}" style="color:#3b6cf6; text-decoration:underline;">@${escapeHtml(input.handle)}</a>`
   return {
     subject: t('email.welcomeSubject'),
     html: wrap(
       locale,
       t('email.welcomePreheader'),
       `<p><strong style="font-family:${TITLE_FONT}; font-size:20px; line-height:26px;">${t('email.welcomeTitle', { name: escapeHtml(input.name) })}</strong></p>
-       <p>${t('email.welcomeBody', { handle: escapeHtml(input.handle) })}</p>
+       <p>${t('email.welcomeBody', { handle: handleLink })}</p>
        <ul style="margin:20px 0 0; padding-left:20px; color:#17191c;">
          ${steps.map((step) => `<li style="margin-bottom:8px;">${step}</li>`).join('\n         ')}
        </ul>
@@ -383,7 +392,8 @@ export function welcomeEmail(locale: Locale, input: { name: string; handle: stri
     text: [
       t('email.welcomeTitle', { name: input.name }),
       '',
-      t('email.welcomeBody', { handle: input.handle }),
+      t('email.welcomeBody', { handle: `@${input.handle}` }),
+      profile,
       '',
       ...steps.map((step) => `- ${step}`),
       '',

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -340,7 +340,7 @@ export const ar: Localized<ServerMessages> = {
 
     welcomeTitle: 'أهلاً، {name}',
 
-    welcomeBody: 'ملفك الشخصي متاح على ‎@{handle}‎. هذا ما يبدأ به معظم الناس:',
+    welcomeBody: 'ملفك الشخصي متاح على ‎{handle}‎. هذا ما يبدأ به معظم الناس:',
 
     welcomeStep1: 'ابحث عن شخص يتحدث اللغة التي تتعلمها وألقِ التحية.',
 

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -347,7 +347,7 @@ export const de: Localized<ServerMessages> = {
 
     welcomeTitle: 'Willkommen, {name}',
 
-    welcomeBody: 'Dein Profil ist unter @{handle} online. Das machen die meisten zuerst:',
+    welcomeBody: 'Dein Profil ist unter {handle} online. Das machen die meisten zuerst:',
 
     welcomeStep1: 'Finde jemanden, der deine Lernsprache spricht, und sag Hallo.',
 

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -352,7 +352,7 @@ export const en = {
 
     welcomeTitle: 'Welcome, {name}',
 
-    welcomeBody: 'Your profile is live at @{handle}. Here is what people do first:',
+    welcomeBody: 'Your profile is live at {handle}. Here is what people do first:',
 
     welcomeStep1: 'Find someone who speaks what you are learning, and say hello.',
 

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -349,7 +349,7 @@ export const es: Localized<ServerMessages> = {
 
     welcomeTitle: 'Hola, {name}',
 
-    welcomeBody: 'Tu perfil ya está en @{handle}. Esto es lo que hace la gente primero:',
+    welcomeBody: 'Tu perfil ya está en {handle}. Esto es lo que hace la gente primero:',
 
     welcomeStep1: 'Encuentra a alguien que hable lo que estás aprendiendo y salúdalo.',
 

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -354,7 +354,7 @@ export const fr: Localized<ServerMessages> = {
 
     welcomeTitle: 'Bienvenue, {name}',
 
-    welcomeBody: 'Votre profil est en ligne sur @{handle}. Voici ce que les gens font en premier :',
+    welcomeBody: 'Votre profil est en ligne sur {handle}. Voici ce que les gens font en premier :',
 
     welcomeStep1: 'Trouvez quelqu’un qui parle la langue que vous apprenez et dites bonjour.',
 

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -345,7 +345,7 @@ export const ptBR: Localized<ServerMessages> = {
 
     welcomeTitle: 'Boas-vindas, {name}',
 
-    welcomeBody: 'Seu perfil está no ar em @{handle}. É isto que as pessoas fazem primeiro:',
+    welcomeBody: 'Seu perfil está no ar em {handle}. É isto que as pessoas fazem primeiro:',
 
     welcomeStep1: 'Encontre alguém que fale o que você está aprendendo e diga oi.',
 

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -352,7 +352,7 @@ export const ru: Localized<ServerMessages> = {
 
     welcomeTitle: 'Добро пожаловать, {name}',
 
-    welcomeBody: 'Ваш профиль доступен по адресу @{handle}. Вот с чего обычно начинают:',
+    welcomeBody: 'Ваш профиль доступен по адресу {handle}. Вот с чего обычно начинают:',
 
     welcomeStep1: 'Найдите того, кто говорит на языке, который вы учите, и поздоровайтесь.',
 

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -330,7 +330,7 @@ export const tr: Localized<ServerMessages> = {
 
     welcomeTitle: 'Hoş geldin, {name}',
 
-    welcomeBody: 'Profilin @{handle} adresinde yayında. İnsanlar genelde önce şunları yapıyor:',
+    welcomeBody: 'Profilin {handle} adresinde yayında. İnsanlar genelde önce şunları yapıyor:',
 
     welcomeStep1: 'Öğrendiğin dili konuşan birini bul ve selam ver.',
 

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -181,7 +181,11 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
     })
     const mail = emailSender.messages.at(-1)
     expect(mail?.html).toContain('Sofia R.')
-    expect(mail?.html).toContain('welcomed')
+    // The handle is the link, `@` included, and the text half spells the
+    // address out because a plain-text mail cannot hide one behind a word.
+    expect(mail?.html).toContain('href="https://app.langx.io/welcomed"')
+    expect(mail?.html).toContain('@welcomed</a>')
+    expect(mail?.text).toContain('https://app.langx.io/welcomed')
     // Transactional: it answers something they just did, so no unsubscribe.
     expect(mail?.headers).toBeUndefined()
   })


### PR DESCRIPTION
It was the one thing in that letter a person would try to click.

`@sofia` now links to `app.langx.io/sofia` — the same `profileUrl()` the report mail and the digest faces already use.

**The `@` moved inside the placeholder.** The catalogue said `@{handle}` in all eight locales, which would have left the link starting one character after the thing it points at — a smaller target, and it reads as a typo. It now says `{handle}` and the template passes the whole `@sofia` as the anchor.

The text half gets the address written out on its own line instead, because a plain-text mail cannot hide a URL behind a word.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — green (api 98, mobile 97, shared 27).
- `profiles.test.ts` asserts the `href`, that the `@` is inside the anchor, and that the text half carries the URL.
- Sent to my own address from the production sender and read in Gmail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)