### PR TITLE
Paywall: stop promising a trial the store will not give

### DIFF
--- a/apps/mobile/app/(app)/paywall.tsx
+++ b/apps/mobile/app/(app)/paywall.tsx
@@ -539,7 +539,16 @@ export default function PaywallScreen() {
                 {t('paywall.quotaNotice', { count: PLAN_LIMITS.free.initiationsPer24h ?? 0 })}
               </Text>
             ) : null}
-            {tier !== 'free' ? (
+            {/*
+              Three states, not two. A lifetime grant says so; a plan a store
+              sold says where to manage it; and a plan that came from neither
+              — granted by hand, `store: 'manual'` — says nothing at all,
+              because "manage it in your store account" points at a page with
+              nothing on it. That was already fixed for the lifetime gift and
+              `boughtOn` is what makes it true of every grant: `platformOfStore`
+              answers `null` for anything no store of ours sold.
+            */}
+            {tier !== 'free' && (held.store === 'promotional' || boughtOn) ? (
               <Text style={styles.contextText}>
                 {held.store === 'promotional'
                   ? t('paywall.lifetimeNotice', { plan: TIER_NAMES[tier] })

--- a/apps/mobile/src/lib/manageSubscription.test.ts
+++ b/apps/mobile/src/lib/manageSubscription.test.ts
@@ -28,6 +28,25 @@ describe('manageSubscriptionUrl', () => {
     expect(manageSubscriptionUrl({ store: 'rc_billing', managementURL: url }, 'web')).toBe(url)
   })
 
+  /**
+   * Same reasoning, the case the `promotional` check was too narrow to cover:
+   * a tier written straight into the database has no store subscription
+   * either, and sending its holder to an empty list is the bug this whole
+   * function exists to avoid.
+   */
+  it('has nowhere to send a hand-granted plan either', () => {
+    expect(manageSubscriptionUrl({ store: 'manual' }, 'ios')).toBeNull()
+    expect(manageSubscriptionUrl({ store: 'unknown' }, 'android')).toBeNull()
+    // A store we do sell through still gets its page.
+    expect(manageSubscriptionUrl({ store: 'app_store' }, 'ios')).toContain('apps.apple.com')
+    expect(manageSubscriptionUrl({ store: 'play_store' }, 'android')).toContain('play.google.com')
+  })
+
+  /** Absent is "not recorded", not "nobody sold it" — the older rows. */
+  it('still sends somebody whose store was never written down', () => {
+    expect(manageSubscriptionUrl({ managementURL: null }, 'ios')).toContain('apps.apple.com')
+  })
+
   it('has nowhere to send a web user with no reported URL', () => {
     expect(manageSubscriptionUrl(null, 'web')).toBeNull()
     expect(manageSubscriptionUrl({ managementURL: null }, 'web')).toBeNull()

--- a/apps/mobile/src/lib/manageSubscription.ts
+++ b/apps/mobile/src/lib/manageSubscription.ts
@@ -10,10 +10,15 @@
  * worth testing, and it would be untestable inside the screen.
  */
 
+import { platformOfStore } from '@langx/shared'
+
 /** RevenueCat fills this in for every store it knows, including web checkouts. */
 export interface ManageSource {
   managementURL?: string | null
-  /** `profiles.entitlement.store` — `promotional` for the v1 loyalty gift. */
+  /**
+   * `profiles.entitlement.store` — `promotional` for the v1 loyalty gift,
+   * `manual` for one granted straight into the database.
+   */
   store?: string | null
 }
 
@@ -35,10 +40,18 @@ export function manageSubscriptionUrl(
   platform: string,
 ): string | null {
   if (source?.managementURL) return source.managementURL
-  // A lifetime grant was never sold by a store, so the store's subscriptions
-  // page has nothing on it to manage — and a row that leads to an empty list
-  // reads as "your plan is missing".
-  if (source?.store === 'promotional') return null
+  /*
+   * A plan no store sold has nothing on the store's subscriptions page to
+   * manage, and a row that leads to an empty list reads as "your plan is
+   * missing". That was written for the v1 lifetime gift (`promotional`) and
+   * is just as true of one granted by hand (`manual`) — so the test is
+   * whether a store we sell through is named, not whether it is the one grant
+   * we happened to think of.
+   *
+   * A *missing* store still falls through to the platform page: absent means
+   * "not recorded", which is the older rows, not "nobody sold it".
+   */
+  if (source?.store && platformOfStore(source.store) === null) return null
   if (platform === 'ios') return APP_STORE
   if (platform === 'android') return PLAY_STORE
   return null

--- a/apps/mobile/src/lib/purchases.ts
+++ b/apps/mobile/src/lib/purchases.ts
@@ -144,6 +144,40 @@ function freeTrialDays(intro: PurchasesSdk.PurchasesIntroPrice | null): number |
   return trialDays(intro.periodUnit, intro.periodNumberOfUnits)
 }
 
+/**
+ * Which of these products this *person* would actually get a trial on.
+ *
+ * `introPrice` above describes the **product**, not the customer, and the App
+ * Store gives one introductory offer per subscription group per Apple ID. So
+ * a Fluent subscriber tapping Polyglot — same group — was being promised
+ * seven free days the store was never going to grant, which is a false price
+ * and exactly what App Review 3.1.2 asks to be accurate.
+ *
+ * **iOS only, because the answer only exists there.** RevenueCat documents
+ * that Android always answers `UNKNOWN`, and hiding the trial on `UNKNOWN`
+ * would hide one Play really would give: Billing Library 5 returns an offer's
+ * free phase only to somebody eligible for it, so the Android product data is
+ * already the answer. On iOS, `UNKNOWN` *does* mean hide — the SDK's own
+ * advice is to show non-intro pricing rather than risk the misleading one.
+ *
+ * A failed call hides nothing. Losing a trial somebody is entitled to is a
+ * worse outcome than showing one the store then declines to give, and the
+ * store's own sheet is the last word on the charge either way.
+ */
+async function ineligibleForTrial(
+  sdk: PurchasesModule,
+  productIds: readonly string[],
+): Promise<ReadonlySet<string>> {
+  if (Platform.OS !== 'ios' || productIds.length === 0) return new Set()
+  try {
+    const eligibility = await sdk.default.checkTrialOrIntroductoryPriceEligibility([...productIds])
+    const eligible = sdk.INTRO_ELIGIBILITY_STATUS.INTRO_ELIGIBILITY_STATUS_ELIGIBLE
+    return new Set(productIds.filter((id) => eligibility[id]?.status !== eligible))
+  } catch {
+    return new Set()
+  }
+}
+
 export type PurchaseOutcome = 'purchased' | 'cancelled' | 'unavailable' | 'failed'
 
 let configuredFor: string | null = null
@@ -236,6 +270,20 @@ export async function getOffers(): Promise<PurchaseOffer[]> {
     const available = offerings.current?.availablePackages ?? []
     packagesById.clear()
 
+    /*
+     * One eligibility call for the whole offering rather than one per package:
+     * it is a round trip to StoreKit, and the paywall is already waiting on it
+     * before it can draw a price.
+     */
+    const sellable = available.filter((pkg) => {
+      const definition = packageDefinition(pkg.identifier)
+      return definition !== null && definition.tier !== 'free'
+    })
+    const ineligible = await ineligibleForTrial(
+      sdk,
+      sellable.map((pkg) => pkg.product.identifier),
+    )
+
     const offers: PurchaseOffer[] = []
     for (const pkg of available) {
       // A package the dashboard offers but `PACKAGES` does not know is skipped
@@ -252,7 +300,9 @@ export async function getOffers(): Promise<PurchaseOffer[]> {
         ...(perMonth ? { perMonthPriceString: perMonth } : {}),
         period: definition.period,
         price: pkg.product.price,
-        freeTrialDays: freeTrialDays(pkg.product.introPrice),
+        freeTrialDays: ineligible.has(pkg.product.identifier)
+          ? null
+          : freeTrialDays(pkg.product.introPrice),
       })
     }
     return offers


### PR DESCRIPTION
Two things a Fluent subscriber saw on the Polyglot column that were not true of
them. Found while testing the boosted strip on a hand-granted Fluent account.

## "7 days free" was read off the product, not the person

`freeTrialDays` came straight from `pkg.product.introPrice`, which describes the
*product*. The App Store gives one introductory offer per subscription group per
Apple ID and both plans sit in one group — so a Fluent subscriber tapping
Polyglot was promised a free week the store was never going to grant, and would
have been charged immediately. App Review 3.1.2 asks for exactly these terms to
be accurate.

`getOffers` now asks `checkTrialOrIntroductoryPriceEligibility` once for the
whole offering and drops the trial for anything not `ELIGIBLE`.

**iOS only, deliberately.** RevenueCat documents that Android always answers
`UNKNOWN`, and hiding the trial on `UNKNOWN` would hide one Play really would
give: Billing Library 5 returns an offer's free phase only to somebody eligible
for it, so the Android product data is already the answer. On iOS `UNKNOWN` does
mean hide — that is the SDK's own advice ("display the non-intro pricing, to not
create a misleading situation"). A failed call hides nothing; losing a trial
somebody is entitled to is the worse error, and the store's own sheet is the
last word on the charge either way.

## "Manage or cancel it in your store account" for a plan no store sold

The paywall notice and `manageSubscriptionUrl` both special-cased `promotional`
— the v1 lifetime gift — and sent everyone else to the store's subscriptions
page. A tier written straight into the database (`store: 'manual'`) goes there
too and finds an empty list, which reads as "your plan is missing". That is the
same defect the `promotional` branch was added to fix, one case short.

The test is now whether a store we sell through is named at all, which
`platformOfStore` already answers. A **missing** store still falls through to
the platform page: absent means "not recorded" — the older rows — not "nobody
sold it". `manageSubscription.test.ts` pins both.

## What did not change

The upgrade price. Neither StoreKit nor RevenueCat reports a prorated figure in
advance — Apple computes the credit for unused time in its own purchase sheet —
so there is no upgrade price to display. The list price beside `upgradeNotice`
("the store charges only the difference for the rest of your current period") is
the honest thing to show and stays.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — shared 321,
mobile 794, api 1204.

Not exercised on a device: the eligibility call needs a real StoreKit account
already subscribed in the group, which the sandbox on this machine does not
have. The two branches it can take are the ones the SDK documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
