### PR TITLE
Count the five things the funnel cannot see

### DIFF
--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -829,6 +829,9 @@ export default function ChatScreen() {
       // Logged before it is generalised: "could not be sent" once covered an
       // unsupported HEIC for a whole test cycle, and nothing anywhere said so.
       console.warn('attachment failed', code ?? error)
+      // The quota refusal above returns before this: it is a paywall moment,
+      // already counted as one, and not a failure of the send path.
+      track({ name: 'message_send_failed', properties: { kind: 'media', reason: code ?? null } })
       const reason =
         code === 'UNSUPPORTED_MEDIA_TYPE'
           ? t('errors.attachmentUnsupported')
@@ -878,7 +881,7 @@ export default function ChatScreen() {
         name: 'message_sent',
         properties: { kind: 'text', reply: replyToMessageId !== undefined },
       })
-    } catch {
+    } catch (error) {
       /*
        * Swallowed on purpose, and this is the whole change: it used to be
        * swallowed by *nothing* — `send()` had a `try/finally` with no `catch`,
@@ -894,6 +897,13 @@ export default function ChatScreen() {
           failedAt: new Date().toISOString(),
         }),
       )
+      // Swallowed for the reader, counted for us: an unsent row is quiet by
+      // design and a rising number of them is not something to find out from
+      // a support message.
+      track({
+        name: 'message_send_failed',
+        properties: { kind: 'text', reason: errorCodeOf(error) ?? null },
+      })
     } finally {
       // Landed or failed, the stand-in has somewhere better to be: the echo
       // has usually retired it already, the unsent row takes over otherwise.

--- a/apps/mobile/app/(app)/filters.tsx
+++ b/apps/mobile/app/(app)/filters.tsx
@@ -1,5 +1,6 @@
 import Feather from '@expo/vector-icons/Feather'
 import {
+  DISCOVERY_PRO_FILTER_KEYS,
   GENDERS,
   LANGUAGE_LEVELS,
   levelRank,
@@ -20,6 +21,7 @@ import { RangeSlider } from '../../src/components/ui/RangeSlider'
 import { Screen } from '../../src/components/ui/Screen'
 import { SegmentedControl } from '../../src/components/ui/SegmentedControl'
 import { Toggle } from '../../src/components/ui/Toggle'
+import { track } from '../../src/lib/analytics'
 import { goBackTo } from '../../src/lib/navigation'
 import { openPaywall } from '../../src/lib/paywall'
 import {
@@ -148,6 +150,19 @@ export default function FiltersScreen() {
   }
 
   function apply(): void {
+    /*
+     * Counted here rather than on the results screen: this is the moment
+     * somebody decided what they were looking for. `activeCount` rather than
+     * the size of the query, so this counts filters the way the badge on the
+     * Discover chip does — a level band is one filter, not two bounds.
+     */
+    track({
+      name: 'filters_applied',
+      properties: {
+        count: activeCount(filters),
+        pro: DISCOVERY_PRO_FILTER_KEYS.some((key) => Boolean(filters[key])),
+      },
+    })
     // `replace`, not `push`: the filter screen has done its job and should not
     // sit in the history behind the results it produced.
     router.replace({ pathname: '/(app)/(tabs)/discover', params: toParams(filters) })

--- a/apps/mobile/app/(app)/wallet/store.tsx
+++ b/apps/mobile/app/(app)/wallet/store.tsx
@@ -17,6 +17,7 @@ import { Screen } from '../../../src/components/ui/Screen'
 import { Skeleton } from '../../../src/components/ui/Skeleton'
 import { ScreenHeader } from '../../../src/components/ui/ScreenHeader'
 import { showAlert } from '../../../src/lib/alert'
+import { track } from '../../../src/lib/analytics'
 import { goBackTo } from '../../../src/lib/navigation'
 import { confirmAndRepair } from '../../../src/lib/repairFlow'
 import { showToast } from '../../../src/lib/toast'
@@ -145,7 +146,20 @@ export default function StoreScreen() {
       return
     }
     purchase.mutate(offer.id, {
-      onSuccess: () => showToast(t('store.bought', { title: offer.title })),
+      onSuccess: () => {
+        /*
+         * On success rather than on the tap: a spend that the server refused
+         * is not a spend, and at these volumes a "started" count would be a
+         * second number that only ever confuses the first. `title` is left
+         * out on purpose — it is translated, so it would arrive in eight
+         * spellings for one product; `id` is the same string everywhere.
+         */
+        track({
+          name: 'tokens_spent',
+          properties: { sku: offer.id, kind: offer.kind ?? 'consumable', amount: offer.price },
+        })
+        showToast(t('store.bought', { title: offer.title }))
+      },
       onError: () => void showAlert(t('store.buyFailed'), t('common.retry')),
     })
   }

--- a/apps/mobile/src/hooks/useNotificationRouting.ts
+++ b/apps/mobile/src/hooks/useNotificationRouting.ts
@@ -1,13 +1,29 @@
+import { PUSH_KINDS, type PushKind } from '@langx/shared'
 import { useQueryClient } from '@tanstack/react-query'
 import { router } from 'expo-router'
 import { useEffect } from 'react'
 import { AppState, Platform } from 'react-native'
 import { markConversationRead } from '../api/queries'
+import { track } from '../lib/analytics'
 import { getActiveConversation } from '../lib/activeConversation'
 import { presentationFor } from '../lib/foregroundPush'
 import { previewOf, showMessageBanner } from '../lib/inAppNotifications'
 import { configureNotifications } from '../lib/notifications'
 import { notificationRoute } from '../lib/notificationRoute'
+
+/**
+ * What the payload called itself, for the analytics event only.
+ *
+ * Not `notificationRoute`'s business: that one answers "where does this go",
+ * and two kinds that route to the same screen are the same answer to it and
+ * different answers to "what brought them back". Anything unrecognised counts
+ * as `unknown` rather than being dropped — a kind the app has not learned yet
+ * is exactly the thing worth seeing in the list.
+ */
+function openedKind(data: unknown): PushKind | 'unknown' {
+  const kind = (data as { kind?: unknown } | null)?.kind
+  return PUSH_KINDS.includes(kind as PushKind) ? (kind as PushKind) : 'unknown'
+}
 
 /**
  * Makes a tapped notification open the thing it is about.
@@ -40,7 +56,12 @@ export function useNotificationRouting({ enabled = true }: { enabled?: boolean }
         if (cancelled) return
 
         subscription = Notifications.addNotificationResponseReceivedListener((response) => {
-          const href = notificationRoute(response.notification.request.content.data)
+          const data = response.notification.request.content.data
+          track({
+            name: 'notification_opened',
+            properties: { kind: openedKind(data), cold_start: false },
+          })
+          const href = notificationRoute(data)
           if (href) router.push(href)
         })
 
@@ -75,7 +96,15 @@ export function useNotificationRouting({ enabled = true }: { enabled?: boolean }
 
         const initial = await Notifications.getLastNotificationResponseAsync()
         if (cancelled || !initial) return
-        const href = notificationRoute(initial.notification.request.content.data)
+        const data = initial.notification.request.content.data
+        // The tap that launched the app, rather than one it was already
+        // running for. Different amounts of interruption, so they are counted
+        // apart rather than summed.
+        track({
+          name: 'notification_opened',
+          properties: { kind: openedKind(data), cold_start: true },
+        })
+        const href = notificationRoute(data)
         // `push`, not `replace`: the tab the app opened on stays underneath, so
         // the back gesture out of the conversation goes somewhere sensible
         // instead of off the end of the stack.

--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -8,6 +8,7 @@ import type { MeProfile, MessageDto } from '../api/queries'
 import { invalidateUnread, keys, markConversationRead } from '../api/queries'
 import { getActiveConversation } from '../lib/activeConversation'
 import { previewOf, shouldShowIncomingBanner, showMessageBanner } from '../lib/inAppNotifications'
+import { track } from '../lib/analytics'
 import { invalidateMissedEvents, resumedFromBackground } from '../lib/missedEvents'
 import { applyIncomingMessage, type ConversationPageDto } from '../lib/conversationCache'
 import {
@@ -104,6 +105,16 @@ export function useSocket({ enabled = true }: { enabled?: boolean } = {}): void 
          * one a new message belongs in.
          */
         const meId = queryClient.getQueryData<{ _id: string }>(keys.me)?._id
+
+        /*
+         * The sender gets their own message back here too — that echo is what
+         * retires the optimistic row — so this asks whose it is before
+         * counting it. Without the guard `message_received` would be
+         * `message_sent` with extra steps.
+         */
+        if (meId && message.senderId !== meId) {
+          track({ name: 'message_received', properties: { kind: message.type } })
+        }
 
         queryClient.setQueriesData<InfiniteData<MessagePageDto>>(
           { queryKey: keys.messages(conversationId) },

--- a/apps/mobile/src/lib/analyticsEvents.test.ts
+++ b/apps/mobile/src/lib/analyticsEvents.test.ts
@@ -92,6 +92,11 @@ describe('every event survives the sanitizer', () => {
     { name: 'boosted_strip_shown', properties: { count: 4 } },
     { name: 'boosted_strip_tapped', properties: { slot: 0, tier: 'pro_plus' } },
     { name: 'discovery_card_tapped', properties: { slot: 17 } },
+    { name: 'message_received', properties: { kind: 'audio' } },
+    { name: 'message_send_failed', properties: { kind: 'media', reason: 'MEDIA_TOO_LARGE' } },
+    { name: 'notification_opened', properties: { kind: 'streakReminder', cold_start: true } },
+    { name: 'filters_applied', properties: { count: 3, pro: true } },
+    { name: 'tokens_spent', properties: { sku: 'frame_gold', kind: 'frame', amount: 250 } },
   ]
 
   for (const event of events) {

--- a/apps/mobile/src/lib/analyticsEvents.ts
+++ b/apps/mobile/src/lib/analyticsEvents.ts
@@ -1,4 +1,13 @@
-import type { BillingPeriod, PaidPlanTier, PlanChange, PlanFeature, PlanTier } from '@langx/shared'
+import type {
+  BillingPeriod,
+  CosmeticKind,
+  MessageType,
+  PaidPlanTier,
+  PlanChange,
+  PlanFeature,
+  PlanTier,
+  PushKind,
+} from '@langx/shared'
 import type { OnboardingStep } from './onboardingStep'
 import type { PurchaseOutcome } from './purchases'
 
@@ -28,12 +37,16 @@ export type PaywallSource = (typeof PAYWALL_SOURCES)[number]
  * file. A property added here is a property to declare; a string typed at a
  * call site is one nobody would know to.
  *
- * The events trace the one funnel `docs/decisions.md` chose the tool for —
- * install → onboarding → first conversation → paywall — and stop there, with
- * one deliberate exception. The Boosted strip is a placement people pay for,
- * and whether it delivers anything is not readable from a funnel that ends at
- * the purchase; the three `discovery`/`boosted` events below are that
- * exception, not the list opening up. Screens are captured separately
+ * The events traced the one funnel `docs/decisions.md` chose the tool for —
+ * install → onboarding → first conversation → paywall — and for a while they
+ * stopped there. They no longer do, and the reason is worth stating once: that
+ * funnel ends at the moment somebody pays, and every question about whether
+ * they *stay* lives after it. The Boosted strip is a placement people pay for;
+ * a message that is never answered, a send that quietly fails, a push nobody
+ * taps and a feature nobody uses are the four ways this app can be failing
+ * while the funnel looks fine. Each event below past `review_prompted` earns
+ * its place by answering one of those, and the list is still closed.
+ * Screens are captured separately
  * (`$screen`, see `useScreenTracking`), so a step being *seen* needs no event
  * of its own; these are the steps being *done*. Purchases themselves arrive
  * from RevenueCat's server-side integration, so `purchase_finished` is the
@@ -184,6 +197,90 @@ export type AnalyticsEvent =
        */
       name: 'discovery_card_tapped'
       properties: { slot: number }
+    }
+  | {
+      /**
+       * A message arrived from somebody else while the socket was up.
+       *
+       * The one thing `message_sent` cannot tell you: whether anybody answers.
+       * A language exchange where everyone writes and nobody replies looks,
+       * from the sent side alone, exactly like one that works — and `reply` on
+       * the sent event describes the *sender's* intent, not the fact of an
+       * answer arriving.
+       *
+       * Deliberately narrower than "messages received". It fires where the
+       * socket delivers, so a message that arrived as a push while the app was
+       * closed is not counted, and neither is one read from a cold start's
+       * first fetch. That makes it a lower bound on received traffic and an
+       * honest count of conversations that were live while somebody was
+       * looking. `kind` is the full `MessageType`, not the composer's shorter
+       * list: what can be received is wider than what this app can send.
+       */
+      name: 'message_received'
+      properties: { kind: MessageType }
+    }
+  | {
+      /**
+       * A send that did not land. `reason` is the server's error code where
+       * there was one, `null` for a socket that never answered.
+       *
+       * The counterpart to `message_sent`, and the reason it is worth its own
+       * event rather than a property: a failure rate is invisible in a funnel
+       * built from successes. Both failure paths in the composer are quiet by
+       * design — the text one leaves an unsent row, the media one a retry row —
+       * so nothing anywhere counts them today.
+       */
+      name: 'message_send_failed'
+      properties: { kind: 'text' | 'media'; reason: string | null }
+    }
+  | {
+      /**
+       * A push notification was tapped and the app opened on it.
+       *
+       * Eleven kinds of message go out and not one of them was measured, so
+       * "does the streak reminder bring anybody back" had no answer. `kind` is
+       * what the payload declared; `cold_start` separates a tap that launched
+       * the app from one that came to it already running, which are different
+       * amounts of interruption and convert differently.
+       *
+       * Counts taps, never sends — the server knows what it sent, and a push
+       * that was delivered and ignored leaves no trace on the device.
+       */
+      name: 'notification_opened'
+      properties: { kind: PushKind | 'unknown'; cold_start: boolean }
+    }
+  | {
+      /**
+       * The discovery filter sheet was applied.
+       *
+       * `pro` is the question: the advanced filters are a paid feature, and
+       * `paywall_viewed` already says how many people are *refused* them.
+       * Nothing said how many people who have them use them, which is the
+       * other half of whether they are worth selling.
+       *
+       * `count` is how many filters the search carries, never which — a filter
+       * set is a description of who somebody is looking for, and that is a
+       * sharper thing to keep than this needs.
+       */
+      name: 'filters_applied'
+      properties: { count: number; pro: boolean }
+    }
+  | {
+      /**
+       * Tokens left the balance for something in the wallet store.
+       *
+       * The token economy is a whole screen of the app and a whole sibling
+       * site, and nothing measured whether anybody spends. `sku` is the
+       * catalogue id, which is a product name and not a person; `kind` is the
+       * catalogue it came from, with `consumable` for the streak freeze and
+       * the day repair, which have none.
+       *
+       * Spending only. Earning is the server's business — it happens in cron
+       * jobs and gifts the device never sees — so a balance cannot be
+       * reconstructed from this, and is not meant to be.
+       */
+      name: 'tokens_spent'
+      properties: { sku: string; kind: CosmeticKind | 'consumable'; amount: number }
     }
 
 export type AnalyticsEventName = AnalyticsEvent['name']

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -71,8 +71,13 @@ reached a screen of ours.
 | `boosted_strip_shown`       | `count` (1–12)                                                                                        | Discover is focused with a non-empty Boosted strip                  |
 | `boosted_strip_tapped`      | `slot` (0-based), `tier`                                                                              | A Boosted card is tapped                                            |
 | `discovery_card_tapped`     | `slot` (0-based)                                                                                      | A row in the discovery list below the strip is tapped               |
+| `message_received`          | `kind` (any `MessageType`)                                                                            | A message from somebody else arrives over the socket                |
+| `message_send_failed`       | `kind` (text, media), `reason` (error code or null)                                                   | A send did not land. A quota refusal is a paywall, not a failure    |
+| `notification_opened`       | `kind` (any `PushKind`, or unknown), `cold_start`                                                     | A push was tapped. Counts taps, never sends                         |
+| `filters_applied`           | `count`, `pro`                                                                                        | The discovery filter sheet is applied. How many, never which        |
+| `tokens_spent`              | `sku`, `kind` (cosmetic kind or consumable), `amount`                                                 | A wallet purchase the server accepted. Spending only, never earning |
 
-Four of these carry a number that needs a caveat rather than a footnote:
+Some of these carry a number that needs a caveat rather than a footnote:
 
 - **`seconds_since_install`** counts from the first launch the device recorded,
   which is `FLAG_KEYS.installedAt` (`src/lib/installedAt.ts`) rather than
@@ -104,6 +109,20 @@ Four of these carry a number that needs a caveat rather than a footnote:
   survives an analytics opt-out. `boosted_strip_shown` is the app's first
   high-frequency event, roughly one `$screen`'s worth; every other one here is
   a once-per-account milestone.
+- **`message_received`** is a lower bound, not a count of messages received. It
+  fires where the socket delivers, so a message that arrived as a push while
+  the app was closed is never counted, and neither is one first seen in a cold
+  start's fetch. What it honestly measures is conversations that were live
+  while somebody was looking — which is the thing `message_sent` cannot say.
+- **`message_send_failed`** does not fire for the media quota refusal. That one
+  returns to a paywall and is counted as one; treating it as a failure would
+  put a pricing decision in the same number as a broken upload.
+- **`notification_opened`** counts taps. A push that was delivered and ignored
+  leaves no trace on the device, so the denominator for an open rate has to
+  come from the server's own send log rather than from here.
+- **`tokens_spent`** cannot be summed into a balance. Earning happens in cron
+  jobs and gifts the device never sees, so this is one side of a ledger whose
+  other side exists only on the server.
 
 Purchases themselves — renewals, refunds, what was actually charged — come
 from RevenueCat's server-side PostHog integration (below), not from the app.


### PR DESCRIPTION
Building the new PostHog dashboards turned up five questions with no data behind them at all. The event list traces install → onboarding → first conversation → paywall, and every question about whether somebody *stays* lives after that funnel ends.

| event | the question it answers | why nothing answered it before |
| --- | --- | --- |
| `message_received` | does anybody answer? | `reply` on `message_sent` is the sender's intent, not an answer arriving |
| `message_send_failed` | how often does a send quietly fail? | both failure paths are silent by design; a funnel of successes cannot show it |
| `notification_opened` | does the streak reminder bring anyone back? | eleven kinds of push go out, none measured |
| `filters_applied` | do people who *have* the advanced filters use them? | `paywall_viewed` counts only the ones refused |
| `tokens_spent` | does anybody spend tokens? | a whole screen and a sibling site, unmeasured |

### Decisions worth knowing about

- **`message_received` is a lower bound, deliberately.** It fires where the socket delivers, so a message that arrived as a push while the app was closed is never counted, and neither is one first seen in a cold start's fetch. What it honestly measures is conversations that were live while somebody was looking. It is also guarded on `senderId !== meId` — the sender gets their own message back on that channel, and without the guard this would be `message_sent` with extra steps.
- **The media quota refusal is not a failure.** It returns to a paywall and is already counted as one; putting a pricing decision in the same number as a broken upload would make both useless.
- **The text send's `catch` now binds its error**, so it can report the same error code the media path already reported. That is the only behavioural change to existing code in this PR.
- **`filters_applied` counts how many, never which.** A filter set describes who somebody is looking for, which is sharper than this needs. `activeCount` is reused so a level band counts as one filter, matching the badge on the Discover chip.
- **`tokens_spent` fires on success, not on tap**, and carries `sku` rather than the translated title — otherwise one product would arrive in eight spellings.

### Privacy

No new data category. All five are **App interactions**, already declared in both store forms, and none carries a message body, a name, another person's id, or a free-text string. `reason` is an error code and `sku` is a catalogue id. The closed union and `sanitizeEventProperties` still hold both ends.

### Checks

`pnpm -r typecheck` ✅ · `pnpm test` ✅ (2016 tests) · `pnpm lint` ✅ · `pnpm format:check` ✅

Dashboards for these live in PostHog project 265343 and fill as the OTA spreads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)