### PR TITLE
Send from hi@langx.io, not no-reply@

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,10 @@ APPLE_DOMAIN_ASSOCIATION=
 # app still boots and auth is fully testable locally.
 RESEND_API_KEY=
 # resend.dev needs no domain verification, so this works immediately. Point
-# it at a verified langx.io sender before Faz 13's launch.
+# it at a verified sender of your own before launch — and at a mailbox a
+# person reads rather than a no-reply@: replies are an engagement signal to
+# the mailbox providers, and a no-reply sender throws away both that signal
+# and whatever the person was trying to tell you.
 EMAIL_FROM=LangX <onboarding@resend.dev>
 # Where a bug report or feature request from the app lands. Nothing is stored
 # server-side, so this mailbox is the whole record: it confirms the report and
@@ -101,8 +104,9 @@ RESEND_AUDIENCE_ID=
 # Signing secret of the Resend webhook for bounces and complaints
 # (POST /webhooks/resend). Unset, the route says it is not configured.
 RESEND_WEBHOOK_SECRET=
-# Reply-To on campaign mail, so "reply to this email" from no-reply@ lands
-# with a person. e.g. hi@langx.io
+# Reply-To on campaign mail, so "reply to this email" from a no-reply@ sender
+# lands with a person. Unneeded when EMAIL_FROM is itself a mailbox somebody
+# reads — langx.io sends from hi@langx.io and leaves this empty.
 EMAIL_REPLY_TO=
 
 # ─── API: storage (Faz 2 / 11) ───────────────────────────────────────────────

--- a/apps/api/src/email/sender.ts
+++ b/apps/api/src/email/sender.ts
@@ -25,9 +25,11 @@ export interface EmailMessage {
    */
   headers?: Record<string, string>
   /**
-   * Where a reply goes when the sender is `no-reply@`. Only campaigns set
-   * it: they are the mail that says "reply to this, it reaches a human", and
-   * from the app's transactional address that would be a lie.
+   * Where a reply goes when the From address cannot take one. langx.io sends
+   * from `hi@`, a mailbox a person reads, so nothing sets this here; a
+   * deployment sending from a `no-reply@` still owes its campaigns somewhere
+   * to land, since they are the mail that says "reply to this, it reaches a
+   * human".
    */
   replyTo?: string
   /** Images for this one message, beside the shared ones. See `Email`. */

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -96,10 +96,13 @@ const envSchema = z.object({
    */
   RESEND_WEBHOOK_SECRET: emptyToUndefined(z.string().optional()),
   /**
-   * The Reply-To on campaign mail. Campaigns say "reply to this email, it
-   * reaches a human"; from a `no-reply@` sender that needs somewhere to go.
-   * Optional: unset, campaigns carry no Reply-To and that line should not be
-   * in them.
+   * The Reply-To on campaign mail, for a deployment sending from a
+   * `no-reply@`: campaigns say "reply to this email, it reaches a human" and
+   * that needs somewhere to go. langx.io leaves it unset, because
+   * `EMAIL_FROM` is `hi@langx.io` and the reply already arrives.
+   * Optional: unset, campaigns carry no Reply-To — right when the From
+   * address is readable, and when it is not, that line does not belong in
+   * the mail either.
    */
   EMAIL_REPLY_TO: emptyToUndefined(z.string().optional()),
 

--- a/apps/api/src/modules/notifications/campaignQueue.test.ts
+++ b/apps/api/src/modules/notifications/campaignQueue.test.ts
@@ -157,7 +157,7 @@ describe('the campaign queue', () => {
     expect(row).toMatchObject({ status: 'sending', sent: 1, startedAt: MORNING })
   })
 
-  /** "Reply to this email — it reaches a human" has to be true from a no-reply@ sender. */
+  /** From a no-reply@ sender, only a Reply-To makes "it reaches a human" true. */
   it('carries the Reply-To the context names', async () => {
     await newAccount()
     await queued()

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -266,10 +266,16 @@ rotating it breaks all of them at once, which is the legal way out of the
 mail. Unset, the app falls back to `BETTER_AUTH_SECRET` and inherits exactly
 that problem.
 
-- [x] **`EMAIL_FROM` points at the verified domain**: `LangX <no-reply@langx.io>`,
-      read back from the `langx-api` machine on 6 September 2026. The
-      `onboarding@resend.dev` default in `env.ts` is now only what a bare
-      self-host sends from.
+- [x] **`EMAIL_FROM` points at the verified domain**: `LangX <hi@langx.io>`,
+      set on the `langx-api` machine on 10 September 2026. It was
+      `no-reply@langx.io` until then, and the address changed on Resend's
+      deliverability guidance: a no-reply sender is read as a spam signal by
+      some filters, and it discards the replies that tell a provider the mail
+      is wanted. `hi@` is already the support mailbox (`SUPPORT_EMAIL`), so a
+      reply to a verification or notification mail now reaches the same inbox
+      as a bug report. `EMAIL_REPLY_TO` is redundant once the From address
+      takes replies and is unset in production. The `onboarding@resend.dev`
+      default in `env.ts` is only what a bare self-host sends from.
 
 Read one before anybody else does: leave `RESEND_API_KEY` unset locally and the
 sender prints each message to the log instead, headers included.


### PR DESCRIPTION
[Resend's deliverability guidance](https://resend.com/docs/dashboard/emails/deliverability-insights#don%E2%80%99t-use-%E2%80%9Cno-reply%E2%80%9D): don't send from a no-reply address. Some filters read it as a spam signal, and it discards the replies that tell a mailbox provider the mail is wanted.

`hi@langx.io` is already `SUPPORT_EMAIL` — a mailbox a person reads — so a reply to a verification or notification mail now lands in the same inbox as a bug report. `EMAIL_REPLY_TO` becomes redundant once the From address takes replies, and is unset in production; the code keeps it for a self-host that does send from a `no-reply@`.

The address itself lives in `EMAIL_FROM`, a Fly secret, so the change on production is a secret, not a deploy. This PR is the documentation and the comments that assumed a sender nobody could answer.

- `docs/release-runbook.md` — the `EMAIL_FROM` checklist line, with why
- `.env.example`, `apps/api/src/env.ts`, `apps/api/src/email/sender.ts`, campaign queue test comment

typecheck, lint, format:check, tests: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)