### PR TITLE
Official profiles: fix the bios and clear what adoption left behind

### DIFF
--- a/apps/api/src/modules/official/accounts.test.ts
+++ b/apps/api/src/modules/official/accounts.test.ts
@@ -105,6 +105,26 @@ describe('the official accounts', () => {
     expect(await handle.db.collection(COLLECTIONS.user).countDocuments()).toBe(1)
   })
 
+  /**
+   * The bio is the one sentence a stranger reads on a profile, and it is the
+   * easiest thing to leave describing an account that no longer exists — the
+   * first one invited people to write in, months after the composer was gone.
+   */
+  it('describes what each account actually is', async () => {
+    await ensureOfficialAccounts(handle.db, API_URL)
+    const rows = await handle.db
+      .collection<Profile>(COLLECTIONS.profiles)
+      .find({ official: true })
+      .toArray()
+
+    for (const row of rows) {
+      expect(row.bio, row.handle).toBeTruthy()
+      // Neither takes messages today, so neither may ask for one.
+      expect(row.bio, row.handle).not.toMatch(/ask me|write to me|report someone/i)
+    }
+    expect(rows.find((r) => r.handle === 'langx')?.bio).toContain('doesn’t take messages')
+  })
+
   it('publishes no age for an official account', async () => {
     await ensureOfficialAccounts(handle.db, API_URL)
     const profile = await handle.db

--- a/apps/api/src/modules/official/accounts.ts
+++ b/apps/api/src/modules/official/accounts.ts
@@ -40,8 +40,8 @@ interface OfficialUserDoc {
  */
 const OFFICIAL_BIOS: Record<OfficialHandle, string> = {
   langx:
-    'The LangX assistant. Ask me how the app works, report someone, or tell me about a bug or an idea.',
-  copilot: 'Your in-chat practice partner. Coming soon.',
+    'News and announcements from LangX. This account doesn’t take messages — Settings → About → Feedback reaches the team.',
+  copilot: 'The LangX assistant. Not open yet.',
 }
 
 const idsByHandle = new Map<OfficialHandle, string>()
@@ -127,7 +127,30 @@ async function ensureOne(
      */
     await profiles.updateOne(
       { _id: existing._id },
-      { $set: { avatarUrl, displayName, bio: OFFICIAL_BIOS[handle], updatedAt: now } },
+      {
+        $set: { avatarUrl, displayName, bio: OFFICIAL_BIOS[handle], updatedAt: now },
+        /*
+         * And the things an official account must not be carrying.
+         *
+         * A created one never has them; an **adopted** one arrives with
+         * whatever the person was using it for. Two cats in the gallery and a
+         * country under the name are exactly the kind of leftover that nobody
+         * thinks to look for, because the account otherwise reads correctly.
+         *
+         * `$unset` on an absent field costs nothing, so this runs on every
+         * boot and the account heals itself rather than needing a migration.
+         */
+        $unset: {
+          photos: '',
+          pronouns: '',
+          country: '',
+          cityId: '',
+          cityName: '',
+          cityCountryCode: '',
+          location: '',
+          locationUpdatedAt: '',
+        },
+      },
     )
     return { handle, outcome: 'updated', userId: existing._id }
   }

--- a/apps/api/src/modules/official/adopt.test.ts
+++ b/apps/api/src/modules/official/adopt.test.ts
@@ -112,8 +112,8 @@ describe('adopting an account that was run by hand', () => {
     const profile = await handle.db
       .collection<Profile>(COLLECTIONS.profiles)
       .findOne({ _id: USER_ID })
-    // Kept.
-    expect(profile?.photos).toHaveLength(1)
+    // Kept: the history, which is the reason to adopt rather than rename. The
+    // gallery is not history — see the boot test below, which clears it.
     expect(profile?.streak.current).toBe(9)
     expect(profile?.stats.messagesSent).toBe(24)
     // Applied.
@@ -144,7 +144,16 @@ describe('adopting an account that was run by hand', () => {
       .collection<Profile>(COLLECTIONS.profiles)
       .findOne({ _id: USER_ID })
     expect(profile?.displayName).toBe('LangX')
-    expect(profile?.bio).toContain('LangX assistant')
+    expect(profile?.bio).toContain('News and announcements')
+
+    /*
+     * The leftovers. An adopted account arrives with what the person was
+     * using it for — a gallery, a country under the name — and an official
+     * account has neither. The boot clears them rather than a migration.
+     */
+    expect(profile?.photos).toBeUndefined()
+    expect(profile?.country).toBeUndefined()
+    expect(profile?.pronouns).toBeUndefined()
     expect(profile?.avatarUrl).toBe('https://api.langx.test/public/avatar/official/langx')
   })
 

--- a/apps/api/src/modules/official/adopt.ts
+++ b/apps/api/src/modules/official/adopt.ts
@@ -25,11 +25,12 @@ export interface AdoptionResult {
  * conversations and history are worth keeping. This is that case, done
  * deliberately and once, by a person running a script.
  *
- * What it does **not** do is delete anything of the account's own: the
- * conversations, the messages, the photos and the streak all stay. What it
- * takes away is the ability to sign in, because "nobody can sign in to an
- * official account" is a property of the whole design and not a rule this one
- * gets to be an exception to.
+ * What it does **not** do is delete the account's history: the conversations,
+ * the messages and the streak all stay. What it takes away is the ability to
+ * sign in, because "nobody can sign in to an official account" is a property
+ * of the whole design and not a rule this one gets to be an exception to. The
+ * gallery, the country and the pronouns go on the next boot — see
+ * `ensureOfficialAccounts`, which owns what an official profile looks like.
  *
  * The order matters. Credentials go first, so a run that dies halfway leaves
  * an account nobody can sign into that is not yet official — harmless, and


### PR DESCRIPTION
@langx went live still wearing the account it was adopted from.

- The **bio** said "Ask me how the app works, report someone…" — months after the composer was taken away and the report tool removed. It was true when it was written and became false three scope changes later.
- Two **photos** (cats, from the old profile) in the gallery.
- A **country** under the name.

Everything else read correctly, which is exactly why none of it was obvious.

## What changes

Both bios now describe what the accounts are: `@langx` is news and announcements and says it takes no messages; `@copilot` is the assistant, not open yet.

The boot now `$unset`s what an official profile must not carry — gallery, pronouns, country, city, coordinates — alongside the name, avatar and bio it already owned. `$unset` on an absent field costs nothing, so a created account is unaffected and an adopted one heals on the next boot rather than needing a migration or a second run of the adoption script.

A test refuses any official bio that asks to be written to.

Verified: `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` (2433).

🤖 Generated with [Claude Code](https://claude.com/claude-code)