### PR TITLE
Say the tour's steps out loud

### DIFF
--- a/apps/mobile/src/components/TourHost.tsx
+++ b/apps/mobile/src/components/TourHost.tsx
@@ -1,6 +1,7 @@
 import { router } from 'expo-router'
 import { useCallback, useEffect, useState } from 'react'
 import {
+  AccessibilityInfo,
   Modal,
   Pressable,
   ScrollView,
@@ -143,6 +144,22 @@ export function TourHost() {
             // Counted here rather than in an effect on `anchor`, so a
             // re-measure after a rotation is not a second view of one step.
             track({ name: 'tour_step_viewed', properties: { step: target, index } })
+            /*
+             * Said out loud, because a screen reader has no idea the sentence
+             * changed: the overlay stays mounted from the first step to the
+             * last, so only its contents move, and nothing about that moves
+             * VoiceOver's cursor. A no-op when no screen reader is running.
+             *
+             * The two messages are joined by a *third* message rather than by
+             * a full stop in code — punctuation and spacing before it differ
+             * by language, and this is read aloud in eight of them.
+             */
+            AccessibilityInfo.announceForAccessibility(
+              t('tour.announcement', {
+                title: t(`tour.${target}Title` as MessageKey),
+                body: t(tourBodyKey(target, state) as MessageKey),
+              }),
+            )
           })
         },
         left === MEASURE_RETRIES && step.tab ? SETTLE_MS : left === MEASURE_RETRIES ? 0 : RETRY_MS,
@@ -156,7 +173,7 @@ export function TourHost() {
     }
     // `state` itself is safe to depend on: it only ever gets a new identity
     // when the run actually moves, because nothing publishes without changing.
-  }, [goNext, screen.height, screen.width, state, step, target])
+  }, [goNext, screen.height, screen.width, state, step, t, target])
 
   if (!state || !step) return null
 
@@ -229,6 +246,14 @@ export function TourHost() {
 
         {layout ? (
           <View
+            /*
+             * Politely live as well as announced. The announcement above is
+             * the iOS path; `announceForAccessibility` does nothing on
+             * react-native-web, and TalkBack prefers a live region — and the
+             * bubble is exactly that, one region whose words change while it
+             * stays mounted.
+             */
+            accessibilityLiveRegion="polite"
             style={[
               styles.bubble,
               {

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -101,6 +101,7 @@ export const ar: Localized<EnMessages> = {
     feedAsk: 'تعثرت في جملة؟ انشرها هنا وسيصححها أحدهم.',
   },
   tour: {
+    announcement: '{title}. {body}',
     progress: 'الخطوة {current} من {total}',
     next: 'التالي',
     done: 'فهمت',

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -92,6 +92,7 @@ export const de: Localized<EnMessages> = {
     feedAsk: 'Bei einem Satz festgefahren? Poste ihn hier, jemand korrigiert ihn.',
   },
   tour: {
+    announcement: '{title}. {body}',
     progress: 'Schritt {current} von {total}',
     next: 'Weiter',
     done: 'Alles klar',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -120,6 +120,7 @@ export const en = {
     feedAsk: 'Stuck on a sentence? Post it here and someone will fix it.',
   },
   tour: {
+    announcement: '{title}. {body}',
     progress: 'Step {current} of {total}',
     next: 'Next',
     done: 'Got it',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -91,6 +91,7 @@ export const es: Localized<EnMessages> = {
     feedAsk: '¿Atascado con una frase? Publícala aquí y alguien la corregirá.',
   },
   tour: {
+    announcement: '{title}. {body}',
     progress: 'Paso {current} de {total}',
     next: 'Siguiente',
     done: 'Entendido',

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -93,6 +93,7 @@ export const fr: Localized<EnMessages> = {
     feedAsk: 'Bloqué sur une phrase ? Publie-la ici, quelqu’un la corrigera.',
   },
   tour: {
+    announcement: '{title}\u00a0: {body}',
     progress: 'Étape {current} sur {total}',
     next: 'Suivant',
     done: 'Compris',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -88,6 +88,7 @@ export const ptBR: Localized<EnMessages> = {
     feedAsk: 'Travado numa frase? Publique aqui e alguém corrige.',
   },
   tour: {
+    announcement: '{title}. {body}',
     progress: 'Passo {current} de {total}',
     next: 'Próximo',
     done: 'Entendi',

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -99,6 +99,7 @@ export const ru: Localized<EnMessages> = {
     feedAsk: 'Застрял на фразе? Выложи её здесь, кто-нибудь поправит.',
   },
   tour: {
+    announcement: '{title}. {body}',
     progress: 'Шаг {current} из {total}',
     next: 'Дальше',
     done: 'Понятно',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -103,6 +103,7 @@ export const tr: Localized<EnMessages> = {
     feedAsk: 'Bir cümlede takıldın mı? Buraya at, biri düzeltsin.',
   },
   tour: {
+    announcement: '{title}. {body}',
     progress: 'Adım {current} / {total}',
     next: 'Sonraki',
     done: 'Anladım',


### PR DESCRIPTION
The last open item from the tour's plan, plus the two verification runs that were still owed.

## The change

The overlay is mounted once and its words change under a screen reader that has no reason to look again: VoiceOver's cursor does not move between steps, so somebody using one heard the first step and then silence while the run walked seven more.

Two halves, because the platforms disagree about which one they honour:

- `AccessibilityInfo.announceForAccessibility` when a step is measured — iOS's path, and a no-op on react-native-web.
- `accessibilityLiveRegion="polite"` on the bubble — what the web (`aria-live`) and TalkBack read. The bubble is exactly that: one region whose sentence changes while it stays mounted.

The title and the body are joined by a **third** message (`tour.announcement`) rather than by a full stop in code. It is read aloud in eight languages and French puts a narrow space before its colon.

## What was verified, and what could not be

- **A genuinely fresh install.** The simulator was erased, the app reinstalled, and a new account signed in: the tour opened by itself on the first Discovery view, no replay row involved. On the way there it also showed the empty-list case working as designed — an account whose languages matched nobody got **no** tour and did not burn the flag; it opened once a match existed.
- **Reduce Motion on** (`ReduceMotionEnabled` set on the device): the run plays and advances normally, with the Modal's own animation off.
- **The web accessibility tree**: the bubble comes back as `aria-live="polite"` carrying the step's text, inside the `aria-modal` dialog.
- **VoiceOver itself was not driven.** It cannot be switched on in the simulator from the CLI — the `defaults write` does not take — so the iOS speech was not heard, only the API call and the same text proven exposed on the web.

The four CI checks pass.