### PR TITLE
Make the lowest activity shade visible against an empty square

### DIFF
--- a/apps/mobile/src/components/ActivityMap.tsx
+++ b/apps/mobile/src/components/ActivityMap.tsx
@@ -214,7 +214,11 @@ const useStyles = makeStyles(({ colors, spacing }) => ({
   },
   // Three shades of work, the busiest in ink rather than a fourth blue: at
   // this size two more steps of the same hue stop being tellable apart.
-  low: { backgroundColor: colors.accentBg },
+  //
+  // The lowest is the accent thinned out, not `accentBg`: that tint is a
+  // near-match for `fill` in both schemes, so a quiet day read as a missed
+  // one — a ten-day streak over a map with six squares showing.
+  low: { backgroundColor: colors.accent, opacity: 0.4 },
   mid: { backgroundColor: colors.accent },
   high: { backgroundColor: colors.ink, opacity: 0.85 },
   legend: {


### PR DESCRIPTION
## What

The activity map's lowest shade (1–2 qualifying actions) was drawn with `accentBg`, which is a near-match for the empty-square colour `fill` in both colour schemes (`#e9f0fe` vs `#f4f5f7` in light, `#202b45` vs `#23272d` in dark). A quiet day therefore read as a missed one: a ten-day streak sat over a map that appeared to show only six filled squares.

## Change

`apps/mobile/src/components/ActivityMap.tsx`: the `low` style now draws the accent at 40% opacity instead of `accentBg`, the same device the `high` shade already uses with ink. One style rule and a comment explaining why; no logic changes.

## Verification

- `eslint`, `prettier --check` and `tsc` clean on the mobile package
- `activityMap.test.ts`: 19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoMFoZVzRG97jcaG54tM46

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoMFoZVzRG97jcaG54tM46)_