### PR TITLE
Stop the auth warm-up from mailing a verification link at every boot

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -18,6 +18,7 @@ import { deviceAuthorization } from 'better-auth/plugins/device-authorization'
 import { magicLink } from 'better-auth/plugins/magic-link'
 import type { Db, MongoClient, ObjectId } from 'mongodb'
 import { generateAppleClientSecret } from './auth/appleClientSecret'
+import { WARMUP_EMAIL } from './auth/warmUp'
 import {
   emailForHandle,
   looksLikeHandle,
@@ -339,6 +340,20 @@ export async function createAuth({
        * password a second time to get in.
        */
       sendVerificationEmail: async ({ user, token }, request) => {
+        /*
+         * `warmUpAuthCollections` signs up a disposable account at every boot
+         * and deletes it again, and `sendOnSignUp` has no per-call override —
+         * so without this line each boot mailed a verification link to an
+         * address on the reserved `.invalid` TLD, which by definition never
+         * resolves. Two machines, several deploys a day, and the warm-up's
+         * retry loop sending again on each attempt: 477 of 606 sends over the
+         * month to 2026-09-11 bounced, a 78% bounce rate on the same domain
+         * every real mail leaves from — past what Gmail and Yahoo tolerate
+         * from a bulk sender, with the v1 launch campaign still to go out on
+         * it. The warm-up is left exactly as it was; it was the send that had
+         * no business happening.
+         */
+        if (user.email === WARMUP_EMAIL) return
         const url = verifyEmailUrl(token)
         const locale = await mailLocale(user.id, request?.headers)
         /*

--- a/apps/api/src/auth/warmUp.test.ts
+++ b/apps/api/src/auth/warmUp.test.ts
@@ -26,7 +26,14 @@ describe('Faz 1 — auth collection warm-up', () => {
       MONGODB_DB: 'langx_warmup_test',
       BETTER_AUTH_SECRET: 'a'.repeat(32),
     })
-    const noopEmailSender: EmailSender = { deliverable: true, send: () => Promise.resolve() }
+    const sent: string[] = []
+    const noopEmailSender: EmailSender = {
+      deliverable: true,
+      send: (message) => {
+        sent.push(message.to)
+        return Promise.resolve()
+      },
+    }
     const auth = await createAuth({
       env,
       db: handle.db,
@@ -43,6 +50,12 @@ describe('Faz 1 — auth collection warm-up', () => {
     expect(warnings).toEqual([])
     await expect(handle.db.collection('user').countDocuments()).resolves.toBe(0)
     await expect(handle.db.collection('account').countDocuments()).resolves.toBe(0)
+
+    // The warm-up runs at every boot, on two machines, several deploys a day.
+    // Anything it mails goes to an address on the reserved `.invalid` TLD that
+    // can never resolve, so every one of those sends is a bounce recorded
+    // against the domain the app's real mail leaves from.
+    expect(sent).toEqual([])
 
     // And the real first sign-up a user makes now succeeds on the first try.
     const signUp = await auth.api.signUpEmail({

--- a/apps/api/src/auth/warmUp.ts
+++ b/apps/api/src/auth/warmUp.ts
@@ -1,7 +1,14 @@
 import { ObjectId, type Db } from 'mongodb'
 import type { Auth } from '../auth'
 
-const WARMUP_EMAIL = 'bootstrap-warmup@internal.langx.invalid'
+/**
+ * The disposable account's address. Exported because `auth.ts` has to
+ * recognise it: `emailVerification.sendOnSignUp` is a static setting with no
+ * per-call override, so the only place to stop the warm-up's sign-up from
+ * mailing a verification link is in the send hook itself. See the guard in
+ * `sendVerificationEmail`.
+ */
+export const WARMUP_EMAIL = 'bootstrap-warmup@internal.langx.invalid'
 const WARMUP_PASSWORD = 'bootstrap-warmup-not-a-real-account'
 
 interface WarmUpLogger {


### PR DESCRIPTION
## The problem

`warmUpAuthCollections` calls `auth.api.signUpEmail` at every API boot to absorb Better Auth's first-write index race. `emailVerification.sendOnSignUp: true` is a static setting with no per-call override, so that sign-up sent a real **"Verify your LangX email"** through Resend to `bootstrap-warmup@internal.langx.invalid` — an address on the reserved `.invalid` TLD, which by definition never resolves.

Production Resend, 2026-08-13 → 2026-09-11:

| | |
|---|---|
| Sent | 606 |
| Delivered | 129 |
| Bounced | 477 (476 transient, 1 permanent) |
| `delivery_delayed` events | 2418 |
| **Bounce rate** | **~78%** |

That is far above the Gmail/Yahoo bulk-sender thresholds and above SES's own review threshold — on the same domain the app's real mail leaves from, with the v1 launch campaign to ~3,900 pre-created addresses still waiting to go out on it.

## The fix

One guard, in the one hook that can see the address:

```ts
if (user.email === WARMUP_EMAIL) return
```

Of the three options weighed, this is the only one that changes nothing about the warm-up itself. It still runs the full `signUpEmail` path — which is the point: the long comment in `warmUp.ts` is specific about *which* code path has to be exercised (the mongo adapter's first `create` on `user`/`account`, which triggers `ensureModelIndexes` inside a transaction the adapter cannot roll back cleanly). The other two options both change it:

- **A direct adapter write** would work, and would be tidier — it skips the password hash, the verification token and the mail entirely. But it swaps a proven path for a hand-rolled one, and if the data shape were ever wrong the retry loop would swallow it into a warning and the protection would disappear silently.
- **Skipping when the collections already exist** does not exercise the path at all, and still mails once on a genuinely fresh database.

## What the measurement turned up

Writing the assertion first showed the warm-up sends **two** mails on a fresh database, not one: the retry loop fires `sendVerificationEmail` again on each attempt, and the first attempt is exactly the one that loses the index race. So the per-boot cost was one mail on a warm database and two on a cold one.

## Resend suppression list — checked, nothing to do

The account-wide suppression list (`GET /suppressions`, production account, `langx.io` verified) holds exactly one entry, and it is **not** the warm-up address:

```
review@langx.io — origin: bounce — 2026-09-05
```

The warm-up address was never suppressed: Resend suppresses on hard bounce, and 476 of the 477 were classified transient. Nothing to remove, and leaving it absent costs nothing since after this change we never send there again.

Two things fall out of that check, neither touched here:

1. **`review@langx.io` is suppressed since 5 Sept.** That is the App Review account, and mail to it is being dropped — worth a look given the 2.1(b)/3.1.2 history. Removing a suppression changes account state, so I have not.
2. Domain reputation recovers by the bounce rate dropping, not by editing suppressions. Worth letting the domain send clean for a stretch before the v1 campaign goes out.

## Not fixed here (pre-existing, unchanged by this PR)

The warm-up's sign-up also leaves a `verification` token row and a terms-acceptance row per boot, which the cleanup does not delete. Both predate this change and neither sends mail.

## Checks

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and `pnpm test` (2,496 tests) all pass. The API bundle builds, and `WARMUP_EMAIL` is declared ahead of its use in the output — the new `auth.ts` → `warmUp.ts` import pairs with a type-only import back, so there is no runtime cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)