### PR TITLE
Make a language removable from the row it is on, and let over-limit profiles edit at all

### DIFF
--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -1583,6 +1583,38 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
       expect(grown.statusCode).toBe(403)
     })
 
+    /**
+     * The same grandfathering, above the *absolute* ceiling rather than the
+     * tier's. v1 had no language limit and `mapLanguages` imports whatever it
+     * finds, so a migrated profile can carry more than the top tier allows —
+     * and a body schema that refused it took the repository's careful
+     * "you may always shrink" and made it unreachable. The only way out of an
+     * over-ceiling profile was to delete enough languages in a single request
+     * to land under the ceiling, which is not what the screen sends.
+     */
+    it('lets a migrated profile over the absolute ceiling remove one', async () => {
+      const { user } = await onboardedWith('lang-ceiling@example.com', 'langceiling', [
+        { code: 'en', level: 'intermediate', priority: 1 },
+      ])
+      const imported = ['en', 'de', 'fr', 'es', 'it', 'ru', 'ja'].map((code, index) => ({
+        code,
+        level: 'beginner',
+        priority: index + 1,
+      }))
+      await handle.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .updateOne({ _id: user.userId }, { $set: { learning: imported } })
+
+      const removed = await patch(user, { learning: imported.slice(0, -1) })
+      expect(removed.statusCode, removed.body).toBe(200)
+      expect(removed.json<{ learning: unknown[] }>().learning).toHaveLength(imported.length - 1)
+
+      const grown = await patch(user, {
+        learning: [...imported, { code: 'zh', level: 'beginner', priority: imported.length + 1 }],
+      })
+      expect(grown.statusCode).toBe(403)
+    })
+
     it('gives a paid tier its wider allowance', async () => {
       const { user } = await onboardedWith('lang-paid@example.com', 'langpaid', [
         { code: 'en', level: 'intermediate', priority: 1 },

--- a/apps/mobile/app/(app)/edit-profile.tsx
+++ b/apps/mobile/app/(app)/edit-profile.tsx
@@ -9,7 +9,6 @@ import {
   MAX_INTERESTS,
   PLAN_LIMITS,
   PRONOUNS_MAX_LENGTH,
-  getLanguage,
   type Gender,
   type LanguageLevel,
 } from '@langx/shared'
@@ -76,6 +75,28 @@ const LANGUAGE_STATUS_KEYS = {
   saved: 'editProfile.saved',
   failed: 'editProfile.saveFailed',
 } as const
+
+/**
+ * The × at the end of a language row, drawn only while the block is being
+ * edited. Faint rather than red: it is one tap to put the language back, and a
+ * red mark on every row would make a list of languages look like a list of
+ * warnings.
+ */
+function RemoveLanguage({ label, onPress }: { label: string; onPress: () => void }) {
+  const { colors } = useTheme()
+  const styles = useStyles()
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      hitSlop={10}
+      onPress={onPress}
+      style={({ pressed }) => [styles.removeLanguage, pressed && styles.pressed]}
+    >
+      <Feather name="x" size={15} color={colors.textMuted} />
+    </Pressable>
+  )
+}
 
 export default function EditProfileScreen() {
   useScreenInteractive()
@@ -186,9 +207,23 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
       })
       .then(() => setLanguageStatus('saved'))
       .catch((caught: unknown) => {
-        // Forget what was saved so the next edit retries this one with it.
         void caught
-        savedLanguages.current = ''
+        /*
+         * The signature stays marked as attempted, and that is the whole of
+         * the retry policy.
+         *
+         * It used to be cleared here, to "let the next edit retry this one" —
+         * but clearing it while also setting state made this effect its own
+         * trigger: the render caused by the status change re-entered it, found
+         * nothing recorded as saved, and sent the same rejected body again.
+         * A request the server refuses for a reason that will not change on
+         * its own became a loop, hundreds of requests deep, with the screen
+         * stuck on "Saving…" and the device hammering the API for as long as
+         * the user left it open.
+         *
+         * Nothing is lost by not retrying: every save sends both lists whole,
+         * so the next real edit carries whatever this one was going to.
+         */
         // Reported on the line under the language rows, not in the form's
         // error slot at the foot of the screen: with the picker open that slot
         // is several hundred pixels below the fold, so a language that failed
@@ -269,6 +304,32 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
         ? t('editProfile.storageUnconfigured')
         : t('editProfile.uploadRetry'),
     )
+  }
+
+  /**
+   * Removing a language from the row it is drawn on.
+   *
+   * The picker underneath can deselect one too, but only after you have found
+   * it among a hundred and eighty chips, and only for whichever list it is
+   * currently showing — so the list you are looking at offered no way to take
+   * anything out of it. A button on the row is the one everybody reaches for.
+   * Not a swipe: this screen is also the web build, where there is no touch to
+   * swipe with, and a gesture that exists on two platforms out of three is a
+   * feature half the users cannot find.
+   *
+   * The last one of either list stays, and says why. `save` and the autosave
+   * both refuse a profile with no native or no learning language, so removing
+   * it would be a tap that quietly changes nothing — which is exactly the
+   * complaint this whole button answers.
+   */
+  function removeLanguage(kind: 'native' | 'learning', code: string): void {
+    const list = kind === 'native' ? native : learning
+    if (list.length === 1) {
+      showToast(t('editProfile.pickOneOfEach'))
+      return
+    }
+    if (kind === 'native') setNative((current) => current.filter((each) => each !== code))
+    else setLearning((current) => current.filter((each) => each.code !== code))
   }
 
   /**
@@ -503,7 +564,15 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
             {native.map((code) => (
               <View key={code} style={styles.languageRow}>
                 <Text style={styles.languageName}>{names.language(code)}</Text>
-                <Text style={styles.languageLevel}>{t('onboarding.native')}</Text>
+                <View style={styles.languageLevelRow}>
+                  <Text style={styles.languageLevel}>{t('onboarding.native')}</Text>
+                  {editing !== 'none' ? (
+                    <RemoveLanguage
+                      label={`${t('common.remove')} · ${names.language(code)}`}
+                      onPress={() => removeLanguage('native', code)}
+                    />
+                  ) : null}
+                </View>
               </View>
             ))}
             {learning.map((l) => (
@@ -519,6 +588,12 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
                 <View style={styles.languageLevelRow}>
                   <Text style={styles.languageLevel}>{levelLabel(t, l.level)}</Text>
                   <LevelBars level={l.level} size={12} />
+                  {editing !== 'none' ? (
+                    <RemoveLanguage
+                      label={`${t('common.remove')} · ${names.language(l.code)}`}
+                      onPress={() => removeLanguage('learning', l.code)}
+                    />
+                  ) : null}
                 </View>
               </View>
             ))}
@@ -531,6 +606,43 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
               {t(LANGUAGE_STATUS_KEYS[languageStatus])}
             </Text>
           )}
+
+          {/*
+            The levels sit between the rows they belong to and the picker that
+            adds new ones, and they are drawn whole.
+
+            They used to live inside the picker's pane, in a 140-pixel box with
+            a scroll view of their own: five languages meant hunting for the
+            one you wanted through a window two rows tall, nested inside the
+            page's own scroll. Out here the block is as tall as it needs to be
+            and the page scrolls, which is the only scroll anybody has to
+            think about.
+          */}
+          {editing === 'learning' && learning.length > 0 ? (
+            <View style={styles.levels}>
+              {learning.map((entry) => (
+                <View key={entry.code} style={styles.levelRow}>
+                  {/* The reader's own language for the name, as everywhere else
+                      on this screen — `getLanguage().name` is always English. */}
+                  <Text style={styles.levelLang}>{names.language(entry.code)}</Text>
+                  <View style={styles.row}>
+                    {LANGUAGE_LEVELS.map((level) => (
+                      <Chip
+                        key={level}
+                        label={levelShortLabel(t, level)}
+                        selected={entry.level === level}
+                        onPress={() =>
+                          setLearning((current) =>
+                            current.map((l) => (l.code === entry.code ? { ...l, level } : l)),
+                          )
+                        }
+                      />
+                    ))}
+                  </View>
+                </View>
+              ))}
+            </View>
+          ) : null}
 
           {editing !== 'none' ? (
             <View style={styles.pickerPane}>
@@ -570,31 +682,6 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
                   }
                 }}
               />
-              {editing === 'learning' && learning.length > 0 ? (
-                <ScrollView style={styles.levels} keyboardShouldPersistTaps="handled">
-                  {learning.map((entry) => (
-                    <View key={entry.code} style={styles.levelRow}>
-                      <Text style={styles.levelLang}>
-                        {getLanguage(entry.code)?.name ?? entry.code}
-                      </Text>
-                      <View style={styles.row}>
-                        {LANGUAGE_LEVELS.map((level) => (
-                          <Chip
-                            key={level}
-                            label={levelShortLabel(t, level)}
-                            selected={entry.level === level}
-                            onPress={() =>
-                              setLearning((current) =>
-                                current.map((l) => (l.code === entry.code ? { ...l, level } : l)),
-                              )
-                            }
-                          />
-                        ))}
-                      </View>
-                    </View>
-                  ))}
-                </ScrollView>
-              ) : null}
             </View>
           ) : null}
         </View>
@@ -707,15 +794,26 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   languageLevel: { color: colors.textMuted, fontSize: 14 },
   languageStatus: { ...font.label, color: colors.textMuted, fontWeight: '400' },
   languageBad: { color: colors.danger },
+  // A circle the size of a chip's height, so the × has a real target on a row
+  // whose other contents are text.
+  removeLanguage: {
+    alignItems: 'center',
+    backgroundColor: colors.fill,
+    borderRadius: radius.pill,
+    height: 26,
+    justifyContent: 'center',
+    marginLeft: spacing.xs,
+    width: 26,
+  },
   pickerPane: { height: 320 },
   levels: {
     borderTopColor: colors.border,
     borderTopWidth: 1,
-    maxHeight: 140,
-    paddingTop: spacing.sm,
+    gap: spacing.md,
+    paddingTop: spacing.md,
   },
-  levelRow: { marginBottom: spacing.sm },
-  levelLang: { ...font.caption, color: colors.textMuted, marginBottom: spacing.xs },
+  levelRow: { gap: spacing.xs },
+  levelLang: { ...font.caption, color: colors.textMuted },
   gallery: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm + 1 },
   photo: { backgroundColor: colors.fill, borderRadius: 14, height: PHOTO_TILE, width: PHOTO_TILE },
   photoAdd: {

--- a/apps/mobile/app/(app)/edit-profile.tsx
+++ b/apps/mobile/app/(app)/edit-profile.tsx
@@ -70,6 +70,13 @@ import { useScreenInteractive } from '../../src/hooks/useScreenInteractive'
 /** One number for the stored tiles and the pending ones, so they cannot drift. */
 const PHOTO_TILE = 58
 
+/** What the line under the language rows says, per state of the autosave. */
+const LANGUAGE_STATUS_KEYS = {
+  saving: 'editProfile.savingLanguages',
+  saved: 'editProfile.saved',
+  failed: 'editProfile.saveFailed',
+} as const
+
 export default function EditProfileScreen() {
   useScreenInteractive()
   const styles = useStyles()
@@ -129,7 +136,9 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
   const [editing, setEditing] = useState<'none' | 'native' | 'learning'>('none')
   const tier = useEffectiveTier()
   const [error, setError] = useState<string | undefined>()
-  const [languageStatus, setLanguageStatus] = useState<'idle' | 'saving' | 'saved'>('idle')
+  const [languageStatus, setLanguageStatus] = useState<'idle' | 'saving' | 'saved' | 'failed'>(
+    'idle',
+  )
 
   const photos = profile.photos ?? []
   const learningCodes = learning.map((l) => l.code)
@@ -180,8 +189,12 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
         // Forget what was saved so the next edit retries this one with it.
         void caught
         savedLanguages.current = ''
-        setLanguageStatus('idle')
-        setError(t('editProfile.saveFailed'))
+        // Reported on the line under the language rows, not in the form's
+        // error slot at the foot of the screen: with the picker open that slot
+        // is several hundred pixels below the fold, so a language that failed
+        // to save looked exactly like one that had saved — the row was gone
+        // from the list either way, and came back on the next visit.
+        setLanguageStatus('failed')
       })
     // `update` and `t` are deliberately absent: both change identity on a
     // render this effect can itself cause, and depending on them would make a
@@ -512,8 +525,10 @@ function EditProfileForm({ profile }: { profile: MeProfile }) {
           </View>
 
           {languageStatus === 'idle' ? null : (
-            <Text style={styles.languageStatus}>
-              {t(languageStatus === 'saving' ? 'editProfile.savingLanguages' : 'editProfile.saved')}
+            <Text
+              style={[styles.languageStatus, languageStatus === 'failed' && styles.languageBad]}
+            >
+              {t(LANGUAGE_STATUS_KEYS[languageStatus])}
             </Text>
           )}
 
@@ -691,6 +706,7 @@ const useStyles = makeStyles(({ colors, font, spacing, radius }) => ({
   languageLevelRow: { alignItems: 'center', flexDirection: 'row', gap: 10 },
   languageLevel: { color: colors.textMuted, fontSize: 14 },
   languageStatus: { ...font.label, color: colors.textMuted, fontWeight: '400' },
+  languageBad: { color: colors.danger },
   pickerPane: { height: 320 },
   levels: {
     borderTopColor: colors.border,

--- a/packages/shared/src/profile.ts
+++ b/packages/shared/src/profile.ts
@@ -6,7 +6,7 @@ import { birthDateSchema } from './age'
 import { languageLevelSchema } from './level'
 import { referralSourceSchema } from './referral'
 import { handleSchema } from './handle'
-import { languageCodeSchema } from './languages'
+import { LANGUAGES, languageCodeSchema } from './languages'
 import { z } from 'zod'
 
 export const GENDERS = ['female', 'male', 'other', 'undisclosed'] as const
@@ -120,6 +120,27 @@ const pronounsSchema = z.string().trim().max(PRONOUNS_MAX_LENGTH)
 const interestsSchema = z.array(z.string().trim().min(1).max(30)).max(MAX_INTERESTS)
 const nativeLanguagesSchema = z.array(nativeLanguageSchema).min(1).max(MAX_NATIVE_LANGUAGES)
 const learningLanguagesSchema = z.array(learningLanguageSchema).min(1).max(MAX_LEARNING_LANGUAGES)
+
+/**
+ * The same two lists as they arrive in an *update*, with the catalogue as
+ * their only ceiling.
+ *
+ * v1 had no language limit and the import keeps whatever it finds, so a
+ * migrated profile can hold more languages than even the top tier allows.
+ * `updateProfile` grandfathers exactly that — any list no longer than the one
+ * already stored is accepted, which is what lets somebody over the limit fix
+ * a level or drop a language — but a body schema refusing the request first
+ * made that unreachable: removing one of seven still sends six, and six was
+ * "too big". The one group the grandfathering exists for were the only people
+ * it could not help, and the screen reported it as nothing happening at all.
+ *
+ * The tier ceiling is not lost, only moved to the one place that can apply it
+ * honestly: `assertLanguageCap`, which knows both the tier and what is already
+ * there. What is left here is the bound a schema can state on its own — you
+ * cannot list more languages than there are.
+ */
+const nativeLanguagesUpdateSchema = z.array(nativeLanguageSchema).min(1).max(LANGUAGES.length)
+const learningLanguagesUpdateSchema = z.array(learningLanguageSchema).min(1).max(LANGUAGES.length)
 
 /**
  * Body of `POST /profiles` — onboarding. `birthDate` is validated here
@@ -276,8 +297,8 @@ export const updateProfileSchema = z
     bio: bioSchema,
     /** Empty clears it — there is no separate "remove my pronouns" call. */
     pronouns: pronounsSchema,
-    nativeLanguages: nativeLanguagesSchema,
-    learning: learningLanguagesSchema,
+    nativeLanguages: nativeLanguagesUpdateSchema,
+    learning: learningLanguagesUpdateSchema,
     interests: interestsSchema,
     timezone: z.string().trim().min(1),
     /**


### PR DESCRIPTION
**The report:** languages added under *learning* could not be removed.

Three separate things were in the way, all reproduced on the web build against a throwaway API seeded with a six-language migrated profile.

### 1. The list offered no way to remove anything

The only way out was the picker underneath — find the language among a hundred and eighty chips, and only in whichever list the picker was showing. Each row now carries an **×** while the block is being edited. Not a swipe: this screen is also the web build, where there is no touch to swipe with, and a gesture that exists on two platforms out of three is one half the users cannot find. Removing the last of either list is refused with the sentence that says why — a profile with no native or no learning language is one neither `save` nor the autosave will write.

### 2. The server refused the removal anyway, for anyone over the ceiling

`updateProfile` deliberately grandfathers a profile that sits over its tier's language limit: any list no longer than the one already stored is accepted, so somebody migrated from v1 can still change a level or drop a language. v1 had no limit and `mapLanguages` imports whatever it finds, so those profiles routinely carry more than even Pro+ allows.

`updateProfileSchema` did not know that. It capped both arrays at `MAX_LEARNING_LANGUAGES` (5 — the top tier's row), so the request was refused with `VALIDATION_FAILED` before the grandfathering could run: removing one of seven still sends six, and six was "too big". The only escape was to remove enough languages inside the 600 ms autosave window to land under five in one request. The people the clause was written for were the only ones it could not help.

The update schema's arrays keep `.min(1)` and lose the tier ceiling; what remains is the bound a schema can state on its own — you cannot list more languages than exist. The tier cap stays with `assertLanguageCap`, which knows both the tier and what is already stored, and still refuses any list that grows past it.

### 3. A failed save became a request storm, and said nothing

The catch cleared the saved signature to let the next edit retry — but it also set state, and that render re-entered the effect, found nothing recorded as saved, and sent the same rejected body again. One tap became **490 requests** in the run that caught it, with the screen stuck on "Saving…" for as long as it stayed open. The signature now stays marked as attempted; nothing is lost, because every save sends both lists whole.

The failure also went to the form's error slot at the foot of the screen, hundreds of pixels below an open picker, so a language that failed to save looked exactly like one that had saved. It now reports on the line under the rows that already says "Saving…", in the danger colour.

### While in there

The level chips came out of their 140-pixel box. They lived inside the picker's pane with a scroll view of their own, nested in the page's scroll: five languages meant hunting through a two-row slot. They now sit between the rows they describe and the picker that adds new ones, at full height, with the page as the only scroll — and their names go through `names.language` like every other name on the screen (`getLanguage().name` is always English).

### Checks

`profiles.test.ts` gains the case the existing grandfathering test could not reach — a seven-language import removing one — which fails on `main` with `expected array to have <=5 items`. Typecheck, lint, format and 2497 tests pass.

Driven in the browser: removing one persists (6 → 5 → 1), the last-language guard holds, and a save against a stopped server draws one red line and sends exactly one request.

The server half only takes effect once the API is deployed; the mobile half rides the OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)