### PR TITLE
Greet a v1 user with no name as "there", not as langx_6430

### DIFF
--- a/apps/api/src/modules/notifications/audience.test.ts
+++ b/apps/api/src/modules/notifications/audience.test.ts
@@ -39,6 +39,8 @@ describe('what a Resend audience should contain', () => {
       profile?: boolean
       anonymous?: boolean
       email?: string
+      name?: string
+      displayName?: string
     } = {},
   ): Promise<string> {
     const userId = new ObjectId().toHexString()
@@ -46,7 +48,7 @@ describe('what a Resend audience should contain', () => {
       await handle.db.collection(COLLECTIONS.profiles).insertOne({
         _id: userId,
         handle: `h${userId.slice(-12)}`,
-        displayName: 'Sofia R.',
+        displayName: opts.displayName ?? 'Sofia R.',
         settings: { discoverable: true, notifications: opts.notifications ?? {} },
         ...(opts.deleted ? { deletedAt: new Date() } : {}),
       } as never)
@@ -54,6 +56,7 @@ describe('what a Resend audience should contain', () => {
     await handle.db.collection(COLLECTIONS.user).insertOne({
       _id: authId(userId),
       email: opts.email ?? `${userId}@example.com`,
+      ...(opts.name ? { name: opts.name } : {}),
       emailVerified: opts.verified ?? true,
       ...(opts.anonymous ? { isAnonymous: true } : {}),
       ...(opts.fromV1 ? { precreatedFromV1: { at: new Date(), legacyUserId: 'v1id' } } : {}),
@@ -190,6 +193,25 @@ describe('what a Resend audience should contain', () => {
 
     const plan = await audiencePlan(handle.db, 'consented')
     expect(plan.contacts).toEqual([expect.objectContaining({ userId: gone, action: 'remove' })])
+  })
+
+  /**
+   * v1's generated names are not names: 379 of the 3,901 pre-created rows
+   * carry `langx_` and four hex digits, and a letter greeting one of them
+   * opens "Hi langx_6430,". The plan must offer no name at all so the letter
+   * falls back to "there" — while a `displayName` somebody typed is kept
+   * whatever it happens to look like.
+   */
+  it('drops the name v1 generated for somebody who never chose one', async () => {
+    const generated = await newAccount({ fromV1: true, profile: false, name: 'langx_6430' })
+    const chosen = await newAccount({ fromV1: true, profile: false, name: 'Yash' })
+    const typed = await newAccount({ fromV1: true, displayName: 'langx_abcd' })
+
+    const plan = await audiencePlan(handle.db, 'v1')
+    const byId = new Map(plan.contacts.map((contact) => [contact.userId, contact]))
+    expect(byId.get(generated)?.name).toBeUndefined()
+    expect(byId.get(chosen)?.name).toBe('Yash')
+    expect(byId.get(typed)?.name).toBe('langx_abcd')
   })
 
   it('excludes guests and addresses nobody proved', async () => {

--- a/apps/api/src/modules/notifications/audience.ts
+++ b/apps/api/src/modules/notifications/audience.ts
@@ -106,6 +106,23 @@ export function audienceAction(
 }
 
 /**
+ * v1 gave anybody who never chose a display name a generated one — `langx_`
+ * and four hex digits — and 379 of the 3,901 pre-created rows carry it. It is
+ * not a name the person picked or would recognise, so greeting them with it
+ * addresses a stranger by a serial number: "Hi langx_6430,". Treated as no
+ * name at all, which is what it is, so `{{firstName}}` falls back to "there".
+ *
+ * Only the v1 row's own name is filtered. A `displayName` on a profile was
+ * typed by somebody, whatever it looks like.
+ */
+const V1_GENERATED_NAME = /^langx_[0-9a-f]{4}$/
+
+function chosenName(name: string | undefined): string | undefined {
+  if (!name) return undefined
+  return V1_GENERATED_NAME.test(name) ? undefined : name
+}
+
+/**
  * Reads every mailable account and says what should happen to it.
  *
  * Driven from `user` rather than from `profiles`, unlike `campaignRecipients`:
@@ -190,7 +207,7 @@ export async function audiencePlan(
       continue
     }
 
-    const name = profile?.displayName || user.name
+    const name = profile?.displayName || chosenName(user.name)
     contacts.push({
       userId,
       email,


### PR DESCRIPTION
v1 gave anybody who never chose a display name a generated one — `langx_` and four hex digits — and **379 of the 3,901 pre-created rows still carry it**. `audiencePlan` passed it through as the campaign's `{{firstName}}`, so about one v1 win-back letter in ten was about to open `Hi langx_6430,`.

That matters more than it looks: the launch mail goes out once, to everybody who ever had a v1 account, and nothing in it is fixable after the click. Caught by reading the dry run's five masked sample rows — three of the five were generated names.

The queued campaign `2026-09-v1-launch` is **paused** at 0/3897 sent, waiting on this.

## What changed

`audiencePlan` treats a generated name as no name, so the existing fallback gives `Hi there,`. Only the v1 row's own `name` is filtered — a `displayName` on a profile was typed by a person, whatever it happens to look like.

The pattern is exact rather than a prefix: all 379 are `langx_` plus four lowercase hex digits, checked against production, and a real name that merely starts with those characters is not one of them.

`v1DeletedContacts` needs nothing — none of its 837 rows carries a generated name, and the 38 with no name at all already fall through to `there`.

## Checks

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and `pnpm test` (1327 API + 844 mobile) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)