### PR TITLE
Call the streak board a leaderboard

### DIFF
--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -1773,12 +1773,12 @@ export const ar: Localized<EnMessages> = {
       other: 'تمنح {amount} رمز',
     },
     you: 'أنت',
-    streakTitle: 'جدول السلاسل',
+    streakTitle: 'لوحة الصدارة',
     metricCurrent: 'الآن',
     metricLongest: 'الأطول',
     streakPicker: 'ترتيب السلاسل',
     streakEmptyTitle: 'لا سلاسل بعد',
-    streakEmptyBody: 'احضر يومين متتاليين وستظهر في هذا الجدول.',
+    streakEmptyBody: 'احضر يومين متتاليين وستظهر في هذه اللوحة.',
   },
 
   badges: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -1558,12 +1558,12 @@ export const de: Localized<EnMessages> = {
     badges: 'Abzeichen',
     pays: { one: 'Bringt {amount} Token', other: 'Bringt {amount} Token' },
     you: 'Du',
-    streakTitle: 'Serien-Tabelle',
+    streakTitle: 'Bestenliste',
     metricCurrent: 'Jetzt',
     metricLongest: 'Längste',
     streakPicker: 'Serien-Rangliste',
     streakEmptyTitle: 'Noch keine Serien',
-    streakEmptyBody: 'Sei an zwei Tagen hintereinander da, dann stehst du in dieser Tabelle.',
+    streakEmptyBody: 'Sei an zwei Tagen hintereinander da, dann stehst du in dieser Liste.',
   },
 
   badges: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -1597,12 +1597,12 @@ export const en = {
     badges: 'Badges',
     pays: { one: 'Pays {amount} token', other: 'Pays {amount} tokens' },
     you: 'You',
-    streakTitle: 'Streak table',
+    streakTitle: 'Leaderboard',
     metricCurrent: 'Now',
     metricLongest: 'Longest',
     streakPicker: 'Streak ranking',
     streakEmptyTitle: 'No streaks yet',
-    streakEmptyBody: 'Show up on two days in a row and you are on this table.',
+    streakEmptyBody: 'Show up on two days in a row and you are on this board.',
   },
 
   badges: {

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -1522,12 +1522,12 @@ export const es: Localized<EnMessages> = {
     badges: 'Insignias',
     pays: { one: 'Da {amount} ficha', other: 'Da {amount} fichas' },
     you: 'Tú',
-    streakTitle: 'Tabla de rachas',
+    streakTitle: 'Clasificación',
     metricCurrent: 'Ahora',
     metricLongest: 'Más larga',
     streakPicker: 'Clasificación de rachas',
     streakEmptyTitle: 'Aún no hay rachas',
-    streakEmptyBody: 'Aparece dos días seguidos y estarás en esta tabla.',
+    streakEmptyBody: 'Aparece dos días seguidos y estarás en esta clasificación.',
   },
 
   badges: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -1536,12 +1536,12 @@ export const fr: Localized<EnMessages> = {
     badges: 'Badges',
     pays: { one: 'Rapporte {amount} jeton', other: 'Rapporte {amount} jetons' },
     you: 'Toi',
-    streakTitle: 'Classement des séries',
+    streakTitle: 'Classement',
     metricCurrent: 'En cours',
     metricLongest: 'La plus longue',
     streakPicker: 'Classement des séries',
     streakEmptyTitle: 'Pas encore de séries',
-    streakEmptyBody: 'Viens deux jours de suite et tu figureras dans ce tableau.',
+    streakEmptyBody: 'Viens deux jours de suite et tu figureras dans ce classement.',
   },
 
   badges: {

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -1521,12 +1521,12 @@ export const ptBR: Localized<EnMessages> = {
     badges: 'Insígnias',
     pays: { one: 'Paga {amount} ficha', other: 'Paga {amount} fichas' },
     you: 'Você',
-    streakTitle: 'Tabela de sequências',
+    streakTitle: 'Classificação',
     metricCurrent: 'Agora',
     metricLongest: 'Mais longa',
     streakPicker: 'Ranking de sequências',
     streakEmptyTitle: 'Ainda não há sequências',
-    streakEmptyBody: 'Apareça dois dias seguidos e você entra nesta tabela.',
+    streakEmptyBody: 'Apareça dois dias seguidos e você entra nesta classificação.',
   },
 
   badges: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -1696,7 +1696,7 @@ export const ru: Localized<EnMessages> = {
       other: 'Даёт {amount} жетона',
     },
     you: 'Ты',
-    streakTitle: 'Таблица серий',
+    streakTitle: 'Таблица лидеров',
     metricCurrent: 'Сейчас',
     metricLongest: 'Самая длинная',
     streakPicker: 'Рейтинг серий',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -1527,7 +1527,7 @@ export const tr: Localized<EnMessages> = {
     badges: 'Rozetler',
     pays: { one: '{amount} jeton kazandırır', other: '{amount} jeton kazandırır' },
     you: 'Sen',
-    streakTitle: 'Seri tablosu',
+    streakTitle: 'Liderlik tablosu',
     metricCurrent: 'Şu an',
     metricLongest: 'En uzun',
     streakPicker: 'Seri sıralaması',


### PR DESCRIPTION
The streak page's second row opened a screen titled **Streak table**, while the same kind of screen under Tokens is called **Leaderboard**. Now both use the word people already know; the streak one keeps its own two tabs (Now / Longest) and its own empty state.

- `leaderboard.streakTitle` → the locale's existing word for *Leaderboard* in all eight languages
- `leaderboard.streakEmptyBody` followed the name where it said "this table" (en, de, es, fr, pt-BR, ar; tr and ru already read fine)

No component changed — both the row on the streak page and the screen header read the same key.

Checks: `tsc --noEmit`, eslint, prettier and the mobile i18n tests (48) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)