### PR TITLE
Double the campaign warm-up ramp, and stop greeting people by their address

### DIFF
--- a/apps/api/src/modules/notifications/audience.test.ts
+++ b/apps/api/src/modules/notifications/audience.test.ts
@@ -214,6 +214,24 @@ describe('what a Resend audience should contain', () => {
     expect(byId.get(typed)?.name).toBe('langx_abcd')
   })
 
+  /**
+   * The other shape of no-name: v1 stored the address itself whenever the
+   * provider handed over nothing, which on Apple's relay reads "Hi
+   * 8yr8jmtvmn@privaterelay.appleid.com,".
+   */
+  it('drops a name that is only the address again', async () => {
+    const relay = await newAccount({
+      fromV1: true,
+      profile: false,
+      email: '8yr8jmtvmn@privaterelay.appleid.com',
+      name: '8yr8jmtvmn@privaterelay.appleid.com',
+    })
+
+    const plan = await audiencePlan(handle.db, 'v1')
+    const byId = new Map(plan.contacts.map((contact) => [contact.userId, contact]))
+    expect(byId.get(relay)?.name).toBeUndefined()
+  })
+
   it('excludes guests and addresses nobody proved', async () => {
     await newAccount({ notifications: optedIn, verified: false })
     await newAccount({ notifications: optedIn, anonymous: true, email: 'g@guest.langx.invalid' })

--- a/apps/api/src/modules/notifications/audience.ts
+++ b/apps/api/src/modules/notifications/audience.ts
@@ -112,14 +112,22 @@ export function audienceAction(
  * addresses a stranger by a serial number: "Hi langx_6430,". Treated as no
  * name at all, which is what it is, so `{{firstName}}` falls back to "there".
  *
+ * The other 40 carry their own email address as their name, 34 of them an
+ * Apple relay address, and they read worse still: "Hi 8yr8jmtvmn@privaterelay
+ * .appleid.com,". v1 stored the address whenever the provider handed over no
+ * name, so this is the same absence wearing a different mask.
+ *
  * Only the v1 row's own name is filtered. A `displayName` on a profile was
  * typed by somebody, whatever it looks like.
  */
 const V1_GENERATED_NAME = /^langx_[0-9a-f]{4}$/
+const LOOKS_LIKE_ADDRESS = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
-function chosenName(name: string | undefined): string | undefined {
+export function chosenName(name: string | undefined): string | undefined {
   if (!name) return undefined
-  return V1_GENERATED_NAME.test(name) ? undefined : name
+  const trimmed = name.trim()
+  if (V1_GENERATED_NAME.test(trimmed) || LOOKS_LIKE_ADDRESS.test(trimmed)) return undefined
+  return name
 }
 
 /**

--- a/apps/api/src/modules/notifications/campaignQueue.test.ts
+++ b/apps/api/src/modules/notifications/campaignQueue.test.ts
@@ -197,12 +197,12 @@ describe('the campaign queue', () => {
   })
 
   it("spreads the day's budget over the ticks left in the window", async () => {
-    // More people than the first day's budget allows in one tick.
-    for (let index = 0; index < 30; index++) await newAccount()
-    await queued()
-    // 09:00 → 22 half-hour ticks left until 20:00; 250 / 22 = 12 per tick.
+    // 09:00 → 22 half-hour ticks left until 20:00, so a tick takes the day's
+    // budget divided by 22. More people than two of those ticks can hold.
     const firstDayBudget = CAMPAIGN_WARMUP_PER_DAY[0]
     const perTick = Math.ceil(firstDayBudget / 22)
+    for (let index = 0; index < perTick * 2 + 1; index++) await newAccount()
+    await queued()
     expect(await runCampaignQueuePass(handle.db, ctx, MORNING)).toEqual({ sent: perTick })
     // The next tick sees what is already sent today and keeps the same pace.
     const next = new Date(MORNING.getTime() + 30 * 60 * 1000)

--- a/apps/api/src/modules/notifications/campaignQueue.ts
+++ b/apps/api/src/modules/notifications/campaignQueue.ts
@@ -17,7 +17,7 @@ import {
 import { localeFor } from '../profiles/localeFor'
 import type { JobRun } from '../tokens/pool'
 import type { SchedulerLogger } from '../tokens/poolScheduler'
-import { audiencePlan } from './audience'
+import { audiencePlan, chosenName } from './audience'
 import {
   campaignRecipients,
   claimCampaignRecipients,
@@ -212,10 +212,13 @@ export async function resolveCampaignAudience(
         skipped.suppressed++
         continue
       }
+      // Five of the 837 carry their address as their name, same as the live
+      // v1 rows do; `chosenName` is what decides that there for the letter.
+      const name = chosenName(row.name)
       candidates.push({
         id: row._id,
         email: row.email,
-        firstName: row.name,
+        ...(name ? { firstName: name } : {}),
         scope: 'v1contact',
         hasProfile: false,
       })

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3671,7 +3671,7 @@ and the throttle does not know a verification link from a broadcast.
 
 So the script now writes the campaign into `campaignQueue` and the
 notification scheduler sends it: a day's budget from
-`CAMPAIGN_WARMUP_PER_DAY` (250, 500, 1000, 2000, 4000), spread over the
+`CAMPAIGN_WARMUP_PER_DAY` (500, 1000, 2000, 4000, 8000), spread over the
 half-hour ticks left in `CAMPAIGN_SEND_WINDOW_UTC`, so a process restarted at
 noon carries on at the right pace rather than starting the day over. Two
 instances are serialised through `jobRuns` on the tick's half-hour — that is

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -184,7 +184,7 @@ month.
 | `v1deleted` | the addresses v1's deleted accounts left in `v1DeletedContacts`           |
 
 `--exclude-returned` drops anybody who has since onboarded. Warm-up ramp:
-250 / 500 / 1000 / 2000 / 4000 a day, 08–20 UTC. `--pause` stops the next
+500 / 1000 / 2000 / 4000 / 8000 a day, 08–20 UTC. `--pause` stops the next
 tick.
 
 ---

--- a/packages/shared/src/campaigns.ts
+++ b/packages/shared/src/campaigns.ts
@@ -33,11 +33,16 @@ export type CampaignSource = (typeof CAMPAIGN_SOURCES)[number]
  * A ramp rather than one burst, and not because of any quota: mailbox
  * providers rate a domain on what it did yesterday, and one that goes from
  * twenty mails a day to four thousand in an hour gets throttled — with the
- * penalty landing on the verification links as well as the campaign. Five
+ * penalty landing on the verification links as well as the campaign. Three
  * days for a few thousand people is the price of the transactional mail
  * still arriving.
+ *
+ * Doubled on 11 September 2026, Behic's call, after the first day of the v1
+ * campaign was spent on Apple relay addresses that bounced. The shape is
+ * what matters — each day at most twice the one before — and the domain had
+ * by then sent a few hundred a day for a fortnight rather than twenty.
  */
-export const CAMPAIGN_WARMUP_PER_DAY = [250, 500, 1000, 2000, 4000] as const
+export const CAMPAIGN_WARMUP_PER_DAY = [500, 1000, 2000, 4000, 8000] as const
 
 /** The day's budget for a campaign that started `dayIndex` days ago. */
 export function campaignDayBudget(dayIndex: number): number {


### PR DESCRIPTION
Two things the running v1 campaign asked for.

## The ramp doubles

The campaign started at 16:58 UTC today and spent its first hour on Apple
private relay addresses that bounced — `send.langx.io` was not a registered
email source in Apple's portal, so every `@privaterelay.appleid.com`
recipient answered `550 5.1.1 unauthorized sender`. That is registered now,
but the day it cost is not coming back.

So a day's budget goes **500 / 1000 / 2000 / 4000 / 8000** instead of half
that: three days for the 3,897 v1 accounts rather than five. The shape is
what the ramp was for — no day more than twice the one before, so a mailbox
provider never sees the domain jump — and that is unchanged. What moved is
the floor it starts from: the comment's reasoning ("twenty mails a day") was
written before the domain had been sending a few hundred a day for a
fortnight.

`campaignQueue.test.ts` fixed 30 accounts against the first day's budget,
which is one tick's worth at the new pace; it now derives the fixture from
the budget so it holds at any ramp.

## "Hi 8yr8jmtvmn@privaterelay.appleid.com,"

Forty of the 3,901 pre-created rows carry their own address as their name,
34 of them an Apple relay address. v1 stored the address whenever the
provider handed over no name, so it is the same absence `langx_6430` already
stood for — `chosenName` reads both as no name now, and the letter falls
back to "Hi there,". Eight of the forty have been mailed already and all
eight bounced, so nobody has actually read one.

The deleted-account list carries five of the same and read `row.name`
directly rather than through the filter; it goes through `chosenName` too.

Docs that quote the ramp (`docs/decisions.md`, `docs/notifications.md`)
follow.

**Deploying this needs the campaign paused first** — the shutdown hook does
not wait for an in-flight tick, and a tick interrupted mid-send marks people
sent who never got the mail. Pause, wait a minute, deploy, resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)