### PR TITLE
Tell a failed Discover request apart from an empty one

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/discover.tsx
+++ b/apps/mobile/app/(app)/(tabs)/discover.tsx
@@ -16,6 +16,7 @@ import { ApiRequestError } from '../../../src/api/client'
 import type { DiscoveryItem } from '../../../src/api/types'
 import { BoostedProfiles } from '../../../src/components/BoostedProfiles'
 import { DiscoveryCardSkeleton } from '../../../src/components/skeletons/DiscoveryCardSkeleton'
+import { LoadFailed } from '../../../src/components/LoadFailed'
 import { Avatar } from '../../../src/components/ui/Avatar'
 import { PeopleSearch, PeopleSearchResults } from '../../../src/components/PeopleSearch'
 import { Chip } from '../../../src/components/ui/Chip'
@@ -478,6 +479,24 @@ export default function DiscoverScreen() {
         /* In the list's place, in normal flow — not floated over it. See
            `PeopleSearch` for what floating cost. */
         <PeopleSearchResults from="/(app)/(tabs)/discover" />
+      ) : state === 'empty' && query.isError ? (
+        /**
+         * A request that failed is not an empty app, and this screen said it
+         * was. `listState` folds an error into `'empty'` on purpose — it
+         * leaves the case to the caller — and the caller went straight to
+         * `ListEmptyComponent`, so a timeout told somebody whose request never
+         * arrived that nobody matches their languages, and to loosen filters
+         * they had not set.
+         *
+         * `state` rather than `items.length`, so a failed *second* page keeps
+         * the rows already on screen: `listState` answers `'content'` whenever
+         * there are any.
+         *
+         * Below `locationRevoked`, which is also an error but is recoverable
+         * in one tap and owns its own panel, and below `searching`, where
+         * `PeopleSearchResults` owns its own states.
+         */
+        <LoadFailed onRetry={() => void query.refetch()} />
       ) : (
         <FlatList
           data={items}


### PR DESCRIPTION
## What

Discover feeds `isError` into `listState` and then never looks at it again. `listState` folds an error into `'empty'` on purpose — [its own test](apps/mobile/src/lib/listState.test.ts) says it *"leaves an empty successful result to the caller's empty state"* — and this caller never wrote that branch. So with a failed request and no rows, the `FlatList` fell through to `ListEmptyComponent` and showed:

> **Nobody here yet**
> People whose languages match yours in both directions show up here. Try loosening the filters.

after a request that never succeeded, about filters the reader never set.

Discover is the first screen a new account lands on, so an unknown share of the "new users see an empty screen" reports were never an empty pool — they were a timeout, a cold machine or a flaky connection. Nothing in PostHog could separate the two either.

## The change

One branch and one import. `LoadFailed` already exists for exactly this and is used by `me.tsx`, `wallet/index.tsx`, `wallet/store.tsx`, `edit-profile.tsx`, `share-profile.tsx` and `welcome-back.tsx`; Discover was the outlier.

Ordering is the whole correctness argument, and the branch sits:

- **below `locationRevoked`** — also an error, but recoverable in one tap and owner of its own panel;
- **below `searching`** — `PeopleSearchResults` owns its own states;
- and keys off **`state`, not `items.length`**, so a failed *second* page keeps the rows already on screen (`listState` answers `'content'` whenever there are any).

`nearbyStuck` is unaffected: the query is `enabled: false` there, so there is no error to report.

**No new strings.** `errors.loadFailed` and `common.tryAgain` are already translated in all eight locales, so no locale file changes.

## Verification

Local API patched to return 500 for `GET /discovery` only, so auth and every other route stayed healthy:

| Case | Before | After |
| --- | --- | --- |
| Server failing, no rows | "Nobody here yet / Try loosening the filters" | "Could not load this…" + **Try again** |
| Successful but genuinely empty (`{items: []}`) | "Nobody here yet" | "Nobody here yet" (unchanged) |
| Try again after the route is restored | — | list loads |

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and `pnpm test` (2507 tests) all pass.

No unit test accompanies this: mobile vitest cannot load `react-native`, the repo has no screen/component tests, and the change is a JSX branch. `listState` is untouched, so its existing test still covers the decision underneath.

## Not in scope

The empty state is still button-less and `discover.emptyBody`'s advice is still wrong for a fresh account — those are separate causes of the same complaint.

**The same defect is in six sibling screens**, all of which feed `isError` to `listState` and none of which renders `LoadFailed`: `chats.tsx:127`, `feed.tsx:145`, `corrections.tsx:69`, `chat-media.tsx:128`, `post/[id].tsx:183`, `chat/[id].tsx:296`. Discover goes first because it is what a new account sees. If all seven are wanted, a `'failed'` variant on `listState` becomes the right shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)