### PR TITLE
Raise the campaign ramp to 1000 a day on the first

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3671,7 +3671,7 @@ and the throttle does not know a verification link from a broadcast.
 
 So the script now writes the campaign into `campaignQueue` and the
 notification scheduler sends it: a day's budget from
-`CAMPAIGN_WARMUP_PER_DAY` (500, 1000, 2000, 4000, 8000), spread over the
+`CAMPAIGN_WARMUP_PER_DAY` (1000, 2000, 4000, 8000), spread over the
 half-hour ticks left in `CAMPAIGN_SEND_WINDOW_UTC`, so a process restarted at
 noon carries on at the right pace rather than starting the day over. Two
 instances are serialised through `jobRuns` on the tick's half-hour — that is

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -184,7 +184,7 @@ month.
 | `v1deleted` | the addresses v1's deleted accounts left in `v1DeletedContacts`           |
 
 `--exclude-returned` drops anybody who has since onboarded. Warm-up ramp:
-500 / 1000 / 2000 / 4000 / 8000 a day, 08–20 UTC. `--pause` stops the next
+1000 / 2000 / 4000 / 8000 a day, 08–20 UTC. `--pause` stops the next
 tick.
 
 ---

--- a/packages/shared/src/campaigns.ts
+++ b/packages/shared/src/campaigns.ts
@@ -37,12 +37,14 @@ export type CampaignSource = (typeof CAMPAIGN_SOURCES)[number]
  * days for a few thousand people is the price of the transactional mail
  * still arriving.
  *
- * Doubled on 11 September 2026, Behic's call, after the first day of the v1
- * campaign was spent on Apple relay addresses that bounced. The shape is
- * what matters — each day at most twice the one before — and the domain had
- * by then sent a few hundred a day for a fortnight rather than twenty.
+ * Raised twice on 11 September 2026, Behic's call both times, after the v1
+ * campaign's first day went to Apple relay addresses that bounced and was
+ * lost. The shape is what the ramp is for — each day twice the one before,
+ * never a jump — and that is intact; the floor moved because the reasoning
+ * above was written when the domain sent twenty mails a day and it had been
+ * sending a few hundred for a fortnight by then.
  */
-export const CAMPAIGN_WARMUP_PER_DAY = [500, 1000, 2000, 4000, 8000] as const
+export const CAMPAIGN_WARMUP_PER_DAY = [1000, 2000, 4000, 8000] as const
 
 /** The day's budget for a campaign that started `dayIndex` days ago. */
 export function campaignDayBudget(dayIndex: number): number {


### PR DESCRIPTION
A day's budget goes **1000 / 2000 / 4000 / 8000**.

The v1 campaign lost its first day to Apple relay addresses that bounced
(`send.langx.io` was not a registered email source in Apple's portal — fixed
and verified this afternoon). #1312 doubled the ramp to get that day back;
this raises the first day again so today reaches 1000 and tomorrow 2000,
which is what Behic asked for.

The shape is unchanged — each day twice the one before, never a jump — and
the floor it starts from is what moved. The comment's reasoning was written
when langx.io sent twenty mails a day; it has been sending a few hundred for
a fortnight.

Worth stating plainly: this is four times the original first day. The risk
is not bounces, it is spam-folder placement, and with open tracking off we
cannot measure it. Behic's call, twice.

Docs that quote the numbers follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)