### PR TITLE
Leave guests out of the badge round-up

### DIFF
--- a/apps/api/src/modules/notifications/badges.test.ts
+++ b/apps/api/src/modules/notifications/badges.test.ts
@@ -265,6 +265,49 @@ describe('the badge round-up', () => {
     expect(await notifiedIdsOf(healthy)).toBeDefined()
   })
 
+  /**
+   * A guest is not an audience, and this was the one pass that walked them.
+   *
+   * The second row is the shape a guest is actually found in on the dev
+   * database — no `streak` at all — which is how this surfaced: the round-up
+   * reached it, `getBadgeSummary` read `streak.longest` off nothing, and the
+   * pass logged a skipped profile on every tick. Both rows are asserted, so
+   * the rule stays "a guest is never a candidate" rather than "a guest that
+   * happens to be readable is harmless".
+   */
+  it('leaves a guest out of the audience entirely', async () => {
+    for (const guest of [
+      { _id: new ObjectId().toHexString(), streak: { current: 0, longest: 0 } },
+      { _id: new ObjectId().toHexString() },
+    ]) {
+      await handle.db.collection(COLLECTIONS.profiles).insertOne({
+        ...guest,
+        guest: true,
+        handle: `guest:${guest._id}`,
+        displayName: '',
+        // Otherwise the hour gate hides the bug rather than the fix doing it.
+        timezone: zone,
+        entitlement: { tier: 'free' },
+        settings: { discoverable: false, notifications: {} },
+        stats: { lastActiveAt: now, messagesSent: 0 },
+        createdAt: new Date('2026-09-01T00:00:00Z'),
+      } as never)
+    }
+    const healthy = await newProfile({ messagesSent: 5000, withDevice: true })
+
+    const warn = vi.fn()
+    const result = await runBadgeRoundUpPass(handle.db, senders, now, { warn })
+
+    expect(result).toEqual({ sent: 0, seeded: 1, failed: 0 })
+    expect(warn).not.toHaveBeenCalled()
+    expect(await notifiedIdsOf(healthy)).toBeDefined()
+    const guests = await handle.db
+      .collection<Profile>(COLLECTIONS.profiles)
+      .find({ guest: true })
+      .toArray()
+    expect(guests.map((row) => row.stats?.notifiedBadgeIds)).toEqual([undefined, undefined])
+  })
+
   it('leaves alone anyone for whom it is not the round-up hour', async () => {
     await newProfile({
       withDevice: true,

--- a/apps/api/src/modules/notifications/badges.ts
+++ b/apps/api/src/modules/notifications/badges.ts
@@ -52,6 +52,13 @@ export async function runBadgeRoundUpPass(
   const candidates = await profiles
     .find({
       deletedAt: { $exists: false },
+      // A guest is nobody to notify: no address, no device, and a row that
+      // `purgeStaleGuests` deletes on its own timer. Left in, the round-up
+      // seeds `notifiedBadgeIds` onto a profile that will not exist to read
+      // it, and pays `getBadgeSummary`'s three reads a head to do it. The
+      // other two passes that walk every profile — the newsletter and the
+      // promotions sweep — bound themselves the same way.
+      guest: { $exists: false },
       // Bounds the scan; `notificationsAllowed` decides. Only the oldest
       // stored shape is a bare `false` this can read.
       'settings.notifications': { $ne: false },


### PR DESCRIPTION
Found while verifying an unrelated Discover change. Pre-existing; not caused by recent work.

## What was happening

Every scheduler tick against `langx_dev`:

```
WARN: badge round-up skipped one profile
    userId: "guestseed0001"
    err: TypeError: Cannot read properties of undefined (reading 'longest')
        at getBadgeSummary (apps/api/src/modules/tokens/badges.ts:89:28)
```

## Which rows, and why

One row in `langx_dev`, out of 15: `guestseed0001`. It lacks `streak`, `stats` and `updatedAt`, has only two of the four `privacy` flags, and carries `settings.notifications: true` — the retired bare-boolean shape.

That is not what `ensureGuestProfile` writes, and never was: its [first commit](https://github.com/langx/langx/commit/53202594) (31 Aug 2026) already wrote `streak`, `stats`, `updatedAt` and object-shaped notifications. No version of the guest path can produce this row. It is a hand-made dev fixture from the local test rig.

Every other writer of the collection writes a streak too — `createProfile`, `legacyRestore`'s `buildProfile`, and the official-account path. So the `Profile` type is right to require the field.

## The actual defect

`runBadgeRoundUpPass` is the only notification pass that does not exclude guests:

| pass | bounds on `guest` |
| --- | --- |
| `runNewsletterPass` | `guest: { $exists: false }` |
| `runPromotionsPass` | `guest: { $exists: false }` |
| `runVerifyReminderPass` | sends nothing to a guest |
| `buildAudience` | skips and counts them |
| **`runBadgeRoundUpPass`** | **nothing** |

A guest has no address, no device and no badges worth the name, and the row is deleted by `purgeStaleGuests`. The pass was seeding `notifiedBadgeIds` onto rows that will not exist to read it, and paying `getBadgeSummary`'s three reads a head to do it — and it is what put a guest row in front of a reader written for self-service.

The other two unguarded sweeps are already safe by their own queries: `streakReminderCandidates` filters `'streak.current': { $gte: 1 }`, and discovery filters `discoverable: true` (a guest is `false`).

## Writer, or defensive reader?

Neither. No writer is broken, so there is nothing to fix there; and `getBadgeSummary` is right to trust the type — the per-profile `try`/`catch` that caught this is doing exactly the job [its comment](https://github.com/langx/langx/blob/main/apps/api/src/modules/notifications/badges.ts#L66-L80) claims, and already has a test. The defect was the missing bound, so the fix is one line in the query.

Not verified: whether production carries any streak-less row. Reading the prod DB was blocked here. No writer can produce one, so I expect zero — worth one query before this is considered closed.

## Safety

A guest row is never converted in place: `DELETE /profiles/guest` deletes it and signup builds a fresh profile. So `guest: true` is terminal for a row and this can never exclude a real account. `notifiedBadgeIds` is written and read only inside this pass.

## Test

`leaves a guest out of the audience entirely` — a well-formed guest and one in the shape actually found on dev, both given the round-up hour so the hour gate cannot mask the bug.

Without the fix: `{ sent: 0, seeded: 2, failed: 1 }` — both symptoms, the crash and the guest treated as an audience.
With it: `{ sent: 0, seeded: 1, failed: 0 }`, no warning, no `notifiedBadgeIds` on either guest.

## Checks

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` all clean. `@langx/api` suite: 1345 passed, 8 skipped. One file (`magicLink.test.ts`) failed to start on a mongodb-memory-server port collision with zero test failures; it passes on its own.

The `guestseed0001` row is still malformed — harmless now that nothing walks it, and I have not touched the dev database. Say the word if you want it repaired or deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)