### PR TITLE
Tell a failed list apart from an empty one, everywhere

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/chats.tsx
+++ b/apps/mobile/app/(app)/(tabs)/chats.tsx
@@ -14,6 +14,7 @@ import { Tip } from '../../../src/components/Tip'
 import { SwipeableRow } from '../../../src/components/SwipeableRow'
 import { ConversationRowSkeleton } from '../../../src/components/skeletons/ConversationRowSkeleton'
 import { Avatar } from '../../../src/components/ui/Avatar'
+import { LoadFailed } from '../../../src/components/LoadFailed'
 import { EmptyState } from '../../../src/components/ui/EmptyState'
 import { Screen } from '../../../src/components/ui/Screen'
 import { SegmentedControl } from '../../../src/components/ui/SegmentedControl'
@@ -178,6 +179,13 @@ export default function ChatsScreen() {
             <ConversationRowSkeleton key={key} />
           ))}
         </View>
+      ) : state === 'failed' ? (
+        /*
+         * Otherwise the empty state below tells somebody with a full list that
+         * they have no chats at all, and offers them the free plan's daily
+         * allowance for starting one — advice about a screen that never loaded.
+         */
+        <LoadFailed onRetry={() => void conversations.refetch()} />
       ) : (
         <FlatList
           data={items}

--- a/apps/mobile/app/(app)/(tabs)/discover.tsx
+++ b/apps/mobile/app/(app)/(tabs)/discover.tsx
@@ -479,18 +479,11 @@ export default function DiscoverScreen() {
         /* In the list's place, in normal flow — not floated over it. See
            `PeopleSearch` for what floating cost. */
         <PeopleSearchResults from="/(app)/(tabs)/discover" />
-      ) : state === 'empty' && query.isError ? (
+      ) : state === 'failed' ? (
         /**
-         * A request that failed is not an empty app, and this screen said it
-         * was. `listState` folds an error into `'empty'` on purpose — it
-         * leaves the case to the caller — and the caller went straight to
-         * `ListEmptyComponent`, so a timeout told somebody whose request never
-         * arrived that nobody matches their languages, and to loosen filters
-         * they had not set.
-         *
-         * `state` rather than `items.length`, so a failed *second* page keeps
-         * the rows already on screen: `listState` answers `'content'` whenever
-         * there are any.
+         * A request that failed is not an empty app. Without this branch a
+         * timeout told somebody whose request never arrived that nobody
+         * matches their languages, and to loosen filters they had not set.
          *
          * Below `locationRevoked`, which is also an error but is recoverable
          * in one tap and owns its own panel, and below `searching`, where

--- a/apps/mobile/app/(app)/(tabs)/feed.tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed.tsx
@@ -33,6 +33,7 @@ import { LikeButton } from '../../../src/components/LikeButton'
 import { SegmentedControl } from '../../../src/components/ui/SegmentedControl'
 import { TourTarget } from '../../../src/components/TourTarget'
 import { Tip } from '../../../src/components/Tip'
+import { LoadFailed } from '../../../src/components/LoadFailed'
 import { EmptyState } from '../../../src/components/ui/EmptyState'
 import { Screen } from '../../../src/components/ui/Screen'
 import { dedupeById } from '../../../src/lib/dedupeById'
@@ -315,6 +316,13 @@ export default function FeedScreen() {
             <FeedPostSkeleton key={key} index={index} />
           ))}
         </View>
+      ) : state === 'failed' ? (
+        /*
+         * The worst of the empty states to draw over an error: "Everything is
+         * corrected" tells somebody there is no work left when the request for
+         * the work is what failed.
+         */
+        <LoadFailed onRetry={() => void feed.refetch()} />
       ) : (
         <FlatList
           data={items}

--- a/apps/mobile/app/(app)/chat-media.tsx
+++ b/apps/mobile/app/(app)/chat-media.tsx
@@ -21,6 +21,7 @@ import {
 import { useConversationMedia, useMe, type MessageDto } from '../../src/api/queries'
 import { AudioBubble, VideoTile } from '../../src/components/MediaBubble'
 import { PhotoViewer } from '../../src/components/PhotoViewer'
+import { LoadFailed } from '../../src/components/LoadFailed'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
 import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
@@ -171,6 +172,12 @@ export default function ChatMediaScreen() {
 
       {state === 'skeleton' ? (
         <ActivityIndicator style={styles.loading} />
+      ) : state === 'failed' ? (
+        // Before the tab split, because both tabs read the same query: a
+        // failure is the same failure whichever one is open, and `empty`
+        // otherwise promises that media "will collect here" over a request
+        // that never arrived.
+        <LoadFailed onRetry={() => void page.refetch()} />
       ) : tab === 'visual' ? (
         <FlatList
           key="visual"

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -47,6 +47,7 @@ import { useKeyboardInset } from '../../../src/hooks/useKeyboardInset'
 import { PresenceLine } from '../../../src/components/PresenceLine'
 import { ChatComposer } from '../../../src/components/ChatComposer'
 import { ComposerHint } from '../../../src/components/ComposerHint'
+import { LoadFailed } from '../../../src/components/LoadFailed'
 import { MessageBubble } from '../../../src/components/MessageBubble'
 import { PhotoViewer } from '../../../src/components/PhotoViewer'
 import {
@@ -1542,7 +1543,22 @@ export default function ChatScreen() {
           own box rather than the screen's — that keeps it above the composer
           whatever height the composer has grown to. */}
         <View style={styles.listWrap}>
-          {state === 'skeleton' ? (
+          {state === 'failed' ? (
+            /*
+             * A thread that did not load drew as an empty one — no messages,
+             * composer ready, exactly what a conversation nobody has written
+             * in looks like. The two must not share a picture: one invites you
+             * to say hello, the other loses what was already said.
+             *
+             * The same `flex: 1` the skeleton needs, and for the same reason.
+             * The composer stays live: sending does not depend on the history
+             * having arrived, and taking it away would strand somebody who
+             * only wanted to reply.
+             */
+            <View style={[styles.list, styles.skeletonFill]}>
+              <LoadFailed onRetry={() => void thread.refetch()} />
+            </View>
+          ) : state === 'skeleton' ? (
             // `flex: 1` because the FlatList it stands in for takes the whole
             // height; without it the composer rides up under the placeholders and
             // then drops when the real thread arrives.
@@ -1765,7 +1781,11 @@ export default function ChatScreen() {
             placeholder={
               correcting
                 ? t('chat.writeCorrection')
-                : items.length === 0 && partner
+                : // `state`, not `items.length`: a thread that failed to load
+                  // also has no rows, and inviting somebody to say hello to a
+                  // person they have been talking to for months is the same
+                  // wrong answer the list above used to give.
+                  state === 'empty' && partner
                   ? t('chat.sayHello', { name: partner.displayName })
                   : t('chat.writeMessage')
             }

--- a/apps/mobile/app/(app)/corrections.tsx
+++ b/apps/mobile/app/(app)/corrections.tsx
@@ -3,6 +3,7 @@ import { ActivityIndicator, FlatList, Pressable, Text, View } from 'react-native
 import { router } from 'expo-router'
 import { useCorrectionsWritten, useMyPosts, type MessageDto } from '../../src/api/queries'
 import type { FeedPost } from '../../src/api/types'
+import { LoadFailed } from '../../src/components/LoadFailed'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
 import { Skeleton } from '../../src/components/ui/Skeleton'
@@ -97,6 +98,10 @@ export default function WritingScreen() {
             </View>
           ))}
         </View>
+      ) : state === 'failed' ? (
+        // Above the empty state rather than folded into it: "No corrections
+        // yet" is news about your account, and a failed request is not.
+        <LoadFailed onRetry={() => void active.refetch()} />
       ) : state === 'empty' ? (
         <EmptyState
           icon={tab === 'corrections' ? 'edit-3' : 'message-square'}

--- a/apps/mobile/app/(app)/post/[id].tsx
+++ b/apps/mobile/app/(app)/post/[id].tsx
@@ -25,6 +25,7 @@ import {
 import type { Media, PostCorrection, PronunciationAnswer } from '../../../src/api/types'
 import { AudioBubble, MediaGallery } from '../../../src/components/MediaBubble'
 import { PhotoViewer } from '../../../src/components/PhotoViewer'
+import { LoadFailed } from '../../../src/components/LoadFailed'
 import { PostThreadSkeleton } from '../../../src/components/skeletons/PostThreadSkeleton'
 import { Avatar } from '../../../src/components/ui/Avatar'
 import { Button } from '../../../src/components/ui/Button'
@@ -369,7 +370,20 @@ export default function PostScreen() {
         }
       />
 
-      {state === 'skeleton' || !post ? (
+      {query.isError && !post ? (
+        /*
+         * `!post` rather than `state`, because the `|| !post` below is what
+         * made this the worst of the seven: a failed load leaves `post`
+         * undefined forever, so the condition stayed true and the screen
+         * pulsed placeholders that were never going to resolve. The pronounce
+         * tab counts its rows from a different query, so `state` alone can be
+         * `'content'` while the post itself never arrived.
+         *
+         * A post that is already in hand survives a failed refetch and still
+         * renders below.
+         */
+        <LoadFailed onRetry={() => void query.refetch()} />
+      ) : state === 'skeleton' || !post ? (
         <PostThreadSkeleton />
       ) : (
         <FlatList

--- a/apps/mobile/src/lib/listState.test.ts
+++ b/apps/mobile/src/lib/listState.test.ts
@@ -19,12 +19,27 @@ describe('listState', () => {
     expect(listState({ isPending: true, isError: false, itemCount: 20 })).toBe('content')
   })
 
+  /** And a page two that fails must not throw away page one either. */
+  it('keeps showing content when a later page fails', () => {
+    expect(listState({ isPending: false, isError: true, itemCount: 20 })).toBe('content')
+  })
+
   it('leaves an empty successful result to the caller`s empty state', () => {
+    expect(listState({ isPending: false, isError: false, itemCount: 0 })).toBe('empty')
+  })
+
+  /**
+   * The distinction the callers exist to draw: "nothing here" is news the
+   * reader can act on, "it did not load" is a button. Folding the second into
+   * the first is what made a timeout read as an empty app.
+   */
+  it('tells a failed request apart from an empty one', () => {
+    expect(listState({ isPending: false, isError: true, itemCount: 0 })).toBe('failed')
     expect(listState({ isPending: false, isError: false, itemCount: 0 })).toBe('empty')
   })
 
   /** A failed refetch is pending-with-nothing; a pulse there promises data that is not coming. */
   it('does not pulse forever over an error', () => {
-    expect(listState({ isPending: true, isError: true, itemCount: 0 })).toBe('empty')
+    expect(listState({ isPending: true, isError: true, itemCount: 0 })).toBe('failed')
   })
 })

--- a/apps/mobile/src/lib/listState.ts
+++ b/apps/mobile/src/lib/listState.ts
@@ -1,4 +1,4 @@
-export type ListState = 'skeleton' | 'empty' | 'content'
+export type ListState = 'skeleton' | 'failed' | 'empty' | 'content'
 
 /**
  * What a list should draw right now.
@@ -9,13 +9,23 @@ export type ListState = 'skeleton' | 'empty' | 'content'
  * with nothing. Only `isPending` — no data for this query key at all — is a
  * skeleton; anything else with rows is content, and the caller's empty state
  * gets the rest.
+ *
+ * `'failed'` was folded into `'empty'` once, and every caller then drew its
+ * empty state over a request that never arrived: a timeout said nobody matched
+ * your languages, that every post was already corrected, that you had no chats.
+ * Those are opposite news and only one of them is the reader's to act on, so
+ * the distinction lives here rather than in a condition each screen has to
+ * remember to write — which is exactly what all seven of them forgot.
  */
 export function listState(input: {
   isPending: boolean
   isError: boolean
   itemCount: number
 }): ListState {
+  // Rows outrank everything below, so a failed *second* page leaves the list
+  // that is already on screen alone.
   if (input.itemCount > 0) return 'content'
-  if (input.isPending && !input.isError) return 'skeleton'
+  if (input.isError) return 'failed'
+  if (input.isPending) return 'skeleton'
   return 'empty'
 }


### PR DESCRIPTION
Follow-up to #1314, which fixed Discover alone. The same hole was in six more screens, and one patched caller out of seven is the shape that argues for moving the distinction into `listState` itself.

## The bug

`listState` folded an error into `'empty'` and left the case to the caller. Every caller forgot to write that branch, so a timeout drew whatever "nothing here" panel the screen had — and each one was a different wrong thing to say:

| Screen | What a failed request said |
| --- | --- |
| `feed.tsx` | **"Everything is corrected"** — there is no work left, when the request for the work is what failed |
| `chats.tsx` | **"No chats yet"**, plus an offer of the free plan's daily allowance, to somebody with a full list |
| `corrections.tsx` | "No corrections yet" / "Nothing asked yet" |
| `chat-media.tsx` | "Photos and video you send each other will collect here." |
| `chat/[id].tsx` | an empty conversation with a live composer — indistinguishable from one nobody has written in, and the composer then invited you to **"Say hello"** to someone you have been talking to for months |
| `post/[id].tsx` | **placeholders forever.** `state === 'skeleton' \|\| !post` stays true because a failed load never sets `post`. A deleted post opened from a notification did this too. |

## The change

`'failed'` becomes a fourth `ListState`. Rows still outrank everything, so a failed *page two* leaves page one alone. Each screen then renders `LoadFailed` where its own layout wants it — inside the thread's flex box on chat, above the `'empty'` branch on corrections, before the tab split on chat media.

Two places deliberately do not key off `state`:

- **`post/[id]`** uses `query.isError && !post`, because its pronounce tab counts rows from a *second* query, so `state` can be `'content'` while the post itself never arrived.
- **the chat composer placeholder** moves from `items.length === 0` to `state === 'empty'` — same lie, one line, and it falls back to the neutral "Write a message…".

Discover loses its bespoke `state === 'empty' && query.isError` and its now-stale comment.

**No new strings.** `errors.loadFailed` and `common.tryAgain` were already translated in all eight locales.

## Verification

Local API and app, failing one endpoint at a time in the browser so auth and the rest of the app stayed healthy. Every screen was reached the way a user reaches it, with a fresh query:

| Screen | Result |
| --- | --- |
| Discover | retry panel ✅ |
| Feed | retry panel, no longer "Everything is corrected" ✅ |
| Chats | retry panel; **Try again** reloaded the list ✅ |
| Chat thread | retry panel in place of the thread, composer live, placeholder now "Write a message…" ✅ |
| Post | retry panel instead of placeholders forever (tested with a 404 post, the realistic deleted-post case) ✅ |
| Corrections | retry panel ✅ |
| Chat media | retry panel ✅ |
| Feed, genuinely empty 200 | still "Everything is corrected" — the branch does not fire ✅ |

`listState.test.ts` gains cases for the new state, including that content outranks an error. `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` and `pnpm test` (2524 tests) all pass.

## Known, not addressed

React Query retries 5xx and network failures twice, so the retry panel appears roughly 15–20 seconds after the first attempt; until then the screen pulses skeletons. That is `retry: (failureCount) => failureCount < 2` in `_layout.tsx` and is its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)