### PR TITLE
Make the app honest when the phone has no network

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/chats.tsx
+++ b/apps/mobile/app/(app)/(tabs)/chats.tsx
@@ -15,6 +15,7 @@ import { SwipeableRow } from '../../../src/components/SwipeableRow'
 import { ConversationRowSkeleton } from '../../../src/components/skeletons/ConversationRowSkeleton'
 import { Avatar } from '../../../src/components/ui/Avatar'
 import { EmptyState } from '../../../src/components/ui/EmptyState'
+import { LoadFailed } from '../../../src/components/LoadFailed'
 import { Screen } from '../../../src/components/ui/Screen'
 import { SegmentedControl } from '../../../src/components/ui/SegmentedControl'
 import { Skeleton } from '../../../src/components/ui/Skeleton'
@@ -126,6 +127,7 @@ export default function ChatsScreen() {
     isPending: conversations.isPending,
     isError: conversations.isError,
     itemCount: items.length,
+    isPaused: conversations.fetchStatus === 'paused',
   })
 
   return (
@@ -178,6 +180,11 @@ export default function ChatsScreen() {
             <ConversationRowSkeleton key={key} />
           ))}
         </View>
+      ) : state === 'failed' ? (
+        /* Before the list, because `ListEmptyComponent` would otherwise say
+           "No chats yet" to somebody whose request never arrived — and offer
+           to go and start one. */
+        <LoadFailed onRetry={() => void conversations.refetch()} />
       ) : (
         <FlatList
           data={items}

--- a/apps/mobile/app/(app)/(tabs)/discover.tsx
+++ b/apps/mobile/app/(app)/(tabs)/discover.tsx
@@ -296,6 +296,7 @@ export default function DiscoverScreen() {
     isPending: query.isPending,
     isError: query.isError,
     itemCount: items.length,
+    isPaused: query.fetchStatus === 'paused',
   })
   const count = activeCount(effective)
   const tips = useTips()
@@ -479,14 +480,14 @@ export default function DiscoverScreen() {
         /* In the list's place, in normal flow — not floated over it. See
            `PeopleSearch` for what floating cost. */
         <PeopleSearchResults from="/(app)/(tabs)/discover" />
-      ) : state === 'empty' && query.isError ? (
+      ) : state === 'failed' ? (
         /**
          * A request that failed is not an empty app, and this screen said it
-         * was. `listState` folds an error into `'empty'` on purpose — it
-         * leaves the case to the caller — and the caller went straight to
-         * `ListEmptyComponent`, so a timeout told somebody whose request never
-         * arrived that nobody matches their languages, and to loosen filters
-         * they had not set.
+         * was: the caller went straight to `ListEmptyComponent`, so a timeout
+         * told somebody whose request never arrived that nobody matches their
+         * languages, and to loosen filters they had not set. The case moved
+         * into `listState` afterwards, so the other six lists that had it
+         * could be fixed once rather than six times.
          *
          * `state` rather than `items.length`, so a failed *second* page keeps
          * the rows already on screen: `listState` answers `'content'` whenever

--- a/apps/mobile/app/(app)/(tabs)/feed.tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed.tsx
@@ -34,6 +34,7 @@ import { SegmentedControl } from '../../../src/components/ui/SegmentedControl'
 import { TourTarget } from '../../../src/components/TourTarget'
 import { Tip } from '../../../src/components/Tip'
 import { EmptyState } from '../../../src/components/ui/EmptyState'
+import { LoadFailed } from '../../../src/components/LoadFailed'
 import { Screen } from '../../../src/components/ui/Screen'
 import { dedupeById } from '../../../src/lib/dedupeById'
 import { foldCorrection } from '../../../src/lib/feedCache'
@@ -144,6 +145,7 @@ export default function FeedScreen() {
     isPending: feed.isPending,
     isError: feed.isError,
     itemCount: items.length,
+    isPaused: feed.fetchStatus === 'paused',
   })
 
   /** Owned by the screen, not the card: a card is recycled out from under it. */
@@ -315,6 +317,10 @@ export default function FeedScreen() {
             <FeedPostSkeleton key={key} index={index} />
           ))}
         </View>
+      ) : state === 'failed' ? (
+        /* Rather than the per-tab empty state below, which reads as "nobody
+           has posted" — a sentence nobody can act on and which is not true. */
+        <LoadFailed onRetry={() => void feed.refetch()} />
       ) : (
         <FlatList
           data={items}

--- a/apps/mobile/app/(app)/(tabs)/me.tsx
+++ b/apps/mobile/app/(app)/(tabs)/me.tsx
@@ -1,4 +1,5 @@
 import { LoadFailed } from '../../../src/components/LoadFailed'
+import { queryFailed } from '../../../src/lib/listState'
 import { wornCosmetic, TIER_BADGES, TIER_NAMES, tierUnlocking } from '@langx/shared'
 import Feather from '@expo/vector-icons/Feather'
 import { router } from 'expo-router'
@@ -86,7 +87,7 @@ export default function MeScreen() {
   if (!me.data) {
     return (
       <Screen>
-        {me.isError ? (
+        {queryFailed(me) ? (
           <LoadFailed onRetry={() => void me.refetch()} />
         ) : (
           <ProfileSkeleton avatarSize={80} />

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router'
 import { View } from 'react-native'
 import { DeletionBanner } from '../../src/components/DeletionBanner'
+import { OfflineBanner } from '../../src/components/OfflineBanner'
 import { UpdateBanner } from '../../src/components/UpdateBanner'
 import { useTheme } from '../../src/lib/theme'
 import { useNotificationRouting } from '../../src/hooks/useNotificationRouting'
@@ -64,7 +65,13 @@ export default function AppLayout() {
     <View style={{ backgroundColor: colors.bg, flex: 1 }}>
       {/* Above the navigator so a pending deletion is visible on every screen. */}
       <DeletionBanner />
-      {/* After it, and silent while it is up — only one bar takes the top. */}
+      {/*
+        Then the network, which is the more urgent of the two below it: while
+        it is up, the update notice is offering a trip to a store that cannot
+        be reached either.
+      */}
+      <OfflineBanner />
+      {/* After both, and silent while either is up — only one bar takes the top. */}
       <UpdateBanner />
       <Stack
         screenOptions={{

--- a/apps/mobile/app/(app)/chat-media.tsx
+++ b/apps/mobile/app/(app)/chat-media.tsx
@@ -21,6 +21,7 @@ import {
 import { useConversationMedia, useMe, type MessageDto } from '../../src/api/queries'
 import { AudioBubble, VideoTile } from '../../src/components/MediaBubble'
 import { PhotoViewer } from '../../src/components/PhotoViewer'
+import { LoadFailed } from '../../src/components/LoadFailed'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { Screen } from '../../src/components/ui/Screen'
 import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
@@ -129,6 +130,7 @@ export default function ChatMediaScreen() {
     isPending: page.isPending,
     isError: page.isError,
     itemCount: tab === 'visual' ? tiles.length : messages.length,
+    isPaused: page.fetchStatus === 'paused',
   })
 
   const empty = (
@@ -171,6 +173,10 @@ export default function ChatMediaScreen() {
 
       {state === 'skeleton' ? (
         <ActivityIndicator style={styles.loading} />
+      ) : state === 'failed' ? (
+        /* Before either tab: both of them draw `empty`, which says this
+           conversation has no photos in it — a different claim entirely. */
+        <LoadFailed onRetry={() => void page.refetch()} />
       ) : tab === 'visual' ? (
         <FlatList
           key="visual"

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -15,7 +15,7 @@ import {
   type MessageAsk,
   type MessageTranslation,
 } from '@langx/shared'
-import { useQueryClient } from '@tanstack/react-query'
+import { onlineManager, useQueryClient } from '@tanstack/react-query'
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
@@ -70,6 +70,7 @@ import {
   retireDelivered,
   type UnsentMessage,
 } from '../../../src/lib/unsentMessages'
+import { loadUnsent, saveUnsent } from '../../../src/lib/unsentStore'
 import {
   addOutgoing,
   isOutgoingId,
@@ -139,6 +140,31 @@ export default function ChatScreen() {
   /** Sends in flight, drawn in the thread before the server has answered. */
   const [outgoing, setOutgoing] = useState<OutgoingMessage[]>([])
   const [unsent, setUnsent] = useState<UnsentMessage[]>([])
+  /**
+   * And back out of the device, because until this the rows lived exactly as
+   * long as the screen did. Somebody who types a sentence in a tunnel and goes
+   * back to the chat list to see whether anything else arrived was throwing
+   * away the only copy of it — the composer is empty by then.
+   *
+   * Nothing is written back before the read has landed: saving the empty
+   * initial state would wipe what this is here to keep.
+   */
+  const [unsentHydrated, setUnsentHydrated] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    void loadUnsent(conversationId).then((stored) => {
+      if (cancelled) return
+      if (stored.length > 0) setUnsent(stored)
+      setUnsentHydrated(true)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [conversationId])
+  useEffect(() => {
+    if (!unsentHydrated) return
+    void saveUnsent(conversationId, unsent)
+  }, [conversationId, unsent, unsentHydrated])
   const [correcting, setCorrecting] = useState<MessageDto | null>(null)
   /**
    * What this message asks the other person for, once it is sent.
@@ -870,6 +896,16 @@ export default function ChatScreen() {
     translation?: MessageTranslation,
   ): Promise<void> {
     try {
+      /*
+       * Twelve seconds is what the ack timeout costs, and with no network it
+       * can only end one way: a composer that looks like it is thinking, and
+       * then a red row. The row is the honest answer, and this is the only
+       * thing between it and the person who typed the sentence. `catch` below
+       * does the rest — the code rides along so the funnel can count them.
+       */
+      if (!onlineManager.isOnline()) {
+        throw Object.assign(new Error('offline'), { code: 'OFFLINE' })
+      }
       const socket = await getSocket()
       await emitWithAck(socket, 'message:send', {
         conversationId,

--- a/apps/mobile/app/(app)/chat/[id].tsx
+++ b/apps/mobile/app/(app)/chat/[id].tsx
@@ -54,6 +54,7 @@ import {
   type PendingAttachment,
 } from '../../../src/components/AttachmentPreview'
 import { MessageBubbleSkeleton } from '../../../src/components/skeletons/MessageBubbleSkeleton'
+import { LoadFailed } from '../../../src/components/LoadFailed'
 import { Avatar } from '../../../src/components/ui/Avatar'
 import { Skeleton } from '../../../src/components/ui/Skeleton'
 import { Screen } from '../../../src/components/ui/Screen'
@@ -297,6 +298,7 @@ export default function ChatScreen() {
     isPending: thread.isPending,
     isError: thread.isError,
     itemCount: items.length,
+    isPaused: thread.fetchStatus === 'paused',
   })
   // From the participant list, not from the messages: a thread nobody has
   // replied to yet contains only my own sends, and reading the partner off
@@ -1542,7 +1544,17 @@ export default function ChatScreen() {
           own box rather than the screen's — that keeps it above the composer
           whatever height the composer has grown to. */}
         <View style={styles.listWrap}>
-          {state === 'skeleton' ? (
+          {state === 'failed' && rows.length === 0 ? (
+            /*
+             * `rows.length` as well as the state: a thread that failed to load
+             * can still have something to show — the message just typed into a
+             * tunnel is an unsent row, and replacing it with an error panel
+             * would take away the one copy of that sentence there is.
+             */
+            <View style={[styles.list, styles.skeletonFill]}>
+              <LoadFailed onRetry={() => void thread.refetch()} />
+            </View>
+          ) : state === 'skeleton' ? (
             // `flex: 1` because the FlatList it stands in for takes the whole
             // height; without it the composer rides up under the placeholders and
             // then drops when the real thread arrives.

--- a/apps/mobile/app/(app)/corrections.tsx
+++ b/apps/mobile/app/(app)/corrections.tsx
@@ -4,6 +4,7 @@ import { router } from 'expo-router'
 import { useCorrectionsWritten, useMyPosts, type MessageDto } from '../../src/api/queries'
 import type { FeedPost } from '../../src/api/types'
 import { EmptyState } from '../../src/components/ui/EmptyState'
+import { LoadFailed } from '../../src/components/LoadFailed'
 import { Screen } from '../../src/components/ui/Screen'
 import { Skeleton } from '../../src/components/ui/Skeleton'
 import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
@@ -68,6 +69,7 @@ export default function WritingScreen() {
     isPending: active.isPending,
     isError: active.isError,
     itemCount: tab === 'corrections' ? corrections.length : myPosts.length,
+    isPaused: active.fetchStatus === 'paused',
   })
 
   return (
@@ -97,6 +99,11 @@ export default function WritingScreen() {
             </View>
           ))}
         </View>
+      ) : state === 'failed' ? (
+        /* Not the empty state below it: "you have not corrected anybody yet"
+           is a sentence about the reader, and getting it wrong is worse than
+           the usual version of this bug. */
+        <LoadFailed onRetry={() => void active.refetch()} />
       ) : state === 'empty' ? (
         <EmptyState
           icon={tab === 'corrections' ? 'edit-3' : 'message-square'}

--- a/apps/mobile/app/(app)/edit-profile.tsx
+++ b/apps/mobile/app/(app)/edit-profile.tsx
@@ -25,6 +25,7 @@ import {
   type MeProfile,
 } from '../../src/api/queries'
 import { LoadFailed } from '../../src/components/LoadFailed'
+import { queryFailed } from '../../src/lib/listState'
 import { ApiRequestError } from '../../src/api/client'
 import { LanguagePicker } from '../../src/components/LanguagePicker'
 import { useDebounced } from '../../src/hooks/useDebounced'
@@ -114,7 +115,7 @@ export default function EditProfileScreen() {
   if (!me.data) {
     return (
       <Screen>
-        {me.isError ? (
+        {queryFailed(me) ? (
           <LoadFailed onRetry={() => void me.refetch()} />
         ) : (
           <View style={styles.loading}>

--- a/apps/mobile/app/(app)/post/[id].tsx
+++ b/apps/mobile/app/(app)/post/[id].tsx
@@ -26,6 +26,7 @@ import type { Media, PostCorrection, PronunciationAnswer } from '../../../src/ap
 import { AudioBubble, MediaGallery } from '../../../src/components/MediaBubble'
 import { PhotoViewer } from '../../../src/components/PhotoViewer'
 import { PostThreadSkeleton } from '../../../src/components/skeletons/PostThreadSkeleton'
+import { LoadFailed } from '../../../src/components/LoadFailed'
 import { Avatar } from '../../../src/components/ui/Avatar'
 import { Button } from '../../../src/components/ui/Button'
 import { FormField } from '../../../src/components/ui/FormField'
@@ -184,6 +185,7 @@ export default function PostScreen() {
     isPending: query.isPending,
     isError: query.isError,
     itemCount: replies.length,
+    isPaused: query.fetchStatus === 'paused',
   })
 
   const mine = post ? post.author._id === me.data?._id : false
@@ -369,7 +371,12 @@ export default function PostScreen() {
         }
       />
 
-      {state === 'skeleton' || !post ? (
+      {state === 'failed' && !post ? (
+        /* A post that did not load is not a post with no replies, and the
+           skeleton below would have pulsed over it for as long as the screen
+           was open. */
+        <LoadFailed onRetry={() => void query.refetch()} />
+      ) : state === 'skeleton' || !post ? (
         <PostThreadSkeleton />
       ) : (
         <FlatList

--- a/apps/mobile/app/(app)/share-profile.tsx
+++ b/apps/mobile/app/(app)/share-profile.tsx
@@ -4,6 +4,7 @@ import * as Clipboard from 'expo-clipboard'
 import { Image } from 'expo-image'
 import { Text, View } from 'react-native'
 import { LoadFailed } from '../../src/components/LoadFailed'
+import { queryFailed } from '../../src/lib/listState'
 import { useMe } from '../../src/api/queries'
 import { Button } from '../../src/components/ui/Button'
 import { Screen } from '../../src/components/ui/Screen'
@@ -47,7 +48,7 @@ export default function ShareProfileScreen() {
   if (!me.data) {
     return (
       <Screen>
-        {me.isError ? (
+        {queryFailed(me) ? (
           <LoadFailed onRetry={() => void me.refetch()} />
         ) : (
           <View style={styles.loading}>

--- a/apps/mobile/app/(app)/wallet/index.tsx
+++ b/apps/mobile/app/(app)/wallet/index.tsx
@@ -3,6 +3,7 @@ import { Pressable, Text, View } from 'react-native'
 import { router, type Href } from 'expo-router'
 import Feather from '@expo/vector-icons/Feather'
 import { LoadFailed } from '../../../src/components/LoadFailed'
+import { queryFailed } from '../../../src/lib/listState'
 import { useMe, useWallet } from '../../../src/api/queries'
 import { GiftCard } from '../../../src/components/store/GiftCard'
 import { ListRow } from '../../../src/components/ui/ListRow'
@@ -80,7 +81,7 @@ export default function WalletScreen() {
   if (!me.data) {
     return (
       <Screen>
-        {me.isError ? (
+        {queryFailed(me) ? (
           <LoadFailed onRetry={() => void me.refetch()} />
         ) : (
           <View style={styles.loading}>

--- a/apps/mobile/app/(app)/wallet/store.tsx
+++ b/apps/mobile/app/(app)/wallet/store.tsx
@@ -2,6 +2,7 @@ import Feather from '@expo/vector-icons/Feather'
 import { shiftDayKey, TOKEN_RULES, wornCosmetic } from '@langx/shared'
 import { Text, View } from 'react-native'
 import { LoadFailed } from '../../../src/components/LoadFailed'
+import { queryFailed } from '../../../src/lib/listState'
 import {
   useActivity,
   useEquip,
@@ -66,7 +67,7 @@ export default function StoreScreen() {
   if (!me.data) {
     return (
       <Screen>
-        {me.isError ? (
+        {queryFailed(me) ? (
           <LoadFailed onRetry={() => void me.refetch()} />
         ) : (
           <View style={styles.loading}>

--- a/apps/mobile/app/(auth)/sign-in.tsx
+++ b/apps/mobile/app/(auth)/sign-in.tsx
@@ -9,6 +9,7 @@ import { Screen } from '../../src/components/ui/Screen'
 import { ScreenHeader } from '../../src/components/ui/ScreenHeader'
 import { SocialAuthButtons } from '../../src/components/SocialAuthButtons'
 import { authClient } from '../../src/lib/auth-client'
+import { useIsOnline } from '../../src/hooks/useIsOnline'
 import { authErrorKey } from '../../src/lib/errors'
 import { goBackTo } from '../../src/lib/navigation'
 import { withSignInProgress } from '../../src/lib/signInProgress'
@@ -24,6 +25,9 @@ export default function SignIn() {
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string>()
+  // Better Auth has no code for "nobody answered", so the form would have
+  // said "Sign in failed" to somebody whose request never left the phone.
+  const online = useIsOnline()
   /**
    * Only Better Auth's own sign-in. A v1 password cannot be checked here — the
    * hash is one-way and from another system — and the bridge that once asked
@@ -43,7 +47,9 @@ export default function SignIn() {
         authClient.signIn.email({ email, password }),
       )
       if (signInError) {
-        setError(t(authErrorKey(signInError) ?? 'errors.signInFailed'))
+        setError(
+          t(authErrorKey(signInError) ?? (online ? 'errors.signInFailed' : 'common.offline')),
+        )
         return
       }
       /*

--- a/apps/mobile/app/(auth)/sign-up.tsx
+++ b/apps/mobile/app/(auth)/sign-up.tsx
@@ -15,6 +15,7 @@ import { recordSignupSubmitted } from '../../src/lib/signupOrigin'
 import { useGuestBrowse } from '../../src/hooks/useGuestBrowse'
 import { shouldGateGuest } from '../../src/lib/guestGate'
 import { authClient } from '../../src/lib/auth-client'
+import { useIsOnline } from '../../src/hooks/useIsOnline'
 import { authErrorKey } from '../../src/lib/errors'
 import { goBackTo } from '../../src/lib/navigation'
 import { PASSWORD_MIN_LENGTH, passwordIssueKey } from '../../src/lib/passwordForm'
@@ -39,6 +40,9 @@ export default function SignUp() {
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string>()
+  // Better Auth has no code for "nobody answered", so the form would have
+  // said "Sign in failed" to somebody whose request never left the phone.
+  const online = useIsOnline()
   const [accepted, setAccepted] = useState(false)
   const { data: session } = authClient.useSession()
   const fromGuest = shouldGateGuest(session?.user)
@@ -72,7 +76,7 @@ export default function SignUp() {
     setLoading(false)
 
     if (signUpError) {
-      setError(t(authErrorKey(signUpError) ?? 'errors.signUpFailed'))
+      setError(t(authErrorKey(signUpError) ?? (online ? 'errors.signUpFailed' : 'common.offline')))
       return
     }
     router.replace({ pathname: '/(auth)/check-email', params: { email } })

--- a/apps/mobile/app/(onboarding)/welcome-back.tsx
+++ b/apps/mobile/app/(onboarding)/welcome-back.tsx
@@ -5,6 +5,7 @@ import { Redirect, router, type Href } from 'expo-router'
 import { useState } from 'react'
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native'
 import { LoadFailed } from '../../src/components/LoadFailed'
+import { queryFailed } from '../../src/lib/listState'
 import { api } from '../../src/api/client'
 import { keys, useMe } from '../../src/api/queries'
 import { NotificationPriming } from '../../src/components/NotificationPriming'
@@ -98,7 +99,7 @@ export default function WelcomeBackScreen() {
   if (!me.data) {
     return (
       <Screen>
-        {me.isError ? <LoadFailed onRetry={() => void me.refetch()} /> : <ActivityIndicator />}
+        {queryFailed(me) ? <LoadFailed onRetry={() => void me.refetch()} /> : <ActivityIndicator />}
       </Screen>
     )
   }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -18,6 +18,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Text } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
+import { isRequestTimeout } from '../src/api/apiFetch'
 import { ApiRequestError } from '../src/api/client'
 import { AlertHost } from '../src/components/AlertHost'
 import { MessageMenuHost } from '../src/components/MessageMenuHost'
@@ -84,6 +85,14 @@ function createQueryClient(): QueryClient {
           // Retrying a 4xx just repeats the same refusal. Only transient
           // failures — network, 5xx — are worth a second attempt.
           if (error instanceof ApiRequestError && error.status < 500) return false
+          /*
+           * One extra attempt for a timeout, not two. Each one costs the full
+           * ten seconds before anything can appear on screen, and the case
+           * this exists for — a tunnel, a captive portal — will not answer the
+           * third either. A phone that is merely slow still gets its second
+           * chance.
+           */
+          if (isRequestTimeout(error)) return failureCount < 1
           return failureCount < 2
         },
       },

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -36,6 +36,7 @@ import { forgetAnalyticsIdentity, identifyForAnalytics, startAnalytics } from '.
 import { markInstalled } from '../src/lib/installedAt'
 import { ensurePlaybackAudioMode } from '../src/lib/audioSession'
 import { configureObserve } from '../src/lib/observe'
+import { configureQueryNetwork } from '../src/lib/queryNetwork'
 import { useScreenTracking } from '../src/hooks/useScreenTracking'
 import { isAccountSwitch } from '../src/lib/sessionSwitch'
 import { ThemeProvider, useTheme } from '../src/lib/theme'
@@ -66,6 +67,13 @@ void SplashScreen.preventAutoHideAsync().catch(() => undefined)
  * that, so there is no effect early enough to do this in.
  */
 configureObserve()
+
+/*
+ * And what the radio is doing, for the same "read once, before anything needs
+ * it" reason. Module scope because `onlineManager`'s listener is global and
+ * setting it twice would leave the first subscription running.
+ */
+configureQueryNetwork()
 
 function createQueryClient(): QueryClient {
   return new QueryClient({

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -39,7 +39,7 @@ export default function Index() {
   // Disabled while signed out: without a session `/profiles/me` is a 401, and
   // an unread failed request per launch is the least of it — the gate below
   // reads "no profile" off a 404, which a signed-out request never gets to.
-  const { data: profile, isPending, error, refetch } = useMe(signedIn)
+  const { data: profile, isPending, error, refetch, fetchStatus } = useMe(signedIn)
   const [draftReady, setDraftReady] = useState(isDraftHydrated)
 
   // Reading the stored draft is asynchronous, and redirecting before it lands
@@ -66,7 +66,14 @@ export default function Index() {
 
   if (!signedIn) return <Redirect href={authLandingHref()} />
 
-  if (isPending || !draftReady) return <SplashFill />
+  /*
+   * `fetchStatus` as well as `isPending`, because a query held back for want of
+   * a network is pending and will stay pending: with `onlineManager` wired to
+   * the radio, a launch in a tunnel never fires the request at all. Without
+   * this that is a splash with no spinner to end and no button to press — the
+   * exact screen the retry below exists to replace.
+   */
+  if ((isPending && fetchStatus !== 'paused') || !draftReady) return <SplashFill />
 
   /*
    * Before the onboarding branch, because a suspended account has no profile

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -2,11 +2,15 @@ import { Redirect } from 'expo-router'
 import { useEffect, useState } from 'react'
 import { ApiRequestError } from '../src/api/client'
 import { SplashFill } from '../src/components/AppSplash'
+import { LoadFailed } from '../src/components/LoadFailed'
+import { Screen } from '../src/components/ui/Screen'
 import { useSignalAppReady } from '../src/hooks/useAppReady'
 import { useMe } from '../src/api/queries'
 import { getDraft, hydrateDraft, isDraftHydrated } from '../src/hooks/useOnboardingDraft'
 import { authClient } from '../src/lib/auth-client'
 import { authLandingHref } from '../src/lib/authLanding'
+import { errorStatusOf } from '../src/lib/errors'
+import { meState } from '../src/lib/meState'
 import { furthestOnboardingStep, onboardingHref } from '../src/lib/onboardingStep'
 
 /**
@@ -33,9 +37,9 @@ export default function Index() {
   const { data: session } = authClient.useSession()
   const signedIn = Boolean(session)
   // Disabled while signed out: without a session `/profiles/me` is a 401, and
-  // an unread failed request per launch is the least of it — `needsOnboarding`
-  // below reads "no profile" off exactly that shape.
-  const { data: profile, isPending, error } = useMe(signedIn)
+  // an unread failed request per launch is the least of it — the gate below
+  // reads "no profile" off a 404, which a signed-out request never gets to.
+  const { data: profile, isPending, error, refetch } = useMe(signedIn)
   const [draftReady, setDraftReady] = useState(isDraftHydrated)
 
   // Reading the stored draft is asynchronous, and redirecting before it lands
@@ -73,9 +77,32 @@ export default function Index() {
     return <Redirect href="/suspended" />
   }
 
-  const needsOnboarding = !profile || (error instanceof ApiRequestError && error.status === 404)
+  /*
+   * `!profile` used to be the whole test, and it read a failed request as an
+   * account with no profile — which is what sent a member with no network into
+   * the onboarding wizard. `meState` says which of the two this is; the status
+   * is the only thing that can tell them apart.
+   */
+  const state = meState({ hasProfile: Boolean(profile), errorStatus: errorStatusOf(error) })
+
   // Back to the step the draft has actually earned, not always the first one.
-  if (needsOnboarding) return <Redirect href={onboardingHref(furthestOnboardingStep(getDraft()))} />
+  if (state === 'onboarding') {
+    return <Redirect href={onboardingHref(furthestOnboardingStep(getDraft()))} />
+  }
+
+  /*
+   * Everything that is not an answer. A screen with a button rather than a
+   * spinner, because the thing it is waiting for may never arrive on its own —
+   * and rather than a redirect, because this screen is the one that asks the
+   * question, and it has to still be here to ask it again.
+   */
+  if (!profile) {
+    return (
+      <Screen>
+        <LoadFailed onRetry={() => void refetch()} />
+      </Screen>
+    )
+  }
 
   /**
    * A restored v1 user skips the wizard entirely, so without this they would

--- a/apps/mobile/src/api/apiFetch.ts
+++ b/apps/mobile/src/api/apiFetch.ts
@@ -16,7 +16,26 @@ import { authClient } from '../lib/auth-client'
  * reaches the branch that would say so. Fifteen seconds is far past a slow
  * answer on a bad connection and far short of forever.
  */
-const REQUEST_TIMEOUT_MS = 15_000
+const REQUEST_TIMEOUT_MS = 10_000
+
+/**
+ * What a request we abandoned ourselves rejects with.
+ *
+ * Worth its own type because the retry policy has to tell it from every other
+ * failure: three attempts at fifteen seconds each meant a tunnel took
+ * three-quarters of a minute to reach the screen that says so. Measured on a
+ * device, with the list pulsing throughout.
+ */
+export class RequestTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`Request timed out after ${ms}ms`)
+    this.name = 'RequestTimeoutError'
+  }
+}
+
+export function isRequestTimeout(error: unknown): boolean {
+  return error instanceof RequestTimeoutError
+}
 
 /**
  * `fetch`, with the timeout the platform does not give it.
@@ -29,9 +48,18 @@ const REQUEST_TIMEOUT_MS = 15_000
 async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
   if (init.signal) return fetch(url, init)
   const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  let timedOut = false
+  const timer = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, REQUEST_TIMEOUT_MS)
   try {
     return await fetch(url, { ...init, signal: controller.signal })
+  } catch (error) {
+    // Rethrown as our own, so the retry policy can recognise the one failure
+    // that has already cost the caller ten seconds.
+    if (timedOut) throw new RequestTimeoutError(REQUEST_TIMEOUT_MS)
+    throw error
   } finally {
     clearTimeout(timer)
   }

--- a/apps/mobile/src/api/apiFetch.ts
+++ b/apps/mobile/src/api/apiFetch.ts
@@ -4,6 +4,40 @@ import { versionHeaders } from '../lib/appVersion'
 import { authClient } from '../lib/auth-client'
 
 /**
+ * How long one request may take before it counts as not having happened.
+ *
+ * Nothing underneath has a timeout of its own. RN's `XMLHttpRequest.timeout`
+ * defaults to 0 and Android's OkHttp client is built with
+ * `connectTimeout(0)/readTimeout(0)`, so a connection that is accepted and
+ * then answers nothing — a tunnel, a captive portal, a hotel Wi-Fi that wants
+ * a login first — leaves the request pending for as long as the app is open.
+ * Measured on iOS: still pending after three minutes, with the screen holding
+ * its skeletons the whole time, because a query that never settles never
+ * reaches the branch that would say so. Fifteen seconds is far past a slow
+ * answer on a bad connection and far short of forever.
+ */
+const REQUEST_TIMEOUT_MS = 15_000
+
+/**
+ * `fetch`, with the timeout the platform does not give it.
+ *
+ * `AbortSignal.timeout()` would be the one-liner and React Native does not
+ * have it — the global behind `AbortSignal` is `abort-controller@3.0.0`, which
+ * predates that static. A caller's own signal wins: nothing passes one today,
+ * and an upload that does must not have its own cancellation taken away.
+ */
+async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  if (init.signal) return fetch(url, init)
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
  * Fetch wrapper for *our own* API routes (not Better Auth's, which the
  * client already calls directly). Native has no real cookie jar — the
  * session lives in SecureStore — so the cookie has to be read back out and
@@ -28,7 +62,7 @@ export async function apiFetch(path: string, init: RequestInit = {}): Promise<Re
      * web for exactly this reason. Those routes carry no session by design,
      * so the cookie stays home.
      */
-    return fetch(url, {
+    return fetchWithTimeout(url, {
       ...init,
       credentials: path.startsWith('/public/') ? 'omit' : 'include',
       headers: { ...init.headers, ...versionHeaders() },
@@ -36,7 +70,7 @@ export async function apiFetch(path: string, init: RequestInit = {}): Promise<Re
   }
 
   const cookie = await authClient.getCookie()
-  return fetch(url, {
+  return fetchWithTimeout(url, {
     ...init,
     credentials: 'omit',
     headers: { ...init.headers, ...versionHeaders(), cookie },

--- a/apps/mobile/src/api/apiFetch.ts
+++ b/apps/mobile/src/api/apiFetch.ts
@@ -45,7 +45,15 @@ export function isRequestTimeout(error: unknown): boolean {
  * predates that static. A caller's own signal wins: nothing passes one today,
  * and an upload that does must not have its own cancellation taken away.
  */
-async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+async function fetchWithTimeout(path: string, init: RequestInit): Promise<Response> {
+  /*
+   * Always our own host, and built *here* rather than taken as a parameter.
+   * Paths carry request-derived pieces (a handle, an id, a cursor), and a
+   * whole URL arriving from outside would let one of those pick the host —
+   * which is the shape CodeQL reads as request forgery, and it read this
+   * wrapper that way the moment the URL came in through the door.
+   */
+  const url = `${API_URL}${path}`
   if (init.signal) return fetch(url, init)
   const controller = new AbortController()
   let timedOut = false
@@ -75,11 +83,6 @@ async function fetchWithTimeout(url: string, init: RequestInit): Promise<Respons
  * handles this without help.
  */
 export async function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
-  // Always our own host. Paths carry request-derived pieces (a handle, an id,
-  // a cursor), and a path that could also be a whole URL would let one of
-  // those pick the host — which is the shape CodeQL flags as request forgery.
-  const url = `${API_URL}${path}`
-
   if (Platform.OS === 'web') {
     /*
      * `/public/` answers with the wildcard origin (`app.ts`, `publicCors`),
@@ -90,7 +93,7 @@ export async function apiFetch(path: string, init: RequestInit = {}): Promise<Re
      * web for exactly this reason. Those routes carry no session by design,
      * so the cookie stays home.
      */
-    return fetchWithTimeout(url, {
+    return fetchWithTimeout(path, {
       ...init,
       credentials: path.startsWith('/public/') ? 'omit' : 'include',
       headers: { ...init.headers, ...versionHeaders() },
@@ -98,7 +101,7 @@ export async function apiFetch(path: string, init: RequestInit = {}): Promise<Re
   }
 
   const cookie = await authClient.getCookie()
-  return fetchWithTimeout(url, {
+  return fetchWithTimeout(path, {
     ...init,
     credentials: 'omit',
     headers: { ...init.headers, ...versionHeaders(), cookie },

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -286,9 +286,17 @@ export function useMe(enabled = true) {
     queryKey: keys.me,
     queryFn: () => api.get<MeProfile>('/profiles/me'),
     enabled,
-    // A 404 here means "signed in but no profile yet" — onboarding, not an
-    // error to retry.
-    retry: false,
+    /*
+     * The client's default predicate, not `retry: false`.
+     *
+     * `false` was written for the 404 — "signed in but no profile yet" is an
+     * answer, and retrying it only delays onboarding — but it applied to lost
+     * packets too, so one dropped request settled this query with nothing and
+     * `index.tsx` had to decide a launch on the strength of a single attempt.
+     * The default (`app/_layout.tsx`) already refuses to retry any 4xx, so the
+     * 404 still settles at once and a bad second on the train gets two more
+     * tries before anybody is told anything.
+     */
   })
 }
 

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -76,6 +76,7 @@ import { api, ApiRequestError } from './client'
 import { authClient } from '../lib/auth-client'
 import type { ConversationPageDto } from '../lib/conversationCache'
 import { putWithProgress } from '../lib/putWithProgress'
+import { reportActionError } from '../lib/reportActionError'
 import { isAllowedAudioType } from '../lib/recordingFormat'
 import {
   applyAnswer,
@@ -1063,6 +1064,12 @@ export function useSetLike() {
       // new name belongs in a keyset page.
       void client.invalidateQueries({ queryKey: keys.likers(targetType, targetId) })
     },
+    /*
+     * The heart is drawn from `LikeButton`'s own state, so a refused like
+     * springs back on its own — and used to do it in silence, which reads as
+     * the button being broken rather than as the tap not having landed.
+     */
+    onError: reportActionError,
   })
 }
 
@@ -1147,10 +1154,13 @@ export function useMarkNotificationsRead() {
       )
       return { previous }
     },
-    onError: (_error, _input, context) => {
+    onError: (error, _input, context) => {
       if (context?.previous !== undefined) {
         client.setQueryData(keys.notificationsUnread, context.previous)
       }
+      // The badge coming back is the only sign otherwise, and it looks like
+      // the count is wrong rather than like the request failed.
+      reportActionError(error)
     },
     onSuccess: (_result, id) => {
       // Stamped into the loaded pages rather than refetched: the dot has to go
@@ -1204,8 +1214,11 @@ export function useSetFollow(handleOrId: string) {
       }
       return { previous }
     },
-    onError: (_error, _input, context) => {
+    onError: (error, _input, context) => {
       if (context?.previous) client.setQueryData(keys.profile(handleOrId), context.previous)
+      // And say so: the button has already sprung back, and a silent
+      // spring-back is indistinguishable from a button that does not work.
+      reportActionError(error)
     },
     onSuccess: (follow) => {
       const previous = client.getQueryData<PublicProfileDto>(keys.profile(handleOrId))

--- a/apps/mobile/src/components/OfflineBanner.tsx
+++ b/apps/mobile/src/components/OfflineBanner.tsx
@@ -1,0 +1,61 @@
+import Feather from '@expo/vector-icons/Feather'
+import { Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useMe } from '../api/queries'
+import { useIsOnline } from '../hooks/useIsOnline'
+import { makeStyles, spacing, useTheme } from '../lib/theme'
+import { useT } from '../i18n'
+
+/**
+ * Says the one thing the app had no way of saying.
+ *
+ * Every offline failure used to arrive as something else: a list with no rows
+ * said "Nobody here yet", a tab that never loaded stayed on its skeletons, a
+ * heart un-filled itself with no explanation. All three are the same fact, and
+ * a person who cannot be told it assumes the app is broken — which, from where
+ * they are sitting, it is.
+ *
+ * One bar, above the navigator like the other two, and it takes itself away
+ * the moment the network is back. Nothing to dismiss: unlike an update notice
+ * this is not a decision anybody is being asked to make.
+ */
+export function OfflineBanner() {
+  const styles = useStyles()
+  const { colors } = useTheme()
+  const t = useT()
+  const insets = useSafeAreaInsets()
+  const online = useIsOnline()
+  const me = useMe()
+
+  if (online) return null
+  // One bar at the top at a time, and a pending deletion is the more urgent of
+  // the two — it has a deadline attached and this one does not.
+  if (me.data?.deletedAt) return null
+
+  return (
+    // Its own top inset, for the reason the other two carry one: this sits
+    // above the navigator, outside every `Screen`, and the layout does not
+    // inset for it.
+    <View style={[styles.root, { paddingTop: insets.top + spacing.sm }]}>
+      <Feather name="wifi-off" size={16} color={colors.warning} />
+      <Text style={styles.text}>{t('common.offline')}</Text>
+    </View>
+  )
+}
+
+const useStyles = makeStyles(({ colors, font, spacing }) => ({
+  /*
+   * The warning tint rather than the update notice's blue or a deletion's red.
+   * Nothing is wrong with the app and nothing has been lost — the phone is
+   * simply somewhere without a signal — so it reads as a state, not an alarm.
+   */
+  root: {
+    alignItems: 'center',
+    backgroundColor: colors.warningBg,
+    flexDirection: 'row',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+  },
+  text: { ...font.caption, color: colors.text, flex: 1, fontWeight: '700' },
+}))

--- a/apps/mobile/src/components/UpdateBanner.tsx
+++ b/apps/mobile/src/components/UpdateBanner.tsx
@@ -5,6 +5,7 @@ import { Platform, Pressable, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useMe } from '../api/queries'
 import { appPlatform, useAppConfig } from '../hooks/useAppConfig'
+import { useIsOnline } from '../hooks/useIsOnline'
 import { FLAG_KEYS, readFlag, writeFlag } from '../lib/localFlags'
 import { openStoreListing } from '../lib/storeListing'
 import { makeStyles, spacing, useTheme } from '../lib/theme'
@@ -37,6 +38,7 @@ export function UpdateBanner() {
   const config = useAppConfig()
   const me = useMe()
   const insets = useSafeAreaInsets()
+  const online = useIsOnline()
 
   /*
    * Three states, not two: `undefined` is "the flag has not been read yet".
@@ -71,6 +73,12 @@ export function UpdateBanner() {
   // One bar at the top at a time, and a pending deletion is the more urgent of
   // the two by a distance. `DeletionBanner` takes the status-bar inset when it
   // renders, so this one can take it unconditionally.
+  //
+  // `OfflineBanner` is the third, and it wins over this one for as long as it
+  // is up: an update that cannot be downloaded is not the news of the moment,
+  // and `config.data` behind this is cached from whenever the network last
+  // worked anyway.
+  if (!online) return null
   if (me.data?.deletedAt) return null
   if (
     !shouldShowUpdateNotice({ updateAvailable: Boolean(data.updateAvailable), latest, dismissed })

--- a/apps/mobile/src/hooks/useIsOnline.ts
+++ b/apps/mobile/src/hooks/useIsOnline.ts
@@ -1,0 +1,21 @@
+import { onlineManager } from '@tanstack/react-query'
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Whether the phone has a network, as far as anything here can tell.
+ *
+ * Read from TanStack Query's `onlineManager` rather than from `expo-network`
+ * directly, so that what the banner says and what the queries do can never
+ * disagree: `lib/queryNetwork.ts` is the one place that decides, and this is a
+ * view of it.
+ *
+ * The third argument is the answer during the web build's prerender, where
+ * there is no network to ask about and no viewer to tell.
+ */
+export function useIsOnline(): boolean {
+  return useSyncExternalStore(
+    (onStoreChange) => onlineManager.subscribe(() => onStoreChange()),
+    () => onlineManager.isOnline(),
+    () => true,
+  )
+}

--- a/apps/mobile/src/hooks/usePullToRefresh.ts
+++ b/apps/mobile/src/hooks/usePullToRefresh.ts
@@ -1,5 +1,8 @@
+import { onlineManager } from '@tanstack/react-query'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { currentTranslate } from '../i18n/runtime'
 import { isPulling, nextPull, NO_PULL, settlePull } from '../lib/pullToRefresh'
+import { showToast } from '../lib/toast'
 
 /**
  * `refreshing` and `onRefresh` for a `RefreshControl`, driven by the pull
@@ -59,6 +62,15 @@ export function usePullToRefresh(refetch: () => unknown): {
       .catch(() => undefined)
       .finally(() => {
         if (!mounted.current) return
+        /*
+         * `refetch()` resolves whether or not it worked — react-query hands
+         * the error back in the result rather than rejecting — so there is no
+         * failure to catch here without changing twelve call sites. The state
+         * of the radio answers the only question a pull actually asks: a
+         * spinner that opens and closes with nothing new on screen is read as
+         * "there is nothing new", and in a tunnel that is not what happened.
+         */
+        if (!onlineManager.isOnline()) showToast(currentTranslate()('errors.offlineAction'))
         setActive((current) => settlePull(current, pull))
       })
   }, [])

--- a/apps/mobile/src/hooks/useSettingsModel.ts
+++ b/apps/mobile/src/hooks/useSettingsModel.ts
@@ -19,6 +19,7 @@ import {
   useUpdateProfile,
 } from '../api/queries'
 import { useAnalyticsPreference } from './useAnalyticsPreference'
+import { useIsOnline } from './useIsOnline'
 import { unregisterPushToken } from './usePushRegistration'
 import { useTips } from './useTips'
 import { forgetTour } from './useTour'
@@ -50,6 +51,7 @@ import { showToast } from '../lib/toast'
  */
 export function useSettingsModel() {
   const t = useT()
+  const online = useIsOnline()
   const { preference: locale, deviceLocale } = useLocalePreference()
   // The *resolved* locale, not the preference: `auto` is not something
   // `toLocaleDateString` can read.
@@ -213,7 +215,16 @@ export function useSettingsModel() {
   function setPrivacy(patch: Partial<MeProfile['privacy']>): void {
     update.mutate(
       { privacy: patch },
-      { onError: () => void showAlert(t('settings.privacyFailed'), t('common.retry')) },
+      {
+        // "Try again in a moment" is true of a server having a bad second and
+        // useless on a train, where the moment to try again is the one after
+        // the tunnel.
+        onError: () =>
+          void showAlert(
+            t('settings.privacyFailed'),
+            online ? t('common.retry') : t('common.offline'),
+          ),
+      },
     )
   }
 

--- a/apps/mobile/src/hooks/useSocket.ts
+++ b/apps/mobile/src/hooks/useSocket.ts
@@ -1,6 +1,6 @@
 import { notificationsAllowed, PRESENCE_HEARTBEAT_MS } from '@langx/shared'
 import type { InfiniteData } from '@tanstack/react-query'
-import { useQueryClient } from '@tanstack/react-query'
+import { onlineManager, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import { AppState } from 'react-native'
 import type { Socket } from 'socket.io-client'
@@ -23,7 +23,7 @@ import {
   applyPinned,
   type MessagePageDto,
 } from '../lib/messageCache'
-import { closeSocket, getSocket } from '../lib/socket'
+import { closeSocket, getSocket, restartSocket } from '../lib/socket'
 
 /**
  * Opens the app's single socket and turns realtime events into cache updates.
@@ -69,6 +69,21 @@ export function useSocket({ enabled = true }: { enabled?: boolean } = {}): void 
     const appStateSubscription = AppState.addEventListener('change', (next) => {
       if (resumedFromBackground(lastAppState, next)) resync()
       lastAppState = next
+    })
+
+    /**
+     * The third signal, and the only one that arrives while the app is open
+     * and the socket believes everything is fine.
+     *
+     * `lib/queryNetwork.ts` has the radio wired to `onlineManager`, so this is
+     * the OS saying the network came back. The socket cannot know that:
+     * nothing closed its connection, it is holding one that stopped carrying
+     * packets, and its own ping timeout is 45 seconds away. Restarting it here
+     * turns those 45 seconds into about one — and the reconnect that follows
+     * fires `resync` through the handler below, so the gap is covered too.
+     */
+    const unsubscribeOnline = onlineManager.subscribe((online) => {
+      if (online) restartSocket()
     })
 
     void (async () => {
@@ -304,6 +319,7 @@ export function useSocket({ enabled = true }: { enabled?: boolean } = {}): void 
       cancelled = true
       if (heartbeat) clearInterval(heartbeat)
       appStateSubscription.remove()
+      unsubscribeOnline()
       opened?.io.off('reconnect', resync)
       closeSocket()
     }

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -28,6 +28,7 @@ export const ar: Localized<EnMessages> = {
     save: 'حفظ',
     tryAgain: 'إعادة المحاولة',
     retry: 'حاول مرة أخرى بعد قليل.',
+    offline: 'لا يوجد اتصال بالإنترنت',
     checking: 'جارٍ التحقق…',
     oneMoment: 'لحظة…',
     skip: 'ليس الآن',

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -311,6 +311,8 @@ export const ar: Localized<EnMessages> = {
     invalidToken: 'هذا الرابط لم يعد صالحًا.',
     uploadFailed: 'فشل الرفع',
     loadFailed: 'تعذّر التحميل. تحقّق من اتصالك وحاول مرة أخرى.',
+    offlineAction: 'لم يتم التنفيذ — أنت غير متصل بالإنترنت.',
+    actionFailed: 'لم يتم التنفيذ. حاول مرة أخرى.',
   },
 
   location: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -266,6 +266,8 @@ export const de: Localized<EnMessages> = {
     invalidToken: 'Dieser Link ist nicht mehr gültig.',
     uploadFailed: 'Upload fehlgeschlagen',
     loadFailed: 'Das konnte nicht geladen werden. Prüfe deine Verbindung und versuch es erneut.',
+    offlineAction: 'Das ging nicht durch — du bist offline.',
+    actionFailed: 'Das ging nicht durch. Versuch es noch mal.',
   },
 
   location: {

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -15,6 +15,7 @@ export const de: Localized<EnMessages> = {
     save: 'Speichern',
     tryAgain: 'Erneut versuchen',
     retry: 'Versuch es gleich noch einmal.',
+    offline: 'Keine Internetverbindung',
     checking: 'Wird geprüft…',
     oneMoment: 'Einen Moment…',
     skip: 'Später',

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -304,6 +304,9 @@ export const en = {
     invalidToken: 'That link is no longer valid.',
     uploadFailed: 'Upload failed',
     loadFailed: 'Could not load this. Check your connection and try again.',
+    /** A write that never reached a server: the one failure the reader can place. */
+    offlineAction: 'That didn’t go through — you’re offline.',
+    actionFailed: 'That didn’t go through. Try again.',
   },
 
   location: {

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -33,6 +33,8 @@ export const en = {
     save: 'Save',
     tryAgain: 'Try again',
     retry: 'Try again in a moment.',
+    /** The offline banner, and the only place the app says this at all. */
+    offline: 'No internet connection',
     checking: 'Checking…',
     oneMoment: 'One moment…',
     skip: 'Skip for now',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -18,6 +18,7 @@ export const es: Localized<EnMessages> = {
     save: 'Guardar',
     tryAgain: 'Reintentar',
     retry: 'Inténtalo de nuevo en un momento.',
+    offline: 'Sin conexión a internet',
     checking: 'Comprobando…',
     oneMoment: 'Un momento…',
     skip: 'Ahora no',

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -264,6 +264,8 @@ export const es: Localized<EnMessages> = {
     invalidToken: 'Ese enlace ya no es válido.',
     uploadFailed: 'Error al subir',
     loadFailed: 'No se pudo cargar. Revisa tu conexión e inténtalo de nuevo.',
+    offlineAction: 'No se pudo completar: estás sin conexión.',
+    actionFailed: 'No se pudo completar. Inténtalo de nuevo.',
   },
 
   location: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -266,6 +266,8 @@ export const fr: Localized<EnMessages> = {
     invalidToken: 'Ce lien n’est plus valable.',
     uploadFailed: 'Échec de l’envoi',
     loadFailed: 'Impossible de charger. Vérifie ta connexion et réessaie.',
+    offlineAction: 'Ça n’est pas passé — tu es hors ligne.',
+    actionFailed: 'Ça n’est pas passé. Réessaie.',
   },
 
   location: {

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -15,6 +15,7 @@ export const fr: Localized<EnMessages> = {
     save: 'Enregistrer',
     tryAgain: 'Réessayer',
     retry: 'Réessaie dans un instant.',
+    offline: 'Pas de connexion internet',
     checking: 'Vérification…',
     oneMoment: 'Un instant…',
     skip: 'Plus tard',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -15,6 +15,7 @@ export const ptBR: Localized<EnMessages> = {
     save: 'Salvar',
     tryAgain: 'Tentar de novo',
     retry: 'Tente de novo em um instante.',
+    offline: 'Sem conexão com a internet',
     checking: 'Verificando…',
     oneMoment: 'Um instante…',
     skip: 'Agora não',

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -261,6 +261,8 @@ export const ptBR: Localized<EnMessages> = {
     invalidToken: 'Esse link não é mais válido.',
     uploadFailed: 'Falha no envio',
     loadFailed: 'Não deu para carregar. Confira sua conexão e tente de novo.',
+    offlineAction: 'Não deu certo — você está sem conexão.',
+    actionFailed: 'Não deu certo. Tente de novo.',
   },
 
   location: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -302,6 +302,8 @@ export const ru: Localized<EnMessages> = {
     invalidToken: 'Эта ссылка больше не действует.',
     uploadFailed: 'Не удалось загрузить',
     loadFailed: 'Не удалось загрузить. Проверь соединение и попробуй снова.',
+    offlineAction: 'Не отправилось — нет подключения.',
+    actionFailed: 'Не отправилось. Попробуйте ещё раз.',
   },
 
   location: {

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -25,6 +25,7 @@ export const ru: Localized<EnMessages> = {
     save: 'Сохранить',
     tryAgain: 'Повторить',
     retry: 'Попробуй ещё раз через минуту.',
+    offline: 'Нет подключения к интернету',
     checking: 'Проверяем…',
     oneMoment: 'Минуту…',
     skip: 'Пока пропустить',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -24,6 +24,7 @@ export const tr: Localized<EnMessages> = {
     save: 'Kaydet',
     tryAgain: 'Tekrar dene',
     retry: 'Birazdan tekrar dene.',
+    offline: 'İnternet bağlantısı yok',
     checking: 'Kontrol ediliyor…',
     oneMoment: 'Bir saniye…',
     skip: 'Şimdilik geç',

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -275,6 +275,8 @@ export const tr: Localized<EnMessages> = {
     invalidToken: 'Bu bağlantı artık geçerli değil.',
     uploadFailed: 'Yüklenemedi',
     loadFailed: 'Bu yüklenemedi. Bağlantını kontrol edip tekrar dene.',
+    offlineAction: 'Bu işlem gitmedi — internet yok.',
+    actionFailed: 'Bu işlem gitmedi. Tekrar dene.',
   },
 
   location: {

--- a/apps/mobile/src/lib/auth-client.ts
+++ b/apps/mobile/src/lib/auth-client.ts
@@ -24,6 +24,15 @@ export const authClient = createAuthClient({
    * is the only thing that can tell the server which language to write in.
    */
   fetchOptions: {
+    /*
+     * The same fifteen seconds `apiFetch` gives our own routes, and for the
+     * same reason: nothing in React Native's fetch stack times out on its own,
+     * so a connection that is accepted and never answered leaves `/get-session`
+     * pending for as long as the app is open — which is a launch that never
+     * resolves. Better Auth uses `@better-fetch/fetch`, which takes the number
+     * here and does the aborting itself.
+     */
+    timeout: 15_000,
     headers: {
       get 'accept-language'() {
         return currentLocale()

--- a/apps/mobile/src/lib/errors.ts
+++ b/apps/mobile/src/lib/errors.ts
@@ -85,3 +85,18 @@ export function errorCodeOf(error: unknown): string | undefined {
   const code = (error as { code?: unknown }).code
   return typeof code === 'string' ? code : undefined
 }
+
+/**
+ * The HTTP status behind a failure, when a server gave one.
+ *
+ * `ApiRequestError` carries it; a request that never reached a server carries
+ * nothing. That is the distinction the launch gate turns on — "the server said
+ * no" and "there was no server" used to arrive as the same empty `data` — and
+ * reading it structurally, like `errorCodeOf` above, is what keeps this module
+ * loadable by tests that cannot import the API client.
+ */
+export function errorStatusOf(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const status = (error as { status?: unknown }).status
+  return typeof status === 'number' ? status : undefined
+}

--- a/apps/mobile/src/lib/listState.test.ts
+++ b/apps/mobile/src/lib/listState.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { listState } from './listState'
+import { listState, queryFailed } from './listState'
 
 describe('listState', () => {
   it('shows a skeleton only while there is nothing for this query key yet', () => {
@@ -46,5 +46,20 @@ describe('listState', () => {
     expect(listState({ isPending: true, isError: false, itemCount: 4, isPaused: true })).toBe(
       'content',
     )
+  })
+})
+
+describe('queryFailed', () => {
+  it('is true for an error', () => {
+    expect(queryFailed({ isError: true, fetchStatus: 'idle' })).toBe(true)
+  })
+
+  /** The whole reason it exists: a paused query looks like a slow one. */
+  it('is true for a query waiting on a network that is not there', () => {
+    expect(queryFailed({ isError: false, fetchStatus: 'paused' })).toBe(true)
+  })
+
+  it('is false while a request is actually in flight', () => {
+    expect(queryFailed({ isError: false, fetchStatus: 'fetching' })).toBe(false)
   })
 })

--- a/apps/mobile/src/lib/listState.test.ts
+++ b/apps/mobile/src/lib/listState.test.ts
@@ -25,6 +25,26 @@ describe('listState', () => {
 
   /** A failed refetch is pending-with-nothing; a pulse there promises data that is not coming. */
   it('does not pulse forever over an error', () => {
-    expect(listState({ isPending: true, isError: true, itemCount: 0 })).toBe('empty')
+    expect(listState({ isPending: true, isError: true, itemCount: 0 })).toBe('failed')
+  })
+
+  /** The whole point of the variant: "it did not load" is not "there is nothing". */
+  it('separates a failed request from an empty answer', () => {
+    expect(listState({ isPending: false, isError: true, itemCount: 0 })).toBe('failed')
+  })
+
+  /** A query held back for want of a network is the same news, arriving earlier. */
+  it('treats a paused query as failed rather than as a first load', () => {
+    expect(listState({ isPending: true, isError: false, itemCount: 0, isPaused: true })).toBe(
+      'failed',
+    )
+  })
+
+  /** Rows already on screen outlast both. */
+  it('keeps rows over an error or a pause', () => {
+    expect(listState({ isPending: false, isError: true, itemCount: 4 })).toBe('content')
+    expect(listState({ isPending: true, isError: false, itemCount: 4, isPaused: true })).toBe(
+      'content',
+    )
   })
 })

--- a/apps/mobile/src/lib/listState.ts
+++ b/apps/mobile/src/lib/listState.ts
@@ -1,4 +1,4 @@
-export type ListState = 'skeleton' | 'empty' | 'content'
+export type ListState = 'skeleton' | 'empty' | 'failed' | 'content'
 
 /**
  * What a list should draw right now.
@@ -9,13 +9,28 @@ export type ListState = 'skeleton' | 'empty' | 'content'
  * with nothing. Only `isPending` — no data for this query key at all — is a
  * skeleton; anything else with rows is content, and the caller's empty state
  * gets the rest.
+ *
+ * `'failed'` used to be folded into `'empty'`, which meant every screen told
+ * somebody whose request never arrived that there was nothing to see: "Nobody
+ * here yet", "No chats yet", with a button offering to go and start one.
+ * Discovery wrote the branch by hand first (#1314); it is here now because
+ * six other screens had the same defect and a variant nobody can forget to
+ * handle is the only way that stays fixed.
+ *
+ * `isPaused` is the same news arriving a different way. With `onlineManager`
+ * wired to the radio (`lib/queryNetwork.ts`), a query made with no network is
+ * never sent — it waits — so it is `isPending` forever with no error to show,
+ * which is a skeleton that pulses until the train leaves the tunnel.
  */
 export function listState(input: {
   isPending: boolean
   isError: boolean
   itemCount: number
+  /** `query.fetchStatus === 'paused'`: waiting for a network that is not there. */
+  isPaused?: boolean
 }): ListState {
   if (input.itemCount > 0) return 'content'
-  if (input.isPending && !input.isError) return 'skeleton'
+  if (input.isError || input.isPaused) return 'failed'
+  if (input.isPending) return 'skeleton'
   return 'empty'
 }

--- a/apps/mobile/src/lib/listState.ts
+++ b/apps/mobile/src/lib/listState.ts
@@ -34,3 +34,19 @@ export function listState(input: {
   if (input.isPending) return 'skeleton'
   return 'empty'
 }
+
+/**
+ * A query that is not going to answer: it failed, or it is waiting for a
+ * network that is not there.
+ *
+ * The second half only exists because `onlineManager` is wired to the radio
+ * now (`lib/queryNetwork.ts`). Pausing is the right behaviour — the request
+ * runs by itself when the phone is back — but to a screen it looks exactly
+ * like a first load that is taking its time, and "taking its time" is drawn as
+ * a skeleton, forever. Every screen that draws a `LoadFailed` has to ask this
+ * rather than `isError`, which is why it is one function and not six
+ * conditions.
+ */
+export function queryFailed(query: { isError: boolean; fetchStatus: string }): boolean {
+  return query.isError || query.fetchStatus === 'paused'
+}

--- a/apps/mobile/src/lib/localFlags.ts
+++ b/apps/mobile/src/lib/localFlags.ts
@@ -57,6 +57,15 @@ export const FLAG_KEYS = {
    * when the profile is created, cleared with the draft.
    */
   signupOrigin: 'signupOrigin',
+  /**
+   * JSON: the messages that could not be sent, by conversation.
+   *
+   * A device flag rather than anything on the account, for the obvious reason
+   * — the thing it holds is what never reached the server. `unsentStore.ts`
+   * owns the shape; it is bounded on both axes so this cannot grow without
+   * limit.
+   */
+  unsentMessages: 'unsentMessages',
   /** `auto` | `light` | `dark`. A device preference, not an account one. */
   themePreference: 'themePreference',
   /**

--- a/apps/mobile/src/lib/meState.test.ts
+++ b/apps/mobile/src/lib/meState.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { meState } from './meState'
+
+describe('meState', () => {
+  it('goes to the app when the profile is here', () => {
+    expect(meState({ hasProfile: true, errorStatus: undefined })).toBe('ready')
+  })
+
+  it('treats a 404 as the onboarding it was built to report', () => {
+    expect(meState({ hasProfile: false, errorStatus: 404 })).toBe('onboarding')
+  })
+
+  it('does not send a member with no network into onboarding', () => {
+    // No status at all: the request never reached a server.
+    expect(meState({ hasProfile: false, errorStatus: undefined })).toBe('failed')
+  })
+
+  it('treats a server-side refusal as a failure too, not as a missing profile', () => {
+    expect(meState({ hasProfile: false, errorStatus: 500 })).toBe('failed')
+    expect(meState({ hasProfile: false, errorStatus: 401 })).toBe('failed')
+  })
+})

--- a/apps/mobile/src/lib/meState.ts
+++ b/apps/mobile/src/lib/meState.ts
@@ -1,0 +1,30 @@
+/**
+ * Where a launch lands, once `/profiles/me` has settled.
+ *
+ * The distinction this exists to draw: **a request that failed is not a
+ * profile that does not exist.** `index.tsx` read `!profile` as "no profile
+ * yet", so a phone with no network — a tunnel, a lift, a basement — restored
+ * its session from the keychain cache and then sent a member with a complete
+ * profile into the onboarding wizard. Nothing they filled in there could be
+ * saved (`createProfile` refuses a second one), and it did not heal when the
+ * network came back: the redirect had already happened and `index`, the only
+ * screen that asks this question, was gone with it. Only a relaunch fixed it.
+ *
+ * A 404 is the one answer that means "signed in, no profile" — that is what
+ * the route was built to report. Everything else is a failure to answer, and a
+ * failure is a screen with a retry button.
+ *
+ * Pure, and free of `api/client` on purpose: the status is read off the error
+ * by `errorStatusOf` at the call site, so this module stays inside what the
+ * mobile test setup can load.
+ */
+export type MeState = 'ready' | 'onboarding' | 'failed'
+
+export function meState(input: {
+  hasProfile: boolean
+  /** The HTTP status the server answered with, or `undefined` if none did. */
+  errorStatus: number | undefined
+}): MeState {
+  if (input.hasProfile) return 'ready'
+  return input.errorStatus === 404 ? 'onboarding' : 'failed'
+}

--- a/apps/mobile/src/lib/putWithProgress.ts
+++ b/apps/mobile/src/lib/putWithProgress.ts
@@ -27,7 +27,13 @@ export function putWithProgress(options: {
     }
     request.onload = () => {
       if (request.status >= 200 && request.status < 300) resolve()
-      else reject(new Error(`Upload failed (${request.status})`))
+      // The status rides along: a bucket that answered and refused is not the
+      // same failure as one that was never reached, and `isOfflineFailure`
+      // tells the two apart by exactly this.
+      else
+        reject(
+          Object.assign(new Error(`Upload failed (${request.status})`), { status: request.status }),
+        )
     }
     // No status to report: the request never reached the bucket. Same message
     // shape as above so callers have one thing to catch.

--- a/apps/mobile/src/lib/queryNetwork.ts
+++ b/apps/mobile/src/lib/queryNetwork.ts
@@ -1,0 +1,60 @@
+import { focusManager, onlineManager } from '@tanstack/react-query'
+import { addNetworkStateListener, getNetworkStateAsync } from 'expo-network'
+import { AppState, Platform } from 'react-native'
+
+/**
+ * Tells TanStack Query what the phone's radio is doing.
+ *
+ * Both managers ship with browser defaults — `navigator.onLine` and
+ * `visibilitychange` — neither of which exists on native, so on a phone the
+ * library believed it was permanently online and permanently focused. Two
+ * things followed. A query fired into a dead connection and sat there (nothing
+ * in the fetch stack times out on its own), and a query that failed while the
+ * app was in a tunnel was never retried on the way out of it: coming back to
+ * the app refetched nothing, because nothing had told the library the app had
+ * come back.
+ *
+ * With this, a query made while offline is *paused* rather than sent, and runs
+ * the moment the network returns. The screens still have to say so — a paused
+ * query looks exactly like a slow one — which is what `OfflineBanner` and
+ * `listState`'s failed branch are for.
+ *
+ * Deliberately not on the web: the browser's own events are already right
+ * there, and `document.visibilityState` is the better signal for a tab.
+ */
+export function configureQueryNetwork(): void {
+  if (Platform.OS === 'web') return
+
+  onlineManager.setEventListener((setOnline) => {
+    /*
+     * Only an explicit "no" counts as offline. `isInternetReachable` is
+     * undefined until the OS has decided, and a first launch in a lift would
+     * otherwise pause every query behind a guess. Pausing a query that could
+     * have run is the worse of the two failures by a distance: the app looks
+     * broken and nothing retries it until the next event.
+     */
+    const subscription = addNetworkStateListener((state) => {
+      setOnline((state.isInternetReachable ?? state.isConnected) !== false)
+    })
+    return () => subscription.remove()
+  })
+
+  /*
+   * The listener above only fires on a *change*, so an app opened with the
+   * radio already off would start out believing it was online. One read at
+   * startup is what closes that gap; a failure to read it leaves the default,
+   * which is online, for the reason above.
+   */
+  void getNetworkStateAsync()
+    .then((state) =>
+      onlineManager.setOnline((state.isInternetReachable ?? state.isConnected) !== false),
+    )
+    .catch(() => undefined)
+
+  focusManager.setEventListener((handleFocus) => {
+    const subscription = AppState.addEventListener('change', (status) =>
+      handleFocus(status === 'active'),
+    )
+    return () => subscription.remove()
+  })
+}

--- a/apps/mobile/src/lib/reportActionError.ts
+++ b/apps/mobile/src/lib/reportActionError.ts
@@ -1,0 +1,33 @@
+import { currentTranslate } from '../i18n/runtime'
+import { errorStatusOf } from './errors'
+import { showToast } from './toast'
+
+/**
+ * Whether a failure means "nobody answered".
+ *
+ * `ApiRequestError` carries the status the server sent back; a transport
+ * failure — no route, a tunnel, `apiFetch`'s own fifteen-second timeout —
+ * carries none. That is the whole distinction, and it is the one the reader
+ * cares about: "that didn't go through" is a shrug, "you're offline" is an
+ * explanation with an end to it.
+ */
+export function isOfflineFailure(caught: unknown): boolean {
+  return errorStatusOf(caught) === undefined
+}
+
+/**
+ * Says a tap did not take.
+ *
+ * The optimistic mutations put the heart back, the follow button back, the
+ * unread badge back — and said nothing at all, so on a train the interface
+ * appeared to undo itself for no reason, over and over. The rollback is right;
+ * the silence was the bug.
+ *
+ * Reads the locale itself rather than taking a `t`, because the callers are
+ * mutations in `api/queries.ts`, which is not a component and has no hook to
+ * read one with. `AppGate` does the same for the update toast.
+ */
+export function reportActionError(caught: unknown): void {
+  const t = currentTranslate()
+  showToast(isOfflineFailure(caught) ? t('errors.offlineAction') : t('errors.actionFailed'))
+}

--- a/apps/mobile/src/lib/reportWriteError.ts
+++ b/apps/mobile/src/lib/reportWriteError.ts
@@ -1,6 +1,7 @@
 import { MAX_VIDEO_SECONDS } from '@langx/shared'
 import { ApiRequestError } from '../api/client'
 import type { TranslateFn } from '../i18n'
+import { isOfflineFailure } from './reportActionError'
 import { showToast } from './toast'
 
 /**
@@ -20,6 +21,17 @@ import { showToast } from './toast'
  * show up as one screen naming a failure the other one shrugs at.
  */
 export function reportWriteError(caught: unknown, t: TranslateFn): void {
+  /*
+   * Before anything about attachments, because this is the branch a post
+   * written on a train lands in and "the attachment did not upload" was the
+   * sentence it got — for a post with no attachment in it. An upload that
+   * reaches the bucket and is refused carries a status (`putWithProgress`),
+   * so this really is the case where nothing answered.
+   */
+  if (isOfflineFailure(caught)) {
+    showToast(t('errors.offlineAction'))
+    return
+  }
   if (!(caught instanceof ApiRequestError)) {
     showToast(t('feed.attachmentFailed'))
     return

--- a/apps/mobile/src/lib/socket.ts
+++ b/apps/mobile/src/lib/socket.ts
@@ -67,6 +67,28 @@ export function closeSocket(): void {
 }
 
 /**
+ * Starts the one socket over without losing the handlers `useSocket` hung on
+ * it.
+ *
+ * A tunnel does not close a connection, it stops carrying it — so socket.io
+ * goes on believing it is connected until its own ping times out, which the
+ * server's defaults put at 45 seconds. Measured: 45.1. The OS knows within a
+ * second, and this is what turns that knowledge into a working connection
+ * instead of a socket that is quietly writing into a pipe nobody is reading.
+ *
+ * `disconnect()` and `connect()` in the same tick, deliberately: in between
+ * them the socket is `!active`, which is the exact state `getSocket()` throws a
+ * socket away for, and nothing can observe it because nothing here awaits. The
+ * app's own listeners survive — socket.io's `destroy()` drops the manager's
+ * subscriptions, not the events the app registered.
+ */
+export function restartSocket(): void {
+  if (!socket) return
+  socket.disconnect()
+  socket.connect()
+}
+
+/**
  * Promise wrapper over socket.io's ack callback, with the API's error shape.
  *
  * `.timeout()` is not optional decoration. Without it socket.io registers the

--- a/apps/mobile/src/lib/socket.ts
+++ b/apps/mobile/src/lib/socket.ts
@@ -23,6 +23,22 @@ let socket: Socket | null = null
 export async function getSocket(): Promise<Socket> {
   if (socket?.connected) return socket
 
+  /*
+   * `active` is socket.io's own word for "still trying", and it goes false for
+   * good when a *middleware* error refuses the handshake — an expired session,
+   * or the server's auth lookup having a bad second. The client stops
+   * reconnecting at that point and nothing here noticed: the check above only
+   * asks whether the socket is connected, so every later call was handed the
+   * dead one back. Realtime stayed dead until the app was force-quit, and
+   * every message typed meanwhile waited out its ack timeout and turned red.
+   * Throwing it away is enough; the lines below build a fresh one, with a
+   * cookie read fresh as well, which is the other half of an expired session.
+   */
+  if (socket && !socket.active) {
+    socket.close()
+    socket = null
+  }
+
   const auth: Record<string, string> = {}
   if (Platform.OS !== 'web') {
     auth.cookie = (await authClient.getCookie()) ?? ''

--- a/apps/mobile/src/lib/unsentMessages.test.ts
+++ b/apps/mobile/src/lib/unsentMessages.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { addUnsent, MAX_UNSENT, newClientId, removeUnsent, retireDelivered } from './unsentMessages'
+import {
+  addUnsent,
+  MAX_UNSENT,
+  MAX_UNSENT_THREADS,
+  newClientId,
+  removeUnsent,
+  retireDelivered,
+  storeUnsent,
+  type UnsentByConversation,
+  type UnsentMessage,
+} from './unsentMessages'
 
 const at = (clientId: string, body = 'hi') => ({ clientId, body, failedAt: '2026-08-31T12:00:00Z' })
 
@@ -61,5 +71,33 @@ describe('retireDelivered', () => {
 
   it('returns the same list when nothing matches', () => {
     expect(retireDelivered(list, ['zzz'])).toHaveLength(2)
+  })
+})
+
+describe('storeUnsent', () => {
+  const row = (clientId: string): UnsentMessage => ({
+    clientId,
+    body: 'merhaba',
+    failedAt: '2026-09-11T18:00:00.000Z',
+  })
+
+  it('keeps the thread just written at the front', () => {
+    const stored = storeUnsent({ b: [row('b1')] }, 'a', [row('a1')])
+    expect(Object.keys(stored)).toEqual(['a', 'b'])
+  })
+
+  it('drops a thread once its last row has gone', () => {
+    expect(storeUnsent({ a: [row('a1')] }, 'a', [])).toEqual({})
+  })
+
+  it('remembers only the most recent threads', () => {
+    let stored: UnsentByConversation = {}
+    for (let i = 0; i < MAX_UNSENT_THREADS + 4; i++) {
+      stored = storeUnsent(stored, `c${i}`, [row(`m${i}`)])
+    }
+    expect(Object.keys(stored)).toHaveLength(MAX_UNSENT_THREADS)
+    // The newest is kept, the oldest is not.
+    expect(stored[`c${MAX_UNSENT_THREADS + 3}`]).toBeDefined()
+    expect(stored.c0).toBeUndefined()
   })
 })

--- a/apps/mobile/src/lib/unsentMessages.ts
+++ b/apps/mobile/src/lib/unsentMessages.ts
@@ -11,10 +11,14 @@
  * `src/lib/**` and `src/i18n/**`. The same logic inside the chat screen would
  * never be tested.
  *
- * Not persisted yet, deliberately. Surviving an app kill needs a real store —
- * `localFlags` swallows its own write failures by design, which is exactly the
- * wrong contract for a queue — and a server-side `clientId` so a retry cannot
- * double-post. Both are their own change; this one stops the silent loss.
+ * Persisted since the tunnel work, through `unsentStore.ts` — the half of it
+ * that touches `localFlags` lives there, so this file stays loadable by the
+ * tests. The two things that made it wait have both arrived: the server
+ * refuses a second message with the same `(senderId, clientId)` by unique
+ * index, so a retry cannot double-post, and the store's swallowed write
+ * failures are the right contract after all once the promise is read as "kept
+ * where possible" rather than "queued". A write that fails leaves exactly what
+ * was there before this: a row that lives as long as the screen does.
  */
 
 export interface UnsentMessage {
@@ -72,4 +76,35 @@ export function retireDelivered(
  */
 export function newClientId(now: number, random: number): string {
   return `${now.toString(36)}-${Math.floor(random * 1e9).toString(36)}`
+}
+
+/**
+ * Every conversation's unsent rows, as one stored value.
+ *
+ * One key rather than a key per conversation: the store is `expo-secure-store`
+ * on native, whose keys are not enumerable, so anything written per
+ * conversation could never be found again to clean up. Bounded on both axes —
+ * `MAX_UNSENT` rows within a thread, `MAX_UNSENT_THREADS` threads — because a
+ * record that only ever grows is a slow way to fill a keychain.
+ */
+export type UnsentByConversation = Record<string, UnsentMessage[]>
+
+export const MAX_UNSENT_THREADS = 10
+
+/**
+ * Writes one conversation's rows into the record, newest thread first, and
+ * drops a thread that has nothing left in it. Pure, so the bounding is
+ * testable without a device.
+ */
+export function storeUnsent(
+  stored: UnsentByConversation,
+  conversationId: string,
+  list: readonly UnsentMessage[],
+): UnsentByConversation {
+  const rest: [string, UnsentMessage[]][] = Object.entries(stored).filter(
+    ([id]) => id !== conversationId,
+  )
+  const kept: [string, UnsentMessage[]][] =
+    list.length > 0 ? [[conversationId, [...list]], ...rest] : rest
+  return Object.fromEntries(kept.slice(0, MAX_UNSENT_THREADS))
 }

--- a/apps/mobile/src/lib/unsentStore.ts
+++ b/apps/mobile/src/lib/unsentStore.ts
@@ -1,0 +1,35 @@
+import { FLAG_KEYS, readJsonFlag, writeJsonFlag } from './localFlags'
+import { storeUnsent, type UnsentByConversation, type UnsentMessage } from './unsentMessages'
+
+/**
+ * Where the "not sent" rows live between one opening of a chat and the next.
+ *
+ * They used to live in React state and nowhere else, so the sentence somebody
+ * typed in a tunnel survived exactly as long as the screen did: going back to
+ * the list to see whether anything else had arrived threw it away. The row is
+ * the only copy of that sentence there is — the composer is empty by then —
+ * which makes losing it the worst outcome in this whole area.
+ *
+ * Best-effort by design, not a queue. `localFlags` swallows a failed write, so
+ * the promise here is "kept where possible": a device that cannot store it is
+ * left exactly where it was before any of this, with a row that lives as long
+ * as the screen. Retrying is safe whatever survives — the server refuses a
+ * second message with the same `(senderId, clientId)` by unique index.
+ *
+ * Split from `unsentMessages.ts` so that module stays free of `react-native`
+ * and inside what the mobile test setup can load; the shape-keeping is there
+ * and tested, the device is here.
+ */
+export async function loadUnsent(conversationId: string): Promise<UnsentMessage[]> {
+  const stored = await readJsonFlag<UnsentByConversation>(FLAG_KEYS.unsentMessages)
+  const rows = stored?.[conversationId]
+  return Array.isArray(rows) ? rows : []
+}
+
+export async function saveUnsent(
+  conversationId: string,
+  list: readonly UnsentMessage[],
+): Promise<void> {
+  const stored = (await readJsonFlag<UnsentByConversation>(FLAG_KEYS.unsentMessages)) ?? {}
+  await writeJsonFlag(FLAG_KEYS.unsentMessages, storeUnsent(stored, conversationId, list))
+}


### PR DESCRIPTION
A metro ride, measured: the transport layer in Node against a real socket.io
server and a TCP proxy, then the dev client on a simulator with the API killed
(no route) and frozen with `kill -STOP` (a tunnel: accepted, never answered).
Three things were wrong, and the fixes are one commit each.

**The app said a member was new.** With no route the session comes back from
the keychain cache, so the app is signed in — and then `/profiles/me` failed,
`index.tsx` read `!profile` as "no profile yet", and somebody with a complete
profile was dropped into the onboarding wizard. Nothing they filled in could be
saved, and it did not heal when the network returned. Only a 404 means "no
profile" now; everything else is a screen with a retry button.

**Nothing timed out.** RN's `XMLHttpRequest.timeout` is 0 and Android's OkHttp
is built with `connectTimeout(0)/readTimeout(0)`, so a tunnel left requests
pending — still pending after three minutes on iOS, with the list pulsing
throughout. `apiFetch` and the Better Auth client now give up after ten
seconds, and a timeout gets one retry rather than two: about twenty seconds to
a screen somebody can act on, verified on the device.

**Nothing said why.** There was no component anywhere that could say "no
internet". `onlineManager` and `focusManager` are wired to `expo-network` and
`AppState` (both already dependencies), so a query with no network waits
instead of being fired into the dark and runs by itself on the way out of the
tunnel. `OfflineBanner` says it once for every screen. `listState` grows a
`'failed'` state so seven lists stop claiming there is nothing there — chats,
feed, corrections, chat media, a post, a thread, and discovery, which had the
branch by hand since #1314. The optimistic mutations stopped rolling back in
silence, the chat composer stops waiting out a twelve-second ack it cannot
win, and the rows it leaves behind now survive the screen: a sentence typed in
a tunnel was the only copy there was, and leaving the thread threw it away.

## Verified

- `pnpm test` (857), typecheck, eslint, prettier.
- Simulator, API killed: cold start lands on "Could not load this" with a Try
  again that works, not on "Step 1 of 5".
- Simulator, API frozen: Feed and Chats reach the same screen in about twenty
  seconds instead of pulsing for three minutes.
- Browser build, online state faked: the banner appears with the failed panel
  at once, and both go away on their own when the network comes back.

Not verified on a device: the banner itself (the simulator cannot lose its
radio) and the instant unsent row (the dev account has no conversation) — both
exercised in the browser build and by their own units instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)