### PR TITLE
Send one notification email a day instead of four

### DIFF
--- a/apps/api/src/email/notify.ts
+++ b/apps/api/src/email/notify.ts
@@ -7,7 +7,7 @@ import { isEmailSuppressed } from '../modules/notifications/suppressions'
 import type { Profile } from '../modules/profiles/profiles'
 import type { Email } from './templates'
 import type { EmailSender } from './sender'
-import { signUnsubscribeToken, unsubscribeUrl } from './unsubscribeToken'
+import { signUnsubscribeToken, unsubscribeUrl, type UnsubscribeScope } from './unsubscribeToken'
 
 /** What every notification sender needs, built once in `index.ts`. */
 export interface NotificationEmailContext {
@@ -64,7 +64,47 @@ export async function sendNotificationEmail(
     return 'opted-out'
   }
 
-  const address = await emailFor(db, input.userId)
+  return deliver(db, ctx, input.userId, input.type, input.build)
+}
+
+/**
+ * The evening digest, which is the one mail that is not about a single kind.
+ *
+ * No preference check here, and that is not a hole in the wall `notify.ts`
+ * builds. Every section of a digest asks `notificationsAllowed` for *its own*
+ * kind while it is being built, a kind switched off produces no section, and a
+ * digest with no sections is never handed to this function. So the check still
+ * happens exactly once per kind — it has moved from the envelope to the
+ * paragraphs, because that is where the kinds now live.
+ *
+ * The unsubscribe scope is `all` for the same reason: a letter carrying every
+ * kind cannot honestly offer to stop one of them, and `routes/email.ts`
+ * already knows how to switch email off across the board. Per-kind control is
+ * the settings screen, which the footer's second link points at.
+ */
+export async function sendDigestEmail(
+  db: Db,
+  ctx: NotificationEmailContext,
+  input: { userId: string; build: (locale: Locale, unsubscribe: string) => Email },
+): Promise<NotificationEmailOutcome> {
+  const profile = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .findOne({ _id: input.userId }, { projection: { deletedAt: 1 } })
+  if (!profile) return 'no-profile'
+  if (profile.deletedAt) return 'deleted'
+
+  return deliver(db, ctx, input.userId, 'all', input.build)
+}
+
+/** Address, suppression, locale and the footer — everything past the consent. */
+async function deliver(
+  db: Db,
+  ctx: NotificationEmailContext,
+  userId: string,
+  scope: UnsubscribeScope,
+  build: (locale: Locale, unsubscribe: string) => Email,
+): Promise<NotificationEmailOutcome> {
+  const address = await emailFor(db, userId)
   if (!address) return 'no-email'
   // Never to an unproved address. Somebody who typed a stranger's email at
   // sign-up and never clicked the link has not agreed to anything, and the
@@ -74,15 +114,15 @@ export async function sendNotificationEmail(
   // preference says what they want, the suppression says what can arrive.
   if (await isEmailSuppressed(db, address.email)) return 'suppressed'
 
-  const locale = await localeFor(db, input.userId)
+  const locale = await localeFor(db, userId)
   const url = unsubscribeUrl(
     ctx.apiBaseUrl,
-    signUnsubscribeToken(ctx.unsubscribeSecret, input.userId, input.type),
+    signUnsubscribeToken(ctx.unsubscribeSecret, userId, scope),
   )
 
   await ctx.sender.send({
     to: address.email,
-    ...input.build(locale, url),
+    ...build(locale, url),
     headers: unsubscribeHeaders(url),
   })
   return 'sent'

--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -169,6 +169,96 @@ export interface Email {
 }
 
 /**
+ * One thing worth saying, on its way into the evening's single mail.
+ *
+ * Nothing here is a letter. A section is a heading, a paragraph or two and one
+ * link, and the mail is however many of them the day produced — which is the
+ * whole point of the rewrite: five senders that each used to post their own
+ * envelope now hand their contents to one.
+ *
+ * `subject` and `preheader` belong to the section rather than to the mail
+ * because the mail has no words of its own. The section that leads lends the
+ * envelope its subject, and that is deliberately a real sentence about
+ * something that happened — "3 unread messages" — rather than a
+ * "Your day on LangX" that says nothing and gets opened accordingly.
+ */
+export interface DigestSection {
+  /** The mail's subject, if this section leads it. */
+  subject: string
+  /** And its preheader. */
+  preheader: string
+  /** The section's own paragraphs. The heading is drawn by the composer. */
+  html: string
+  /** The same, as plain-text lines. */
+  text: string[]
+  /** Where this section's link goes. */
+  cta: { url: string; label: string }
+  /** Faces, for the two sections that carry any. */
+  attachments?: InlineAsset[]
+}
+
+/** Between two sections. Light enough not to read as the end of the mail. */
+const SECTION_RULE = '<hr style="border:none; border-top:1px solid #e8eaec; margin:28px 0 0;" />'
+
+function sectionHeading(text: string): string {
+  return `<p style="margin:20px 0 0;"><strong style="font-family:${TITLE_FONT}; font-size:18px; line-height:24px; color:#17191c;">${text}</strong></p>`
+}
+
+/**
+ * The one notification email of the day.
+ *
+ * The lead section gets the button; every other one gets an inline link under
+ * its own heading. One button rather than five is not a style choice — a mail
+ * with five equal buttons has no primary action, and the lead section is by
+ * construction the most urgent thing in it.
+ *
+ * The caller guarantees at least one section. An empty digest is not a mail
+ * with nothing in it, it is a mail that must never be sent, and that decision
+ * belongs where the sections are gathered rather than here.
+ */
+export function dailyDigestEmail(
+  locale: Locale,
+  { sections, unsubscribe }: { sections: DigestSection[]; unsubscribe: string },
+): Email {
+  const [lead, ...rest] = sections
+  if (!lead) throw new Error('a digest with no sections must not be built')
+
+  const bodyHtml = [
+    sectionHeading(lead.subject),
+    lead.html,
+    ...rest.flatMap((section) => [
+      SECTION_RULE,
+      sectionHeading(section.subject),
+      section.html,
+      `<p style="margin:12px 0 0;"><a href="${section.cta.url}" style="color:#3b6cf6; text-decoration:none; font-weight:600;">${section.cta.label}</a></p>`,
+    ]),
+  ].join('\n      ')
+
+  return {
+    subject: lead.subject,
+    html: notificationEmail(locale, {
+      preheader: lead.preheader,
+      bodyHtml,
+      cta: lead.cta,
+      unsubscribeUrl: unsubscribe,
+      manageUrl: webUrl('/settings'),
+    }).html,
+    text: notificationText(
+      locale,
+      [
+        lead.subject,
+        ...lead.text,
+        '',
+        lead.cta.url,
+        ...rest.flatMap((section) => ['', '—', section.subject, ...section.text, section.cta.url]),
+      ],
+      unsubscribe,
+    ),
+    attachments: sections.flatMap((section) => section.attachments ?? []),
+  }
+}
+
+/**
  * The shell for mail somebody *chose* to receive, as opposed to the two above,
  * which answer something they just did.
  *
@@ -585,14 +675,10 @@ function monthLabel(locale: Locale, month: string): string {
  * the answer is a mail nobody clicks, and the correction is worth seeing
  * beside the sentence it corrects.
  */
-export function feedDigestEmail(
+export function feedDigestSection(
   locale: Locale,
-  {
-    items,
-    morePosts,
-    unsubscribe,
-  }: { items: FeedDigestItem[]; morePosts: number; unsubscribe: string },
-): Email {
+  { items, morePosts }: { items: FeedDigestItem[]; morePosts: number },
+): DigestSection {
   const t = translator(locale)
   const total = items.reduce(
     (sum, item) => sum + item.corrections + item.answers + item.comments,
@@ -610,31 +696,20 @@ export function feedDigestEmail(
     })
     .join('\n       ')
   const more = morePosts > 0 ? t('email.feedDigestMore', { count: morePosts }) : ''
-  const cta = { url: webUrl('/me'), label: t('email.feedDigestButton') }
 
   return {
     subject,
-    html: notificationEmail(locale, {
-      preheader: t('email.feedDigestPreheader'),
-      bodyHtml: `<p>${t('email.feedDigestBody', { count: total })}</p>
+    preheader: t('email.feedDigestPreheader'),
+    html: `<p>${t('email.feedDigestBody', { count: total })}</p>
        ${rows}
        ${more ? `<p style="margin:16px 0 0; color:#62676d;">${more}</p>` : ''}`,
-      cta,
-      unsubscribeUrl: unsubscribe,
-      manageUrl: webUrl('/settings'),
-    }).html,
-    text: notificationText(
-      locale,
-      [
-        t('email.feedDigestBody', { count: total }),
-        '',
-        ...items.map((item) => `"${item.excerpt}" — ${postUrl(item.postId)}`),
-        ...(more ? ['', more] : []),
-        '',
-        cta.url,
-      ],
-      unsubscribe,
-    ),
+    text: [
+      t('email.feedDigestBody', { count: total }),
+      '',
+      ...items.map((item) => `"${item.excerpt}" — ${postUrl(item.postId)}`),
+      ...(more ? ['', more] : []),
+    ],
+    cta: { url: webUrl('/me'), label: t('email.feedDigestButton') },
   }
 }
 
@@ -779,24 +854,16 @@ export function securityEmail(
  * month and only the web the next, and a reminder that changes its voice
  * depending on how it arrived reads as two different features.
  */
-export function streakReminderEmail(
-  locale: Locale,
-  { count, unsubscribe }: { count: number; unsubscribe: string },
-): Email {
+export function streakReminderSection(locale: Locale, { count }: { count: number }): DigestSection {
   const t = translator(locale)
   const title = t('push.streakTitle', { count })
   const body = t('push.streakBody')
-  const cta = { url: webUrl('/chats'), label: t('email.openChats') }
   return {
     subject: title,
-    html: notificationEmail(locale, {
-      preheader: body,
-      bodyHtml: `<p><strong>${title}</strong></p><p>${body}</p>`,
-      cta,
-      unsubscribeUrl: unsubscribe,
-      manageUrl: webUrl('/settings'),
-    }).html,
-    text: notificationText(locale, [title, body, '', cta.url], unsubscribe),
+    preheader: body,
+    html: `<p>${body}</p>`,
+    text: [body],
+    cta: { url: webUrl('/chats'), label: t('email.openChats') },
   }
 }
 
@@ -809,46 +876,39 @@ export function streakReminderEmail(
  * Resend's logs, and in an inbox that may not be private, is a different
  * disclosure than the one anyone agreed to.
  */
-export function unreadDigestEmail(
+export function unreadDigestSection(
   locale: Locale,
   {
     count,
     faces,
     moreThreads,
     url,
-    unsubscribe,
   }: {
     count: number
     /** Who wrote, in the order the threads came back. */
     faces: AvatarFace[]
     moreThreads: number
     url: string
-    unsubscribe: string
   },
-): Email {
+): DigestSection {
   const t = translator(locale)
-  const subject = t('email.digestSubject', { count })
   // `Intl.ListFormat` because "Ada, Bo and Cy" is not "Ada, Bo, Cy" in most of
   // the eight languages, and joining with a comma is wrong in all of them.
-  const names = faces.map((face) => face.name)
-  const joined = formatList(locale, names)
+  const joined = formatList(
+    locale,
+    faces.map((face) => face.name),
+  )
   const body = t('email.digestBody', { count, names: joined })
   const more = moreThreads > 0 ? t('email.digestMore', { count: moreThreads }) : ''
-  const cta = { url, label: t('email.digestButton') }
 
   return {
-    subject,
-    html: notificationEmail(locale, {
-      preheader: t('email.digestPreheader'),
-      bodyHtml: `<p>${body}</p>`,
-      // The faces stand in for the "and N more" sentence rather than
-      // repeating it: a grey +N disc says the same thing in less room.
-      extraHtml: facesRow(faces, moreThreads, locale === 'ar' ? 'rtl' : 'ltr'),
-      cta,
-      unsubscribeUrl: unsubscribe,
-      manageUrl: webUrl('/settings'),
-    }).html,
-    text: notificationText(locale, [body, ...(more ? [more] : []), '', cta.url], unsubscribe),
+    subject: t('email.digestSubject', { count }),
+    preheader: t('email.digestPreheader'),
+    // The faces stand in for the "and N more" sentence rather than repeating
+    // it: a grey +N disc says the same thing in less room.
+    html: `<p>${body}</p>${facesRow(faces, moreThreads, locale === 'ar' ? 'rtl' : 'ltr')}`,
+    text: [body, ...(more ? [more] : [])],
+    cta: { url, label: t('email.digestButton') },
     attachments: faces.flatMap((face) => (face.asset ? [face.asset] : [])),
   }
 }
@@ -863,6 +923,112 @@ function formatList(locale: Locale, items: string[]): string {
 }
 
 /**
+ * "People you could practise with" — the same faces the digest draws, for
+ * people the reader has never met rather than ones who wrote to them.
+ *
+ * Names and photos only, and nothing about why each one was picked. The
+ * matching is mutual language fit and the body says so in general terms; a
+ * line reading "she is learning your native language at B1" would be a
+ * profile field sent to somebody who never opened that profile, which is a
+ * different disclosure than the one a discoverable account agreed to.
+ */
+export function matchSuggestionsSection(
+  locale: Locale,
+  {
+    faces,
+    more,
+  }: {
+    /** Who to show, already ordered by fit. */
+    faces: AvatarFace[]
+    /** How many further matches there were, for the grey disc. */
+    more: number
+  },
+): DigestSection {
+  const t = translator(locale)
+  const body = t('email.matchesBody', {
+    names: formatList(
+      locale,
+      faces.map((face) => face.name),
+    ),
+  })
+
+  return {
+    subject: t('email.matchesSubject'),
+    preheader: t('email.matchesPreheader'),
+    html: `<p>${body}</p>${facesRow(faces, more, locale === 'ar' ? 'rtl' : 'ltr')}`,
+    text: [body],
+    cta: { url: webUrl('/discover'), label: t('email.matchesButton') },
+    attachments: faces.flatMap((face) => (face.asset ? [face.asset] : [])),
+  }
+}
+
+/**
+ * "Yesterday's pool paid you N tokens", which used to be a push and nothing
+ * else.
+ *
+ * It is still not worth a letter of its own — a mail whose entire content is a
+ * number going up is how a sending domain gets filtered — but it is worth a
+ * paragraph in one that was going out anyway, because the pool is the part of
+ * the wallet nobody can see happening.
+ */
+export function walletPoolSection(locale: Locale, { count }: { count: number }): DigestSection {
+  const t = translator(locale)
+  const title = t('push.wallet.poolTitle', { count })
+  const body = t('email.walletBody')
+
+  return {
+    subject: title,
+    preheader: title,
+    html: `<p>${body}</p>`,
+    text: [body],
+    cta: { url: webUrl('/wallet'), label: t('email.walletButton') },
+  }
+}
+
+/** One call in the diary: when it starts, on the reader's clock, and with whom. */
+export interface DigestMeeting {
+  /** Already formatted in the reader's zone — this file has no clock. */
+  time: string
+  name: string
+  conversationId: string
+}
+
+/**
+ * "Tomorrow you have a call with Ada at 18:00."
+ *
+ * Not the hour-before reminder, which stays a push: an email an hour before a
+ * call is either too late to read or a copy of the buzz that already worked.
+ * This answers the question an hour's notice cannot — what is in the diary
+ * tomorrow — which is the only form of this the evening mail can honestly
+ * carry.
+ */
+export function meetingsSection(
+  locale: Locale,
+  { meetings }: { meetings: DigestMeeting[] },
+): DigestSection {
+  const t = translator(locale)
+  const title = t('email.meetingsSubject', { count: meetings.length })
+  const rows = meetings
+    .map(
+      (meeting) =>
+        `<p style="margin:12px 0 0;"><a href="${webUrl(`/chat/${meeting.conversationId}`)}" style="color:#17191c; text-decoration:none;"><strong>${escapeHtml(meeting.time)}</strong> &nbsp;${escapeHtml(meeting.name)}</a></p>`,
+    )
+    .join('\n       ')
+
+  return {
+    subject: title,
+    preheader: t('email.meetingsPreheader'),
+    html: `<p>${t('email.meetingsBody', { count: meetings.length })}</p>\n       ${rows}`,
+    text: [
+      t('email.meetingsBody', { count: meetings.length }),
+      '',
+      ...meetings.map((meeting) => `${meeting.time} ${meeting.name}`),
+    ],
+    cta: { url: webUrl('/chats'), label: t('email.meetingsButton') },
+  }
+}
+
+/**
  * "People looked at your profile this week."
  *
  * `names` is `null` for a free account — not empty, which would read as
@@ -870,29 +1036,23 @@ function formatList(locale: Locale, items: string[]): string {
  * half, so this says how many either way and adds the line about upgrading
  * only when it has something to withhold.
  */
-export function profileVisitsEmail(
+export function profileVisitsSection(
   locale: Locale,
-  { count, names, unsubscribe }: { count: number; names: string[] | null; unsubscribe: string },
-): Email {
+  { count, names }: { count: number; names: string[] | null },
+): DigestSection {
   const t = translator(locale)
-  const subject = t('email.visitsSubject', { count })
   const body = t('email.visitsBody', { count })
   const detail =
     names && names.length > 0
       ? t('email.visitsNames', { names: formatList(locale, names) })
       : t('email.visitsLocked')
-  const cta = { url: webUrl('/viewers'), label: t('email.visitsButton') }
 
   return {
-    subject,
-    html: notificationEmail(locale, {
-      preheader: t('email.visitsPreheader'),
-      bodyHtml: `<p>${body}</p><p style="color:#62676d;">${detail}</p>`,
-      cta,
-      unsubscribeUrl: unsubscribe,
-      manageUrl: webUrl('/settings'),
-    }).html,
-    text: notificationText(locale, [body, detail, '', cta.url], unsubscribe),
+    subject: t('email.visitsSubject', { count }),
+    preheader: t('email.visitsPreheader'),
+    html: `<p>${body}</p><p style="color:#62676d;">${detail}</p>`,
+    text: [body, detail],
+    cta: { url: webUrl('/viewers'), label: t('email.visitsButton') },
   }
 }
 
@@ -904,27 +1064,22 @@ export function profileVisitsEmail(
  * badge is new; several become a count, because five English labels inside an
  * Arabic sentence read worse than a number does.
  */
-export function badgeEarnedEmail(
+export function badgeEarnedSection(
   locale: Locale,
-  { count, label, unsubscribe }: { count: number; label: string | null; unsubscribe: string },
-): Email {
+  { count, label }: { count: number; label: string | null },
+): DigestSection {
   const t = translator(locale)
   const title = label
     ? t('email.badgeOneSubject', { label })
     : t('email.badgeManySubject', { count })
   const body = t('email.badgeBody')
-  const cta = { url: webUrl('/me'), label: t('email.badgeButton') }
 
   return {
     subject: title,
-    html: notificationEmail(locale, {
-      preheader: title,
-      bodyHtml: `<p><strong>${title}</strong></p><p>${body}</p>`,
-      cta,
-      unsubscribeUrl: unsubscribe,
-      manageUrl: webUrl('/settings'),
-    }).html,
-    text: notificationText(locale, [title, body, '', cta.url], unsubscribe),
+    preheader: title,
+    html: `<p>${body}</p>`,
+    text: [body],
+    cta: { url: webUrl('/me'), label: t('email.badgeButton') },
   }
 }
 

--- a/apps/api/src/i18n/messages/ar.ts
+++ b/apps/api/src/i18n/messages/ar.ts
@@ -255,6 +255,35 @@ export const ar: Localized<ServerMessages> = {
 
     feedDigestButton: 'اقرأ الردود',
 
+    /** The digest's one passenger: people the reader has never spoken to. */
+    matchesSubject: 'أشخاص يمكنك التدرب معهم',
+
+    matchesPreheader: 'أشخاص جدد لغاتهم تناسب لغاتك',
+
+    matchesBody: '{names} يتحدثون اللغات التي تتعلمها، ويتعلمون لغتك.',
+
+    matchesButton: 'شاهد من هنا',
+
+    /** Yesterday's pool, as a paragraph rather than the letter it never was. */
+    walletBody: 'هي في محفظتك بالفعل. يوزَّع المجمّع كل ليلة على كل من ساعد شخصًا في اليوم السابق.',
+
+    walletButton: 'افتح محفظتي',
+
+    /** Tomorrow's diary. The hour-before reminder is still a push. */
+    meetingsSubject: {
+      one: 'لديك مكالمة غدًا',
+      other: 'لديك {count} مكالمات غدًا',
+    },
+
+    meetingsPreheader: 'ما ينتظرك غدًا',
+
+    meetingsBody: {
+      one: 'اتفقت على مكالمة واحدة غدًا.',
+      other: 'اتفقت على {count} مكالمات غدًا.',
+    },
+
+    meetingsButton: 'افتح محادثاتي',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/de.ts
+++ b/apps/api/src/i18n/messages/de.ts
@@ -260,6 +260,36 @@ export const de: Localized<ServerMessages> = {
 
     feedDigestButton: 'Antworten lesen',
 
+    /** The digest's one passenger: people the reader has never spoken to. */
+    matchesSubject: 'Leute, mit denen du üben könntest',
+
+    matchesPreheader: 'Neue Leute, deren Sprachen zu deinen passen',
+
+    matchesBody: '{names} sprechen die Sprachen, die du lernst — und lernen deine.',
+
+    matchesButton: 'Sieh, wer hier ist',
+
+    /** Yesterday's pool, as a paragraph rather than the letter it never was. */
+    walletBody:
+      'Sie liegen schon in deiner Wallet. Der Pool wird jede Nacht unter allen aufgeteilt, die am Tag davor jemandem geholfen haben.',
+
+    walletButton: 'Wallet öffnen',
+
+    /** Tomorrow's diary. The hour-before reminder is still a push. */
+    meetingsSubject: {
+      one: 'Morgen ein Gespräch',
+      other: 'Morgen {count} Gespräche',
+    },
+
+    meetingsPreheader: 'Was morgen ansteht',
+
+    meetingsBody: {
+      one: 'Du hast für morgen ein Gespräch zugesagt.',
+      other: 'Du hast für morgen {count} Gespräche zugesagt.',
+    },
+
+    meetingsButton: 'Chats öffnen',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/en.ts
+++ b/apps/api/src/i18n/messages/en.ts
@@ -265,6 +265,36 @@ export const en = {
 
     feedDigestButton: 'Read the replies',
 
+    /** The digest's one passenger: people the reader has never spoken to. */
+    matchesSubject: 'People you could practise with',
+
+    matchesPreheader: 'New people whose languages match yours',
+
+    matchesBody: '{names} speak the languages you are learning — and are learning yours.',
+
+    matchesButton: 'See who is here',
+
+    /** Yesterday's pool, as a paragraph rather than the letter it never was. */
+    walletBody:
+      'They are in your wallet already. The pool is shared out every night between everybody who helped somebody the day before.',
+
+    walletButton: 'Open my wallet',
+
+    /** Tomorrow's diary. The hour-before reminder is still a push. */
+    meetingsSubject: {
+      one: 'A call tomorrow',
+      other: '{count} calls tomorrow',
+    },
+
+    meetingsPreheader: 'What is in your diary tomorrow',
+
+    meetingsBody: {
+      one: 'You agreed to one call tomorrow.',
+      other: 'You agreed to {count} calls tomorrow.',
+    },
+
+    meetingsButton: 'Open my chats',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/es.ts
+++ b/apps/api/src/i18n/messages/es.ts
@@ -262,6 +262,36 @@ export const es: Localized<ServerMessages> = {
 
     feedDigestButton: 'Leer las respuestas',
 
+    /** The digest's one passenger: people the reader has never spoken to. */
+    matchesSubject: 'Gente con la que podrías practicar',
+
+    matchesPreheader: 'Gente nueva cuyos idiomas encajan con los tuyos',
+
+    matchesBody: '{names} hablan los idiomas que estás aprendiendo, y están aprendiendo el tuyo.',
+
+    matchesButton: 'Mira quién está aquí',
+
+    /** Yesterday's pool, as a paragraph rather than the letter it never was. */
+    walletBody:
+      'Ya están en tu monedero. El fondo se reparte cada noche entre quienes ayudaron a alguien el día anterior.',
+
+    walletButton: 'Abrir mi monedero',
+
+    /** Tomorrow's diary. The hour-before reminder is still a push. */
+    meetingsSubject: {
+      one: 'Mañana tienes una llamada',
+      other: 'Mañana tienes {count} llamadas',
+    },
+
+    meetingsPreheader: 'Lo que tienes mañana en la agenda',
+
+    meetingsBody: {
+      one: 'Has quedado en una llamada para mañana.',
+      other: 'Has quedado en {count} llamadas para mañana.',
+    },
+
+    meetingsButton: 'Abrir mis chats',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/fr.ts
+++ b/apps/api/src/i18n/messages/fr.ts
@@ -267,6 +267,36 @@ export const fr: Localized<ServerMessages> = {
 
     feedDigestButton: 'Lire les réponses',
 
+    /** The digest's one passenger: people the reader has never spoken to. */
+    matchesSubject: 'Des personnes avec qui pratiquer',
+
+    matchesPreheader: 'De nouvelles personnes dont les langues correspondent aux vôtres',
+
+    matchesBody: '{names} parlent les langues que vous apprenez — et apprennent la vôtre.',
+
+    matchesButton: 'Voir qui est là',
+
+    /** Yesterday's pool, as a paragraph rather than the letter it never was. */
+    walletBody:
+      "Ils sont déjà dans votre portefeuille. La cagnotte est partagée chaque nuit entre celles et ceux qui ont aidé quelqu'un la veille.",
+
+    walletButton: 'Ouvrir mon portefeuille',
+
+    /** Tomorrow's diary. The hour-before reminder is still a push. */
+    meetingsSubject: {
+      one: 'Un appel demain',
+      other: '{count} appels demain',
+    },
+
+    meetingsPreheader: 'Ce qui vous attend demain',
+
+    meetingsBody: {
+      one: 'Vous avez accepté un appel pour demain.',
+      other: 'Vous avez accepté {count} appels pour demain.',
+    },
+
+    meetingsButton: 'Ouvrir mes discussions',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/pt-BR.ts
+++ b/apps/api/src/i18n/messages/pt-BR.ts
@@ -259,6 +259,36 @@ export const ptBR: Localized<ServerMessages> = {
 
     feedDigestButton: 'Ler as respostas',
 
+    /** The digest's one passenger: people the reader has never spoken to. */
+    matchesSubject: 'Pessoas com quem você poderia praticar',
+
+    matchesPreheader: 'Pessoas novas cujos idiomas combinam com os seus',
+
+    matchesBody: '{names} falam os idiomas que você está aprendendo — e estão aprendendo o seu.',
+
+    matchesButton: 'Veja quem está aqui',
+
+    /** Yesterday's pool, as a paragraph rather than the letter it never was. */
+    walletBody:
+      'Eles já estão na sua carteira. O fundo é dividido toda noite entre quem ajudou alguém no dia anterior.',
+
+    walletButton: 'Abrir minha carteira',
+
+    /** Tomorrow's diary. The hour-before reminder is still a push. */
+    meetingsSubject: {
+      one: 'Amanhã você tem uma chamada',
+      other: 'Amanhã você tem {count} chamadas',
+    },
+
+    meetingsPreheader: 'O que está na sua agenda amanhã',
+
+    meetingsBody: {
+      one: 'Você combinou uma chamada para amanhã.',
+      other: 'Você combinou {count} chamadas para amanhã.',
+    },
+
+    meetingsButton: 'Abrir minhas conversas',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/ru.ts
+++ b/apps/api/src/i18n/messages/ru.ts
@@ -270,6 +270,36 @@ export const ru: Localized<ServerMessages> = {
 
     feedDigestButton: 'Читать ответы',
 
+    /** The digest's one passenger: people the reader has never spoken to. */
+    matchesSubject: 'Люди, с которыми можно попрактиковаться',
+
+    matchesPreheader: 'Новые люди, чьи языки совпадают с вашими',
+
+    matchesBody: '{names} говорят на языках, которые вы учите, и учат ваш.',
+
+    matchesButton: 'Посмотреть, кто здесь',
+
+    /** Yesterday's pool, as a paragraph rather than the letter it never was. */
+    walletBody:
+      'Они уже в вашем кошельке. Пул каждую ночь делится между всеми, кто накануне кому-то помог.',
+
+    walletButton: 'Открыть кошелёк',
+
+    /** Tomorrow's diary. The hour-before reminder is still a push. */
+    meetingsSubject: {
+      one: 'Завтра у вас звонок',
+      other: 'Завтра у вас {count} звонков',
+    },
+
+    meetingsPreheader: 'Что у вас запланировано на завтра',
+
+    meetingsBody: {
+      one: 'Вы договорились об одном звонке на завтра.',
+      other: 'Вы договорились о {count} звонках на завтра.',
+    },
+
+    meetingsButton: 'Открыть чаты',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/i18n/messages/tr.ts
+++ b/apps/api/src/i18n/messages/tr.ts
@@ -245,6 +245,36 @@ export const tr: Localized<ServerMessages> = {
 
     feedDigestButton: 'Yanıtları oku',
 
+    /** The digest's one passenger: people the reader has never spoken to. */
+    matchesSubject: 'Pratik yapabileceğin kişiler',
+
+    matchesPreheader: 'Dilleri seninkilerle eşleşen yeni kişiler',
+
+    matchesBody: '{names} senin öğrendiğin dilleri konuşuyor — ve senin dilini öğreniyor.',
+
+    matchesButton: 'Kimler var, bak',
+
+    /** Yesterday's pool, as a paragraph rather than the letter it never was. */
+    walletBody:
+      'Jetonlar çoktan cüzdanında. Havuz her gece, bir önceki gün birine yardım eden herkes arasında paylaştırılıyor.',
+
+    walletButton: 'Cüzdanımı aç',
+
+    /** Tomorrow's diary. The hour-before reminder is still a push. */
+    meetingsSubject: {
+      one: 'Yarın bir görüşmen var',
+      other: 'Yarın {count} görüşmen var',
+    },
+
+    meetingsPreheader: 'Yarın ajandanda ne var',
+
+    meetingsBody: {
+      one: 'Yarın için bir görüşmeye söz verdin.',
+      other: 'Yarın için {count} görüşmeye söz verdin.',
+    },
+
+    meetingsButton: 'Sohbetlerimi aç',
+
     /**
 
      * The nudges in `modules/notifications/promotions.ts`, in its order.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -101,7 +101,7 @@ async function main(): Promise<void> {
   const schedulers = [
     startDailyPoolScheduler(db, app.log),
     startPurgeScheduler(db, app.log, { storage, ...(analytics ? { analytics } : {}) }),
-    startStreakReminderScheduler(db, push, notificationEmail, app.log),
+    startStreakReminderScheduler(db, push, app.log),
     startMeetingReminderScheduler(db, push, app.log),
     startLegacyImportScheduler(db, app.log),
     startNotificationScheduler(db, { push, email: notificationEmail }, app.log, {

--- a/apps/api/src/modules/notifications/badges.test.ts
+++ b/apps/api/src/modules/notifications/badges.test.ts
@@ -4,14 +4,11 @@ import { MongoMemoryServer } from 'mongodb-memory-server'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { connectToDatabase, type DbHandle } from '../../db/client'
 import { COLLECTIONS } from '../../db/collections'
-import type { NotificationEmailContext } from '../../email/notify'
 import { authId } from '../../lib/authId'
 import { CapturingEmailSender } from '../../testSupport/authFlow'
 import type { Profile } from '../profiles/profiles'
 import { LoggingPushSender, type Device } from '../push/devices'
 import { runBadgeRoundUpPass } from './badges'
-
-const SECRET = 'f'.repeat(40)
 
 function zoneWhereItIsRoundUpHour(now: Date): string {
   const offset = (now.getUTCHours() - BADGE_ROUND_UP_LOCAL_HOUR + 24) % 24
@@ -24,7 +21,6 @@ describe('the badge round-up', () => {
   let handle: DbHandle
   let push: LoggingPushSender
   let sender: CapturingEmailSender
-  let senders: { push: LoggingPushSender; email: NotificationEmailContext }
   const now = new Date('2026-09-03T15:00:00Z')
   const zone = zoneWhereItIsRoundUpHour(now)
 
@@ -54,10 +50,6 @@ describe('the badge round-up', () => {
     }
     push = new LoggingPushSender()
     sender = new CapturingEmailSender()
-    senders = {
-      push,
-      email: { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api.langx.io' },
-    }
   })
 
   async function newProfile(
@@ -107,6 +99,14 @@ describe('the badge round-up', () => {
     return profile?.stats.notifiedBadgeIds
   }
 
+  /** What the round-up left on the profile for the evening digest to collect. */
+  async function pendingOf(userId: string): Promise<Profile['stats']['digestBadges']> {
+    const profile = await handle.db
+      .collection<Profile>(COLLECTIONS.profiles)
+      .findOne({ _id: userId })
+    return profile?.stats.digestBadges
+  }
+
   /**
    * The one that matters on the day this ships: everybody already has badges,
    * and none of them are news.
@@ -114,7 +114,7 @@ describe('the badge round-up', () => {
   it('seeds a profile it has never seen and says nothing', async () => {
     const userId = await newProfile({ messagesSent: 5000, withDevice: true })
 
-    const result = await runBadgeRoundUpPass(handle.db, senders, now)
+    const result = await runBadgeRoundUpPass(handle.db, push, now)
     expect(result).toEqual({ sent: 0, seeded: 1, failed: 0 })
     expect(push.sent).toHaveLength(0)
     expect((await notifiedIdsOf(userId))?.length).toBeGreaterThan(0)
@@ -122,13 +122,13 @@ describe('the badge round-up', () => {
 
   it('names a single new badge', async () => {
     const userId = await newProfile({ messagesSent: 0, withDevice: true })
-    await runBadgeRoundUpPass(handle.db, senders, now)
+    await runBadgeRoundUpPass(handle.db, push, now)
     // Cross one threshold between passes.
     await handle.db
       .collection(COLLECTIONS.profiles)
       .updateOne({ _id: userId as never }, { $set: { 'stats.messagesSent': 100 } })
 
-    const result = await runBadgeRoundUpPass(handle.db, senders, now)
+    const result = await runBadgeRoundUpPass(handle.db, push, now)
     expect(result.sent).toBe(1)
     expect(push.sent[0]?.data.kind).toBe('badgeEarned')
     expect(push.sent[0]?.title).toContain('100 messages')
@@ -136,7 +136,7 @@ describe('the badge round-up', () => {
 
   it('counts them instead when several arrive at once', async () => {
     const userId = await newProfile({ withDevice: true })
-    await runBadgeRoundUpPass(handle.db, senders, now)
+    await runBadgeRoundUpPass(handle.db, push, now)
     await handle.db
       .collection(COLLECTIONS.profiles)
       .updateOne(
@@ -144,45 +144,66 @@ describe('the badge round-up', () => {
         { $set: { 'stats.messagesSent': 5000, 'streak.longest': 60 } },
       )
 
-    await runBadgeRoundUpPass(handle.db, senders, now)
+    await runBadgeRoundUpPass(handle.db, push, now)
     // More than one, so a count rather than a list of English labels.
     expect(push.sent[0]?.title).not.toContain('messages')
   })
 
   it('says nothing twice about the same badge', async () => {
     const userId = await newProfile({ withDevice: true })
-    await runBadgeRoundUpPass(handle.db, senders, now)
+    await runBadgeRoundUpPass(handle.db, push, now)
     await handle.db
       .collection(COLLECTIONS.profiles)
       .updateOne({ _id: userId as never }, { $set: { 'stats.messagesSent': 100 } })
 
-    await runBadgeRoundUpPass(handle.db, senders, now)
-    const again = await runBadgeRoundUpPass(handle.db, senders, now)
+    await runBadgeRoundUpPass(handle.db, push, now)
+    const again = await runBadgeRoundUpPass(handle.db, push, now)
     expect(again.sent).toBe(0)
     expect(push.sent).toHaveLength(1)
   })
 
-  it('emails somebody with no phone who asked for it', async () => {
-    const userId = await newProfile({ notifications: { badges: { email: true } } })
-    await runBadgeRoundUpPass(handle.db, senders, now)
+  /**
+   * The mail half is no longer sent from here. `notifiedBadgeIds` is
+   * overwritten by this pass, so the difference it found cannot be recomputed
+   * at seven o'clock — it is written down instead, and the digest collects it.
+   */
+  it('leaves tonight’s badge news for the digest to carry', async () => {
+    const userId = await newProfile()
+    await runBadgeRoundUpPass(handle.db, push, now)
     await handle.db
       .collection(COLLECTIONS.profiles)
       .updateOne({ _id: userId as never }, { $set: { 'stats.messagesSent': 100 } })
 
-    expect((await runBadgeRoundUpPass(handle.db, senders, now)).sent).toBe(1)
-    expect(sender.messages[0]?.subject).toContain('100 messages')
+    // No phone, so nothing was pushed and the mail is the only channel left.
+    expect((await runBadgeRoundUpPass(handle.db, push, now)).sent).toBe(0)
+    expect(await pendingOf(userId)).toMatchObject({
+      count: 1,
+      label: '100 messages',
+      pushed: false,
+    })
   })
 
-  /** Email is off by default for this kind; the round-up must respect that. */
-  it('sends nothing to somebody with no phone who did not ask for mail', async () => {
-    const userId = await newProfile()
-    await runBadgeRoundUpPass(handle.db, senders, now)
+  /** A badge that buzzed a phone is a passenger, not a reason to write. */
+  it('records that a phone was already told', async () => {
+    const userId = await newProfile({ withDevice: true })
+    await runBadgeRoundUpPass(handle.db, push, now)
     await handle.db
       .collection(COLLECTIONS.profiles)
       .updateOne({ _id: userId as never }, { $set: { 'stats.messagesSent': 100 } })
 
-    expect((await runBadgeRoundUpPass(handle.db, senders, now)).sent).toBe(0)
-    expect(sender.messages).toHaveLength(0)
+    expect((await runBadgeRoundUpPass(handle.db, push, now)).sent).toBe(1)
+    expect(await pendingOf(userId)).toMatchObject({ pushed: true })
+  })
+
+  it('writes nothing down for somebody who turned badge mail off', async () => {
+    const userId = await newProfile({ notifications: { badges: { push: true, email: false } } })
+    await runBadgeRoundUpPass(handle.db, push, now)
+    await handle.db
+      .collection(COLLECTIONS.profiles)
+      .updateOne({ _id: userId as never }, { $set: { 'stats.messagesSent': 100 } })
+
+    await runBadgeRoundUpPass(handle.db, push, now)
+    expect(await pendingOf(userId)).toBeUndefined()
   })
 
   /**
@@ -194,12 +215,12 @@ describe('the badge round-up', () => {
       withDevice: true,
       notifications: { badges: { push: false, email: false } },
     })
-    await runBadgeRoundUpPass(handle.db, senders, now)
+    await runBadgeRoundUpPass(handle.db, push, now)
     await handle.db
       .collection(COLLECTIONS.profiles)
       .updateOne({ _id: userId as never }, { $set: { 'stats.messagesSent': 100 } })
 
-    expect((await runBadgeRoundUpPass(handle.db, senders, now)).sent).toBe(0)
+    expect((await runBadgeRoundUpPass(handle.db, push, now)).sent).toBe(0)
     expect(push.sent).toHaveLength(0)
     expect(await notifiedIdsOf(userId)).toContain('messages.100')
   })
@@ -219,11 +240,11 @@ describe('the badge round-up', () => {
       withDevice: true,
       notifications: { badges: { push: false, email: false } },
     })
-    await runBadgeRoundUpPass(handle.db, senders, now)
+    await runBadgeRoundUpPass(handle.db, push, now)
     await handle.db
       .collection(COLLECTIONS.profiles)
       .updateOne({ _id: userId as never }, { $set: { 'stats.messagesSent': 100 } })
-    await runBadgeRoundUpPass(handle.db, senders, now)
+    await runBadgeRoundUpPass(handle.db, push, now)
 
     expect(push.sent).toHaveLength(0)
     expect(sender.messages).toHaveLength(0)
@@ -256,7 +277,7 @@ describe('the badge round-up', () => {
     const healthy = await newProfile({ messagesSent: 5000, withDevice: true })
 
     const warn = vi.fn()
-    const result = await runBadgeRoundUpPass(handle.db, senders, now, { warn })
+    const result = await runBadgeRoundUpPass(handle.db, push, now, { warn })
 
     expect(result.failed).toBe(1)
     expect(warn).toHaveBeenCalledOnce()
@@ -270,7 +291,7 @@ describe('the badge round-up', () => {
       withDevice: true,
       timezone: zone === 'Etc/GMT+1' ? 'Etc/GMT+2' : 'Etc/GMT+1',
     })
-    expect(await runBadgeRoundUpPass(handle.db, senders, now)).toEqual({
+    expect(await runBadgeRoundUpPass(handle.db, push, now)).toEqual({
       sent: 0,
       seeded: 0,
       failed: 0,

--- a/apps/api/src/modules/notifications/badges.test.ts
+++ b/apps/api/src/modules/notifications/badges.test.ts
@@ -317,7 +317,7 @@ describe('the badge round-up', () => {
     const healthy = await newProfile({ messagesSent: 5000, withDevice: true })
 
     const warn = vi.fn()
-    const result = await runBadgeRoundUpPass(handle.db, senders, now, { warn })
+    const result = await runBadgeRoundUpPass(handle.db, push, now, { warn })
 
     expect(result).toEqual({ sent: 0, seeded: 1, failed: 0 })
     expect(warn).not.toHaveBeenCalled()

--- a/apps/api/src/modules/notifications/badges.ts
+++ b/apps/api/src/modules/notifications/badges.ts
@@ -4,16 +4,17 @@ import {
   localDayKey,
   localHour,
   notificationsAllowed,
+  type Locale,
 } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
-import { sendNotificationEmail, type NotificationEmailContext } from '../../email/notify'
-import { badgeEarnedEmail } from '../../email/templates'
+import { badgeEarnedSection } from '../../email/templates'
 import { translator } from '../../i18n'
 import type { Profile } from '../profiles/profiles'
 import type { SchedulerLogger } from '../tokens/poolScheduler'
 import { sendPush, tokensByLocale, type PushSender } from '../push/devices'
 import { getBadgeSummary } from '../tokens/badges'
+import type { DigestCandidate } from './digest'
 import { recordNotifications } from './inbox'
 import { claimOnce } from './ledger'
 
@@ -44,7 +45,7 @@ import { claimOnce } from './ledger'
  */
 export async function runBadgeRoundUpPass(
   db: Db,
-  senders: { push: PushSender; email: NotificationEmailContext },
+  push: PushSender,
   now: Date = new Date(),
   logger?: Pick<SchedulerLogger, 'warn'>,
 ): Promise<{ sent: number; seeded: number; failed: number }> {
@@ -156,33 +157,66 @@ export async function runBadgeRoundUpPass(
     const only = fresh.length === 1 ? findBadge(fresh[0] as string) : undefined
 
     const byLocale = wantsPush ? await tokensByLocale(db, profile._id) : new Map<never, never>()
-    if (byLocale.size > 0) {
-      for (const [locale, tokens] of byLocale) {
-        const t = translator(locale)
-        await sendPush(db, senders.push, {
-          to: tokens,
-          title: only
-            ? t('push.badgeOneTitle', { label: only.label })
-            : t('push.badgeManyTitle', { count: fresh.length }),
-          body: t('push.badgeBody'),
-          data: { kind: 'badgeEarned' },
-        })
-      }
-      sent++
-      return
+    for (const [locale, tokens] of byLocale) {
+      const t = translator(locale)
+      await sendPush(db, push, {
+        to: tokens,
+        title: only
+          ? t('push.badgeOneTitle', { label: only.label })
+          : t('push.badgeManyTitle', { count: fresh.length }),
+        body: t('push.badgeBody'),
+        data: { kind: 'badgeEarned' },
+      })
     }
+    const pushed = byLocale.size > 0
+    if (pushed) sent++
 
+    /*
+     * The mail half is no longer sent from here — it is left for tonight's
+     * digest, an hour later, because `notifiedBadgeIds` has just been
+     * overwritten and the difference this pass found cannot be recomputed.
+     *
+     * Written whether or not a push went out, with `pushed` recorded beside
+     * it. A badge that already buzzed a phone is worth a line in a mail that
+     * is going anyway and is not worth a mail of its own, and that is a
+     * distinction only the digest can act on.
+     */
     if (!wantsEmail) return
-    const outcome = await sendNotificationEmail(db, senders.email, {
-      userId: profile._id,
-      type: 'badges',
-      build: (locale, unsubscribe) =>
-        badgeEarnedEmail(locale, {
-          count: fresh.length,
-          label: only?.label ?? null,
-          unsubscribe,
-        }),
-    })
-    if (outcome === 'sent') sent++
+    await profiles.updateOne(
+      { _id: profile._id },
+      {
+        $set: {
+          'stats.digestBadges': {
+            day: localDayKey(now, zone),
+            count: fresh.length,
+            label: only?.label ?? null,
+            pushed,
+          },
+        },
+      },
+    )
+  }
+}
+
+/**
+ * What the round-up left for tonight, if it is still tonight.
+ *
+ * The day key is compared rather than trusted: a row survives on the profile
+ * until the next badge is earned, and congratulating somebody again next
+ * Tuesday for a badge they got today is exactly the failure `notifiedBadgeIds`
+ * exists to prevent.
+ */
+export function badgeSectionFor(db: Db, profile: Profile, now: Date): DigestCandidate | null {
+  const pending = profile.stats?.digestBadges
+  if (!pending) return null
+  if (pending.day !== localDayKey(now, profile.timezone ?? 'UTC')) return null
+
+  return {
+    // A badge that already buzzed a phone rides along; one that did not is
+    // the news itself.
+    trigger: !pending.pushed,
+    claim: () => claimOnce(db, 'badgeDigest', profile._id, pending.day),
+    build: (locale: Locale) =>
+      badgeEarnedSection(locale, { count: pending.count, label: pending.label }),
   }
 }

--- a/apps/api/src/modules/notifications/digest.test.ts
+++ b/apps/api/src/modules/notifications/digest.test.ts
@@ -1,0 +1,273 @@
+import { DAILY_DIGEST_LOCAL_HOUR, utcDayKey } from '@langx/shared'
+import { ObjectId } from 'mongodb'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import type { NotificationEmailContext } from '../../email/notify'
+import { authId } from '../../lib/authId'
+import { CapturingEmailSender } from '../../testSupport/authFlow'
+import { LoggingPushSender } from '../push/devices'
+import { runDailyDigestPass } from './digest'
+import { runPromotionsPass } from './promotions'
+
+const SECRET = 'e'.repeat(40)
+const HOUR = 60 * 60 * 1000
+const DAY = 24 * HOUR
+
+/** Seven in the evening UTC, so a UTC reader is in their own evening. */
+const EVENING = new Date(`2026-09-14T${String(DAILY_DIGEST_LOCAL_HOUR).padStart(2, '0')}:00:00Z`)
+
+describe('the one notification email of the day', () => {
+  let mongo: MongoMemoryServer
+  let handle: DbHandle
+  let sender: CapturingEmailSender
+  let ctx: NotificationEmailContext
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create()
+    handle = await connectToDatabase(mongo.getUri(), 'daily_digest_test')
+  })
+
+  afterAll(async () => {
+    await handle.close()
+    await mongo.stop()
+  })
+
+  beforeEach(async () => {
+    for (const name of [
+      COLLECTIONS.profiles,
+      COLLECTIONS.user,
+      COLLECTIONS.devices,
+      COLLECTIONS.conversations,
+      COLLECTIONS.messages,
+      COLLECTIONS.tokenLedger,
+      COLLECTIONS.notificationLedger,
+      COLLECTIONS.blocks,
+    ]) {
+      await handle.db.collection(name).deleteMany({})
+    }
+    sender = new CapturingEmailSender()
+    ctx = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api.langx.io' }
+  })
+
+  async function newProfile(
+    opts: {
+      notifications?: unknown
+      timezone?: string
+      awayHours?: number
+      name?: string
+      speaks?: string
+      learns?: string
+      avatar?: boolean
+    } = {},
+  ): Promise<string> {
+    const userId = new ObjectId().toHexString()
+    await handle.db.collection(COLLECTIONS.profiles).insertOne({
+      _id: userId,
+      handle: `h${userId.slice(-8)}`,
+      displayName: opts.name ?? `User ${userId.slice(0, 4)}`,
+      timezone: opts.timezone ?? 'UTC',
+      createdAt: new Date(EVENING.getTime() - 30 * DAY),
+      entitlement: { tier: 'free' },
+      nativeLanguages: [{ code: opts.speaks ?? 'en' }],
+      learning: [{ code: opts.learns ?? 'es', level: 'a1', priority: 1 }],
+      interests: [],
+      birthDate: '1996-04-01',
+      streak: { current: 0 },
+      privacy: { incognito: false, hideOnlineStatus: false },
+      ...(opts.avatar === false ? {} : { avatarUrl: 'https://media.langx.test/a.jpg' }),
+      settings: { discoverable: true, notifications: opts.notifications ?? {} },
+      stats: { lastActiveAt: new Date(EVENING.getTime() - (opts.awayHours ?? 10) * HOUR) },
+    } as never)
+    await handle.db
+      .collection(COLLECTIONS.user)
+      .insertOne({ _id: authId(userId), email: `${userId}@example.com`, emailVerified: true })
+    return userId
+  }
+
+  /** An unread thread — the most ordinary reason for the mail to go at all. */
+  async function unreadThread(reader: string, writer: string): Promise<void> {
+    await handle.db.collection(COLLECTIONS.conversations).insertOne({
+      participants: [reader, writer],
+      unread: { [reader]: 2 },
+      lastMessage: {
+        createdAt: new Date(EVENING.getTime() - HOUR),
+        senderId: writer,
+        type: 'text',
+      },
+    })
+  }
+
+  /** Tokens that arrived overnight. */
+  async function poolPaid(userId: string, amount: number): Promise<void> {
+    await handle.db.collection(COLLECTIONS.tokenLedger).insertOne({
+      userId,
+      kind: 'dailyPool',
+      refId: utcDayKey(new Date(EVENING.getTime() - DAY)),
+      amount,
+      createdAt: new Date(EVENING.getTime() - 12 * HOUR),
+    })
+  }
+
+  /** A call both sides accepted, tomorrow morning. */
+  async function meetingTomorrow(a: string, b: string): Promise<void> {
+    const conversationId = new ObjectId()
+    await handle.db
+      .collection(COLLECTIONS.conversations)
+      .insertOne({ _id: conversationId, participants: [a, b], unread: {} })
+    await handle.db.collection(COLLECTIONS.messages).insertOne({
+      conversationId,
+      senderId: b,
+      type: 'meeting',
+      meeting: {
+        startsAt: new Date(EVENING.getTime() + 15 * HOUR),
+        durationMinutes: 30,
+        status: 'accepted',
+      },
+      createdAt: new Date(EVENING.getTime() - DAY),
+    })
+  }
+
+  it('says nothing to somebody with nothing pending', async () => {
+    await newProfile()
+    expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 0 })
+    expect(sender.messages).toHaveLength(0)
+  })
+
+  it('carries every kind that has something to say in one mail', async () => {
+    const reader = await newProfile()
+    await unreadThread(reader, await newProfile({ name: 'Ada Lovelace' }))
+    await poolPaid(reader, 7)
+    await meetingTomorrow(reader, await newProfile({ name: 'Bo Diddley' }))
+
+    // Two: the other side of tomorrow's call is told about it as well.
+    expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 2 })
+
+    const mail = sender.messages.find((message) => message.to === `${reader}@example.com`)
+    // The subject comes from the first section that survived — the one that
+    // cannot wait, which is somebody waiting for an answer.
+    expect(mail?.subject).toContain('2')
+    expect(mail?.html).toContain('Ada Lovelace')
+    expect(mail?.html).toContain('Bo Diddley')
+    expect(mail?.html).toContain('7')
+    // One letter, and it says how to stop all of them.
+    expect(mail?.headers?.['List-Unsubscribe-Post']).toBe('List-Unsubscribe=One-Click')
+    expect(mail?.headers?.['List-Unsubscribe']).toContain('.all.')
+  })
+
+  it('leaves out a kind whose switch is off, and sends the rest', async () => {
+    const reader = await newProfile({ notifications: { wallet: { push: true, email: false } } })
+    await unreadThread(reader, await newProfile())
+    await poolPaid(reader, 7)
+
+    expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 1 })
+    expect(sender.messages[0]?.html).not.toContain('7 token')
+  })
+
+  it('sends nothing at all when every kind is off', async () => {
+    const reader = await newProfile({
+      notifications: {
+        messages: { push: true, email: false },
+        wallet: { push: true, email: false },
+      },
+    })
+    await unreadThread(reader, await newProfile())
+    await poolPaid(reader, 7)
+
+    expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 0 })
+    expect(sender.messages).toHaveLength(0)
+  })
+
+  /**
+   * The rule the whole design rests on: suggestions ride along, they never
+   * summon the mail. An account with nothing happening hears nothing, however
+   * many people it could be introduced to.
+   */
+  describe('people you could practise with', () => {
+    async function threeMatches(): Promise<void> {
+      for (const name of ['Cy Twombly', 'Di Prima', 'Eve Babitz']) {
+        await newProfile({ name, speaks: 'es', learns: 'en' })
+      }
+    }
+
+    it('never writes a letter of its own', async () => {
+      await newProfile()
+      await threeMatches()
+
+      expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 0 })
+      expect(sender.messages).toHaveLength(0)
+    })
+
+    it('rides along when the mail is going anyway', async () => {
+      const reader = await newProfile()
+      await threeMatches()
+      await poolPaid(reader, 7)
+
+      expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 1 })
+      expect(sender.messages[0]?.html).toContain('Cy Twombly')
+    })
+
+    it('does not offer somebody they are already talking to', async () => {
+      const reader = await newProfile()
+      await threeMatches()
+      const known = await newProfile({ name: 'Fay Weldon', speaks: 'es', learns: 'en' })
+      const fayHandle = `h${known.slice(-8)}`
+      await unreadThread(reader, known)
+
+      await runDailyDigestPass(handle.db, ctx, EVENING)
+      const html = sender.messages[0]?.html ?? ''
+      // She is in the mail once, as the person who wrote — and not a second
+      // time under the suggestions, which link to a profile.
+      expect(html).toContain('Fay Weldon')
+      expect(html.split(fayHandle)).toHaveLength(2)
+    })
+  })
+
+  it('goes once a day, however many times the tick runs', async () => {
+    const reader = await newProfile()
+    await unreadThread(reader, await newProfile())
+
+    await runDailyDigestPass(handle.db, ctx, EVENING)
+    expect(
+      await runDailyDigestPass(handle.db, ctx, new Date(EVENING.getTime() + 30 * 60 * 1000)),
+    ).toMatchObject({ sent: 0 })
+    expect(sender.messages).toHaveLength(1)
+  })
+
+  it('waits for the evening where the reader is', async () => {
+    const reader = await newProfile({ timezone: 'Asia/Tokyo' })
+    await unreadThread(reader, await newProfile())
+
+    // Seven in the evening UTC is four in the morning in Tokyo.
+    expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 0 })
+    // Nothing claimed, so their own evening still gets to send it.
+    expect(await handle.db.collection(COLLECTIONS.notificationLedger).countDocuments({})).toBe(0)
+  })
+
+  /**
+   * The other half of "one mail a day": marketing runs an hour later and
+   * stands down on any day the digest has already written.
+   */
+  it('takes the day’s slot from the nudges', async () => {
+    const reader = await newProfile({ avatar: false })
+    // The writer wants no marketing, so the only nudge in play is the
+    // reader's — they have no photo, which `promo.photo` would ask about.
+    await unreadThread(
+      reader,
+      await newProfile({ notifications: { promotions: { push: false, email: false } } }),
+    )
+    const push = new LoggingPushSender()
+
+    expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 1 })
+    const nudges = await runPromotionsPass(
+      handle.db,
+      { email: ctx, push },
+      new Date(EVENING.getTime() + HOUR),
+    )
+
+    // Without the digest this account would have been asked for a photo.
+    expect(nudges).toEqual({ sent: 0 })
+    expect(sender.messages).toHaveLength(1)
+  })
+})

--- a/apps/api/src/modules/notifications/digest.ts
+++ b/apps/api/src/modules/notifications/digest.ts
@@ -1,0 +1,217 @@
+import {
+  DAILY_DIGEST_LOCAL_HOUR,
+  localDayKey,
+  localHour,
+  notificationsAllowed,
+  type Locale,
+  type NotificationType,
+} from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { sendDigestEmail, type NotificationEmailContext } from '../../email/notify'
+import { dailyDigestEmail, type DigestSection } from '../../email/templates'
+import type { Profile } from '../profiles/profiles'
+import { tokensByLocale } from '../push/devices'
+import type { SchedulerLogger } from '../tokens/poolScheduler'
+import { streakSectionFor } from '../push/reminderScheduler'
+import { badgeSectionFor } from './badges'
+import { collectFeedReplies, feedRepliesSection } from './feedDigest'
+import { alreadyClaimed, claimOnce } from './ledger'
+import { matchSuggestionsSectionFor } from './matches'
+import { collectUpcomingMeetings, meetingsSectionFor } from './meetings'
+import { profileVisitsSectionFor } from './profileVisits'
+import { unreadDigestSection } from './unreadDigest'
+import { collectPoolPayouts, walletPoolSectionFor } from './wallet'
+
+/**
+ * One thing worth saying to one person tonight, ready to go into the mail.
+ *
+ * `trigger` is the field the whole design rests on. A section that is true
+ * there is something that **happened** — somebody wrote, a call was agreed, a
+ * streak is about to break — and its presence is a reason to send. A section
+ * that is false is a passenger: worth reading in a mail that is going anyway,
+ * never worth an envelope of its own. Match suggestions are the obvious case,
+ * but so is anything a push has already delivered to a phone: saying it again
+ * twelve hours later is not news, and a mail sent only to repeat it is the
+ * thing this rewrite exists to stop.
+ *
+ * `claim` is the section's own place in the ledger, not the digest's. The two
+ * are different questions — the mail is once a day, while an absence produces
+ * one unread mention however many evenings it spans, and profile visits are
+ * still weekly — so each section keeps the period key it had when it was a
+ * letter of its own.
+ */
+export interface DigestCandidate {
+  trigger: boolean
+  claim: () => Promise<boolean>
+  build: (locale: Locale) => DigestSection
+}
+
+/**
+ * The one notification email of the day.
+ *
+ * Everything that used to post its own envelope — unread messages, the day's
+ * replies, the weekly visitors, badges, the pool, tomorrow's calls, the streak
+ * nudge for anybody without a phone — is a paragraph in here now, and the
+ * count of letters a person can receive in a day went from four to one.
+ *
+ * Three rules hold it together:
+ *
+ * 1. **Nothing pending, nothing sent.** No section may invent a reason to
+ *    write; see `trigger` above. A quiet account hears nothing, which is the
+ *    point rather than a side effect.
+ * 2. **The reader's own evening.** Seven o'clock where they are, on a
+ *    half-hourly tick that catches every whole and half-hour offset.
+ * 3. **Each kind still answers for itself.** `notificationsAllowed` is asked
+ *    per section, before the work of building it, so a switch somebody turned
+ *    off silences its paragraph and nothing else. A mail with no paragraphs
+ *    left is not sent at all, which is how the eight switches still add up to
+ *    an honest "no email from LangX".
+ *
+ * The order below is the order in the mail, and the first section that
+ * survives lends the envelope its subject — so it runs from what cannot wait
+ * to what could have waited a fortnight.
+ */
+export async function runDailyDigestPass(
+  db: Db,
+  ctx: NotificationEmailContext,
+  now: Date = new Date(),
+  storagePublicBaseUrl?: string,
+  logger?: Pick<SchedulerLogger, 'warn'>,
+): Promise<{ sent: number; failed: number }> {
+  const profiles = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .find({
+      deletedAt: { $exists: false },
+      guest: { $exists: false },
+      // Bounds the scan only; `notificationsAllowed` decides per section. Two
+      // of the three stored shapes are objects this cannot read into.
+      'settings.notifications': { $ne: false },
+    })
+    .toArray()
+
+  const readers = profiles.filter(
+    (profile) => localHour(now, profile.timezone ?? 'UTC') === DAILY_DIGEST_LOCAL_HOUR,
+  )
+  if (readers.length === 0) return { sent: 0, failed: 0 }
+
+  /*
+   * The three collectors that answer for everybody at once, read after the
+   * hour filter so a tick with nobody in their evening costs three queries it
+   * never makes. Each of them replaces what would otherwise be a query per
+   * reader — the reason `feedDigest` was written from the replies inwards
+   * rather than from the profiles outwards in the first place.
+   */
+  const [replies, payouts, meetings] = await Promise.all([
+    collectFeedReplies(db, now),
+    collectPoolPayouts(db, now),
+    collectUpcomingMeetings(db, now),
+  ])
+
+  let sent = 0
+  let failed = 0
+  for (const profile of readers) {
+    /*
+     * One reader at a time, and one reader's failure is their own.
+     *
+     * This walks every profile in the database and hands each one to eight
+     * builders, two of which read documents written by earlier versions of
+     * this app. A single malformed row would otherwise throw here, the
+     * scheduler would log it, wait thirty minutes and do exactly the same
+     * thing again — and nobody after that row in the list would ever get a
+     * digest. Same doctrine as the badge round-up, and for the same reason.
+     */
+    try {
+      sent += await digestOne(profile)
+    } catch (error) {
+      failed++
+      logger?.warn({ err: error, userId: profile._id }, 'daily digest skipped one reader')
+    }
+  }
+
+  return { sent, failed }
+
+  async function digestOne(profile: Profile): Promise<number> {
+    const day = localDayKey(now, profile.timezone ?? 'UTC')
+    // The cheap look before a dozen queries; `claimOnce` below still decides.
+    if (await alreadyClaimed(db, 'dailyDigest', profile._id, day)) return 0
+
+    /*
+     * Whether anything can buzz this person, asked at most once and only if a
+     * section actually needs to know. It decides two things: the streak nudge
+     * exists here only for somebody the 20:00 push cannot reach, and the pool
+     * paragraph is a passenger for anybody the morning push already told.
+     */
+    let device: boolean | undefined
+    const hasPushDevice = async (): Promise<boolean> => {
+      if (device === undefined) device = (await tokensByLocale(db, profile._id)).size > 0
+      return device
+    }
+
+    const candidates: DigestCandidate[] = []
+    /*
+     * One section's failure is its own, and that is the finer half of the
+     * guard around this loop.
+     *
+     * Some of these builders read documents this app has been writing for two
+     * versions, and one of them — the suggestions — runs the discovery
+     * aggregate over the whole profile collection. A row old enough to be
+     * missing a field it expects throws. Letting that reach the outer catch
+     * would cost the reader their *entire* digest, unread messages included,
+     * because the app could not think of anybody to introduce them to. So a
+     * paragraph that cannot be built is dropped and the mail goes without it.
+     */
+    const add = async (
+      kind: NotificationType,
+      make: () => Promise<DigestCandidate | null> | DigestCandidate | null,
+    ): Promise<void> => {
+      if (!notificationsAllowed(profile.settings?.notifications, kind, 'email')) return
+      try {
+        const candidate = await make()
+        if (candidate) candidates.push(candidate)
+      } catch (error) {
+        logger?.warn({ err: error, userId: profile._id, kind }, 'digest section skipped')
+      }
+    }
+
+    await add('messages', () => unreadDigestSection(db, profile, now, storagePublicBaseUrl))
+    await add('streak', async () => streakSectionFor(db, profile, now, await hasPushDevice()))
+    await add('meetings', () => meetingsSectionFor(db, profile, meetings.get(profile._id), now))
+    await add('social', () => feedRepliesSection(db, profile, replies.get(profile._id), now))
+    await add('badges', () => badgeSectionFor(db, profile, now))
+    await add('wallet', async () =>
+      walletPoolSectionFor(db, profile, payouts.get(profile._id), await hasPushDevice(), now),
+    )
+    await add('profileVisits', () => profileVisitsSectionFor(db, profile, now))
+    await add('promotions', () =>
+      matchSuggestionsSectionFor(db, profile, now, storagePublicBaseUrl),
+    )
+
+    if (!candidates.some((candidate) => candidate.trigger)) return 0
+    if (!(await claimOnce(db, 'dailyDigest', profile._id, day))) return 0
+
+    /*
+     * Claimed before the send, like every ledger write in this app: a mail
+     * nobody got is better than one that arrives every half hour because the
+     * write that would have stopped it never happened.
+     *
+     * A claim can still lose — another tick, or a section whose own period was
+     * taken between the look above and here — and a mail left holding only
+     * passengers is exactly the letter rule 1 forbids, so it is dropped rather
+     * than sent thinner.
+     */
+    const included: DigestCandidate[] = []
+    for (const candidate of candidates) if (await candidate.claim()) included.push(candidate)
+    if (!included.some((candidate) => candidate.trigger)) return 0
+
+    const outcome = await sendDigestEmail(db, ctx, {
+      userId: profile._id,
+      build: (locale, unsubscribe) =>
+        dailyDigestEmail(locale, {
+          sections: included.map((candidate) => candidate.build(locale)),
+          unsubscribe,
+        }),
+    })
+    return outcome === 'sent' ? 1 : 0
+  }
+}

--- a/apps/api/src/modules/notifications/feedDigest.test.ts
+++ b/apps/api/src/modules/notifications/feedDigest.test.ts
@@ -1,17 +1,18 @@
 import { ObjectId } from 'mongodb'
 import { MongoMemoryServer } from 'mongodb-memory-server'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { DAILY_DIGEST_LOCAL_HOUR } from '@langx/shared'
 import { connectToDatabase, type DbHandle } from '../../db/client'
 import { COLLECTIONS } from '../../db/collections'
 import type { NotificationEmailContext } from '../../email/notify'
 import { authId } from '../../lib/authId'
 import { CapturingEmailSender } from '../../testSupport/authFlow'
-import { FEED_DIGEST_LOCAL_HOUR, runFeedDigestPass } from './feedDigest'
+import { runDailyDigestPass } from './digest'
 
 const SECRET = 'f'.repeat(40)
 const HOUR = 60 * 60 * 1000
 /** 19:00 UTC — the digest hour for a reader on UTC. */
-const EVENING = new Date(`2026-09-14T${String(FEED_DIGEST_LOCAL_HOUR).padStart(2, '0')}:00:00Z`)
+const EVENING = new Date(`2026-09-14T${String(DAILY_DIGEST_LOCAL_HOUR).padStart(2, '0')}:00:00Z`)
 
 describe("the day's replies to somebody's posts", () => {
   let mongo: MongoMemoryServer
@@ -96,7 +97,7 @@ describe("the day's replies to somebody's posts", () => {
     // Yesterday's replies belong to yesterday's digest.
     await reply(COLLECTIONS.postCorrections, postId, new Date(EVENING.getTime() - 30 * HOUR))
 
-    expect(await runFeedDigestPass(handle.db, ctx, EVENING)).toEqual({ sent: 1 })
+    expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 1 })
     const mail = sender.messages[0]
     expect(mail?.subject).toContain('3')
     expect(mail?.html).toContain('I go to the school yesterday')
@@ -116,7 +117,7 @@ describe("the day's replies to somebody's posts", () => {
       createdAt: new Date(EVENING.getTime() - HOUR),
     })
 
-    await runFeedDigestPass(handle.db, ctx, EVENING)
+    await runDailyDigestPass(handle.db, ctx, EVENING)
     expect(sender.messages[0]?.html).toContain('my own words')
     expect(sender.messages[0]?.html).not.toContain('THE CORRECTED SENTENCE')
     expect(sender.messages[0]?.text).not.toContain('THE CORRECTED SENTENCE')
@@ -127,13 +128,17 @@ describe("the day's replies to somebody's posts", () => {
     await reply(COLLECTIONS.postCorrections, await newPost(author, 'hello'))
 
     // Noon is not the evening.
-    expect(await runFeedDigestPass(handle.db, ctx, new Date('2026-09-14T12:00:00Z'))).toEqual({
+    expect(
+      await runDailyDigestPass(handle.db, ctx, new Date('2026-09-14T12:00:00Z')),
+    ).toMatchObject({
       sent: 0,
     })
-    expect(await runFeedDigestPass(handle.db, ctx, EVENING)).toEqual({ sent: 1 })
+    expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 1 })
     // A reply landing after the letter waits for tomorrow's.
     await reply(COLLECTIONS.postComments, await newPost(author, 'again'))
-    expect(await runFeedDigestPass(handle.db, ctx, new Date(EVENING.getTime() + HOUR))).toEqual({
+    expect(
+      await runDailyDigestPass(handle.db, ctx, new Date(EVENING.getTime() + HOUR)),
+    ).toMatchObject({
       sent: 0,
     })
   })
@@ -141,12 +146,12 @@ describe("the day's replies to somebody's posts", () => {
   it('says nothing to somebody who turned the email half off', async () => {
     const author = await newProfile({ notifications: { social: { push: true, email: false } } })
     await reply(COLLECTIONS.postCorrections, await newPost(author, 'hello'))
-    expect(await runFeedDigestPass(handle.db, ctx, EVENING)).toEqual({ sent: 0 })
+    expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 0 })
   })
 
   it('sends nothing on a day nobody answered anybody', async () => {
     await newProfile()
-    expect(await runFeedDigestPass(handle.db, ctx, EVENING)).toEqual({ sent: 0 })
+    expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 0 })
     expect(sender.messages).toHaveLength(0)
   })
 
@@ -155,7 +160,7 @@ describe("the day's replies to somebody's posts", () => {
     for (let index = 0; index < 5; index++) {
       await reply(COLLECTIONS.postCorrections, await newPost(author, `sentence ${index}`))
     }
-    expect(await runFeedDigestPass(handle.db, ctx, EVENING)).toEqual({ sent: 1 })
+    expect(await runDailyDigestPass(handle.db, ctx, EVENING)).toMatchObject({ sent: 1 })
     expect(sender.messages[0]?.html).toContain('2 more posts')
   })
 })

--- a/apps/api/src/modules/notifications/feedDigest.ts
+++ b/apps/api/src/modules/notifications/feedDigest.ts
@@ -1,21 +1,13 @@
-import {
-  NOTIFICATION_EMAIL_LOCAL_HOURS,
-  localDayKey,
-  localHour,
-  notificationsAllowed,
-} from '@langx/shared'
+import { localDayKey, type Locale } from '@langx/shared'
 import { ObjectId, type Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
-import { sendNotificationEmail, type NotificationEmailContext } from '../../email/notify'
-import { feedDigestEmail } from '../../email/templates'
+import { feedDigestSection as buildSection } from '../../email/templates'
 import type { Post } from '../feed/documents'
 import type { Profile } from '../profiles/profiles'
+import type { DigestCandidate } from './digest'
 import { claimOnce } from './ledger'
 
 const DAY_MS = 24 * 60 * 60 * 1000
-
-/** The hour, on the reader's own clock, the day's corrections are worth reading. */
-export const FEED_DIGEST_LOCAL_HOUR = 19
 
 /** Named in the mail before it says "and N more". */
 export const FEED_DIGEST_MAX_POSTS = 3
@@ -31,31 +23,20 @@ export interface FeedDigestItem {
 
 /**
  * "Three people corrected your sentence" — the day's replies to somebody's
- * posts, in one letter.
+ * posts, gathered once for the whole tick.
  *
- * The push half of `social` fires on the reply and is throttled to one an
- * hour; this is the other half, and the two answer different questions. A
- * push says *something happened, look now*; a digest says *here is what the
- * day amounted to*, which is the one worth reading when the corrections are
- * the reason somebody posted at all.
- *
- * Evening rather than morning: a sentence posted in the morning has had the
- * day to be answered, and a correction is something people sit down with.
- *
- * One claim per local day. A reply that lands after the digest has gone waits
- * for tomorrow's — the push already said it, and a second letter about the
- * same post on the same day is how a digest becomes noise.
+ * Driven from the replies rather than from the profiles, and that is the
+ * reason this is a collector rather than a per-reader query: on any given day
+ * the people with something to read are a handful, and asking each profile in
+ * turn whether anybody answered it would be a collection scan per reader.
+ * One pass over a day of replies answers it for everybody at once.
  */
-export async function runFeedDigestPass(
+export async function collectFeedReplies(
   db: Db,
-  ctx: NotificationEmailContext,
-  now: Date = new Date(),
-): Promise<{ sent: number }> {
+  now: Date,
+): Promise<Map<string, FeedDigestItem[]>> {
   const since = new Date(now.getTime() - DAY_MS)
 
-  // Driven from the replies rather than from the profiles: on any given day
-  // the people with something to read are a handful, and scanning every
-  // profile to find them would be a collection scan per tick.
   const [corrections, answers, comments] = await Promise.all([
     repliesSince(db, COLLECTIONS.postCorrections, since),
     repliesSince(db, COLLECTIONS.pronunciationAnswers, since),
@@ -63,21 +44,18 @@ export async function runFeedDigestPass(
   ])
 
   const byPost = new Map<string, { corrections: number; answers: number; comments: number }>()
-  const bump = (
-    postId: ObjectId,
-    key: 'corrections' | 'answers' | 'comments',
-    authorId: string,
-  ) => {
+  const bump = (postId: ObjectId, key: 'corrections' | 'answers' | 'comments') => {
     const id = postId.toHexString()
     const seen = byPost.get(id) ?? { corrections: 0, answers: 0, comments: 0 }
     seen[key]++
     byPost.set(id, seen)
-    return authorId
   }
-  for (const row of corrections) bump(row.postId, 'corrections', row.authorId)
-  for (const row of answers) bump(row.postId, 'answers', row.authorId)
-  for (const row of comments) bump(row.postId, 'comments', row.authorId)
-  if (byPost.size === 0) return { sent: 0 }
+  for (const row of corrections) bump(row.postId, 'corrections')
+  for (const row of answers) bump(row.postId, 'answers')
+  for (const row of comments) bump(row.postId, 'comments')
+
+  const perAuthor = new Map<string, FeedDigestItem[]>()
+  if (byPost.size === 0) return perAuthor
 
   const posts = await db
     .collection<Post>(COLLECTIONS.posts)
@@ -88,8 +66,6 @@ export async function runFeedDigestPass(
     )
     .toArray()
 
-  /** Each author's own posts, with what the day did to them. */
-  const perAuthor = new Map<string, FeedDigestItem[]>()
   for (const post of posts) {
     const counts = byPost.get(post._id.toHexString())
     if (!counts) continue
@@ -101,40 +77,38 @@ export async function runFeedDigestPass(
     })
     perAuthor.set(post.authorId, items)
   }
+  return perAuthor
+}
 
-  let sent = 0
-  for (const [authorId, items] of perAuthor) {
-    const profile = await db
-      .collection<Profile>(COLLECTIONS.profiles)
-      .findOne({ _id: authorId }, { projection: { settings: 1, timezone: 1, deletedAt: 1 } })
-    if (!profile || profile.deletedAt) continue
-    if (!notificationsAllowed(profile.settings?.notifications, 'social', 'email')) continue
+/**
+ * One reader's share of that, as a section.
+ *
+ * One claim per local day. A reply that lands after the mail has gone waits
+ * for tomorrow's — the push already said it, and a second letter about the
+ * same post on the same day is how a digest becomes noise.
+ */
+export function feedRepliesSection(
+  db: Db,
+  profile: Profile,
+  items: FeedDigestItem[] | undefined,
+  now: Date,
+): DigestCandidate | null {
+  if (!items || items.length === 0) return null
 
-    const zone = profile.timezone ?? 'UTC'
-    const hour = localHour(now, zone)
-    if (hour < FEED_DIGEST_LOCAL_HOUR) continue
-    if (hour > NOTIFICATION_EMAIL_LOCAL_HOURS.latest) continue
-    if (!(await claimOnce(db, 'feedDigest', authorId, localDayKey(now, zone)))) continue
+  // Busiest first: the post with the most to read is the one worth naming.
+  const ranked = [...items].sort(
+    (a, b) => b.corrections + b.answers + b.comments - (a.corrections + a.answers + a.comments),
+  )
+  const named = ranked.slice(0, FEED_DIGEST_MAX_POSTS)
+  const day = localDayKey(now, profile.timezone ?? 'UTC')
 
-    // Busiest first: the post with the most to read is the one worth naming.
-    const ranked = [...items].sort(
-      (a, b) => b.corrections + b.answers + b.comments - (a.corrections + a.answers + a.comments),
-    )
-    const named = ranked.slice(0, FEED_DIGEST_MAX_POSTS)
-    const outcome = await sendNotificationEmail(db, ctx, {
-      userId: authorId,
-      type: 'social',
-      build: (locale, unsubscribe) =>
-        feedDigestEmail(locale, {
-          items: named,
-          morePosts: ranked.length - named.length,
-          unsubscribe,
-        }),
-    })
-    if (outcome === 'sent') sent++
+  return {
+    // The corrections are what the sentence was posted for.
+    trigger: true,
+    claim: () => claimOnce(db, 'feedDigest', profile._id, day),
+    build: (locale: Locale) =>
+      buildSection(locale, { items: named, morePosts: ranked.length - named.length }),
   }
-
-  return { sent }
 }
 
 interface ReplyRow {

--- a/apps/api/src/modules/notifications/ledger.ts
+++ b/apps/api/src/modules/notifications/ledger.ts
@@ -3,10 +3,20 @@ import { COLLECTIONS } from '../../db/collections'
 
 /** Which scheduled pass a row belongs to; first component of the `_id`. */
 export type NotificationJob =
+  /** The evening mail itself: one per person per local day, and its ceiling. */
+  | 'dailyDigest'
+  /*
+   * Its sections, each keeping the period it had when it was a letter of its
+   * own — an absence, a week, a day, a pool run. The mail is daily; almost
+   * nothing in it is.
+   */
   | 'unreadDigest'
   | 'profileVisitsPush'
   | 'profileVisitsEmail'
   | 'badgeEarned'
+  | 'badgeDigest'
+  | 'meetingsDigest'
+  | 'wallet.poolDigest'
   | 'verifyReminder'
   | 'feedDigest'
   /** The feed's own pushes: one per follower ever, one per post per hour. */

--- a/apps/api/src/modules/notifications/matches.ts
+++ b/apps/api/src/modules/notifications/matches.ts
@@ -1,0 +1,126 @@
+import { MATCH_SUGGESTIONS, discoveryQuerySchema, profileUrl, type Locale } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { fetchAvatarAsset, type AvatarFace } from '../../email/avatars'
+import { matchSuggestionsSection } from '../../email/templates'
+import type { Conversation } from '../chat/conversations'
+import { discoverProfiles } from '../discovery/discovery'
+import type { Profile } from '../profiles/profiles'
+import type { DigestCandidate } from './digest'
+import { alreadyClaimed, claimOnce } from './ledger'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * "People you could practise with" — the digest's one passenger.
+ *
+ * **It is never a reason to send.** Everything else in the evening mail is
+ * something that happened; this is the app volunteering strangers, and a
+ * letter whose only content is a list of them is the letter people mean when
+ * they say an app mails too much. So it rides along when the mail is already
+ * going and is silent otherwise, which also means a dormant account — the one
+ * with nothing happening by definition — is never sent it at all.
+ *
+ * Who may appear is not decided here. `discoverProfiles` is the same matching
+ * the Discover screen uses, so a profile that has made itself undiscoverable,
+ * a guest, a suspended account and anybody blocked in either direction are all
+ * excluded by the same rule in the same place. That was the condition for
+ * putting names and faces in front of somebody who never opened their profile:
+ * one definition, not two.
+ */
+export async function matchSuggestionsSectionFor(
+  db: Db,
+  profile: Profile,
+  now: Date,
+  storagePublicBaseUrl?: string,
+): Promise<DigestCandidate | null> {
+  // Long enough to have finished onboarding and scrolled Discover once. An
+  // account with no `createdAt` at all is not given the benefit of the doubt:
+  // the only rows like that are imports, and an import is somebody who has
+  // never seen this app.
+  if (!profile.createdAt) return null
+  if (
+    now.getTime() - new Date(profile.createdAt).getTime() <
+    MATCH_SUGGESTIONS.minAccountDays * DAY_MS
+  )
+    return null
+
+  const lastActiveAt = profile.stats?.lastActiveAt
+  if (!lastActiveAt) return null
+  // Past this, `promo.away30` has already said "this is the last we will say
+  // about it". Suggestions arriving on day forty would make that a lie.
+  const away = now.getTime() - new Date(lastActiveAt).getTime()
+  if (away > MATCH_SUGGESTIONS.maxAwayDays * DAY_MS) return null
+
+  const period = fortnight(now)
+  // The cheap look before the expensive one: discovery is an aggregate per
+  // reader, and most evenings this has already been said this fortnight.
+  if (await alreadyClaimed(db, 'promo.matches', profile._id, period)) return null
+
+  const page = await discoverProfiles(
+    db,
+    profile._id,
+    discoveryQuerySchema.parse({ limit: MATCH_SUGGESTIONS.candidates }),
+  )
+
+  // Somebody they have already written to is not a suggestion. This is also
+  // what keeps the list moving as the app grows: the pool a reader has not
+  // met shrinks as they meet it.
+  const known = await knownPartners(db, profile._id)
+  const fresh = page.items.filter((item) => !known.has(item._id))
+  /*
+   * Below the floor the mail would stop being a suggestion and start being an
+   * admission of how few people are here. Silence is the better answer, and
+   * the fix for it is more members rather than a shorter list.
+   */
+  if (fresh.length < MATCH_SUGGESTIONS.minCandidates) return null
+
+  const shown = fresh.slice(0, MATCH_SUGGESTIONS.faces)
+  const faces: AvatarFace[] = []
+  for (const item of shown) {
+    const asset = item.avatarUrl
+      ? await fetchAvatarAsset(item.avatarUrl, `match-${item._id}`, storagePublicBaseUrl)
+      : null
+    faces.push({
+      name: item.displayName,
+      seed: item._id,
+      ...(asset ? { asset } : {}),
+      url: profileUrl(item.handle),
+    })
+  }
+
+  return {
+    trigger: false,
+    claim: () => claimOnce(db, 'promo.matches', profile._id, period),
+    build: (locale: Locale) =>
+      matchSuggestionsSection(locale, { faces, more: fresh.length - shown.length }),
+  }
+}
+
+/** Everybody this person already has a conversation with, in either direction. */
+async function knownPartners(db: Db, userId: string): Promise<Set<string>> {
+  const conversations = await db
+    .collection<Conversation>(COLLECTIONS.conversations)
+    .find({ participants: userId }, { projection: { participants: 1 } })
+    .toArray()
+  const known = new Set<string>()
+  for (const conversation of conversations) {
+    for (const id of conversation.participants) if (id !== userId) known.add(id)
+  }
+  return known
+}
+
+/**
+ * Which fortnight it is, counted off a fixed epoch rather than off the
+ * reader's join date — so the answer is the same at every tick of the two
+ * weeks and needs nothing stored to work it out.
+ *
+ * Fourteen days is a claim about the size of the pool, not about attention.
+ * The section is three faces out of everybody whose languages fit; while the
+ * app is small that set barely moves from one week to the next, and a weekly
+ * suggestion would be the same three people with a new date on it. It also
+ * sits under the ledger's thirty-day expiry, which a monthly key would not.
+ */
+function fortnight(now: Date): string {
+  return `f${Math.floor(now.getTime() / (MATCH_SUGGESTIONS.everyDays * DAY_MS))}`
+}

--- a/apps/api/src/modules/notifications/meetings.ts
+++ b/apps/api/src/modules/notifications/meetings.ts
@@ -1,0 +1,137 @@
+import { localDayKey, type Locale } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { meetingsSection, type DigestMeeting } from '../../email/templates'
+import type { Conversation, Message } from '../chat/conversations'
+import type { Profile } from '../profiles/profiles'
+import type { DigestCandidate } from './digest'
+import { claimOnce } from './ledger'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+/** Wide enough to cover tomorrow in every timezone the readers are in. */
+const LOOKAHEAD_MS = 3 * DAY_MS
+
+/** One accepted call, from the point of view of one of the two people in it. */
+interface UpcomingMeeting {
+  startsAt: Date
+  conversationId: string
+  withId: string
+}
+
+/**
+ * Every accepted call in the next few days, indexed by who agreed to it.
+ *
+ * Read once per tick, like the day's feed replies, because the alternative is
+ * asking the message collection the same question once per reader. Three days
+ * of lookahead rather than one: "tomorrow" is a different stretch of UTC for
+ * somebody in Auckland and somebody in Los Angeles, and the filtering to one
+ * reader's tomorrow happens against their own clock below.
+ */
+export async function collectUpcomingMeetings(
+  db: Db,
+  now: Date,
+): Promise<Map<string, UpcomingMeeting[]>> {
+  const due = await db
+    .collection<Message>(COLLECTIONS.messages)
+    .find({
+      type: 'meeting',
+      // Only what both sides agreed to. A proposal nobody answered is not a
+      // commitment, and a withdrawn one is not either.
+      'meeting.status': 'accepted',
+      'meeting.startsAt': { $gte: now, $lt: new Date(now.getTime() + LOOKAHEAD_MS) },
+      deletedAt: { $exists: false },
+    })
+    .toArray()
+
+  const byUser = new Map<string, UpcomingMeeting[]>()
+  if (due.length === 0) return byUser
+
+  const conversations = await db
+    .collection<Conversation>(COLLECTIONS.conversations)
+    .find(
+      { _id: { $in: due.map((message) => message.conversationId) } },
+      { projection: { participants: 1 } },
+    )
+    .toArray()
+  const participantsOf = new Map(
+    conversations.map((conversation) => [
+      conversation._id.toHexString(),
+      conversation.participants,
+    ]),
+  )
+
+  for (const message of due) {
+    const startsAt = message.meeting?.startsAt
+    if (!startsAt) continue
+    const conversationId = message.conversationId.toHexString()
+    const participants = participantsOf.get(conversationId)
+    if (!participants) continue
+
+    // Both people, because the proposer is as likely to have forgotten as the
+    // invitee — the same reasoning the hour-before push follows.
+    for (const userId of participants) {
+      const withId = participants.find((id) => id !== userId)
+      if (!withId) continue
+      const mine = byUser.get(userId) ?? []
+      mine.push({ startsAt: new Date(startsAt), conversationId, withId })
+      byUser.set(userId, mine)
+    }
+  }
+  return byUser
+}
+
+/**
+ * "Tomorrow you have a call with Ada at 18:00."
+ *
+ * Deliberately tomorrow rather than today: this arrives at seven in the
+ * evening, and a call later tonight has either happened or is about to, with
+ * the hour-before push covering it either way. What an evening mail can
+ * usefully say is what the next day holds.
+ *
+ * The times are formatted inside `build`, because that is the only place that
+ * knows the reader's language; the zone comes from their profile and the
+ * instant from the message, so this file has no clock of its own.
+ */
+export async function meetingsSectionFor(
+  db: Db,
+  profile: Profile,
+  upcoming: UpcomingMeeting[] | undefined,
+  now: Date,
+): Promise<DigestCandidate | null> {
+  if (!upcoming || upcoming.length === 0) return null
+
+  const zone = profile.timezone ?? 'UTC'
+  const tomorrow = localDayKey(new Date(now.getTime() + DAY_MS), zone)
+  const mine = upcoming
+    .filter((meeting) => localDayKey(meeting.startsAt, zone) === tomorrow)
+    .sort((a, b) => a.startsAt.getTime() - b.startsAt.getTime())
+  if (mine.length === 0) return null
+
+  const partners = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .find(
+      { _id: { $in: mine.map((meeting) => meeting.withId) } },
+      { projection: { displayName: 1, handle: 1 } },
+    )
+    .toArray()
+  const nameOf = new Map(
+    partners.map((partner) => [partner._id, partner.displayName ?? partner.handle ?? '']),
+  )
+
+  return {
+    trigger: true,
+    claim: () => claimOnce(db, 'meetingsDigest', profile._id, tomorrow),
+    build: (locale: Locale) =>
+      meetingsSection(locale, {
+        meetings: mine.map((meeting): DigestMeeting => ({
+          time: new Intl.DateTimeFormat(locale, {
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZone: zone,
+          }).format(meeting.startsAt),
+          name: nameOf.get(meeting.withId) ?? '',
+          conversationId: meeting.conversationId,
+        })),
+      }),
+  }
+}

--- a/apps/api/src/modules/notifications/newsletter.test.ts
+++ b/apps/api/src/modules/notifications/newsletter.test.ts
@@ -11,7 +11,7 @@ import { lastMonthKey, runNewsletterPass } from './newsletter'
 
 const SECRET = 'n'.repeat(40)
 /** The first of October at noon UTC: the recap is about September. */
-const FIRST = new Date('2026-10-01T12:00:00Z')
+const FIRST = new Date('2026-10-01T20:00:00Z')
 
 describe('the monthly recap', () => {
   let mongo: MongoMemoryServer
@@ -144,7 +144,7 @@ describe('the monthly recap', () => {
     expect(await runNewsletterPass(handle.db, ctx, FIRST)).toEqual({ sent: 1 })
     expect(await runNewsletterPass(handle.db, ctx, FIRST)).toEqual({ sent: 0 })
     // A day later is still the same month's recap.
-    expect(await runNewsletterPass(handle.db, ctx, new Date('2026-10-03T12:00:00Z'))).toEqual({
+    expect(await runNewsletterPass(handle.db, ctx, new Date('2026-10-03T20:00:00Z'))).toEqual({
       sent: 0,
     })
   })
@@ -152,26 +152,28 @@ describe('the monthly recap', () => {
   /** A deploy on the third must not skip the month; the claim stops the double. */
   it('catches up within the first week', async () => {
     await newProfile()
-    expect(await runNewsletterPass(handle.db, ctx, new Date('2026-10-05T12:00:00Z'))).toEqual({
+    expect(await runNewsletterPass(handle.db, ctx, new Date('2026-10-05T20:00:00Z'))).toEqual({
       sent: 1,
     })
     // And after the window it waits for the next month rather than arriving late.
     await handle.db.collection(COLLECTIONS.notificationLedger).deleteMany({})
-    expect(await runNewsletterPass(handle.db, ctx, new Date('2026-10-20T12:00:00Z'))).toEqual({
+    expect(await runNewsletterPass(handle.db, ctx, new Date('2026-10-20T20:00:00Z'))).toEqual({
       sent: 0,
     })
   })
 
-  it('waits for ten in the morning, on the reader’s own clock', async () => {
+  it('waits for the marketing slot, on the reader’s own clock', async () => {
     await newProfile({ timezone: 'Asia/Tokyo' })
-    // Noon UTC is 21:00 in Tokyo on the 1st — past ten, so it goes.
-    expect(await runNewsletterPass(handle.db, ctx, FIRST)).toEqual({ sent: 1 })
+    // 11:00 UTC is eight in the evening in Tokyo on the 1st.
+    expect(await runNewsletterPass(handle.db, ctx, new Date('2026-10-01T11:00:00Z'))).toEqual({
+      sent: 1,
+    })
 
     await handle.db.collection(COLLECTIONS.profiles).deleteMany({})
     await handle.db.collection(COLLECTIONS.notificationLedger).deleteMany({})
     sender.messages.length = 0
     await newProfile({ timezone: 'America/Los_Angeles' })
-    // 03:00 in Los Angeles is not ten in the morning anywhere.
+    // 03:00 in Los Angeles is not eight in the evening anywhere.
     expect(await runNewsletterPass(handle.db, ctx, new Date('2026-10-01T10:00:00Z'))).toEqual({
       sent: 0,
     })

--- a/apps/api/src/modules/notifications/newsletter.ts
+++ b/apps/api/src/modules/notifications/newsletter.ts
@@ -1,11 +1,11 @@
-import { NEWSLETTER_LOCAL_HOUR, localDayKey, localHour, notificationsAllowed } from '@langx/shared'
+import { PROMOTION_LOCAL_HOUR, localDayKey, localHour, notificationsAllowed } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import { sendNotificationEmail, type NotificationEmailContext } from '../../email/notify'
 import { newsletterEmail } from '../../email/templates'
 import { noteFor } from '../../email/newsletters'
 import type { Profile } from '../profiles/profiles'
-import { claimOnce } from './ledger'
+import { alreadyClaimed, claimOnce } from './ledger'
 import { recentlyMarketed } from './marketing'
 
 /** What a month looked like for one person, and for everybody. */
@@ -88,7 +88,7 @@ export async function personalMonth(
  * **Monthly rather than weekly**, and the reason is the numbers themselves: a
  * week of a language exchange is three conversations and a correction, which
  * reads as an accusation rather than a summary. Switching it is
- * `NEWSLETTER_LOCAL_HOUR`'s neighbours in `packages/shared`, not a rewrite.
+ * `PROMOTION_LOCAL_HOUR`'s neighbours in `packages/shared`, not a rewrite.
  *
  * **"On or after the first", not "on the first."** A deploy on the third
  * would otherwise skip the month silently, and the claim is what stops it
@@ -121,10 +121,16 @@ export async function runNewsletterPass(
     if (!notificationsAllowed(profile.settings?.notifications, 'promotions', 'email')) continue
     const zone = profile.timezone ?? 'UTC'
     // Their first of the month — or one of the six days after it, so a
-    // deploy that slipped does not skip a month — and any hour from ten
-    // onwards, since a tick missed at ten is not a month skipped either.
-    if (!isSendingDay(localDayKey(now, zone))) continue
-    if (localHour(now, zone) < NEWSLETTER_LOCAL_HOUR) continue
+    // deploy that slipped does not skip a month.
+    const day = localDayKey(now, zone)
+    if (!isSendingDay(day)) continue
+    // The marketing slot, which is an hour after the digest rather than the
+    // morning it used to be. Seven days of chances at it is what makes one
+    // missed evening not a missed month.
+    if (localHour(now, zone) !== PROMOTION_LOCAL_HOUR) continue
+    // The recap never takes the day's slot from the evening mail. Real news
+    // outranks a summary of a month that has already finished.
+    if (await alreadyClaimed(db, 'dailyDigest', profile._id, day)) continue
     if (await recentlyMarketed(db, profile._id, now)) continue
 
     // Computed on the first tick that needs it, then reused for the rest.

--- a/apps/api/src/modules/notifications/profileVisits.test.ts
+++ b/apps/api/src/modules/notifications/profileVisits.test.ts
@@ -1,4 +1,4 @@
-import { PROFILE_VISITS_LOCAL_HOUR } from '@langx/shared'
+import { DAILY_DIGEST_LOCAL_HOUR, PROFILE_VISITS_LOCAL_HOUR } from '@langx/shared'
 import { ObjectId } from 'mongodb'
 import { MongoMemoryServer } from 'mongodb-memory-server'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
@@ -8,7 +8,8 @@ import type { NotificationEmailContext } from '../../email/notify'
 import { authId } from '../../lib/authId'
 import { CapturingEmailSender } from '../../testSupport/authFlow'
 import { LoggingPushSender, type Device } from '../push/devices'
-import { runProfileVisitsEmailPass, runProfileVisitsPushPass } from './profileVisits'
+import { runDailyDigestPass } from './digest'
+import { runProfileVisitsPushPass } from './profileVisits'
 
 const SECRET = 'e'.repeat(40)
 const DAY = 24 * 60 * 60 * 1000
@@ -29,6 +30,14 @@ describe('the profile-visit round-up', () => {
   // A Monday, so the weekly pass has something to do.
   const monday = new Date('2026-09-07T14:00:00Z')
   const zone = zoneWhereItIsRoundUpHour(monday)
+  /*
+   * The same Monday, later: the visits mail is a section of the evening
+   * digest now, so it goes out at seven rather than at the round-up hour the
+   * push still uses. Same zone, same local day.
+   */
+  const mondayEvening = new Date(
+    monday.getTime() + (DAILY_DIGEST_LOCAL_HOUR - PROFILE_VISITS_LOCAL_HOUR) * 60 * 60 * 1000,
+  )
 
   beforeAll(async () => {
     mongo = await MongoMemoryServer.create()
@@ -106,7 +115,7 @@ describe('the profile-visit round-up', () => {
       await view(await newProfile({ name: 'Ada' }), me)
       await view(await newProfile({ name: 'Bo' }), me)
 
-      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toEqual({ sent: 1 })
+      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toMatchObject({ sent: 1 })
       const sent = push.sent[0]
       expect(sent?.data.kind).toBe('profileVisits')
       expect(sent?.title).toContain('2')
@@ -119,19 +128,19 @@ describe('the profile-visit round-up', () => {
       await view(await newProfile(), me)
 
       await runProfileVisitsPushPass(handle.db, push, monday)
-      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toEqual({ sent: 0 })
+      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toMatchObject({ sent: 0 })
       expect(push.sent).toHaveLength(1)
     })
 
     it('says nothing when nobody looked', async () => {
       await newProfile({ withDevice: true })
-      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toEqual({ sent: 0 })
+      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toMatchObject({ sent: 0 })
     })
 
     it('ignores a view older than a day', async () => {
       const me = await newProfile({ withDevice: true })
       await view(await newProfile(), me, 3)
-      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toEqual({ sent: 0 })
+      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toMatchObject({ sent: 0 })
     })
 
     it('does not count somebody the viewed person blocked', async () => {
@@ -142,7 +151,7 @@ describe('the profile-visit round-up', () => {
         .collection(COLLECTIONS.blocks)
         .insertOne({ blockerId: me, blockedId: blocked, createdAt: monday })
 
-      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toEqual({ sent: 0 })
+      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toMatchObject({ sent: 0 })
     })
 
     it('respects the switch', async () => {
@@ -151,24 +160,24 @@ describe('the profile-visit round-up', () => {
         notifications: { profileVisits: { push: false } },
       })
       await view(await newProfile(), me)
-      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toEqual({ sent: 0 })
+      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toMatchObject({ sent: 0 })
     })
 
     /** The email face of this kind is the weekly summary, not a daily one. */
     it('has no email fallback', async () => {
       const me = await newProfile()
       await view(await newProfile(), me)
-      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toEqual({ sent: 0 })
+      expect(await runProfileVisitsPushPass(handle.db, push, monday)).toMatchObject({ sent: 0 })
       expect(sender.messages).toHaveLength(0)
     })
   })
 
-  describe('the weekly email', () => {
+  describe('the weekly section of the evening digest', () => {
     it('gives a free account the count and the reason to upgrade', async () => {
       const me = await newProfile()
       await view(await newProfile({ name: 'Ada Lovelace' }), me, 2)
 
-      expect(await runProfileVisitsEmailPass(handle.db, email, monday)).toEqual({ sent: 1 })
+      expect(await runDailyDigestPass(handle.db, email, mondayEvening)).toMatchObject({ sent: 1 })
       const message = sender.messages[0]
       expect(message?.subject).toContain('1')
       expect(message?.html).not.toContain('Ada Lovelace')
@@ -180,7 +189,7 @@ describe('the profile-visit round-up', () => {
       const me = await newProfile({ tier: 'pro_plus' })
       await view(await newProfile({ name: 'Ada Lovelace' }), me, 2)
 
-      await runProfileVisitsEmailPass(handle.db, email, monday)
+      await runDailyDigestPass(handle.db, email, mondayEvening)
       expect(sender.messages[0]?.html).toContain('Ada Lovelace')
     })
 
@@ -193,7 +202,7 @@ describe('the profile-visit round-up', () => {
       const me = await newProfile({ tier: 'pro' })
       await view(await newProfile({ name: 'Ada Lovelace' }), me, 2)
 
-      await runProfileVisitsEmailPass(handle.db, email, monday)
+      await runDailyDigestPass(handle.db, email, mondayEvening)
       expect(sender.messages[0]?.html).not.toContain('Ada Lovelace')
     })
 
@@ -201,16 +210,16 @@ describe('the profile-visit round-up', () => {
       const me = await newProfile()
       await view(await newProfile(), me, 2)
 
-      const tuesday = new Date(monday.getTime() + DAY)
-      expect(await runProfileVisitsEmailPass(handle.db, email, tuesday)).toEqual({ sent: 0 })
+      const tuesday = new Date(mondayEvening.getTime() + DAY)
+      expect(await runDailyDigestPass(handle.db, email, tuesday)).toMatchObject({ sent: 0 })
     })
 
     it('does not send twice in one week', async () => {
       const me = await newProfile()
       await view(await newProfile(), me, 2)
 
-      await runProfileVisitsEmailPass(handle.db, email, monday)
-      expect(await runProfileVisitsEmailPass(handle.db, email, monday)).toEqual({ sent: 0 })
+      await runDailyDigestPass(handle.db, email, mondayEvening)
+      expect(await runDailyDigestPass(handle.db, email, mondayEvening)).toMatchObject({ sent: 0 })
       expect(sender.messages).toHaveLength(1)
     })
 
@@ -218,7 +227,7 @@ describe('the profile-visit round-up', () => {
       const me = await newProfile()
       for (const daysAgo of [0, 2, 5]) await view(await newProfile(), me, daysAgo)
 
-      await runProfileVisitsEmailPass(handle.db, email, monday)
+      await runDailyDigestPass(handle.db, email, mondayEvening)
       expect(sender.messages[0]?.subject).toContain('3')
     })
   })

--- a/apps/api/src/modules/notifications/profileVisits.ts
+++ b/apps/api/src/modules/notifications/profileVisits.ts
@@ -6,18 +6,19 @@ import {
   localHour,
   notificationsAllowed,
   weekKey,
+  type Locale,
   type NotificationChannel,
 } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
-import { sendNotificationEmail, type NotificationEmailContext } from '../../email/notify'
-import { profileVisitsEmail } from '../../email/templates'
+import { profileVisitsSection as buildSection } from '../../email/templates'
 import { translator } from '../../i18n'
 import { viewSummarySince } from '../moderation/profileViews'
 import type { Profile } from '../profiles/profiles'
 import { sendPush, tokensByLocale, type PushSender } from '../push/devices'
+import type { DigestCandidate } from './digest'
 import { recordNotification } from './inbox'
-import { claimOnce } from './ledger'
+import { alreadyClaimed, claimOnce } from './ledger'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -142,54 +143,44 @@ export async function runProfileVisitsPushPass(
 }
 
 /**
- * The same thing once a week, by email, and this one may name people — to the
- * tier that is allowed to see them. `viewSummarySince` decides that; nothing
- * here knows what a plan is.
+ * The same thing once a week, as a section, and this one may name people — to
+ * the tier that is allowed to see them. `viewSummarySince` decides that;
+ * nothing here knows what a plan is.
+ *
+ * Weekly rather than daily, unchanged by the move into the digest. The mail is
+ * capped at one a day now, so a daily line would cost nothing in envelopes —
+ * but "two people looked at you" every evening is a smaller thing said more
+ * often, and the promise on the settings screen is a weekly summary.
  */
-export async function runProfileVisitsEmailPass(
+export async function profileVisitsSectionFor(
   db: Db,
-  ctx: NotificationEmailContext,
-  now: Date = new Date(),
-): Promise<{ sent: number }> {
-  const candidates = await profilesAtLocalHour(
+  profile: Profile,
+  now: Date,
+): Promise<DigestCandidate | null> {
+  // The weekday on *their* calendar, not the server's: the local day key is
+  // already computed for that zone, so parsing it back is exact.
+  const localDay = localDayKey(now, profile.timezone ?? 'UTC')
+  const weekday = new Date(`${localDay}T00:00:00Z`).getUTCDay()
+  if (weekday !== PROFILE_VISITS_WEEKLY_LOCAL_WEEKDAY) return null
+
+  const week = weekKey(now)
+  if (await alreadyClaimed(db, 'profileVisitsEmail', profile._id, week)) return null
+
+  const summary = await viewSummarySince(
     db,
-    PROFILE_VISITS_LOCAL_HOUR,
-    'email',
-    'profileVisits',
-    now,
+    profile._id,
+    new Date(now.getTime() - 7 * DAY_MS),
+    PROFILE_VISITS_EMAIL_MAX_NAMES,
   )
-  let sent = 0
+  if (!summary || summary.count === 0) return null
 
-  for (const profile of candidates) {
-    const zone = profile.timezone ?? 'UTC'
-    // The weekday on *their* calendar, not the server's: the local day key is
-    // already computed for that zone, so parsing it back is exact.
-    const localDay = localDayKey(now, zone)
-    const weekday = new Date(`${localDay}T00:00:00Z`).getUTCDay()
-    if (weekday !== PROFILE_VISITS_WEEKLY_LOCAL_WEEKDAY) continue
-
-    const summary = await viewSummarySince(
-      db,
-      profile._id,
-      new Date(now.getTime() - 7 * DAY_MS),
-      PROFILE_VISITS_EMAIL_MAX_NAMES,
-    )
-    if (!summary || summary.count === 0) continue
-
-    if (!(await claimOnce(db, 'profileVisitsEmail', profile._id, weekKey(now)))) continue
-
-    const outcome = await sendNotificationEmail(db, ctx, {
-      userId: profile._id,
-      type: 'profileVisits',
-      build: (locale, unsubscribe) =>
-        profileVisitsEmail(locale, {
-          count: summary.count,
-          names: summary.viewers?.map((viewer) => viewer.displayName) ?? null,
-          unsubscribe,
-        }),
-    })
-    if (outcome === 'sent') sent++
+  return {
+    trigger: true,
+    claim: () => claimOnce(db, 'profileVisitsEmail', profile._id, week),
+    build: (locale: Locale) =>
+      buildSection(locale, {
+        count: summary.count,
+        names: summary.viewers?.map((viewer) => viewer.displayName) ?? null,
+      }),
   }
-
-  return { sent }
 }

--- a/apps/api/src/modules/notifications/promotions.test.ts
+++ b/apps/api/src/modules/notifications/promotions.test.ts
@@ -14,7 +14,7 @@ import { runPromotionsPass } from './promotions'
 const SECRET = 'p'.repeat(40)
 const DAY = 24 * 60 * 60 * 1000
 /** 12:00 UTC, so UTC is inside the reader's waking hours. */
-const NOW = new Date('2026-09-14T12:00:00Z')
+const NOW = new Date('2026-09-14T20:00:00Z')
 
 describe('the nudges that need permission', () => {
   let mongo: MongoMemoryServer

--- a/apps/api/src/modules/notifications/promotions.ts
+++ b/apps/api/src/modules/notifications/promotions.ts
@@ -1,4 +1,4 @@
-import { NOTIFICATION_EMAIL_LOCAL_HOURS, localHour, notificationsAllowed } from '@langx/shared'
+import { PROMOTION_LOCAL_HOUR, localDayKey, localHour, notificationsAllowed } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import { sendNotificationEmail, type NotificationEmailContext } from '../../email/notify'
@@ -7,7 +7,7 @@ import { translator } from '../../i18n'
 import type { Profile } from '../profiles/profiles'
 import { sendPush, tokensByLocale, type PushSender } from '../push/devices'
 import { QUOTA_REFUSAL_WINDOW_MS } from '../../lib/quota'
-import { claimOnce } from './ledger'
+import { alreadyClaimed, claimOnce } from './ledger'
 import { recentlyMarketed } from './marketing'
 import { readAggregates } from '../tokens/ledger'
 
@@ -261,11 +261,14 @@ export const PROMOTIONS: Promotion[] = [
 
 /**
  * One tick: everybody eligible for something hears the first thing they are
- * eligible for.
+ * eligible for — if the evening has not already spoken for them.
  *
- * Quiet hours are the reader's, not the server's — a promotional mail landing
- * at 3am is the same buzz as a push, and this is the class of mail people are
- * least forgiving about.
+ * One hour rather than the waking day, and that hour is deliberately *after*
+ * the digest's. It used to run any time between nine and nine, which with a
+ * daily mail in the picture would have let a nudge at ten in the morning take
+ * the day's one slot and leave the evening's real news with nowhere to go. At
+ * twenty hundred the question is already settled: if a digest went out, this
+ * is not the day for marketing.
  */
 export async function runPromotionsPass(
   db: Db,
@@ -285,9 +288,9 @@ export async function runPromotionsPass(
 
   let sent = 0
   for (const profile of profiles) {
-    const hour = localHour(now, profile.timezone ?? 'UTC')
-    if (hour < NOTIFICATION_EMAIL_LOCAL_HOURS.earliest) continue
-    if (hour > NOTIFICATION_EMAIL_LOCAL_HOURS.latest) continue
+    const zone = profile.timezone ?? 'UTC'
+    if (localHour(now, zone) !== PROMOTION_LOCAL_HOUR) continue
+    if (await alreadyClaimed(db, 'dailyDigest', profile._id, localDayKey(now, zone))) continue
     if (await recentlyMarketed(db, profile._id, now)) continue
 
     const candidate: PromotionCandidate = { profile, now, db }

--- a/apps/api/src/modules/notifications/scheduler.ts
+++ b/apps/api/src/modules/notifications/scheduler.ts
@@ -4,13 +4,12 @@ import type { PushSender } from '../push/devices'
 import type { SchedulerLogger } from '../tokens/poolScheduler'
 import { runBadgeRoundUpPass } from './badges'
 import { runCampaignQueuePass } from './campaignQueue'
-import { runProfileVisitsEmailPass, runProfileVisitsPushPass } from './profileVisits'
-import { runFeedDigestPass } from './feedDigest'
+import { runDailyDigestPass } from './digest'
+import { runProfileVisitsPushPass } from './profileVisits'
 import { runNewsletterPass } from './newsletter'
 import { runLikesRoundUpPass } from './social'
 import { runPromotionsPass } from './promotions'
 import { runGiftReadyPass, runPoolPayoutPass } from './wallet'
-import { runUnreadDigestPass } from './unreadDigest'
 import { runVerifyReminderPass } from './verifyReminder'
 
 /**
@@ -55,12 +54,8 @@ export function startNotificationScheduler(
     const now = new Date()
     try {
       await Promise.allSettled([
-        run('unread digest', () =>
-          runUnreadDigestPass(db, senders.email, now, options.storagePublicBaseUrl),
-        ),
         run('profile visit push', () => runProfileVisitsPushPass(db, senders.push, now)),
-        run('profile visit email', () => runProfileVisitsEmailPass(db, senders.email, now)),
-        run('badge round-up', () => runBadgeRoundUpPass(db, senders, now, logger)),
+        run('badge round-up', () => runBadgeRoundUpPass(db, senders.push, now, logger)),
         ...(options.resendVerification
           ? [
               run('verify reminder', () =>
@@ -72,12 +67,19 @@ export function startNotificationScheduler(
               ),
             ]
           : []),
-        // Before the nudges: on the first of a month the recap is the thing
-        // worth saying, and the cap would otherwise let a nudge take its place.
-        run('feed digest', () => runFeedDigestPass(db, senders.email, now)),
         run('pool payout', () => runPoolPayoutPass(db, senders.push, now)),
         run('gift ready', () => runGiftReadyPass(db, senders.push, now)),
         run('likes round-up', () => runLikesRoundUpPass(db, senders.push, now)),
+        /*
+         * The one notification email, and everything after it in this list is
+         * marketing that must not take its slot. The digest runs at 19:00 and
+         * both of those at 20:00, so the ordering is settled by the clock
+         * rather than by the position here — this array is concurrent, and a
+         * guarantee that rested on it would be a guarantee resting on nothing.
+         */
+        run('daily digest', () =>
+          runDailyDigestPass(db, senders.email, now, options.storagePublicBaseUrl, logger),
+        ),
         run('newsletter', () => runNewsletterPass(db, senders.email, now)),
         run('promotions', () => runPromotionsPass(db, senders, now)),
         run('campaign queue', () =>

--- a/apps/api/src/modules/notifications/unreadDigest.test.ts
+++ b/apps/api/src/modules/notifications/unreadDigest.test.ts
@@ -1,4 +1,4 @@
-import { UNREAD_DIGEST_MAX_SENDERS } from '@langx/shared'
+import { DAILY_DIGEST_LOCAL_HOUR, UNREAD_DIGEST_MAX_SENDERS } from '@langx/shared'
 import { ObjectId } from 'mongodb'
 import { MongoMemoryServer } from 'mongodb-memory-server'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,15 +7,15 @@ import { COLLECTIONS } from '../../db/collections'
 import type { NotificationEmailContext } from '../../email/notify'
 import { authId } from '../../lib/authId'
 import { CapturingEmailSender } from '../../testSupport/authFlow'
-import { runUnreadDigestPass } from './unreadDigest'
+import { runDailyDigestPass } from './digest'
 
 const STORAGE_BASE = 'https://media.langx.test'
 const SECRET = 'd'.repeat(40)
 const HOUR = 60 * 60 * 1000
 
-/** A zone in which `now` reads as noon, safely inside the send window. */
-function zoneWhereItIsNoon(now: Date): string {
-  const offset = (now.getUTCHours() - 12 + 24) % 24
+/** A zone in which `now` reads as the digest's hour. */
+function zoneWhereItIsEvening(now: Date): string {
+  const offset = (now.getUTCHours() - DAILY_DIGEST_LOCAL_HOUR + 24) % 24
   if (offset === 0) return 'UTC'
   return offset <= 12 ? `Etc/GMT+${offset}` : `Etc/GMT-${24 - offset}`
 }
@@ -26,7 +26,7 @@ describe('the unread-message digest', () => {
   let sender: CapturingEmailSender
   let ctx: NotificationEmailContext
   const now = new Date('2026-09-03T15:00:00Z')
-  const zone = zoneWhereItIsNoon(now)
+  const zone = zoneWhereItIsEvening(now)
 
   beforeAll(async () => {
     mongo = await MongoMemoryServer.create()
@@ -105,7 +105,7 @@ describe('the unread-message digest', () => {
     const writer = await newProfile({ name: 'Ada Lovelace' })
     await thread(reader, writer, { unread: 2 })
 
-    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 1 })
+    expect(await runDailyDigestPass(handle.db, ctx, now)).toMatchObject({ sent: 1 })
     const message = sender.messages[0]
     expect(message?.subject).toContain('2')
     expect(message?.html).toContain('Ada Lovelace')
@@ -134,7 +134,7 @@ describe('the unread-message digest', () => {
       'fetch',
       vi.fn().mockResolvedValue(new Response(png, { headers: { 'content-type': 'image/png' } })),
     )
-    expect(await runUnreadDigestPass(handle.db, ctx, now, STORAGE_BASE)).toEqual({ sent: 1 })
+    expect(await runDailyDigestPass(handle.db, ctx, now, STORAGE_BASE)).toMatchObject({ sent: 1 })
     vi.unstubAllGlobals()
 
     const message = sender.messages[0]
@@ -151,7 +151,7 @@ describe('the unread-message digest', () => {
     const writer = await newProfile({ name: 'Ada', avatarUrl: `${STORAGE_BASE}/avatars/a.png` })
     await thread(reader, writer)
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('gone')))
-    expect(await runUnreadDigestPass(handle.db, ctx, now, STORAGE_BASE)).toEqual({ sent: 1 })
+    expect(await runDailyDigestPass(handle.db, ctx, now, STORAGE_BASE)).toMatchObject({ sent: 1 })
     vi.unstubAllGlobals()
     expect(sender.messages[0]?.attachments ?? []).toEqual([])
     expect(sender.messages[0]?.html).toContain('>A<')
@@ -165,17 +165,19 @@ describe('the unread-message digest', () => {
     const reader = await newProfile()
     await thread(reader, await newProfile())
 
-    await runUnreadDigestPass(handle.db, ctx, now)
-    expect(await runUnreadDigestPass(handle.db, ctx, new Date(now.getTime() + HOUR))).toEqual({
-      sent: 0,
-    })
+    await runDailyDigestPass(handle.db, ctx, now)
+    // The next evening, when the digest's own daily key has rolled over and
+    // only the section's `lastActiveAt` key is left to stop it.
+    expect(
+      await runDailyDigestPass(handle.db, ctx, new Date(now.getTime() + 24 * HOUR)),
+    ).toMatchObject({ sent: 0 })
     expect(sender.messages).toHaveLength(1)
   })
 
   it('sends again after they came back, left, and were written to once more', async () => {
     const reader = await newProfile()
     const id = await thread(reader, await newProfile())
-    await runUnreadDigestPass(handle.db, ctx, now)
+    await runDailyDigestPass(handle.db, ctx, now)
 
     // They opened the app, went away again, and a new message arrived after
     // that — which is a fresh `lastActiveAt`, so a fresh period key.
@@ -191,38 +193,38 @@ describe('the unread-message digest', () => {
         { $set: { 'lastMessage.createdAt': new Date(cameBack.getTime() + HOUR) } },
       )
 
-    expect(await runUnreadDigestPass(handle.db, ctx, later)).toEqual({ sent: 1 })
+    expect(await runDailyDigestPass(handle.db, ctx, later)).toMatchObject({ sent: 1 })
     expect(sender.messages).toHaveLength(2)
   })
 
   it('leaves alone somebody who was here an hour ago', async () => {
     const reader = await newProfile({ awayHours: 1 })
     await thread(reader, await newProfile())
-    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+    expect(await runDailyDigestPass(handle.db, ctx, now)).toMatchObject({ sent: 0 })
   })
 
   it('leaves alone somebody gone longer than a fortnight', async () => {
     const reader = await newProfile({ awayHours: 24 * 20 })
     await thread(reader, await newProfile())
-    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+    expect(await runDailyDigestPass(handle.db, ctx, now)).toMatchObject({ sent: 0 })
   })
 
   it('respects the switch for message email', async () => {
     const reader = await newProfile({ notifications: { messages: { email: false } } })
     await thread(reader, await newProfile())
-    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+    expect(await runDailyDigestPass(handle.db, ctx, now)).toMatchObject({ sent: 0 })
   })
 
   /** 3am mail is a phone buzzing, whatever it says on the label. */
-  it('waits for waking hours in the reader’s own timezone', async () => {
+  it('waits for the evening in the reader’s own timezone', async () => {
     const middleOfTheNight = (now.getUTCHours() - 3 + 24) % 24
     const reader = await newProfile({
       timezone: middleOfTheNight === 0 ? 'UTC' : `Etc/GMT+${middleOfTheNight}`,
     })
     await thread(reader, await newProfile())
 
-    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
-    // And nothing was claimed, so the 9am tick still gets to send it.
+    expect(await runDailyDigestPass(handle.db, ctx, now)).toMatchObject({ sent: 0 })
+    // And nothing was claimed, so their own seven o'clock still gets to send it.
     expect(await handle.db.collection(COLLECTIONS.notificationLedger).countDocuments({})).toBe(0)
   })
 
@@ -234,7 +236,7 @@ describe('the unread-message digest', () => {
       .collection(COLLECTIONS.blocks)
       .insertOne({ blockerId: reader, blockedId: writer, createdAt: now })
 
-    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+    expect(await runDailyDigestPass(handle.db, ctx, now)).toMatchObject({ sent: 0 })
   })
 
   it('ignores a thread the reader archived', async () => {
@@ -244,7 +246,7 @@ describe('the unread-message digest', () => {
       .collection(COLLECTIONS.conversations)
       .updateOne({ _id: id }, { $set: { [`archivedBy.${reader}`]: true } })
 
-    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+    expect(await runDailyDigestPass(handle.db, ctx, now)).toMatchObject({ sent: 0 })
   })
 
   it('ignores a thread whose last word was the reader’s own', async () => {
@@ -255,7 +257,7 @@ describe('the unread-message digest', () => {
       .collection(COLLECTIONS.conversations)
       .updateOne({ _id: id }, { $set: { 'lastMessage.senderId': reader } })
 
-    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 0 })
+    expect(await runDailyDigestPass(handle.db, ctx, now)).toMatchObject({ sent: 0 })
   })
 
   it('says how many more there are once it has named enough', async () => {
@@ -264,7 +266,7 @@ describe('the unread-message digest', () => {
       await thread(reader, await newProfile(), { unread: 1, minutesAgo: 60 + i })
     }
 
-    expect(await runUnreadDigestPass(handle.db, ctx, now)).toEqual({ sent: 1 })
+    expect(await runDailyDigestPass(handle.db, ctx, now)).toMatchObject({ sent: 1 })
     expect(sender.messages[0]?.text).toContain('1 more')
   })
 })

--- a/apps/api/src/modules/notifications/unreadDigest.ts
+++ b/apps/api/src/modules/notifications/unreadDigest.ts
@@ -1,159 +1,131 @@
 import {
-  NOTIFICATION_EMAIL_LOCAL_HOURS,
   UNREAD_DIGEST_AWAY_HOURS,
   UNREAD_DIGEST_MAX_AWAY_DAYS,
   UNREAD_DIGEST_MAX_SENDERS,
-  localHour,
-  notificationsAllowed,
   profileUrl,
   webUrl,
+  type Locale,
 } from '@langx/shared'
 import type { Db, Filter } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
-import { sendNotificationEmail, type NotificationEmailContext } from '../../email/notify'
-import { unreadDigestEmail } from '../../email/templates'
+import { unreadDigestSection as buildSection } from '../../email/templates'
 import type { Conversation } from '../chat/conversations'
 import { blockedUserIds } from '../moderation/blocks'
 import { fetchAvatarAsset, type AvatarFace } from '../../email/avatars'
 import { alreadyClaimed, claimOnce } from './ledger'
+import type { DigestCandidate } from './digest'
 import type { Profile } from '../profiles/profiles'
 
 const HOUR_MS = 60 * 60 * 1000
 const DAY_MS = 24 * HOUR_MS
 
 /**
- * "You have unread messages", for somebody who has not opened the app since
- * they arrived.
+ * "You have unread messages", naming who wrote and how many — and nothing
+ * they said.
  *
  * The period key is `stats.lastActiveAt`, not the local day. While a person
  * stays away that timestamp does not move, so the key does not change and a
- * fortnight of absence is **one** email rather than fourteen. Coming back and
- * leaving again produces a new key, which is exactly when a second digest is
- * worth sending. A daily key would have made this a daily nag, which is the
- * thing an unread-message email is most often guilty of.
+ * fortnight of absence is **one** mention rather than fourteen. Coming back
+ * and leaving again produces a new key, which is exactly when this is worth
+ * saying again. A daily key would have made it a daily nag, which is the thing
+ * an unread-message email is most often guilty of — and folding it into a mail
+ * that goes out every evening is precisely how that mistake would be made.
  *
- * Counts and names only — never a line of anybody's message. The privacy sheet
+ * Counts and names only, never a line of anybody's message. The privacy sheet
  * describes notification mail as exactly that, and message text sitting in a
  * third party's logs is a different disclosure than the one users agreed to.
  */
-export async function runUnreadDigestPass(
+export async function unreadDigestSection(
   db: Db,
-  ctx: NotificationEmailContext,
-  now: Date = new Date(),
+  profile: Profile,
+  now: Date,
   storagePublicBaseUrl?: string,
-): Promise<{ sent: number }> {
-  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
-  const conversations = db.collection<Conversation>(COLLECTIONS.conversations)
+): Promise<DigestCandidate | null> {
+  const lastActiveAt = profile.stats?.lastActiveAt
+  if (!lastActiveAt) return null
+  const away = now.getTime() - new Date(lastActiveAt).getTime()
+  // Long enough to have slept through the push, and not so long that this is
+  // a campaign wearing a notification's clothes.
+  if (away < UNREAD_DIGEST_AWAY_HOURS * HOUR_MS) return null
+  if (away > UNREAD_DIGEST_MAX_AWAY_DAYS * DAY_MS) return null
 
-  const candidates = await profiles
-    .find(
-      {
-        'stats.lastActiveAt': {
-          $lte: new Date(now.getTime() - UNREAD_DIGEST_AWAY_HOURS * HOUR_MS),
-          $gte: new Date(now.getTime() - UNREAD_DIGEST_MAX_AWAY_DAYS * DAY_MS),
-        },
-        deletedAt: { $exists: false },
-        // Bounds the scan only; `notificationsAllowed` decides. The other two
-        // stored shapes are objects this cannot read into — see the same
-        // filter in `streakReminderCandidates`.
-        'settings.notifications': { $ne: false },
-      },
-      { projection: { timezone: 1, settings: 1, stats: 1 } },
-    )
-    .toArray()
+  const periodKey = new Date(lastActiveAt).toISOString()
+  if (await alreadyClaimed(db, 'unreadDigest', profile._id, periodKey)) return null
 
-  let sent = 0
-  for (const profile of candidates) {
-    if (!notificationsAllowed(profile.settings?.notifications, 'messages', 'email')) continue
-
-    const hour = localHour(now, profile.timezone ?? 'UTC')
-    if (hour < NOTIFICATION_EMAIL_LOCAL_HOURS.earliest) continue
-    if (hour > NOTIFICATION_EMAIL_LOCAL_HOURS.latest) continue
-
-    const lastActiveAt = profile.stats?.lastActiveAt
-    if (!lastActiveAt) continue
-    const periodKey = new Date(lastActiveAt).toISOString()
-
-    if (await alreadyClaimed(db, 'unreadDigest', profile._id, periodKey)) continue
-
-    const filter: Filter<Conversation> = {
-      participants: profile._id,
-      'lastMessage.createdAt': { $gt: new Date(lastActiveAt) },
-      'lastMessage.senderId': { $ne: profile._id },
-      [`unread.${profile._id}`]: { $gt: 0 },
-      [`archivedBy.${profile._id}`]: { $exists: false },
-      [`deletedBy.${profile._id}`]: { $exists: false },
-    }
-
-    // One more than we name, so "and N more" is answerable without a second
-    // count for the overwhelming majority who have three threads or fewer.
-    const threads = await conversations
-      .find(filter, { projection: { participants: 1, unread: 1, lastMessage: 1 } })
-      .sort({ 'lastMessage.createdAt': -1 })
-      .limit(UNREAD_DIGEST_MAX_SENDERS + 1)
-      .toArray()
-    if (threads.length === 0) continue
-
-    const hidden = new Set(await blockedUserIds(db, profile._id))
-    const visible = threads.filter((thread) =>
-      thread.participants.every((id) => id === profile._id || !hidden.has(id)),
-    )
-    if (visible.length === 0) continue
-
-    const named = visible.slice(0, UNREAD_DIGEST_MAX_SENDERS)
-    const partnerIds = named
-      .map((thread) => thread.participants.find((id) => id !== profile._id))
-      .filter((id): id is string => Boolean(id))
-
-    const partners = await profiles
-      .find(
-        { _id: { $in: partnerIds }, deletedAt: { $exists: false } },
-        { projection: { displayName: 1, handle: 1, avatarUrl: 1 } },
-      )
-      .toArray()
-    const byId = new Map(partners.map((partner) => [partner._id, partner]))
-    /*
-     * Faces, not just names. The photo is fetched here rather than linked,
-     * for the reason every image in this app's mail is — see
-     * `email/avatars.ts` — and a fetch that fails leaves initials on a
-     * coloured disc, which is what somebody with no photo gets anyway.
-     */
-    const faces: AvatarFace[] = []
-    for (const id of partnerIds) {
-      const partner = byId.get(id)
-      const name = partner?.displayName ?? partner?.handle
-      if (!partner || !name) continue
-      const asset = partner.avatarUrl
-        ? await fetchAvatarAsset(partner.avatarUrl, `avatar-${id}`, storagePublicBaseUrl)
-        : null
-      faces.push({
-        name,
-        seed: id,
-        ...(asset ? { asset } : {}),
-        ...(partner.handle ? { url: profileUrl(partner.handle) } : {}),
-      })
-    }
-    if (faces.length === 0) continue
-
-    const count = visible.reduce((total, thread) => total + (thread.unread[profile._id] ?? 0), 0)
-    const moreThreads = Math.max(0, visible.length - faces.length)
-    // One thread has somewhere specific to land; several do not, and a link to
-    // the wrong conversation is worse than a link to the list.
-    const url =
-      visible.length === 1 && visible[0]
-        ? webUrl(`/chat/${visible[0]._id.toHexString()}`)
-        : webUrl('/chats')
-
-    if (!(await claimOnce(db, 'unreadDigest', profile._id, periodKey))) continue
-
-    const outcome = await sendNotificationEmail(db, ctx, {
-      userId: profile._id,
-      type: 'messages',
-      build: (locale, unsubscribe) =>
-        unreadDigestEmail(locale, { count, faces, moreThreads, url, unsubscribe }),
-    })
-    if (outcome === 'sent') sent++
+  const filter: Filter<Conversation> = {
+    participants: profile._id,
+    'lastMessage.createdAt': { $gt: new Date(lastActiveAt) },
+    'lastMessage.senderId': { $ne: profile._id },
+    [`unread.${profile._id}`]: { $gt: 0 },
+    [`archivedBy.${profile._id}`]: { $exists: false },
+    [`deletedBy.${profile._id}`]: { $exists: false },
   }
 
-  return { sent }
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  // One more than we name, so "and N more" is answerable without a second
+  // count for the overwhelming majority who have three threads or fewer.
+  const threads = await db
+    .collection<Conversation>(COLLECTIONS.conversations)
+    .find(filter, { projection: { participants: 1, unread: 1, lastMessage: 1 } })
+    .sort({ 'lastMessage.createdAt': -1 })
+    .limit(UNREAD_DIGEST_MAX_SENDERS + 1)
+    .toArray()
+  if (threads.length === 0) return null
+
+  const hidden = new Set(await blockedUserIds(db, profile._id))
+  const visible = threads.filter((thread) =>
+    thread.participants.every((id) => id === profile._id || !hidden.has(id)),
+  )
+  if (visible.length === 0) return null
+
+  const named = visible.slice(0, UNREAD_DIGEST_MAX_SENDERS)
+  const partnerIds = named
+    .map((thread) => thread.participants.find((id) => id !== profile._id))
+    .filter((id): id is string => Boolean(id))
+
+  const partners = await profiles
+    .find(
+      { _id: { $in: partnerIds }, deletedAt: { $exists: false } },
+      { projection: { displayName: 1, handle: 1, avatarUrl: 1 } },
+    )
+    .toArray()
+  const byId = new Map(partners.map((partner) => [partner._id, partner]))
+  /*
+   * Faces, not just names. The photo is fetched here rather than linked, for
+   * the reason every image in this app's mail is — see `email/avatars.ts` —
+   * and a fetch that fails leaves initials on a coloured disc, which is what
+   * somebody with no photo gets anyway.
+   */
+  const faces: AvatarFace[] = []
+  for (const id of partnerIds) {
+    const partner = byId.get(id)
+    const name = partner?.displayName ?? partner?.handle
+    if (!partner || !name) continue
+    const asset = partner.avatarUrl
+      ? await fetchAvatarAsset(partner.avatarUrl, `avatar-${id}`, storagePublicBaseUrl)
+      : null
+    faces.push({
+      name,
+      seed: id,
+      ...(asset ? { asset } : {}),
+      ...(partner.handle ? { url: profileUrl(partner.handle) } : {}),
+    })
+  }
+  if (faces.length === 0) return null
+
+  const count = visible.reduce((total, thread) => total + (thread.unread[profile._id] ?? 0), 0)
+  const moreThreads = Math.max(0, visible.length - faces.length)
+  // One thread has somewhere specific to land; several do not, and a link to
+  // the wrong conversation is worse than a link to the list.
+  const url =
+    visible.length === 1 && visible[0]
+      ? webUrl(`/chat/${visible[0]._id.toHexString()}`)
+      : webUrl('/chats')
+
+  return {
+    // Somebody is waiting for an answer. Nothing outranks it.
+    trigger: true,
+    claim: () => claimOnce(db, 'unreadDigest', profile._id, periodKey),
+    build: (locale: Locale) => buildSection(locale, { count, faces, moreThreads, url }),
+  }
 }

--- a/apps/api/src/modules/notifications/wallet.ts
+++ b/apps/api/src/modules/notifications/wallet.ts
@@ -1,9 +1,11 @@
-import { giftReadyAt, localHour, notificationsAllowed, utcDayKey } from '@langx/shared'
+import { giftReadyAt, localHour, notificationsAllowed, utcDayKey, type Locale } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
+import { walletPoolSection } from '../../email/templates'
 import { translator } from '../../i18n'
 import type { Profile } from '../profiles/profiles'
 import { sendPush, tokensByLocale, type PushSender } from '../push/devices'
+import type { DigestCandidate } from './digest'
 import { claimOnce } from './ledger'
 
 /**
@@ -14,9 +16,10 @@ import { claimOnce } from './ledger'
  * were silent, which made a currency people had to remember to check — and a
  * currency nobody checks is a feature nobody found.
  *
- * `wallet.email` is off by default and there is no sender for it. Mail about
- * a number going up is the kind that gets a domain filtered; the wallet is
- * two taps away, and the push is the whole point.
+ * The gift stays push-only. A button being available is not something that
+ * happened, and a mail saying so would be a mail about nothing. The pool is
+ * the other case: it pays overnight while nobody is watching, so it earns a
+ * paragraph in the evening digest — see `walletPoolSectionFor`.
  */
 
 /** The hour, on the reader's clock, at which yesterday's pool is worth saying. */
@@ -64,31 +67,28 @@ export async function runPoolPayoutPass(
   sender: PushSender,
   now: Date = new Date(),
 ): Promise<{ sent: number }> {
-  const day = utcDayKey(new Date(now.getTime() - 24 * 60 * 60 * 1000))
-  const paid = await db
-    .collection<LedgerRow>(COLLECTIONS.tokenLedger)
-    .find({ kind: 'dailyPool', refId: day }, { projection: { userId: 1, amount: 1 } })
-    .toArray()
-  if (paid.length === 0) return { sent: 0 }
+  const paid = await collectPoolPayouts(db, now)
+  if (paid.size === 0) return { sent: 0 }
+  const day = poolDay(now)
 
   const profiles = await db
     .collection<Profile>(COLLECTIONS.profiles)
     .find(
-      { _id: { $in: paid.map((row) => row.userId) }, deletedAt: { $exists: false } },
+      { _id: { $in: [...paid.keys()] }, deletedAt: { $exists: false } },
       { projection: { settings: 1, timezone: 1 } },
     )
     .toArray()
   const byId = new Map(profiles.map((profile) => [profile._id, profile]))
 
   let sent = 0
-  for (const row of paid) {
-    const profile = byId.get(row.userId)
+  for (const [userId, amount] of paid) {
+    const profile = byId.get(userId)
     if (!profile) continue
     if (localHour(now, profile.timezone ?? 'UTC') !== WALLET_LOCAL_HOUR) continue
     if (!(await claimOnce(db, 'wallet.pool', profile._id, day))) continue
     if (
       await pushWallet(db, sender, profile, (t) => ({
-        title: t('push.wallet.poolTitle', { count: row.amount }),
+        title: t('push.wallet.poolTitle', { count: amount }),
         body: t('push.wallet.poolBody'),
       }))
     ) {
@@ -96,6 +96,53 @@ export async function runPoolPayoutPass(
     }
   }
   return { sent }
+}
+
+/** Which pool run is the one being talked about: the one that paid overnight. */
+function poolDay(now: Date): string {
+  return utcDayKey(new Date(now.getTime() - 24 * 60 * 60 * 1000))
+}
+
+/**
+ * Yesterday's pool, for everybody it paid, read once for the whole tick.
+ *
+ * The same rows `runPoolPayoutPass` pushes from, asked an hour-block later so
+ * the evening mail can mention them. One query for everybody rather than one
+ * per reader: the pool pays a few hundred people at most and the digest would
+ * otherwise ask the ledger the same question once per profile.
+ */
+export async function collectPoolPayouts(db: Db, now: Date): Promise<Map<string, number>> {
+  const day = poolDay(now)
+  const paid = await db
+    .collection<LedgerRow>(COLLECTIONS.tokenLedger)
+    .find({ kind: 'dailyPool', refId: day }, { projection: { userId: 1, amount: 1 } })
+    .toArray()
+  return new Map(paid.map((row) => [row.userId, row.amount]))
+}
+
+/**
+ * One reader's share of it, as a section.
+ *
+ * A passenger for anybody with a phone: the push said this at nine in the
+ * morning and a mail repeating it twelve hours later is not news. For the web
+ * audience, which has no push at all, it is the only way the pool is ever
+ * visible, and there it is worth the mail.
+ */
+export function walletPoolSectionFor(
+  db: Db,
+  profile: Profile,
+  amount: number | undefined,
+  hasPushDevice: boolean,
+  now: Date,
+): DigestCandidate | null {
+  if (!amount || amount <= 0) return null
+  const day = poolDay(now)
+
+  return {
+    trigger: !hasPushDevice,
+    claim: () => claimOnce(db, 'wallet.poolDigest', profile._id, day),
+    build: (locale: Locale) => walletPoolSection(locale, { count: amount }),
+  }
 }
 
 /**

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -293,6 +293,21 @@ export interface Profile {
      * two-year-old streak the day this ships.
      */
     notifiedBadgeIds?: string[]
+    /**
+     * Tonight's badge news, left for the digest to collect an hour later.
+     *
+     * The round-up cannot simply be recomputed at the digest's hour: it works
+     * by diffing what is earned against `notifiedBadgeIds` and then writing
+     * the new list, so by 19:00 the difference it found at 18:00 is gone.
+     * Rather than move that pass or make the digest do badge arithmetic, the
+     * pass leaves what it found here and the digest reads it.
+     *
+     * `day` is the reader's local day, so a stale row from last week cannot
+     * be mistaken for tonight's. `pushed` is why the section is sometimes a
+     * passenger: a badge that already buzzed a phone is not a reason to send
+     * a mail, only something to mention in one that is going anyway.
+     */
+    digestBadges?: { day: string; count: number; label: string | null; pushed: boolean }
   }
   /**
    * Who invited this account, if anybody. Written once by `attachReferral`

--- a/apps/api/src/modules/push/reminderScheduler.test.ts
+++ b/apps/api/src/modules/push/reminderScheduler.test.ts
@@ -4,13 +4,9 @@ import { MongoMemoryServer } from 'mongodb-memory-server'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { connectToDatabase, type DbHandle } from '../../db/client'
 import { COLLECTIONS } from '../../db/collections'
-import type { NotificationEmailContext } from '../../email/notify'
 import { authId } from '../../lib/authId'
-import { CapturingEmailSender } from '../../testSupport/authFlow'
 import { LoggingPushSender, type Device } from './devices'
 import { runStreakReminderTick } from './reminderScheduler'
-
-const SECRET = 'c'.repeat(40)
 
 /**
  * A fixed zone in which `now` is the reminder hour.
@@ -29,8 +25,6 @@ describe('the streak reminder pass', () => {
   let mongo: MongoMemoryServer
   let handle: DbHandle
   let push: LoggingPushSender
-  let sender: CapturingEmailSender
-  let email: NotificationEmailContext
   const now = new Date('2026-09-03T14:00:00Z')
   const zone = zoneWhereItIsReminderHour(now)
 
@@ -54,8 +48,6 @@ describe('the streak reminder pass', () => {
       await handle.db.collection(name).deleteMany({})
     }
     push = new LoggingPushSender()
-    sender = new CapturingEmailSender()
-    email = { sender, unsubscribeSecret: SECRET, apiBaseUrl: 'https://api.langx.io' }
   })
 
   async function seed(
@@ -98,87 +90,67 @@ describe('the streak reminder pass', () => {
     return userId
   }
 
-  it('pushes to a phone and sends no email', async () => {
+  it('pushes to a phone', async () => {
     await seed({ withDevice: true })
-    const result = await runStreakReminderTick(handle.db, push, email, now)
+    const result = await runStreakReminderTick(handle.db, push, now)
 
-    expect(result).toEqual({ pushed: 1, emailed: 0 })
+    expect(result).toEqual({ pushed: 1 })
     expect(push.sent).toHaveLength(1)
     expect(push.sent[0]?.data.kind).toBe('streakReminder')
-    expect(sender.messages).toHaveLength(0)
   })
 
   /**
-   * The web audience, and anyone who declined the permission. Before this
-   * they were found, ledgered and then silently skipped.
+   * The web audience, and anyone who declined the permission. They are nudged
+   * an hour earlier, as a section of the evening digest — so this pass leaves
+   * them alone *and leaves the day unclaimed*, which is what lets the digest
+   * claim it. Claiming here would silence the only channel they have.
    */
-  it('emails somebody with no phone signed in', async () => {
+  it('leaves somebody with no phone to the evening digest', async () => {
     await seed()
-    const result = await runStreakReminderTick(handle.db, push, email, now)
+    const result = await runStreakReminderTick(handle.db, push, now)
 
-    expect(result).toEqual({ pushed: 0, emailed: 1 })
+    expect(result).toEqual({ pushed: 0 })
     expect(push.sent).toHaveLength(0)
-    expect(sender.messages).toHaveLength(1)
-    // The same words as the push, with the streak count filled in.
-    expect(sender.messages[0]?.subject).toContain('3')
-    expect(sender.messages[0]?.headers?.['List-Unsubscribe-Post']).toBe(
-      'List-Unsubscribe=One-Click',
-    )
+    expect(await handle.db.collection(COLLECTIONS.streakReminders).countDocuments({})).toBe(0)
   })
 
   it('nudges once a day however many times it runs', async () => {
-    await seed()
-    await runStreakReminderTick(handle.db, push, email, now)
-    const second = await runStreakReminderTick(handle.db, push, email, now)
+    await seed({ withDevice: true })
+    await runStreakReminderTick(handle.db, push, now)
+    const second = await runStreakReminderTick(handle.db, push, now)
 
-    expect(second).toEqual({ pushed: 0, emailed: 0 })
-    expect(sender.messages).toHaveLength(1)
+    expect(second).toEqual({ pushed: 0 })
+    expect(push.sent).toHaveLength(1)
   })
 
   it('says nothing to somebody who turned both channels off', async () => {
-    await seed({ notifications: { streak: { push: false, email: false } } })
-    await runStreakReminderTick(handle.db, push, email, now)
+    await seed({ withDevice: true, notifications: { streak: { push: false, email: false } } })
+    await runStreakReminderTick(handle.db, push, now)
 
-    expect(sender.messages).toHaveLength(0)
     expect(push.sent).toHaveLength(0)
     // Not even claimed: the day should still be free if they change their mind.
     expect(await handle.db.collection(COLLECTIONS.streakReminders).countDocuments({})).toBe(0)
   })
 
-  it('emails somebody who wants mail but not a push', async () => {
+  it('does not push to somebody who asked for mail instead', async () => {
     await seed({ withDevice: true, notifications: { streak: { push: false, email: true } } })
-    const result = await runStreakReminderTick(handle.db, push, email, now)
+    const result = await runStreakReminderTick(handle.db, push, now)
 
-    expect(result).toEqual({ pushed: 0, emailed: 1 })
+    expect(result).toEqual({ pushed: 0 })
     expect(push.sent).toHaveLength(0)
-  })
-
-  /**
-   * The day is claimed before the send is attempted, so a person the mail
-   * cannot reach is not retried thirty minutes later — and again the next
-   * evening after that.
-   */
-  it('still claims the day when the address is unverified', async () => {
-    await seed({ verified: false })
-    const result = await runStreakReminderTick(handle.db, push, email, now)
-
-    expect(result).toEqual({ pushed: 0, emailed: 0 })
-    expect(sender.messages).toHaveLength(0)
-    expect(await handle.db.collection(COLLECTIONS.streakReminders).countDocuments({})).toBe(1)
+    // The digest is their channel, so the day must still be theirs to claim.
+    expect(await handle.db.collection(COLLECTIONS.streakReminders).countDocuments({})).toBe(0)
   })
 
   it('leaves alone anyone for whom it is not the reminder hour', async () => {
-    await seed({ timezone: 'Etc/GMT+1' === zone ? 'Etc/GMT+2' : 'Etc/GMT+1' })
-    const result = await runStreakReminderTick(handle.db, push, email, now)
-    expect(result).toEqual({ pushed: 0, emailed: 0 })
+    await seed({ withDevice: true, timezone: 'Etc/GMT+1' === zone ? 'Etc/GMT+2' : 'Etc/GMT+1' })
+    const result = await runStreakReminderTick(handle.db, push, now)
+    expect(result).toEqual({ pushed: 0 })
   })
 
   it('leaves alone anyone who has already kept the streak today', async () => {
     const today = new Intl.DateTimeFormat('en-CA', { timeZone: zone }).format(now)
-    await seed({ lastQualifiedDay: today })
-    expect(await runStreakReminderTick(handle.db, push, email, now)).toEqual({
-      pushed: 0,
-      emailed: 0,
-    })
+    await seed({ withDevice: true, lastQualifiedDay: today })
+    expect(await runStreakReminderTick(handle.db, push, now)).toEqual({ pushed: 0 })
   })
 })

--- a/apps/api/src/modules/push/reminderScheduler.ts
+++ b/apps/api/src/modules/push/reminderScheduler.ts
@@ -1,8 +1,8 @@
-import { localDayKey } from '@langx/shared'
+import { localDayKey, type Locale } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
-import { sendNotificationEmail, type NotificationEmailContext } from '../../email/notify'
-import { streakReminderEmail } from '../../email/templates'
+import { streakReminderSection } from '../../email/templates'
+import type { DigestCandidate } from '../notifications/digest'
 import type { Profile } from '../profiles/profiles'
 import type { SchedulerLogger } from '../tokens/poolScheduler'
 import { sendPush, streakReminderCandidates, tokensByLocale, type PushSender } from './devices'
@@ -33,73 +33,101 @@ export interface ReminderLedgerEntry {
  * `now`, the way `runDailyPool` is driven; the scheduler below is then only a
  * clock.
  *
- * A phone gets the push. Somebody with none — the whole web audience, and
- * anyone who declined the permission — gets the same words as an email, in the
- * *same iteration*, because the ledger insert above has already claimed the
- * day for them. A second pass would need either a second ledger or a re-read
- * of this one, and both put back the read-then-write race the `_id` insert was
- * chosen to avoid.
+ * **Push only since the daily digest.** Somebody with no phone signed in — the
+ * whole web audience, and anyone who declined the permission — is nudged an
+ * hour earlier instead, as a section of the evening mail; see
+ * `streakSectionFor` below. The day is claimed in the same ledger either way,
+ * so nobody is nudged twice and the ordering between the two hours settles
+ * itself.
  */
 export async function runStreakReminderTick(
   db: Db,
   sender: PushSender,
-  email: NotificationEmailContext,
   now: Date = new Date(),
-): Promise<{ pushed: number; emailed: number }> {
+): Promise<{ pushed: number }> {
   const candidates = await streakReminderCandidates(db, now)
   let pushed = 0
-  let emailed = 0
 
   for (const candidate of candidates) {
+    if (!candidate.push) continue
+    const byLocale = await tokensByLocale(db, candidate.userId)
+    if (byLocale.size === 0) continue
+
     const profile = await db
       .collection<Profile>(COLLECTIONS.profiles)
       .findOne({ _id: candidate.userId }, { projection: { timezone: 1 } })
     const day = localDayKey(now, profile?.timezone ?? 'UTC')
+    if (!(await claimStreakDay(db, candidate.userId, day, now))) continue
 
-    try {
-      await db
-        .collection<ReminderLedgerEntry>(COLLECTIONS.streakReminders)
-        .insertOne({ _id: `${candidate.userId}:${day}`, sentOn: now })
-    } catch {
-      continue // already nudged today
+    for (const [locale, tokens] of byLocale) {
+      const t = translator(locale)
+      await sendPush(db, sender, {
+        to: tokens,
+        title: t('push.streakTitle', { count: candidate.streak }),
+        body: t('push.streakBody'),
+        data: { kind: 'streakReminder' },
+      })
     }
-
-    const byLocale = candidate.push
-      ? await tokensByLocale(db, candidate.userId)
-      : new Map<never, never>()
-    if (byLocale.size > 0) {
-      for (const [locale, tokens] of byLocale) {
-        const t = translator(locale)
-        await sendPush(db, sender, {
-          to: tokens,
-          title: t('push.streakTitle', { count: candidate.streak }),
-          body: t('push.streakBody'),
-          data: { kind: 'streakReminder' },
-        })
-      }
-      pushed++
-      continue
-    }
-
-    // Not a second notification, a fallback for the one that had nowhere to
-    // go. Somebody holding both a phone and an inbox gets exactly one nudge.
-    if (!candidate.email) continue
-    const outcome = await sendNotificationEmail(db, email, {
-      userId: candidate.userId,
-      type: 'streak',
-      build: (locale, unsubscribe) =>
-        streakReminderEmail(locale, { count: candidate.streak, unsubscribe }),
-    })
-    if (outcome === 'sent') emailed++
+    pushed++
   }
 
-  return { pushed, emailed }
+  return { pushed }
+}
+
+/**
+ * The same nudge for somebody the push cannot reach, an hour earlier, inside
+ * the evening mail.
+ *
+ * Only for an account with no phone signed in. Somebody holding both a phone
+ * and an inbox still gets exactly one nudge, which is the rule this had before
+ * the digest existed — it has only changed which of the two arrives first.
+ *
+ * The cost of the earlier hour is named rather than hidden: 19:00 is before
+ * 20:00, so a person who practises at half past seven is told at seven that
+ * they have not. The alternative was a second envelope at eight, which is the
+ * thing this whole change exists to stop.
+ */
+export function streakSectionFor(
+  db: Db,
+  profile: Profile,
+  now: Date,
+  hasPushDevice: boolean,
+): DigestCandidate | null {
+  if (hasPushDevice) return null
+  const streak = profile.streak?.current ?? 0
+  if (streak < 1) return null
+
+  const day = localDayKey(now, profile.timezone ?? 'UTC')
+  // Already practised today: there is nothing to save.
+  if (profile.streak?.lastQualifiedDay === day) return null
+
+  return {
+    trigger: true,
+    claim: () => claimStreakDay(db, profile._id, day, now),
+    build: (locale: Locale) => streakReminderSection(locale, { count: streak }),
+  }
+}
+
+/**
+ * One nudge per person per local day, whichever hour and channel gets there
+ * first. The insert failing on a duplicate `_id` *is* the check — a read
+ * followed by a write has a gap, and two ticks landing in it is somebody
+ * nagged twice about the same streak.
+ */
+async function claimStreakDay(db: Db, userId: string, day: string, now: Date): Promise<boolean> {
+  try {
+    await db
+      .collection<ReminderLedgerEntry>(COLLECTIONS.streakReminders)
+      .insertOne({ _id: `${userId}:${day}`, sentOn: now })
+    return true
+  } catch {
+    return false
+  }
 }
 
 export function startStreakReminderScheduler(
   db: Db,
   sender: PushSender,
-  email: NotificationEmailContext,
   logger: SchedulerLogger,
   options: { intervalMs?: number } = {},
 ): { stop: () => void } {
@@ -110,8 +138,8 @@ export function startStreakReminderScheduler(
     if (running) return
     running = true
     try {
-      const { pushed, emailed } = await runStreakReminderTick(db, sender, email, new Date())
-      if (pushed > 0 || emailed > 0) logger.info({ pushed, emailed }, 'streak reminders sent')
+      const { pushed } = await runStreakReminderTick(db, sender, new Date())
+      if (pushed > 0) logger.info({ pushed }, 'streak reminders sent')
     } catch (error) {
       logger.error({ err: error }, 'streak reminder run failed')
     } finally {

--- a/apps/api/src/routes/profiles.test.ts
+++ b/apps/api/src/routes/profiles.test.ts
@@ -539,7 +539,7 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
     expect(
       updated.json<{ settings: { notifications: Record<string, unknown> } }>().settings
         .notifications.meetings,
-    ).toEqual({ push: false, email: false })
+    ).toEqual({ push: false, email: true })
 
     const reread = await app.inject({
       method: 'GET',
@@ -549,7 +549,7 @@ describe('Faz 2 — profiles, username claim, avatar upload', () => {
     expect(
       reread.json<{ settings: { notifications: Record<string, unknown> } }>().settings.notifications
         .meetings,
-    ).toEqual({ push: false, email: false })
+    ).toEqual({ push: false, email: true })
   })
 
   /**

--- a/apps/mobile/src/i18n/messages/ar.ts
+++ b/apps/mobile/src/i18n/messages/ar.ts
@@ -629,7 +629,7 @@ export const ar: Localized<EnMessages> = {
     profileVisits: 'زيارات الملف',
     profileVisitsBody: 'مرة كل يوم، كم شخصًا اطّلع على ملفك. وملخّص بالبريد كل أسبوع.',
     meetings: 'المواعيد',
-    meetingsBody: 'قبل ساعة من مكالمة اتفقتما عليها. إشعار فقط.',
+    meetingsBody: 'قبل ساعة من مكالمة اتفقتما عليها. وبريد المساء يقول ما ينتظرك غدًا.',
     social: 'الموجز ومن فيه',
     socialBody: 'المتابعات والتصحيحات على منشوراتك والإعجابات.',
     wallet: 'الرموز',
@@ -637,7 +637,7 @@ export const ar: Localized<EnMessages> = {
     promotions: 'الأخبار والعروض',
     promotionsBody: 'بين حين وآخر عن الجديد. نقرة واحدة توقفه.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
-    channel: { push: 'إشعار فوري', email: 'البريد' },
+    channel: { push: 'إشعار فوري', email: 'بريد يومي' },
     emailUnverified: 'وثّق عنوان بريدك لتفعيل هذا.',
     primingTitle: 'تفعيل الإشعارات؟',
     primingBody:

--- a/apps/mobile/src/i18n/messages/de.ts
+++ b/apps/mobile/src/i18n/messages/de.ts
@@ -572,7 +572,8 @@ export const de: Localized<EnMessages> = {
     profileVisitsBody:
       'Einmal am Tag, wie viele dein Profil angesehen haben. Wöchentlich eine Zusammenfassung per E-Mail.',
     meetings: 'Termine',
-    meetingsBody: 'Eine Stunde vor einem Gespräch, dem ihr beide zugestimmt habt. Nur Push.',
+    meetingsBody:
+      'Eine Stunde vor einem Gespräch, dem ihr beide zugestimmt habt. Die Abendmail sagt, was morgen ansteht.',
     social: 'Der Feed und die Leute darin',
     socialBody: 'Follows, Korrekturen an deinen Beiträgen und Likes.',
     wallet: 'Token',
@@ -580,7 +581,7 @@ export const de: Localized<EnMessages> = {
     promotions: 'Neues und Angebote',
     promotionsBody: 'Gelegentlich, was es Neues gibt. Ein Tipp beendet es.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
-    channel: { push: 'Push', email: 'E-Mail' },
+    channel: { push: 'Push', email: 'Tägliche E-Mail' },
     emailUnverified: 'Bestätige deine E-Mail-Adresse, um das einzuschalten.',
     primingTitle: 'Mitteilungen einschalten?',
     primingBody:

--- a/apps/mobile/src/i18n/messages/en.ts
+++ b/apps/mobile/src/i18n/messages/en.ts
@@ -622,7 +622,8 @@ export const en = {
     profileVisitsBody:
       'Once a day, how many people looked at your profile. A summary by email each week.',
     meetings: 'Meetings',
-    meetingsBody: 'An hour before a call you both agreed to. Push only.',
+    meetingsBody:
+      'An hour before a call you both agreed to. The evening mail says what tomorrow holds.',
     social: 'The feed and the people on it',
     socialBody: 'Follows, corrections on your posts, and likes.',
     wallet: 'Tokens',
@@ -630,7 +631,7 @@ export const en = {
     promotions: 'News and offers',
     promotionsBody: 'Occasional word about what is new. One tap to stop.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
-    channel: { push: 'Push', email: 'Email' },
+    channel: { push: 'Push', email: 'Daily email' },
     emailUnverified: 'Verify your email address to turn this on.',
     primingTitle: 'Turn on notifications?',
     primingBody:

--- a/apps/mobile/src/i18n/messages/es.ts
+++ b/apps/mobile/src/i18n/messages/es.ts
@@ -564,7 +564,8 @@ export const es: Localized<EnMessages> = {
     profileVisitsBody:
       'Una vez al día, cuánta gente miró tu perfil. Un resumen por correo cada semana.',
     meetings: 'Citas',
-    meetingsBody: 'Una hora antes de una llamada que ambos aceptasteis. Solo push.',
+    meetingsBody:
+      'Una hora antes de una llamada que ambos aceptasteis. El correo de la tarde dice qué hay mañana.',
     social: 'El feed y quienes están en él',
     socialBody: 'Seguidores, correcciones a tus publicaciones y me gusta.',
     wallet: 'Tokens',
@@ -572,7 +573,7 @@ export const es: Localized<EnMessages> = {
     promotions: 'Novedades y ofertas',
     promotionsBody: 'De vez en cuando, lo nuevo. Un toque para parar.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
-    channel: { push: 'Push', email: 'Correo' },
+    channel: { push: 'Push', email: 'Correo diario' },
     emailUnverified: 'Verifica tu dirección de correo para activarlo.',
     primingTitle: '¿Activar las notificaciones?',
     primingBody:

--- a/apps/mobile/src/i18n/messages/fr.ts
+++ b/apps/mobile/src/i18n/messages/fr.ts
@@ -570,7 +570,8 @@ export const fr: Localized<EnMessages> = {
     profileVisitsBody:
       'Une fois par jour, combien de personnes ont consulté votre profil. Un résumé par e-mail chaque semaine.',
     meetings: 'Rendez-vous',
-    meetingsBody: 'Une heure avant un appel que vous avez accepté tous les deux. Push uniquement.',
+    meetingsBody:
+      "Une heure avant un appel que vous avez accepté tous les deux. L'e-mail du soir dit ce qui vous attend demain.",
     social: 'Le fil et les gens qui y sont',
     socialBody: 'Abonnements, corrections de vos publications et j’aime.',
     wallet: 'Jetons',
@@ -578,7 +579,7 @@ export const fr: Localized<EnMessages> = {
     promotions: 'Actualités et offres',
     promotionsBody: 'De temps en temps, les nouveautés. Un geste pour arrêter.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
-    channel: { push: 'Push', email: 'E-mail' },
+    channel: { push: 'Push', email: 'E-mail quotidien' },
     emailUnverified: 'Vérifiez votre adresse e-mail pour l’activer.',
     primingTitle: 'Activer les notifications ?',
     primingBody:

--- a/apps/mobile/src/i18n/messages/pt-BR.ts
+++ b/apps/mobile/src/i18n/messages/pt-BR.ts
@@ -560,7 +560,8 @@ export const ptBR: Localized<EnMessages> = {
     profileVisitsBody:
       'Uma vez por dia, quantas pessoas olharam seu perfil. Um resumo por e-mail toda semana.',
     meetings: 'Encontros',
-    meetingsBody: 'Uma hora antes de uma chamada que vocês dois aceitaram. Só push.',
+    meetingsBody:
+      'Uma hora antes de uma chamada que vocês dois aceitaram. O e-mail da noite diz o que há amanhã.',
     social: 'O feed e quem está nele',
     socialBody: 'Seguidores, correções nas suas publicações e curtidas.',
     wallet: 'Tokens',
@@ -568,7 +569,7 @@ export const ptBR: Localized<EnMessages> = {
     promotions: 'Novidades e ofertas',
     promotionsBody: 'De vez em quando, o que há de novo. Um toque para parar.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
-    channel: { push: 'Push', email: 'E-mail' },
+    channel: { push: 'Push', email: 'E-mail diário' },
     emailUnverified: 'Verifique seu endereço de e-mail para ativar isto.',
     primingTitle: 'Ativar as notificações?',
     primingBody:

--- a/apps/mobile/src/i18n/messages/ru.ts
+++ b/apps/mobile/src/i18n/messages/ru.ts
@@ -615,7 +615,8 @@ export const ru: Localized<EnMessages> = {
     profileVisitsBody:
       'Раз в день, сколько человек посмотрели ваш профиль. Раз в неделю сводка на почту.',
     meetings: 'Встречи',
-    meetingsBody: 'За час до звонка, на который вы оба согласились. Только пуш.',
+    meetingsBody:
+      'За час до звонка, на который вы оба согласились. Вечернее письмо расскажет, что запланировано на завтра.',
     social: 'Лента и люди в ней',
     socialBody: 'Подписки, исправления ваших постов и лайки.',
     wallet: 'Токены',
@@ -623,7 +624,7 @@ export const ru: Localized<EnMessages> = {
     promotions: 'Новости и предложения',
     promotionsBody: 'Изредка о новом. Одно касание — и всё прекратится.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
-    channel: { push: 'Пуш', email: 'Почта' },
+    channel: { push: 'Пуш', email: 'Письмо раз в день' },
     emailUnverified: 'Подтвердите адрес почты, чтобы включить это.',
     primingTitle: 'Включить уведомления?',
     primingBody:

--- a/apps/mobile/src/i18n/messages/tr.ts
+++ b/apps/mobile/src/i18n/messages/tr.ts
@@ -567,7 +567,8 @@ export const tr: Localized<EnMessages> = {
     profileVisits: 'Profil ziyaretleri',
     profileVisitsBody: 'Günde bir kez, profiline kaç kişinin baktığı. Haftada bir e-postayla özet.',
     meetings: 'Randevular',
-    meetingsBody: 'İkinizin de kabul ettiği bir görüşmeden bir saat önce. Sadece bildirim.',
+    meetingsBody:
+      'İkinizin de kabul ettiği bir görüşmeden bir saat önce. Akşam maili yarın ne olduğunu söyler.',
     social: 'Akış ve oradaki insanlar',
     socialBody: 'Takipler, gönderilerine gelen düzeltmeler ve beğeniler.',
     wallet: 'Token’lar',
@@ -575,7 +576,7 @@ export const tr: Localized<EnMessages> = {
     promotions: 'Haberler ve kampanyalar',
     promotionsBody: 'Arada yeniliklerden haber. Tek dokunuşla durur.',
     /** The two halves of every kind above; the row title, so no kind name in it. */
-    channel: { push: 'Anlık bildirim', email: 'E-posta' },
+    channel: { push: 'Anlık bildirim', email: 'Günlük e-posta' },
     emailUnverified: 'Bunu açmak için e-posta adresini doğrula.',
     primingTitle: 'Bildirimler açılsın mı?',
     primingBody:

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -14,28 +14,58 @@ there is a switch, an unsubscribe link, or neither.
 | Class             | Asks a preference?         | Unsubscribe?   | Why                                                                                                                                                                                               |
 | ----------------- | -------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Transactional** | no                         | no             | It answers something the person just did, or it is about their money or their account's safety. A switch whose honest label is "do not tell me when somebody signs in as me" is not one to offer. |
-| **Notification**  | yes, per kind per channel  | yes, one click | They asked for it by installing the app. `sendNotificationEmail` is the only way one leaves.                                                                                                      |
+| **Notification**  | yes, per kind per channel  | yes, one click | They asked for it by installing the app. Push leaves when it happens; **mail leaves once a day**, as one digest — see below.                                                                      |
 | **Campaign**      | `promotions` must allow it | yes, one click | A decision somebody makes on a particular day. Queued by hand, dripped by the API.                                                                                                                |
+
+### One mail a day
+
+Every notification email is a **section of one letter**, sent at 19:00 on the
+reader's own clock, and only when something is actually pending. Two rules make
+that true rather than aspirational:
+
+- **Nothing pending, nothing sent.** A section is either a _trigger_ —
+  something happened — or a _passenger_, which rides along in a mail that is
+  going anyway and may never summon one. The suggestions are a passenger, and
+  so is anything a push has already delivered to a phone.
+- **Marketing runs an hour later and stands down.** The nine nudges and the
+  monthly recap moved to 20:00 local, and both skip anybody whose digest has
+  already gone out today.
+
+Security and transactional mail sit outside all of this: they answer something
+that just happened, and are never batched or held back.
+
+The assembler is `modules/notifications/digest.ts`; each section is built by
+the module that owns its subject.
 
 ## The eight kinds
 
 `NOTIFICATION_TYPES` in `packages/shared/src/notifications.ts`. Every kind has
 two channels and both are real.
 
-| Kind            | Push    | Email  | Covers                                  |
-| --------------- | ------- | ------ | --------------------------------------- |
-| `messages`      | on      | on     | Chat, and the unread digest             |
-| `streak`        | on      | on     | The evening nudge, and the repair offer |
-| `badges`        | on      | off    | A badge earned                          |
-| `profileVisits` | on      | on     | Who looked at you                       |
-| `meetings`      | on      | off    | An hour before a call you agreed to     |
-| `social`        | on      | on     | The feed reacting to you                |
-| `wallet`        | on      | off    | Tokens arriving                         |
-| `promotions`    | **off** | **on** | Marketing, the newsletter, campaigns    |
+| Kind            | Push    | Email  | Covers                                                    |
+| --------------- | ------- | ------ | --------------------------------------------------------- |
+| `messages`      | on      | on     | Chat, and the unread section                              |
+| `streak`        | on      | on     | The evening nudge, and the repair offer                   |
+| `badges`        | on      | on     | A badge earned                                            |
+| `profileVisits` | on      | on     | Who looked at you                                         |
+| `meetings`      | on      | on     | Push: an hour before. Mail: what tomorrow's diary holds   |
+| `social`        | on      | on     | The feed reacting to you                                  |
+| `wallet`        | on      | on     | Tokens arriving                                           |
+| `promotions`    | **off** | **on** | Marketing, the newsletter, campaigns, and the suggestions |
 
 `promotions.email` defaults **on** since 10 September 2026 — the reversal is
 in `decisions.md`. `promotions.push` stays off: nobody asked to be buzzed at
 by marketing.
+
+`badges`, `meetings` and `wallet` email moved from off to on when the digest
+landed. What kept them off was never the content — it was that none of them is
+worth _a letter_. A paragraph in one that was going out anyway costs no
+envelope, so the objection went away with the envelopes.
+
+An email switch now decides whether a kind gets a **paragraph**, not whether it
+gets a message of its own. Turn them all off and no digest is sent at all —
+which is also what the footer's one-click unsubscribe does, since a letter
+carrying every kind cannot honestly offer to stop one of them.
 
 ---
 
@@ -89,30 +119,56 @@ A renewal that succeeds says nothing — the store already mails a receipt.
 
 ---
 
-## 2. Notifications — a switch each, both channels
+## 2. Notifications — a switch each, two very different channels
 
 All of these run on the half-hourly pass in
 `modules/notifications/scheduler.ts` unless the trigger says otherwise, and
 every one claims a row in `notificationLedger` before it sends.
 
-| Message                                          | Kind            | Channel                       | When                                        | Period key                                      |
-| ------------------------------------------------ | --------------- | ----------------------------- | ------------------------------------------- | ----------------------------------------------- |
-| A message arrived                                | `messages`      | push                          | on the message                              | — (fan-out)                                     |
-| Unread digest                                    | `messages`      | email                         | 8 h–14 d after `lastActiveAt`, waking hours | `lastActiveAt` — one absence, one letter        |
-| Streak reminder                                  | `streak`        | push, or email with no device | 20:00 local                                 | local day                                       |
-| Badge round-up                                   | `badges`        | push                          | 18:00 local                                 | badge ids                                       |
-| Profile visits                                   | `profileVisits` | push daily / email weekly     | 12:00 local / Monday                        | local day / ISO week                            |
-| Meeting reminder                                 | `meetings`      | push                          | an hour before                              | message id                                      |
-| **Somebody followed you**                        | `social`        | push                          | on the follow                               | one per follower, **ever**                      |
-| **A correction, answer or comment on your post** | `social`        | push                          | on the reply                                | one per post per **hour**                       |
-| **Your posts' likes**                            | `social`        | push                          | daily batch                                 | UTC day                                         |
-| **The day's replies to your posts**              | `social`        | email                         | 19:00 local                                 | local day                                       |
-| **Yesterday's pool paid you N tokens**           | `wallet`        | push                          | 09:00 local                                 | pool day                                        |
-| **Your hourly gift is ready**                    | `wallet`        | push                          | waking hours                                | UTC day, and only if they have taken one before |
+**Push, the moment it happens:**
 
-The unread digest carries **faces**: up to three writers, photo fetched from
-our own bucket and attached to the mail, initials on a coloured disc when
-there is none. Each face links to `app.langx.io/<handle>`.
+| Message                                          | Kind            | When           | Period key                                      |
+| ------------------------------------------------ | --------------- | -------------- | ----------------------------------------------- |
+| A message arrived                                | `messages`      | on the message | — (fan-out)                                     |
+| Streak reminder                                  | `streak`        | 20:00 local    | local day                                       |
+| Badge round-up                                   | `badges`        | 18:00 local    | badge ids                                       |
+| Profile visits                                   | `profileVisits` | 12:00 local    | local day                                       |
+| Meeting reminder                                 | `meetings`      | an hour before | message id                                      |
+| **Somebody followed you**                        | `social`        | on the follow  | one per follower, **ever**                      |
+| **A correction, answer or comment on your post** | `social`        | on the reply   | one per post per **hour**                       |
+| **Your posts' likes**                            | `social`        | daily batch    | UTC day                                         |
+| **Yesterday's pool paid you N tokens**           | `wallet`        | 09:00 local    | pool day                                        |
+| **Your hourly gift is ready**                    | `wallet`        | waking hours   | UTC day, and only if they have taken one before |
+
+**Email, all of it in one letter at 19:00 local.** The order is the order in
+the mail, and the first section that survives gives the letter its subject —
+so it runs from what cannot wait to what could have waited a fortnight. A
+_passenger_ never causes the mail to be sent; it is only ever included in one
+that was going anyway.
+
+| Section                            | Kind            | Trigger?                 | Period key                               |
+| ---------------------------------- | --------------- | ------------------------ | ---------------------------------------- |
+| Unread messages, with faces        | `messages`      | yes                      | `lastActiveAt` — one absence, one saying |
+| Your streak breaks tonight         | `streak`        | only with no push device | local day                                |
+| Tomorrow's calls                   | `meetings`      | yes                      | tomorrow's local day                     |
+| The day's replies to your posts    | `social`        | yes                      | local day                                |
+| Badges earned                      | `badges`        | only if no push went     | local day                                |
+| Yesterday's pool paid you N tokens | `wallet`        | only with no push device | pool day                                 |
+| Who looked at you                  | `profileVisits` | yes, Mondays             | ISO week                                 |
+| People you could practise with     | `promotions`    | **no — passenger**       | fortnight                                |
+
+Two of those sections say something the phone has already said, and that is
+what the trigger column is for: they are worth a line in a letter that is
+going out, and never worth one of their own. The hourly gift is in neither
+table — a button becoming available is not something that happened.
+
+The unread section and the suggestions carry **faces**: up to three people,
+photo fetched from our own bucket and attached to the mail, initials on a
+coloured disc when there is none. Each face links to `app.langx.io/<handle>`.
+
+The badge section is the one that cannot be recomputed at seven o'clock: the
+round-up overwrites `notifiedBadgeIds` at six, so it leaves what it found in
+`stats.digestBadges` for the digest to collect.
 
 ### The three throttles that matter
 
@@ -122,8 +178,10 @@ there is none. Each face links to `app.langx.io/<handle>`.
   anybody can do here.
 - **One follow notice per follower, ever.** Unfollowing and following again
   is not news.
-- **One digest per local day.** A reply landing after the letter has gone
-  waits for tomorrow's — the push already said it.
+- **One mail per local day, and one section per its own period.** The letter
+  is daily; almost nothing in it is. An absence produces one unread section
+  however many evenings it spans, visitors stay weekly, and a reply landing
+  after the letter has gone waits for tomorrow's — the push already said it.
 
 ---
 
@@ -133,8 +191,13 @@ there is none. Each face links to `app.langx.io/<handle>`.
 
 `modules/notifications/promotions.ts` — a table walked in **priority order**
 for each candidate. The first match is sent, the loop breaks, and
-`MARKETING_MIN_GAP_DAYS` (7) keeps the next one a week off. Quiet hours are
-the reader's own clock.
+`MARKETING_MIN_GAP_DAYS` (7) keeps the next one a week off.
+
+The pass runs at **20:00 on the reader's clock and nowhere else in the day**,
+an hour after the digest, and skips anybody whose digest has already gone out.
+It used to run any time between nine and nine, which with a daily mail in the
+picture would have let a nudge at ten in the morning take the day's one slot
+and leave the evening's real news with nowhere to go.
 
 | #   | Nudge                                   | Trigger                                               | Kind       |
 | --- | --------------------------------------- | ----------------------------------------------------- | ---------- |
@@ -159,8 +222,13 @@ from the people it is for.
 ### The monthly recap
 
 `modules/notifications/newsletter.ts`. "Your **September 2026** on LangX", on
-any of the first seven days of a month at 10:00 local, once per reader per
-month.
+any of the first seven days of a month at 20:00 local — the same marketing
+slot the nudges use, which it outranks — once per reader per month, and never
+on a day the digest has written.
+
+Monthly rather than weekly, and the numbers are the reason: a week of a
+language exchange is three conversations and a correction, which reads as an
+accusation rather than a summary.
 
 - **Your month** — messages, corrections, tokens, streak. A month somebody
   sat out swaps all four for one sentence.
@@ -193,12 +261,13 @@ tick.
 
 Four mechanisms, and each is in the database rather than in a caller's care.
 
-| Mechanism                                                 | Used by                                               |
-| --------------------------------------------------------- | ----------------------------------------------------- |
-| `notificationLedger` `_id` = `<job>:<userId>:<periodKey>` | every scheduled pass; insert failing **is** the check |
-| `emailCampaigns` unique `{campaignId, userId}`            | campaigns, claimed before each batch                  |
-| `knownDevices` `_id` = `<userId>:<fingerprint>`           | the new-device notice                                 |
-| `jobRuns` unique `{job, periodKey}`                       | the daily pool, and the campaign drip's per-tick lock |
+| Mechanism                                                 | Used by                                                                       |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `notificationLedger` `_id` = `<job>:<userId>:<periodKey>` | every scheduled pass; insert failing **is** the check                         |
+| `dailyDigest:<userId>:<localDay>`                         | the one mail a day — and what the nudges and the recap check before they send |
+| `emailCampaigns` unique `{campaignId, userId}`            | campaigns, claimed before each batch                                          |
+| `knownDevices` `_id` = `<userId>:<fingerprint>`           | the new-device notice                                                         |
+| `jobRuns` unique `{job, periodKey}`                       | the daily pool, and the campaign drip's per-tick lock                         |
 
 ## What stops a message arriving at all
 

--- a/packages/shared/src/notifications.ts
+++ b/packages/shared/src/notifications.ts
@@ -105,21 +105,22 @@ export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
   messages: { push: true, email: true },
   streak: { push: true, email: true },
   /*
-   * Push on, email off. A badge is a small good thing that belongs on the
-   * screen you earned it on; an unasked-for email about one is the kind of
-   * mail people describe as spam even when they like the app. The switch is
-   * real either way — turned on, the same words arrive by mail for somebody
-   * with no phone signed in.
+   * Both on since the daily digest, and the argument that kept email off has
+   * been answered rather than overruled. It was never about badges: it was
+   * that an unasked-for *letter* about one is the kind of mail people call
+   * spam even when they like the app. A badge is now a paragraph in a mail
+   * that was going out anyway, and there is no letter to resent.
    */
-  badges: { push: true, email: false },
+  badges: { push: true, email: true },
   profileVisits: { push: true, email: true },
   /*
-   * Push on, email off, for the badge's reason turned around: a reminder an
-   * hour out is only useful on the thing that buzzes, and an email arriving
-   * an hour before a call is either too late to read or a duplicate of the
-   * push that already worked.
+   * Push on, and email on for something the push does not do. The hour-before
+   * reminder is still push only — an email arriving an hour before a call is
+   * either too late to read or a duplicate of the buzz that already worked.
+   * What the digest carries is the other question, the one an hour's notice
+   * cannot answer: what is in the diary tomorrow.
    */
-  meetings: { push: true, email: false },
+  meetings: { push: true, email: true },
   /**
    * Both on, like `messages`, and for the same reason: the email half is a
    * **digest**, not a letter per event. A follow never earns one — the push
@@ -128,7 +129,12 @@ export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
    * somewhere else.
    */
   social: { push: true, email: true },
-  wallet: { push: true, email: false },
+  /*
+   * Email on for the digest's sake only. A letter whose whole content is a
+   * number going up is how a domain gets filtered; a line inside the evening
+   * mail costs nothing and answers "where did these come from".
+   */
+  wallet: { push: true, email: true },
   promotions: { push: false, email: true },
 }
 
@@ -375,19 +381,66 @@ export const UNREAD_DIGEST_MAX_SENDERS = 3
 export const NOTIFICATION_EMAIL_LOCAL_HOURS = { earliest: 9, latest: 21 } as const
 
 /**
- * When the monthly recap goes out, on the reader's own clock.
+ * When the one notification email of the day goes out, on the reader's clock.
  *
- * Ten in the morning: late enough not to be the first thing on a phone,
- * early enough to be read the day it arrives. It is sent on the first of the
- * month or any of the six days after — see `runNewsletterPass` for why the
- * window is wider than the day.
+ * Seven in the evening, which is the hour the feed digest already used: a
+ * sentence posted in the morning has had the day to be answered, and what the
+ * day amounted to is only worth saying once the day has happened.
  *
- * **Monthly rather than weekly**, and the numbers are the reason: a week of a
- * language exchange is three conversations and a correction, which reads as
- * an accusation rather than a summary. A weekly cadence is this constant plus
- * a different period key, not a rewrite.
+ * It is a **ceiling, not a cadence**. The mail goes only if something is
+ * actually pending, and nothing in it may invent a reason to write — see
+ * `runDailyDigestPass` for the trigger/passenger split that enforces that.
  */
-export const NEWSLETTER_LOCAL_HOUR = 10
+export const DAILY_DIGEST_LOCAL_HOUR = 19
+
+/**
+ * And when the marketing slot opens, an hour later: the nine nudges, and the
+ * monthly recap that outranks them.
+ *
+ * A fixed hour rather than the whole waking day, and *after* the digest rather
+ * than before it, which is the only ordering that keeps "one mail a day"
+ * pointing the right way. Marketing at ten in the morning would otherwise take
+ * the day's slot and leave the evening's real news with nowhere to go; at
+ * twenty hundred the question is already settled, and both of them skip
+ * anybody whose digest has gone out today.
+ */
+export const PROMOTION_LOCAL_HOUR = 20
+
+/**
+ * "People you could practise with" — the only section that names people the
+ * reader has never spoken to, so every number here is a restraint. It is the
+ * digest's one passenger and never a reason to send it.
+ *
+ * `everyDays` is the one to argue about, and fourteen is a claim about the
+ * size of the pool rather than about attention. The section is three faces
+ * drawn from everybody whose languages fit; while the app is small that set
+ * barely changes from one week to the next, and a weekly letter would be the
+ * same three people with a new date on it. A fortnight also sits under the
+ * ledger's thirty-day TTL, which a monthly key would not.
+ *
+ * `minCandidates` is what keeps it honest. Below three it is not a
+ * suggestion, it is the app admitting how few people are here — and the
+ * section is left out instead. The right fix for that is more members,
+ * not a shorter list.
+ *
+ * `maxAwayDays` matches the second and last absence nudge. That letter ends
+ * "this is the last we will say about it", and a suggestion landing on day 40
+ * would make it a lie.
+ */
+export const MATCH_SUGGESTIONS = {
+  /** At most one mention per person per fortnight. */
+  everyDays: 14,
+  /** Fewer matches than this and the section is left out. */
+  minCandidates: 3,
+  /** Faces in the mail; the rest become a grey `+N` disc. */
+  faces: 3,
+  /** Read per recipient, so the `+N` is answerable without a second count. */
+  candidates: 8,
+  /** Past this, silence was promised — see `promo.away30`. */
+  maxAwayDays: 30,
+  /** Long enough to have finished onboarding and scrolled Discover once. */
+  minAccountDays: 3,
+} as const
 
 /**
  * What the notification centre can show — and **not a ninth switch**.


### PR DESCRIPTION
Every email sender posted its own envelope and nothing counted across them, so one person could get an unread digest, the day's replies, the Monday visitors and a nudge on the same day. Each was well throttled alone; the volume came from there being no ceiling over them.

They are now **sections of one letter, at 19:00 on the reader's own clock, sent only when something is actually pending.**

## The two rules

- **Nothing pending, nothing sent.** A section is a *trigger* — somebody wrote, a call was agreed, a streak breaks tonight — or a *passenger*, which rides along in a mail that is going anyway and may never summon one. The new "people you could practise with" is a passenger, and so is anything a push has already delivered to a phone. A quiet account hears nothing.
- **Marketing runs an hour later and stands down.** The nine nudges and the monthly recap moved to a fixed 20:00 slot and skip anybody whose digest has gone out today. Before, a nudge at ten in the morning would have taken the day's slot and left the evening's real news with nowhere to go.

Security, transactional and billing mail are untouched — they answer something that just happened and must never be held back. Push is untouched everywhere.

## The sections

| Section | Kind | Trigger? | Period |
| --- | --- | --- | --- |
| Unread messages, with faces | `messages` | yes | one absence |
| Your streak breaks tonight | `streak` | only with no push device | local day |
| Tomorrow's calls | `meetings` | yes | tomorrow |
| The day's replies to your posts | `social` | yes | local day |
| Badges earned | `badges` | only if no push went | local day |
| Yesterday's pool | `wallet` | only with no push device | pool day |
| Who looked at you | `profileVisits` | yes, Mondays | ISO week |
| People you could practise with | `promotions` | **no — passenger** | fortnight |

Each keeps the period key it had as a letter of its own — the mail is daily, almost nothing in it is — and each asks its own switch before it is built, so the eight preferences still decide what arrives. The footer unsubscribes from all of it, which is the only honest offer a letter carrying every kind can make.

`badges`, `meetings` and `wallet` email move from **off to on**. What kept them off was never the content, it was that none of them is worth a letter; a paragraph in one that was going anyway costs no envelope. The meetings mail is deliberately *not* the hour-before reminder — that stays a push — but what tomorrow holds.

## Two things that needed care

- The badge round-up overwrites `notifiedBadgeIds` at six, so the difference it finds cannot be recomputed at seven. It leaves it in `stats.digestBadges` instead.
- A section that throws is dropped on its own rather than costing the reader their whole digest. The suggestions run the discovery aggregate over every profile, and one row old enough to be missing a field it expects must not cost somebody their unread messages.

## Checks

`pnpm test` (2532), `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` — all clean. The catalogue in `docs/notifications.md` is rewritten to match, and the settings copy in eight locales no longer says "Push only" about meetings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)