### PR TITLE
Let the campaign's second day carry the rest

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3671,7 +3671,7 @@ and the throttle does not know a verification link from a broadcast.
 
 So the script now writes the campaign into `campaignQueue` and the
 notification scheduler sends it: a day's budget from
-`CAMPAIGN_WARMUP_PER_DAY` (1000, 2000, 4000, 8000), spread over the
+`CAMPAIGN_WARMUP_PER_DAY` (1000, 4000, 8000), spread over the
 half-hour ticks left in `CAMPAIGN_SEND_WINDOW_UTC`, so a process restarted at
 noon carries on at the right pace rather than starting the day over. Two
 instances are serialised through `jobRuns` on the tick's half-hour — that is

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -252,7 +252,7 @@ accusation rather than a summary.
 | `v1deleted` | the addresses v1's deleted accounts left in `v1DeletedContacts`           |
 
 `--exclude-returned` drops anybody who has since onboarded. Warm-up ramp:
-1000 / 2000 / 4000 / 8000 a day, 08–20 UTC. `--pause` stops the next
+1000 / 4000 / 8000 a day, 08–20 UTC. `--pause` stops the next
 tick.
 
 ---

--- a/packages/shared/src/campaigns.ts
+++ b/packages/shared/src/campaigns.ts
@@ -33,18 +33,20 @@ export type CampaignSource = (typeof CAMPAIGN_SOURCES)[number]
  * A ramp rather than one burst, and not because of any quota: mailbox
  * providers rate a domain on what it did yesterday, and one that goes from
  * twenty mails a day to four thousand in an hour gets throttled — with the
- * penalty landing on the verification links as well as the campaign. Three
+ * penalty landing on the verification links as well as the campaign. Two
  * days for a few thousand people is the price of the transactional mail
  * still arriving.
  *
- * Raised twice on 11 September 2026, Behic's call both times, after the v1
- * campaign's first day went to Apple relay addresses that bounced and was
- * lost. The shape is what the ramp is for — each day twice the one before,
- * never a jump — and that is intact; the floor moved because the reasoning
- * above was written when the domain sent twenty mails a day and it had been
- * sending a few hundred for a fortnight by then.
+ * Raised three times on 11 September 2026, Behic's call each time, after the
+ * v1 campaign's first day went to Apple relay addresses that bounced and was
+ * lost. The second day is now four times the first rather than twice it —
+ * the alternative he was choosing between was sending the whole remainder in
+ * one hour that same evening, and a day spread across the twelve-hour window
+ * is the far smaller jump. What the ramp still buys, and the reason it was
+ * not abandoned outright: the Apple failure was caught at the 144th mail
+ * because the first day was slow.
  */
-export const CAMPAIGN_WARMUP_PER_DAY = [1000, 2000, 4000, 8000] as const
+export const CAMPAIGN_WARMUP_PER_DAY = [1000, 4000, 8000] as const
 
 /** The day's budget for a campaign that started `dayIndex` days ago. */
 export function campaignDayBudget(dayIndex: number): number {


### PR DESCRIPTION
A day's budget goes **1000 / 4000 / 8000**, so the 2,901 v1 accounts still
waiting all go out tomorrow inside the send window rather than over two more
days.

The second day is four times the first rather than twice it, which the ramp's
own comment said it would never be — so the comment now says what is actually
true and why. The alternative on the table was sending the whole remainder in
one hour tonight, to a list that is four years cold and 68% Gmail; a day
spread across the twelve-hour window is the smaller jump by a wide margin.

Checked before agreeing to it: SPF, DKIM, DMARC (`p=none`) and a one-click
`List-Unsubscribe` are all in place, and the 1,985 remaining Gmail addresses
stay under Google's 5,000-a-day bulk-sender threshold. Today's post-fix
numbers give the baseline — 774 sent, 96.1% delivered, 3.9% bounced, zero
complaints.

What the ramp still buys, and why it was not abandoned outright: today's
Apple relay failure was caught at the 144th mail because the first day was
slow.

Timing tomorrow, for the record: the day counter runs from `startedAt`
(11 Sept 16:58 UTC), so 08:00–12:58 UTC is still day 0 and capped at 1000;
the remaining ~1,900 go after 12:58 and finish around 18:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)