### PR TITLE
Four ways a notification failed to reach the phone

### DIFF
--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -917,6 +917,14 @@ export async function markPendingDelivered(db: Db, userId: string): Promise<Deli
  * Blocked counterparts are left out for the same reason their threads are left
  * out of the list: a badge that counts a conversation nobody can open is a
  * number with nowhere to go.
+ *
+ * Deleted threads are left out for a sharper version of that reason. They are
+ * gone from every tab, the archive included, so their count is not merely
+ * pointing nowhere — it can never be cleared either: reading is what zeroes
+ * `unread`, and there is no thread left to open. One deletion of an unread
+ * conversation left a badge that outlived it, on the tab, on the icon and in
+ * every push's `badge`. `listConversations` and the unread digest have always
+ * excluded them; this was the one reader that did not.
  */
 export async function countUnread(db: Db, userId: string): Promise<number> {
   const hidden = await blockedUserIds(db, userId)
@@ -928,6 +936,7 @@ export async function countUnread(db: Db, userId: string): Promise<number> {
         $match: {
           participants: hidden.length > 0 ? { $eq: userId, $nin: hidden } : userId,
           [`archivedBy.${userId}`]: { $ne: true },
+          [`deletedBy.${userId}`]: { $ne: true },
           [unreadPath]: { $gt: 0 },
         },
       },

--- a/apps/api/src/modules/chat/mutations.ts
+++ b/apps/api/src/modules/chat/mutations.ts
@@ -478,10 +478,16 @@ export async function deleteConversationForUser(
    * still listed, which is recoverable by deleting again; the other order
    * would hide a thread whose messages are still there and give no way back
    * to it.
+   *
+   * The unread counter goes with the flag. Every message this thread held is
+   * now hidden for this user, so there is nothing left for the count to be
+   * *of* — and leaving it standing is worse than untidy: `recordMessage`
+   * revives a deleted thread on the next message, and it would come back
+   * showing sixteen unread over the one message the user can actually see.
    */
   const updated = await db
     .collection<Conversation>(COLLECTIONS.conversations)
-    .updateOne({ _id }, { $set: { [`deletedBy.${userId}`]: true } })
+    .updateOne({ _id }, { $set: { [`deletedBy.${userId}`]: true, [`unread.${userId}`]: 0 } })
   if (updated.matchedCount === 0) {
     throw new ApiError(ERROR_CODES.NOT_FOUND, 'Conversation not found')
   }

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -340,6 +340,41 @@ describe('Faz 5 — conversation/message history REST', () => {
       expect(await unreadTotal(viewer)).toBe(0)
     })
 
+    it('forgets what a deleted thread was holding, and does not bring it back', async () => {
+      const viewer = await newUser('unread-deleted-viewer@example.com')
+      const gone = await newUser('unread-deleted-other@example.com')
+      const { sendTextMessage } = await import('../modules/chat/messages')
+
+      const thread = (await startConversation(gone, viewer.userId, 'first'))._id
+      await sendTextMessage(handle.db, gone.userId, {
+        conversationId: thread,
+        body: 'second',
+        clientId: 'unread-deleted-1',
+      })
+      expect(await unreadTotal(viewer)).toBe(2)
+
+      const deleted = await app.inject({
+        method: 'DELETE',
+        url: `/conversations/${thread}`,
+        headers: { cookie: viewer.cookie },
+      })
+      expect(deleted.statusCode, deleted.body).toBe(204)
+      /*
+       * The thread is gone from every tab, so nothing can ever mark it read —
+       * a count left standing here is one the badge can never lose.
+       */
+      expect(await unreadTotal(viewer)).toBe(0)
+
+      // A new message revives the thread, and it comes back holding only what
+      // arrived after the deletion: the two above are hidden for this viewer.
+      await sendTextMessage(handle.db, gone.userId, {
+        conversationId: thread,
+        body: 'are you there',
+        clientId: 'unread-deleted-2',
+      })
+      expect(await unreadTotal(viewer)).toBe(1)
+    })
+
     it('needs a session', async () => {
       expect((await app.inject({ method: 'GET', url: '/me/unread' })).statusCode).toBe(401)
     })

--- a/apps/mobile/src/hooks/useNotificationRouting.ts
+++ b/apps/mobile/src/hooks/useNotificationRouting.ts
@@ -8,6 +8,7 @@ import { track } from '../lib/analytics'
 import { getActiveConversation } from '../lib/activeConversation'
 import { presentationFor } from '../lib/foregroundPush'
 import { previewOf, showMessageBanner } from '../lib/inAppNotifications'
+import { invalidateMissedEvents } from '../lib/missedEvents'
 import { configureNotifications } from '../lib/notifications'
 import { notificationRoute } from '../lib/notificationRoute'
 
@@ -77,6 +78,21 @@ export function useNotificationRouting({ enabled = true }: { enabled?: boolean }
           if (presentationFor(content.data, AppState.currentState === 'active') !== 'suppress') {
             return
           }
+          /*
+           * And the caches, because this push *is* the gap.
+           *
+           * It only arrives when the socket was down while the app was open,
+           * so no `message:new` ever landed: the chat list, the open thread
+           * and the unread total all still hold what they held before the
+           * message existed. The icon does not: the OS applies the push's own
+           * `badge`, which is the server's count. That is how an icon reading
+           * eighteen sits over a Chats tab reading three, with nothing left
+           * to make either of them refetch — the resyncs `useSocket` owns are
+           * a reconnect and a return from the background, and a push landing
+           * on an app that is already open and stays open is neither.
+           */
+          void invalidateMissedEvents(queryClient)
+
           const { conversationId, senderId } = content.data as {
             conversationId?: unknown
             senderId?: unknown

--- a/apps/mobile/src/hooks/usePushRegistration.ts
+++ b/apps/mobile/src/hooks/usePushRegistration.ts
@@ -2,13 +2,13 @@ import Constants from 'expo-constants'
 import * as Device from 'expo-device'
 import { useFocusEffect } from 'expo-router'
 import { useCallback, useEffect } from 'react'
-import { Platform } from 'react-native'
+import { Linking, Platform } from 'react-native'
 import { api } from '../api/client'
 import { deviceId } from '../lib/deviceId'
 import { pushEnabledOnThisDevice } from '../lib/devicePush'
 import { currentLocale } from '../i18n/runtime'
 import { FLAG_KEYS, readBoolFlag, setBoolFlag } from '../lib/localFlags'
-import { shouldAskForPush } from '../lib/pushPermission'
+import { pushSwitchAction, shouldAskForPush } from '../lib/pushPermission'
 
 /**
  * Expo needs to know which project a push token belongs to. It can usually
@@ -151,6 +151,77 @@ export function usePushRegistration({ enabled = true }: { enabled?: boolean } = 
     })()
     return () => subscription?.remove()
   }, [enabled])
+}
+
+/**
+ * Whether the OS has granted this phone notifications at all.
+ *
+ * The switch in Settings reads this beside its own flag, so that it can stop
+ * claiming to be on for a phone that has been granted nothing.
+ */
+export async function pushPermissionGranted(): Promise<boolean> {
+  if (Platform.OS === 'web' || !Device.isDevice) return false
+  try {
+    const Notifications = await import('expo-notifications')
+    return (await Notifications.getPermissionsAsync()).granted
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The second asker, and the only one somebody can reach on purpose.
+ *
+ * Every other ask happens once and passes: the priming card mounts on the two
+ * onboarding exits and `welcome-back` is shown once, so a phone that comes to
+ * an existing account — a reinstall, a new handset — meets neither, and the
+ * chats tab's one attempt is all there is. A phone that misses that is silent
+ * with nowhere to complain: iOS shows no Notifications row for an app that
+ * has never requested, so there is nothing to switch on from the outside
+ * either. Settings is the place a person goes looking, so Settings has to be
+ * able to ask.
+ *
+ * Answers whether notifications are on afterwards, which is what the switch
+ * should then read.
+ */
+export async function enablePushOnThisDevice(): Promise<boolean> {
+  if (Platform.OS === 'web' || !Device.isDevice) return false
+  try {
+    const Notifications = await import('expo-notifications')
+    const current = await Notifications.getPermissionsAsync()
+    switch (
+      pushSwitchAction({
+        granted: current.granted,
+        canAskAgain: current.canAskAgain,
+        platform: Platform.OS,
+      })
+    ) {
+      case 'register':
+        // Granted already, and still worth a registration: a phone with
+        // permission and no device row is exactly the state this is for.
+        await registerPushToken()
+        return true
+      case 'ask': {
+        const result = await Notifications.requestPermissionsAsync()
+        // After the dialog, like the chats tab's — a flag written beside one
+        // that never opened is what silences a phone for good.
+        await setBoolFlag(FLAG_KEYS.pushAsked, true)
+        if (result.granted) await registerPushToken()
+        return result.granted
+      }
+      case 'openSettings':
+        // iOS will not raise the dialog again, so the answer can only be
+        // changed where the OS keeps it. The switch stays off until they come
+        // back with a different one.
+        await Linking.openSettings()
+        return false
+      default:
+        return false
+    }
+  } catch {
+    // Never let notification setup break the screen it is decorating.
+    return false
+  }
 }
 
 /**

--- a/apps/mobile/src/hooks/usePushRegistration.ts
+++ b/apps/mobile/src/hooks/usePushRegistration.ts
@@ -8,6 +8,7 @@ import { deviceId } from '../lib/deviceId'
 import { pushEnabledOnThisDevice } from '../lib/devicePush'
 import { currentLocale } from '../i18n/runtime'
 import { FLAG_KEYS, readBoolFlag, setBoolFlag } from '../lib/localFlags'
+import { shouldAskForPush } from '../lib/pushPermission'
 
 /**
  * Expo needs to know which project a push token belongs to. It can usually
@@ -164,6 +165,14 @@ export function usePushRegistration({ enabled = true }: { enabled?: boolean } = 
  * Once per device (`pushAsked`), whatever the answer: a refusal here must not
  * turn into a dialog on every visit. A grant registers the token straight
  * away, the same as the priming card does.
+ *
+ * `shouldAskForPush` says when that flag is worth trusting, and the flag is
+ * written *after* the dialog rather than before it. Both halves are one fix
+ * for one failure: written first, it recorded an answer to a dialog that
+ * never opened — and since nothing else asks after onboarding, that phone
+ * never sees one again. It does not even leave a Notifications row in iOS
+ * Settings to flip, because iOS adds that row only once an app has actually
+ * requested. It was found on a phone whose owner had never been asked at all.
  */
 export function usePushPermissionPrompt(): void {
   useFocusEffect(
@@ -171,12 +180,21 @@ export function usePushPermissionPrompt(): void {
       void (async () => {
         try {
           if (Platform.OS === 'web' || !Device.isDevice) return
-          if (await readBoolFlag(FLAG_KEYS.pushAsked)) return
           const Notifications = await import('expo-notifications')
           const current = await Notifications.getPermissionsAsync()
-          if (current.granted || !current.canAskAgain) return
-          await setBoolFlag(FLAG_KEYS.pushAsked, true)
+          const ask = shouldAskForPush({
+            granted: current.granted,
+            canAskAgain: current.canAskAgain,
+            // Expo's own enum, never the string: `granted` above is read
+            // through its field for the same reason — the two are not the
+            // same type, and a literal comparison silently never matches.
+            undetermined: current.status === Notifications.PermissionStatus.UNDETERMINED,
+            asked: await readBoolFlag(FLAG_KEYS.pushAsked),
+            platform: Platform.OS,
+          })
+          if (!ask) return
           const result = await Notifications.requestPermissionsAsync()
+          await setBoolFlag(FLAG_KEYS.pushAsked, true)
           if (result.granted) await registerPushToken()
         } catch {
           // Never let notification setup break the screen it is decorating.

--- a/apps/mobile/src/hooks/useSettingsModel.ts
+++ b/apps/mobile/src/hooks/useSettingsModel.ts
@@ -5,8 +5,8 @@ import {
   resolveNotificationPrefs,
   tierUnlocking,
 } from '@langx/shared'
-import { router } from 'expo-router'
-import { useEffect, useState } from 'react'
+import { router, useFocusEffect } from 'expo-router'
+import { useCallback, useEffect, useState } from 'react'
 import { Linking, Platform } from 'react-native'
 import {
   type MeProfile,
@@ -20,7 +20,11 @@ import {
 } from '../api/queries'
 import { useAnalyticsPreference } from './useAnalyticsPreference'
 import { useIsOnline } from './useIsOnline'
-import { unregisterPushToken } from './usePushRegistration'
+import {
+  enablePushOnThisDevice,
+  pushPermissionGranted,
+  unregisterPushToken,
+} from './usePushRegistration'
 import { useTips } from './useTips'
 import { forgetTour } from './useTour'
 import { useLocale, useLocalePreference, useT } from '../i18n'
@@ -32,6 +36,7 @@ import { authClient } from '../lib/auth-client'
 import { authLandingHref } from '../lib/authLanding'
 import { captureLocation, reportLocationFailure } from '../lib/location'
 import { pushEnabledOnThisDevice, setPushEnabledOnThisDevice } from '../lib/devicePush'
+import { pushSwitchIsOn } from '../lib/pushPermission'
 import { manageSubscriptionUrl } from '../lib/manageSubscription'
 import { storeManagementUrl } from '../lib/purchases'
 import { openPaywall } from '../lib/paywall'
@@ -68,19 +73,38 @@ export function useSettingsModel() {
    * Notifications on this phone, as opposed to the account-wide switches
    * below it — those say *what*, this says *where*.
    *
-   * Read from device storage rather than from the profile, so it is right
-   * before any request has answered and stays right on a phone that is
-   * silenced while another one is not. Defaults to on, which is what an
-   * unreadable store also reads as.
+   * Two answers, not one: the device's own flag, and whether the OS has
+   * granted anything at all. The flag alone defaults to on, so a phone that
+   * was never asked — and iOS gives such an app no Notifications row to find
+   * either — sat here showing an on switch over notifications that could not
+   * arrive. `pushSwitchIsOn` is what the switch reads now, and turning it on
+   * is what raises the dialog a second time.
    */
-  const [pushOnThisDevice, setPushOnThisDevice] = useState(true)
-  useEffect(() => {
-    void pushEnabledOnThisDevice().then(setPushOnThisDevice)
-  }, [])
+  const [pushOffOnThisDevice, setPushOffOnThisDevice] = useState(false)
+  const [pushGranted, setPushGranted] = useState(false)
+  const pushOnThisDevice = pushSwitchIsOn({
+    granted: pushGranted,
+    offOnThisDevice: pushOffOnThisDevice,
+    platform: Platform.OS,
+  })
+  /*
+   * On focus rather than on mount: `openSettings` is one of the answers, and
+   * the phone comes back to this screen with the permission changed
+   * underneath it.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      void pushEnabledOnThisDevice().then((on) => setPushOffOnThisDevice(!on))
+      void pushPermissionGranted().then(setPushGranted)
+    }, []),
+  )
 
   async function togglePushOnThisDevice(next: boolean): Promise<void> {
-    setPushOnThisDevice(next)
+    setPushOffOnThisDevice(!next)
     await setPushEnabledOnThisDevice(next)
+    // Turning it off is this app's business alone; turning it on may need the
+    // OS's permission, which only the OS can give.
+    if (next) setPushGranted(await enablePushOnThisDevice())
   }
 
   const profile = me.data

--- a/apps/mobile/src/lib/pushPermission.test.ts
+++ b/apps/mobile/src/lib/pushPermission.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { shouldAskForPush } from './pushPermission'
+
+/** Nobody has answered anything yet, on a phone that has never been asked. */
+const fresh = {
+  granted: false,
+  canAskAgain: true,
+  undetermined: true,
+  asked: false,
+  platform: 'ios',
+}
+
+describe('whether the chats tab raises the notification dialog', () => {
+  it('asks a phone that has not been asked', () => {
+    expect(shouldAskForPush(fresh)).toBe(true)
+    expect(shouldAskForPush({ ...fresh, platform: 'android' })).toBe(true)
+  })
+
+  it('never asks in a browser', () => {
+    expect(shouldAskForPush({ ...fresh, platform: 'web' })).toBe(false)
+  })
+
+  it('leaves an answered phone alone', () => {
+    expect(shouldAskForPush({ ...fresh, granted: true, undetermined: false })).toBe(false)
+    // A refusal iOS will not reopen: only the Settings app can undo it.
+    expect(shouldAskForPush({ ...fresh, canAskAgain: false, undetermined: false })).toBe(false)
+  })
+
+  /**
+   * The flag written beside a dialog that never appeared. iOS cannot collect
+   * an answer without showing one, so this state can only mean it did not —
+   * and nothing else in the app will ever ask again.
+   */
+  it('asks again on iOS when the flag claims an answer the OS has no record of', () => {
+    expect(shouldAskForPush({ ...fresh, asked: true })).toBe(true)
+  })
+
+  /**
+   * Android's dialog is dismissable, and a dismissal leaves exactly the same
+   * state — so the flag stands there, or one dismissal becomes a dialog on
+   * every visit to the tab.
+   */
+  it('trusts the flag on Android, where a dismissal looks the same', () => {
+    expect(shouldAskForPush({ ...fresh, asked: true, platform: 'android' })).toBe(false)
+  })
+
+  it('does not ask again once an answer is on record', () => {
+    expect(shouldAskForPush({ ...fresh, asked: true, undetermined: false })).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/pushPermission.test.ts
+++ b/apps/mobile/src/lib/pushPermission.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { shouldAskForPush } from './pushPermission'
+import { pushSwitchAction, pushSwitchIsOn, shouldAskForPush } from './pushPermission'
 
 /** Nobody has answered anything yet, on a phone that has never been asked. */
 const fresh = {
@@ -46,5 +46,44 @@ describe('whether the chats tab raises the notification dialog', () => {
 
   it('does not ask again once an answer is on record', () => {
     expect(shouldAskForPush({ ...fresh, asked: true, undetermined: false })).toBe(false)
+  })
+})
+
+describe('what the switch in Settings reads', () => {
+  it('is off on a phone the OS has granted nothing, however the flag reads', () => {
+    expect(pushSwitchIsOn({ granted: false, offOnThisDevice: false, platform: 'ios' })).toBe(false)
+  })
+
+  it('is on only when both agree', () => {
+    expect(pushSwitchIsOn({ granted: true, offOnThisDevice: false, platform: 'ios' })).toBe(true)
+    expect(pushSwitchIsOn({ granted: true, offOnThisDevice: true, platform: 'ios' })).toBe(false)
+  })
+
+  /** No push on the web at all, so there is no permission to reflect. */
+  it('keeps meaning the flag alone on web', () => {
+    expect(pushSwitchIsOn({ granted: false, offOnThisDevice: false, platform: 'web' })).toBe(true)
+    expect(pushSwitchIsOn({ granted: false, offOnThisDevice: true, platform: 'web' })).toBe(false)
+  })
+})
+
+describe('what turning that switch on has to do', () => {
+  /** A phone with permission and no device row is the failure this is for. */
+  it('registers the token when permission is already granted', () => {
+    expect(pushSwitchAction({ granted: true, canAskAgain: true, platform: 'ios' })).toBe('register')
+  })
+
+  it('raises the dialog when the OS will still show one', () => {
+    expect(pushSwitchAction({ granted: false, canAskAgain: true, platform: 'ios' })).toBe('ask')
+  })
+
+  /** Somebody who tapped this switch gets an answer, not a switch that springs back. */
+  it('sends them to the OS settings when it will not', () => {
+    expect(pushSwitchAction({ granted: false, canAskAgain: false, platform: 'ios' })).toBe(
+      'openSettings',
+    )
+  })
+
+  it('does nothing on web', () => {
+    expect(pushSwitchAction({ granted: false, canAskAgain: true, platform: 'web' })).toBe('none')
   })
 })

--- a/apps/mobile/src/lib/pushPermission.ts
+++ b/apps/mobile/src/lib/pushPermission.ts
@@ -41,3 +41,49 @@ export function shouldAskForPush(input: {
   if (!input.asked) return true
   return input.platform === 'ios' && input.undetermined
 }
+
+/**
+ * What the "notifications on this phone" switch in Settings should read.
+ *
+ * It used to read the device flag alone, which defaults to on — so a phone the
+ * OS has granted nothing sat there showing an on switch, promising
+ * notifications that could never arrive, and giving the one person actually
+ * hunting the problem no reason to touch it. Off is the truth, and it is also
+ * what makes the switch usable: turning it on is how the dialog gets raised a
+ * second time.
+ *
+ * Web keeps the old meaning. There is no push there at all and no permission
+ * to reflect, so the flag is the whole answer.
+ */
+export function pushSwitchIsOn(input: {
+  granted: boolean
+  offOnThisDevice: boolean
+  platform: string
+}): boolean {
+  if (input.platform === 'web') return !input.offOnThisDevice
+  return input.granted && !input.offOnThisDevice
+}
+
+/**
+ * What turning that switch **on** has to do.
+ *
+ * Unlike the chats tab this is somebody asking for notifications in so many
+ * words, so it ignores `pushAsked` entirely: a person who taps a switch
+ * labelled "notifications on this phone" has earned a dialog, whatever any
+ * flag remembers. When iOS will no longer show one, the only place left that
+ * can change the answer is the Settings app, and sending them there beats a
+ * switch that springs back with no explanation.
+ *
+ * `register` rather than nothing when permission is already granted: the
+ * failure that started this is a phone with permission and no device row, and
+ * the row is what a push is addressed to.
+ */
+export function pushSwitchAction(input: {
+  granted: boolean
+  canAskAgain: boolean
+  platform: string
+}): 'register' | 'ask' | 'openSettings' | 'none' {
+  if (input.platform === 'web') return 'none'
+  if (input.granted) return 'register'
+  return input.canAskAgain ? 'ask' : 'openSettings'
+}

--- a/apps/mobile/src/lib/pushPermission.ts
+++ b/apps/mobile/src/lib/pushPermission.ts
@@ -1,0 +1,43 @@
+/**
+ * Whether the chats tab should raise the system notification dialog.
+ *
+ * `asked` is this device's own record that the dialog has been raised once,
+ * and it is deliberately not the whole answer. It used to be written *before*
+ * the request, so anything between the two — a throw inside
+ * `requestPermissionsAsync`, the app being killed on the frame it opened —
+ * left a flag saying "asked" about a dialog nobody ever saw. Nothing asks
+ * twice: the priming card only mounts on the two onboarding exits, and this is
+ * the only other asker. The phone is then silent for good, and iOS shows no
+ * Notifications row for the app to flip either, because a row appears only
+ * once an app has actually requested. There is no way back from the outside.
+ *
+ * So the flag is trusted only where it can be telling the truth. **iOS cannot
+ * collect an answer without showing the dialog** — it is modal and has two
+ * buttons — so a status still undetermined there means it never appeared,
+ * whatever the flag says, and asking again is the only thing that can be
+ * right. **Android can**: its dialog is dismissable and a dismissal leaves
+ * exactly this state, so the flag stands, which is what keeps one dismissal
+ * from becoming a dialog on every visit.
+ *
+ * Pure, and free of `react-native` and `expo-notifications` for the reason
+ * `locationPermission.ts` gives: the decision is the part worth testing, and a
+ * decision that imports the platform is one nothing can test.
+ */
+export function shouldAskForPush(input: {
+  granted: boolean
+  canAskAgain: boolean
+  /** The OS has no answer on record — nobody has said yes or no yet. */
+  undetermined: boolean
+  /** This device's `pushAsked` flag. */
+  asked: boolean
+  platform: string
+}): boolean {
+  // No dialog to raise in a browser, and `expo-notifications` is what must not
+  // be reached there.
+  if (input.platform === 'web') return false
+  // Already answered, or answerable only in the Settings app. Either way this
+  // screen has nothing to offer.
+  if (input.granted || !input.canAskAgain) return false
+  if (!input.asked) return true
+  return input.platform === 'ios' && input.undetermined
+}

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4344,7 +4344,20 @@ state, so the flag stands there, which is what keeps one dismissal from
 becoming a dialog on every visit to the tab. The asymmetry is the platforms',
 not a preference.
 
-What this does not fix: Settings still shows a per-device push switch that
-reads on while the OS has granted nothing, and turning it off and on again
-asks for nothing. The switch is the obvious place for somebody hunting a
-missing notification to go, and it should be the second asker.
+**And Settings became the second asker**, because the first one cannot be
+enough. Every automatic ask happens once and passes: the priming card mounts
+on the two onboarding exits, `welcome-back` is shown once, and a phone that
+arrives at an existing account — a reinstall, a new handset — reaches neither,
+so the chats tab's single attempt is the whole of it. A phone that misses that
+has nowhere to complain, since iOS shows no Notifications row for an app that
+has never requested. The reinstall that was supposed to prove the flag theory
+is what settled this: it cleared the flag, and the phone was still silent.
+
+So the per-device switch tells the truth and does something about it. It read
+its own flag, which defaults to on, and so sat there promising notifications a
+phone had been granted nothing for; it now reads granted-and-not-silenced, and
+turning it on raises the dialog — ignoring `pushAsked` entirely, because
+somebody who taps a switch labelled "notifications on this phone" has asked in
+so many words. Where iOS will not raise it again the switch opens the Settings
+app instead, which is the only place left that can change the answer, and the
+screen re-reads the permission on focus for when they come back from it.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4315,3 +4315,36 @@ these accounts it now says who chose it and offers the alternative, and
 "Start exploring" walks past it. Settings → Account keeps the row for as long
 as it goes untaken, which is also the answer for the people who came back
 before any of this shipped.
+
+## The one dialog, and the flag that was written before it opened
+
+A phone arrived with no notifications at all, and its iOS Settings page showed
+no Notifications row either — Siri, Search, Cellular Data, and then nothing.
+That row is not something an app can lose: iOS adds it the first time
+an app actually requests authorisation, so its absence is proof the dialog had
+never opened, not that permission had been refused.
+
+Two things met to make that state permanent. The chats tab is the only asker
+after onboarding — `NotificationPriming` mounts on the two onboarding exits and
+`welcome-back` is shown once, so neither is reachable again — and the tab wrote
+`pushAsked` _before_ calling `requestPermissionsAsync`. That order is right for
+a ledger claim, where a notification nobody gets beats one that repeats every
+evening; here it is exactly backwards. Anything between the two — a throw
+inside the request, the app killed on that frame — records an answer to a
+dialog nobody saw, and there is no second asker and no row in Settings to put
+it right from the outside. The phone is silent for good, while the per-kind
+push switches in Settings go on reading as on.
+
+So the flag is written after the dialog returns, and `shouldAskForPush` decides
+when it is worth believing. **iOS cannot collect an answer without showing the
+dialog**, so a status still undetermined there means it never appeared,
+whatever the flag says — and asking again is the only thing that can be right.
+**Android can**: its dialog is dismissable and a dismissal leaves that same
+state, so the flag stands there, which is what keeps one dismissal from
+becoming a dialog on every visit to the tab. The asymmetry is the platforms',
+not a preference.
+
+What this does not fix: Settings still shows a per-device push switch that
+reads on while the OS has granted nothing, and turning it off and on again
+asks for nothing. The switch is the obvious place for somebody hunting a
+missing notification to go, and it should be the second asker.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2549,6 +2549,35 @@ count, and it has no way to know: it hears nothing, and the total is the
 server's to give. Both emitters now also publish to the reader's own room, and
 the client invalidates the badge when it arrives.
 
+## The same number again: eighteen on the icon, three in the app
+
+The icon had two writers and the resyncs covered one gap each — a reconnect
+and a return from the background — so a screenshot arrived with `18` on the
+home screen and `3` on the Chats tab, taken in the same minute. Two separate
+faults, one symptom.
+
+**A push that lands on an app that is already open.** The server skips push for
+anyone holding a socket, so this one only happens when the socket is down while
+the app is in front — and then the push is the only notice of that message
+there is. The OS applies its `badge` (the server's count); the app draws the
+in-app banner and, until now, refetched nothing. The chat list, the open thread
+and `['unread']` kept what they held before the message existed, and nothing
+was left to correct them: the socket never dropped, so no reconnect fired, and
+the app never went to the background, so no resume fired. The received-listener
+now runs `invalidateMissedEvents`, which is what the rest of the app already
+does with a gap the socket left.
+
+**A deleted thread kept its unread count.** `countUnread` excluded the archive
+and blocked counterparts, and not `deletedBy` — which `listConversations` and
+the unread digest have always excluded. Deleting a thread with two unread
+messages left those two in the badge with nowhere to clear them: reading is
+what zeroes `unread`, and there is no thread left to open. The count is dropped
+at deletion now (every message in it is hidden for that user, so it counts
+nothing) and `countUnread` skips deleted threads besides, for the rows already
+written. Both halves are needed: `recordMessage` revives a deleted thread when
+the other person writes again, and without the first it would come back showing
+its old count over the one message the user can see.
+
 ## The root overlays carry a paint order, not just a place in the tree
 
 The first iOS device test sent a message while the app sat on another tab and


### PR DESCRIPTION
Four faults from two reports, all in the path between "something happened" and "the phone says so".

## 1. Nothing ever asked for permission again

A phone was receiving nothing, and its iOS Settings page showed **no Notifications row** — Siri, Search, Cellular Data, and then nothing. iOS adds that row the first time an app actually requests authorisation, so its absence is proof the dialog had never opened. Not a refusal: never asked. It was deleted and reinstalled and stayed that way, which rules out any stored flag — a fresh install has none.

Every automatic ask happens once and passes. `NotificationPriming` mounts on the two onboarding exits; `welcome-back` is shown once (`restoredFromV1 && !acknowledgedAt`); a phone arriving at an existing account — a reinstall, a new handset — reaches neither. The chats tab's single attempt is the whole of it, so a build that predates it never asks at all, and iOS then offers no Notifications row to switch on from the outside either.

**Settings is the second asker now.** The per-device switch read its own flag, which defaults to on, and sat there promising notifications the OS had granted nothing for. It now reads granted-and-not-silenced, and turning it on raises the dialog — ignoring `pushAsked`, because tapping a switch labelled "notifications on this phone" is asking in so many words. Where iOS will not raise one again it opens the Settings app, and the screen re-reads the permission on focus for the way back. Already granted becomes a token registration rather than a no-op: a phone with permission and no device row is the same silence. No new strings — the row, its title and its subtitle already existed.

## 2. `pushAsked` was written before the dialog opened

The chats tab set the flag and then called `requestPermissionsAsync`. Anything in between — a throw inside the request, the app killed on that frame — recorded an answer to a dialog nobody saw, and with no second asker that phone was silent for good.

The flag is written after the dialog returns now, and `shouldAskForPush` (`apps/mobile/src/lib/pushPermission.ts`) says when to believe it: **iOS cannot collect an answer without showing the dialog**, so a status still undetermined there means it never appeared, whatever the flag claims — ask again. **Android can**: its dialog is dismissable and a dismissal leaves the same state, so the flag stands there, which is what keeps one dismissal from becoming a dialog on every visit.

## 3. A push that lands on an app that is already open

The server skips push for anyone holding a socket, so a message push reaching a foreground app means the socket was down — and then the push is the only notice of that message the app gets, since no `message:new` ever arrives.

The OS applies the push's `badge` (the server's count). The app drew the in-app banner and refetched nothing, so the chat list, the open thread and `['unread']` all kept what they held before the message existed. Nothing was left to correct them: the two resyncs in `useSocket` fire on a reconnect and on a return from the background, and a push landing on an app that is already open and stays open is neither. The received-listener now runs `invalidateMissedEvents`, the same resync the rest of the app does with a gap the socket left.

## 4. A deleted thread kept its unread count

Reported as `18` on the app icon over `3` on the Chats tab. `countUnread` excluded archived threads and blocked counterparts, but not `deletedBy` — which `listConversations` and the unread digest have always excluded. Deleting a thread that held unread messages left them in the tab badge, the icon and every later push's badge, with no way to clear them: reading is what zeroes `unread`, and there is no thread left to open.

- `deleteConversationForUser` zeroes `unread.<userId>` with the flag. Every message in the thread is hidden for that user, so there is nothing left for the count to be of.
- `countUnread` skips deleted threads, for the rows already written.

Both halves are needed: `recordMessage` revives a deleted thread when the other person writes again, and without the first it would come back showing its old count over the one message the user can see.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` — clean.
- `apps/mobile` tests: 872 passed, including 13 new cases for the two permission decisions.
- `apps/api` tests cannot run in this environment (`mongodb-memory-server` is refused the `mongod` binary by the network policy); CI is what confirms the new deleted-thread case in `apps/api/src/routes/messages.test.ts`, and it passed on the first commit.

The client call sites have no tests of their own — the repo's mobile tests cover pure helpers — so both permission decisions were extracted into `pushPermission.ts` to be testable; `invalidateMissedEvents` was already covered.

## Ruled out along the way

- **The `aps-environment` entitlement.** `expo-notifications` is not in the `plugins` array while every other plugin-carrying module is, which looked like the answer. `expo config --type introspect` says the entitlement is there anyway, so the omission is not what is breaking push and nothing was changed for it. Worth a separate look: the introspected value is `development`, which in a store build is the APNs sandbox.
- **A socket that cannot name its device.** `fanOut` skips push account-wide when any connected socket has no `deviceId`, which would let a Mac browser tab silence a phone. The client sends one on both platforms at HEAD, and the missing permission explains the report without it.

## Still not fixed

- `registerPushToken` swallows every failure without a log, and `ExpoPushSender` discards every Expo ticket error other than `DeviceNotRegistered` — `InvalidCredentials` included, the usual cause of "iOS gets nothing". Neither leaves a trace, which is why this took a screenshot of an iOS Settings page to identify.
- A message sent into a thread the recipient has archived still sends a push, while `countUnread` deliberately excludes archived threads, so that notification arrives without moving the badge. Looks deliberate.

**Reaching a phone needs a build.** None of this is live for anyone until an update ships, and a store build for anyone whose runtime fingerprint no longer matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZaYTdHrz1chtxpiNRkc1P