### PR TITLE
Stop discarding what Expo and the registration say when they fail

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -37,7 +37,10 @@ async function main(): Promise<void> {
 
   // Before `createAuth`: the security notices it sends go to a phone as well
   // as an inbox.
-  const push = new ExpoPushSender(env.EXPO_ACCESS_TOKEN)
+  // `console` for the same reason `createEmailSender` takes it: this is built
+  // before `buildApp`, so `app.log` does not exist yet — and a push that Expo
+  // refuses has to say so somewhere.
+  const push = new ExpoPushSender(env.EXPO_ACCESS_TOKEN, console)
 
   const auth = await createAuth({ env, db, client, emailSender, revenueCat, push })
   const storage = createStorageProvider(env)

--- a/apps/api/src/modules/push/devices.test.ts
+++ b/apps/api/src/modules/push/devices.test.ts
@@ -145,6 +145,66 @@ describe('ExpoPushSender', () => {
       new ExpoPushSender().send({ to: ['t'], title: 'a', body: 'b', data: { kind: 'message' } }),
     ).resolves.toEqual({ invalidTokens: [] })
   })
+
+  /**
+   * The whole batch refused — a bad access token, a malformed body, Expo
+   * down. Nobody gets a notification and, until this, nothing said so.
+   */
+  it('says so when Expo refuses the request outright', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('nope', { status: 400 })))
+    const logger = { warn: vi.fn() }
+
+    await new ExpoPushSender(undefined, logger).send({
+      to: ['t'],
+      title: 'a',
+      body: 'b',
+      data: { kind: 'message' },
+    })
+
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    const [details, msg] = logger.warn.mock.calls[0] as [Record<string, unknown>, string]
+    expect(msg).toContain('refused')
+    expect(details).toMatchObject({ status: 400, kind: 'message', tokens: 1, body: 'nope' })
+  })
+
+  /**
+   * `InvalidCredentials` is what a missing APNs key looks like: one platform
+   * silent, the other fine, and a ticket nobody was reading.
+   */
+  it('says so when Expo rejects tokens for a reason that is not the device', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(ticketsFor(['MessageRateExceeded', 'ok'])))
+    const logger = { warn: vi.fn() }
+
+    const result = await new ExpoPushSender(undefined, logger).send({
+      to: ['busy', 'fine'],
+      title: 'a',
+      body: 'b',
+      data: { kind: 'message' },
+    })
+
+    // Still not a dead device, so still not deleted — the logging is the only
+    // thing that changed about this case.
+    expect(result.invalidTokens).toEqual([])
+    const [details] = logger.warn.mock.calls[0] as [Record<string, unknown>]
+    expect(details.errors).toEqual({ MessageRateExceeded: 1 })
+  })
+
+  it('stays quiet when Expo accepts everything', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(ticketsFor(['ok', 'DeviceNotRegistered'])))
+    const logger = { warn: vi.fn() }
+
+    const result = await new ExpoPushSender(undefined, logger).send({
+      to: ['fine', 'gone'],
+      title: 'a',
+      body: 'b',
+      data: { kind: 'message' },
+    })
+
+    // A phone that uninstalled the app is an ordinary outcome with an ordinary
+    // answer — the token is dropped, and nobody needs telling.
+    expect(result.invalidTokens).toEqual(['gone'])
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
 })
 
 describe('sendPush', () => {

--- a/apps/api/src/modules/push/devices.ts
+++ b/apps/api/src/modules/push/devices.ts
@@ -191,18 +191,32 @@ export class LoggingPushSender implements PushSender {
 /** Expo accepts at most this many messages in one request. */
 const EXPO_BATCH_SIZE = 100
 
+/**
+ * Just enough of pino's `warn` to log structurally, and narrow for the reason
+ * `EmailSenderLogger` is narrow: the sender is built in `index.ts` before
+ * `buildApp` has constructed `app.log`, because `createAuth` needs one.
+ */
+export interface PushSenderLogger {
+  warn(obj: Record<string, unknown>, msg: string): void
+}
+
 /** Expo's push service — one HTTP call, no SDK, no per-platform certificates. */
 export class ExpoPushSender implements PushSender {
   readonly #endpoint = 'https://exp.host/--/api/v2/push/send'
   readonly #accessToken: string | undefined
+  readonly #logger: PushSenderLogger | undefined
 
   /**
    * `accessToken` is only needed when the Expo project has enhanced push
    * security switched on, which makes an unauthenticated send fail wholesale.
    * Unset is the normal case.
+   *
+   * `logger` is optional so the tests can construct one bare, and passed
+   * everywhere else: everything below it used to fail in silence.
    */
-  constructor(accessToken?: string) {
+  constructor(accessToken?: string, logger?: PushSenderLogger) {
     this.#accessToken = accessToken
+    this.#logger = logger
   }
 
   async send(message: PushMessage): Promise<PushResult> {
@@ -242,19 +256,61 @@ export class ExpoPushSender implements PushSender {
        *
        * Tickets are positional, so a ticket's index is its token's index.
        */
-      if (!response.ok) continue
-      const payload = (await response.json()) as {
-        data?: { status: string; details?: { error?: string } }[]
+      if (!response.ok) {
+        /*
+         * A refused request used to be a `continue` and nothing else, which is
+         * how an entire platform can stop receiving notifications without one
+         * line anywhere saying so. This is the wholesale failure: a bad access
+         * token, a malformed batch, Expo being down. Every message in the
+         * batch is gone, and the only thing that ever notices is somebody
+         * saying "I get no notifications".
+         *
+         * The body is read as text rather than JSON because a 502 from a
+         * proxy in front of Expo is not JSON, and a parse error here would
+         * replace the diagnosis with a different one. Truncated: it is a
+         * reason, not a payload to keep.
+         */
+        this.#logger?.warn(
+          {
+            status: response.status,
+            kind: message.data.kind,
+            tokens: batch.length,
+            body: (await response.text().catch(() => '')).slice(0, 500),
+          },
+          'expo push refused the request',
+        )
+        continue
       }
+      const payload = (await response.json()) as {
+        data?: { status: string; message?: string; details?: { error?: string } }[]
+      }
+      /*
+       * Everything Expo said about a token that is not "gone". These were
+       * dropped on the floor — including `InvalidCredentials`, which is what
+       * a missing or expired APNs key looks like and which silences one whole
+       * platform while the other keeps working. Counted rather than listed:
+       * one line per send, whatever the batch size, and no push tokens in it.
+       */
+      const errors = new Map<string, number>()
       payload.data?.forEach((ticket, ticketIndex) => {
         if (ticket.status === 'ok') return
+        const error = ticket.details?.error ?? ticket.message ?? 'unknown'
         // Only DeviceNotRegistered is permanent. MessageRateExceeded and
         // MessageTooBig say something about this send, not about the device,
         // and deleting a token over either would silence a real phone.
-        if (ticket.details?.error !== 'DeviceNotRegistered') return
+        if (ticket.details?.error !== 'DeviceNotRegistered') {
+          errors.set(error, (errors.get(error) ?? 0) + 1)
+          return
+        }
         const token = batch[ticketIndex]
         if (token) invalidTokens.push(token)
       })
+      if (errors.size > 0) {
+        this.#logger?.warn(
+          { errors: Object.fromEntries(errors), kind: message.data.kind, tokens: batch.length },
+          'expo push rejected some of the batch',
+        )
+      }
     }
 
     return { invalidTokens }

--- a/apps/mobile/src/hooks/usePushRegistration.ts
+++ b/apps/mobile/src/hooks/usePushRegistration.ts
@@ -4,6 +4,7 @@ import { useFocusEffect } from 'expo-router'
 import { useCallback, useEffect } from 'react'
 import { Linking, Platform } from 'react-native'
 import { api } from '../api/client'
+import { track } from '../lib/analytics'
 import { deviceId } from '../lib/deviceId'
 import { pushEnabledOnThisDevice } from '../lib/devicePush'
 import { currentLocale } from '../i18n/runtime'
@@ -31,9 +32,23 @@ function pushTokenOptions(): { projectId?: string } {
  * than once — `/me/devices` upserts on the installation.
  */
 export async function registerPushToken(): Promise<void> {
-  try {
-    if (Platform.OS === 'web' || !Device.isDevice) return
+  if (Platform.OS === 'web' || !Device.isDevice) return
 
+  /*
+   * Two halves, each with its own `catch`, and that is the point rather than
+   * ceremony: Expo minting the token and the API filing it fail for entirely
+   * different reasons — a project id or push credentials on one side, a
+   * session or a network on the other — and a single swallowed error made
+   * them one indistinguishable silence. A phone that lands here keeps the
+   * notification switches reading on while the server has no row to address
+   * anything to, and nobody learns until somebody photographs an iOS Settings
+   * page.
+   *
+   * Still swallowed, because notification setup must never break the app it
+   * is decorating. Only no longer unrecorded.
+   */
+  let token: string
+  try {
     // Imported here, not at module scope. Inside Expo Go on Android,
     // `expo-notifications` throws the moment it is imported — remote push was
     // removed from Expo Go there in SDK 53. At module scope that throw takes
@@ -42,13 +57,18 @@ export async function registerPushToken(): Promise<void> {
     // is missing the required default export". A development build has the
     // native module and works normally.
     const Notifications = await import('expo-notifications')
+    token = (await Notifications.getExpoPushTokenAsync(pushTokenOptions())).data
+  } catch (error) {
+    track({ name: 'push_registration_failed', properties: { step: 'token', reason: why(error) } })
+    return
+  }
 
-    const token = await Notifications.getExpoPushTokenAsync(pushTokenOptions())
+  try {
     await api.post('/me/devices', {
       // The device's language, not the account's: a streak reminder arrives
       // when the app is closed, so nothing else can decide what it says.
       locale: currentLocale(),
-      pushToken: token.data,
+      pushToken: token,
       platform: Platform.OS === 'ios' ? 'ios' : 'android',
       /*
        * Who this phone is, so its row survives a token rotation and so a
@@ -62,9 +82,26 @@ export async function registerPushToken(): Promise<void> {
        */
       pushEnabled: await pushEnabledOnThisDevice(),
     })
-  } catch {
-    // Never let notification setup break the app it is decorating.
+  } catch (error) {
+    track({
+      name: 'push_registration_failed',
+      properties: { step: 'register', reason: why(error) },
+    })
   }
+}
+
+/**
+ * An error's own word for itself, for the analytics property.
+ *
+ * The API's errors carry a `code` — `UNAUTHENTICATED`, `GUEST_ACCOUNT` — and
+ * that is the useful half; anything else falls back to its message. Never the
+ * whole error: a message can carry a URL, and a URL here would carry a push
+ * token.
+ */
+function why(error: unknown): string {
+  const code = (error as { code?: unknown } | null)?.code
+  if (typeof code === 'string' && code.length > 0) return code
+  return error instanceof Error ? error.name : 'unknown'
 }
 
 /**

--- a/apps/mobile/src/lib/analyticsEvents.test.ts
+++ b/apps/mobile/src/lib/analyticsEvents.test.ts
@@ -95,6 +95,7 @@ describe('every event survives the sanitizer', () => {
     { name: 'message_received', properties: { kind: 'audio' } },
     { name: 'message_send_failed', properties: { kind: 'media', reason: 'MEDIA_TOO_LARGE' } },
     { name: 'notification_opened', properties: { kind: 'streakReminder', cold_start: true } },
+    { name: 'push_registration_failed', properties: { step: 'token', reason: 'Error' } },
     { name: 'filters_applied', properties: { count: 3, pro: true } },
     { name: 'tokens_spent', properties: { sku: 'frame_gold', kind: 'frame', amount: 250 } },
   ]

--- a/apps/mobile/src/lib/analyticsEvents.ts
+++ b/apps/mobile/src/lib/analyticsEvents.ts
@@ -252,6 +252,24 @@ export type AnalyticsEvent =
     }
   | {
       /**
+       * This phone has permission and could not register a push token.
+       *
+       * The counterpart to `notification_opened`, and here for the reason
+       * `message_send_failed` is: the failures are invisible in a count of
+       * successes. Everything on this path swallows its error — Expo minting
+       * the token, and the `POST /me/devices` that files it — so a phone can
+       * sit with the notification switches reading on and no row on the
+       * server at all, which is a person who receives nothing and has nothing
+       * to show for it. It was found by a screenshot of an iOS Settings page.
+       *
+       * `step` is which half failed, and `reason` the error's own word for it
+       * — never the token, which is an address for reaching somebody.
+       */
+      name: 'push_registration_failed'
+      properties: { step: 'token' | 'register'; reason: string }
+    }
+  | {
+      /**
        * The discovery filter sheet was applied.
        *
        * `pro` is the question: the advanced filters are a paid feature, and


### PR DESCRIPTION
Follow-up to #1321, and the thing that made it hard: every failure on the push path is swallowed by design and none of them is recorded, so identifying the last one needed a photograph of an iOS Settings page. Both places still swallow — a notification must never break the thing it decorates — but neither is silent now.

## `ExpoPushSender` read the response and acted on one thing in it

- **A refused request was a bare `continue`.** A bad access token, a malformed batch, Expo down: every message in the batch is lost and nothing anywhere says so. It now logs the status, the push kind, the batch size and a truncated body. Read as text rather than JSON, because a 502 from a proxy in front of Expo is not JSON and a parse error there would replace the diagnosis with a different one.
- **Only `DeviceNotRegistered` was ever looked at** among the per-token tickets, so everything else went to the floor — including `InvalidCredentials`, which is what a missing or expired APNs key looks like: one platform silent while the other is fine. Now counted per error and logged once per send. Counts rather than a list, so the line stays one line at any batch size and carries no push tokens.

`DeviceNotRegistered` still deletes the token and still says nothing: a phone that uninstalled the app is an ordinary outcome with an ordinary answer.

The sender takes an optional logger, and `index.ts` passes `console` for the reason `createEmailSender` takes one there — it is built before `buildApp` has constructed `app.log`.

## `registerPushToken` had one `catch` over two different failures

Expo minting the token and the `POST /me/devices` that files it fail for entirely unrelated reasons — a project id or push credentials on one side, a session or a network on the other — and one swallowed error made them a single indistinguishable silence. A phone that lands there keeps every notification switch reading on while the server has no row to address anything to.

Two `catch`es now, each sending `push_registration_failed` with `step` (`token` | `register`) and the error's own `code`, falling back to its name. Never the message: it can carry a URL, and a URL here would carry a push token. The event is declared in the closed `AnalyticsEvent` union like every other, so the store privacy declaration stays answerable from that one file.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` — clean.
- `apps/mobile`: 873 tests pass, including the new event's round trip through the sanitizer.
- `apps/api`: the `ExpoPushSender` suite has no database, so it does run in this environment — 9 pass, including three new cases (refused request logged, non-device ticket errors counted, silence when Expo accepts everything). The rest of the API suites still need CI, which cannot fetch a `mongod` binary here.

## Not done

The `aps-environment` entitlement introspects as `development`, which in a store build is the APNs sandbox. It is left alone deliberately: push is now arriving on a store build, which is evidence against it being broken, and changing it touches `app.config.ts` — a fingerprint change, so a new native build for everyone. Worth confirming against an EAS build log before anyone touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZaYTdHrz1chtxpiNRkc1P

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZaYTdHrz1chtxpiNRkc1P)_