### PR TITLE
Keep the starred list off the messages their reader deleted

### DIFF
--- a/apps/api/src/modules/chat/mutations.ts
+++ b/apps/api/src/modules/chat/mutations.ts
@@ -401,6 +401,14 @@ export async function pinMessage(
  * Backed by `messages.starred_created`; without that index this is a scan of
  * every message the user can see, which is the whole collection on a busy
  * account.
+ *
+ * **Hidden rows are left out, like the media grid leaves them out.** Nothing
+ * unstars a message when it is hidden — "delete for me" and deleting a whole
+ * thread both only add to `hiddenFor` — so this list was the one reader that
+ * still drew the body of something its reader had deleted, and its row led
+ * back to a thread that is gone for them. It cannot be left to the client
+ * either: the list is capped rather than paged, so rows dropped after the
+ * fact make it arrive short of the cap with nothing behind them.
  */
 export async function listStarredMessages(
   db: Db,
@@ -409,7 +417,7 @@ export async function listStarredMessages(
 ): Promise<Message[]> {
   return db
     .collection<Message>(COLLECTIONS.messages)
-    .find({ starredBy: userId, deletedAt: { $exists: false } })
+    .find({ starredBy: userId, deletedAt: { $exists: false }, hiddenFor: { $ne: userId } })
     .sort({ createdAt: -1 })
     .limit(limit)
     .toArray()

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -2006,6 +2006,59 @@ describe('Faz 5 — conversation/message history REST', () => {
       expect(list.json<{ items: unknown[] }>().items).toEqual([])
     })
 
+    /**
+     * The star points at the message; it does not copy it. So it may only
+     * outlive what the reader can still see — and hiding a message never
+     * unstars it, by either route: "delete for me" on the one message, or
+     * deleting the thread it is in.
+     */
+    it('leaves out a message the reader has hidden', async () => {
+      const { b, conversationId, messageId } = await pair('star-hidden')
+      const { deleteMessage, starMessage } = await import('../modules/chat/mutations')
+
+      await starMessage(handle.db, b.userId, { conversationId, messageId, starred: true })
+      await deleteMessage(handle.db, b.userId, { conversationId, messageId, scope: 'me' })
+
+      const list = await app.inject({
+        method: 'GET',
+        url: '/me/starred',
+        headers: { cookie: b.cookie },
+      })
+      expect(list.json<{ items: unknown[] }>().items).toEqual([])
+    })
+
+    it('leaves out one whose whole thread the reader deleted', async () => {
+      const { a, b, conversationId, messageId } = await pair('star-thread-deleted')
+      const { starMessage } = await import('../modules/chat/mutations')
+
+      await starMessage(handle.db, b.userId, { conversationId, messageId, starred: true })
+
+      const deleted = await app.inject({
+        method: 'DELETE',
+        url: `/conversations/${conversationId}`,
+        headers: { cookie: b.cookie },
+      })
+      expect(deleted.statusCode, deleted.body).toBe(204)
+
+      const list = await app.inject({
+        method: 'GET',
+        url: '/me/starred',
+        headers: { cookie: b.cookie },
+      })
+      expect(list.json<{ items: unknown[] }>().items).toEqual([])
+
+      // The other side deleted nothing, so their own star is untouched.
+      await starMessage(handle.db, a.userId, { conversationId, messageId, starred: true })
+      const theirs = await app.inject({
+        method: 'GET',
+        url: '/me/starred',
+        headers: { cookie: a.cookie },
+      })
+      expect(theirs.json<{ items: { _id: string }[] }>().items.map((m) => m._id)).toEqual([
+        messageId,
+      ])
+    })
+
     it('pins one message at a time, and either person can change it', async () => {
       const { a, b, conversationId, messageId } = await pair('pin-one')
       const { sendTextMessage } = await import('../modules/chat/messages')


### PR DESCRIPTION
## The bug

Nothing unstars a message when it is hidden. "Delete for me" adds the reader to `hiddenFor` (`deleteMessage`, scope `me`) and deleting a whole thread adds them to every message in it (`deleteConversationForUser`); neither touches `starredBy`.

`listStarredMessages` filtered only `deletedAt`, so `GET /me/starred` kept returning those messages — and `app/(app)/starred.tsx` draws every row it is given, body, thumbnail, preview and all. Tapping one pushed `/chat/<id>?at=…` for a thread that is gone for that reader.

Reproduce: star a message → delete it for yourself (or delete the conversation) → open Chats → Starred. It is still there.

## The fix

One predicate — `hiddenFor: { $ne: userId }` — the same one `listConversationMedia` already applies, plus a comment saying why it belongs on the server: the starred list is capped rather than paged, so rows dropped client-side would make it arrive short of the cap with nothing behind them. The client does not filter `hidden` here either; only the thread (`messageCache.ts`) and the in-app banner do.

`/me/corrections` reads messages the same way and is **deliberately left alone**: it is the list behind the corrections count on the profile, and hiding rows from the list but not the count would make the two disagree. Worth a separate decision, not a silent one.

## Tests

Two regression tests beside the existing star tests in `routes/messages.test.ts`: one for "delete for me", one for a deleted thread — the second also asserting the other participant's own star is untouched, since the hide is per reader.

## Verification

- `pnpm -r typecheck` — passes
- `pnpm lint`, `pnpm format:check` — pass
- `packages/shared` (326) and `apps/mobile` (872) test suites — pass
- `apps/api` tests **could not run in this sandbox**: `mongodb-memory-server` cannot reach `fastdl.mongodb.org` (egress policy returns 403), so every suite needing a replica set fails at startup, before and after this change alike. The two new tests are unexecuted here and need CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aWL8Tzy8PMUpUdexJMXsF

---
_Generated by [Claude Code](https://claude.ai/code/session_018aWL8Tzy8PMUpUdexJMXsF)_