### PR TITLE
Stop a blurred viewer row from carrying the name behind it

### DIFF
--- a/apps/api/src/modules/moderation/profileViews.test.ts
+++ b/apps/api/src/modules/moderation/profileViews.test.ts
@@ -115,6 +115,35 @@ describe('profile views, a row per day', () => {
     expect(summary.viewers[1]).toMatchObject({ handle: 'xue', displayName: 'xue' })
   })
 
+  /**
+   * What a free account is shown, and the part that is easy to get wrong: the
+   * lock is about identity, and a user id is one — `/profiles/:handleOrId`
+   * turns it into a handle, a name and a face. A blurred row carrying the real
+   * id sells nothing, however well the client blurs it.
+   */
+  it('withholds the viewer id itself while the list is locked', async () => {
+    await handle.db
+      .collection<Profile>(COLLECTIONS.profiles)
+      .updateOne({ _id: 'me' }, { $set: { entitlement: { tier: 'free', updatedAt: DAY } } })
+    await recordProfileView(handle.db, xue, 'me', at(0))
+
+    const summary = await getViewers(handle.db, 'me', { limit: 20 }, at(10 * MIN))
+    expect(summary.locked).toBe(true)
+    // The count is free; it is the names the plan is arguing about.
+    expect(summary.total).toBe(1)
+
+    const row = summary.viewers[0]!
+    expect(row.userId).not.toBe('xue')
+    expect(row.handle).toBeUndefined()
+    expect(row.displayName).toBeUndefined()
+    // Still everything the row is entitled to say about the reader's own
+    // profile, and still a key the client can hold on to between reads.
+    expect(row.day).toBe('2026-09-05')
+    expect(row.viewCount).toBe(1)
+    const again = await getViewers(handle.db, 'me', { limit: 20 }, at(11 * MIN))
+    expect(again.viewers[0]?.userId).toBe(row.userId)
+  })
+
   it('sums visits per day for the last seven days on the first page only', async () => {
     await recordProfileView(handle.db, xue, 'me', at(-3 * 24 * 60 * MIN))
     await recordProfileView(handle.db, xue, 'me', at(0))

--- a/apps/api/src/modules/moderation/profileViews.ts
+++ b/apps/api/src/modules/moderation/profileViews.ts
@@ -60,6 +60,11 @@ export interface ViewerSummary {
    * the whole paid feature in the response body for anyone who reads the JSON.
    */
   viewers: {
+    /**
+     * The viewer — except while `locked`, where it is the row's own id
+     * instead. See the push below: a user id is an identity in this API, and
+     * an identity is the whole of what the lock withholds.
+     */
     userId: string
     /** The UTC day this row is about. */
     day: string
@@ -349,7 +354,20 @@ export async function getViewers(
      */
     if (locked) {
       viewers.push({
-        userId: view.viewerId,
+        /*
+         * The row's own id, not the viewer's, and this is the other half of
+         * not sending the handle.
+         *
+         * `GET /profiles/:handleOrId` takes a **user id** and answers with a
+         * handle, a display name and an avatar. So a blurred row carrying the
+         * real id withheld nothing at all: one request per row, from the
+         * network tab or from anything scripted against the API, and the
+         * whole of what this plan sells was free. The client needs *a* stable
+         * string here — it keys the list by it and seeds a colour from it —
+         * and the row's id is one: unique per person per day, the same on
+         * every page and after every refetch, and it resolves to nobody.
+         */
+        userId: view._id.toHexString(),
         day: dayOf(view),
         lastViewedAt: view.lastViewedAt.toISOString(),
         // `?? 1` for the rows written before the counter existed: a view


### PR DESCRIPTION
## The bug

`getViewers` is careful about what a locked row may carry — no `handle`, no `displayName`, no avatar, and its own comment says why: "sending the real identities and relying on the client to obscure them would put the whole paid feature in the response body for anyone who reads the JSON."

It then sent `userId` on that same row. And `GET /profiles/:handleOrId` takes a **user id**, is behind plain `requireAuth`, has `rateLimit: false`, and answers with the handle, the display name and the avatar.

So the Polyglot `profileViewerIdentities` lock held only against the app's own blur:

```
GET /me/viewers        → { locked: true, viewers: [{ userId: "68c…", day, lastViewedAt, viewCount }, …] }
GET /profiles/68c…     → { handle: "xue", displayName: "Xue", avatarUrl: … }
```

One request per row, from a network tab or from anything scripted against the API, and a free account has the list the plan sells.

## The fix

The locked row carries the **view row's own id** instead of the viewer's. The client needs a stable string there — it keys the list by it (`${userId}:${day}`) and seeds an avatar colour from it — and this is one: unique per person per day, identical on every page and after every refetch, and it resolves to nobody. Nothing else in the app reads it: a locked row's tap goes to the paywall, never to a profile.

Installed builds keep working unchanged, which is why the field stays where it is rather than being renamed or dropped: this has to land ahead of the app, not behind it. The interface now says what the field means while locked.

The digest half of the feature was already right — `viewSummarySince` returns `viewers: null` to a free account and names nobody, so it needed nothing.

## Tests

One in `profileViews.test.ts`: a free-tier reader gets `locked: true`, the real `total`, a row that still says which day and how many visits — and a `userId` that is not the viewer's, stable across two reads.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` — pass
- `apps/api` tests cannot run in this sandbox (`mongodb-memory-server` cannot reach `fastdl.mongodb.org`; the egress policy answers 403), so the new test needs CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aWL8Tzy8PMUpUdexJMXsF

---
_Generated by [Claude Code](https://claude.ai/code/session_018aWL8Tzy8PMUpUdexJMXsF)_