### PR TITLE
Make a bucket check mean the bucket, not its name

### DIFF
--- a/apps/api/src/email/avatars.ts
+++ b/apps/api/src/email/avatars.ts
@@ -1,6 +1,7 @@
 import { GENERATED_AVATAR_BACKGROUNDS } from '@langx/shared'
 import type { InlineAsset } from './inlineAssets'
 import { inlineSrc } from './logo'
+import { isOwnBucketUrl } from '../lib/assertOwnBucket'
 
 /**
  * Faces in an email, which is harder than it sounds.
@@ -75,7 +76,9 @@ export async function fetchAvatarAsset(
   cid: string,
   baseUrl: string | undefined,
 ): Promise<InlineAsset | null> {
-  if (!baseUrl || !url.startsWith(baseUrl)) return null
+  // The slash matters here too: a sibling of the bucket is somebody else's,
+  // and this function fetches what it is given. See `isOwnBucketUrl`.
+  if (!isOwnBucketUrl(baseUrl, url)) return null
   try {
     const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
     if (!response.ok) return null

--- a/apps/api/src/lib/assertOwnBucket.test.ts
+++ b/apps/api/src/lib/assertOwnBucket.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { assertOwnBucket, isOwnBucketUrl } from './assertOwnBucket'
+
+/**
+ * The form `.env.example` documents for Backblaze, and the one path-style S3
+ * hands out: the bucket is the last path segment, with no trailing slash.
+ */
+const BASE = 'https://f003.backblazeb2.com/file/langx-media'
+
+describe('isOwnBucketUrl', () => {
+  it('accepts an object in the bucket', () => {
+    expect(isOwnBucketUrl(BASE, `${BASE}/avatars/abc.jpg`)).toBe(true)
+  })
+
+  /**
+   * The regression. A bucket name on B2, R2 or S3 is registerable by anybody,
+   * so `langx-media-x` is a bucket a stranger can own — and a bare
+   * `startsWith` reads it as ours, which puts their bytes on our profiles, in
+   * our emails, and out of reach of the deletion purge.
+   */
+  it('refuses a sibling bucket whose name merely starts the same way', () => {
+    expect(isOwnBucketUrl(BASE, `${BASE}-evil/avatars/abc.jpg`)).toBe(false)
+    expect(isOwnBucketUrl(BASE, `${BASE}2/avatars/abc.jpg`)).toBe(false)
+  })
+
+  it('accepts the same objects when the base is configured with its slash', () => {
+    expect(isOwnBucketUrl(`${BASE}/`, `${BASE}/avatars/abc.jpg`)).toBe(true)
+    expect(isOwnBucketUrl(`${BASE}/`, `${BASE}-evil/avatars/abc.jpg`)).toBe(false)
+  })
+
+  it('refuses another host, and the bucket root with nothing under it', () => {
+    expect(isOwnBucketUrl(BASE, 'https://example.com/avatars/abc.jpg')).toBe(false)
+    expect(isOwnBucketUrl(BASE, BASE)).toBe(false)
+  })
+
+  it('refuses everything when no bucket is configured', () => {
+    expect(isOwnBucketUrl(undefined, `${BASE}/avatars/abc.jpg`)).toBe(false)
+  })
+})
+
+describe('assertOwnBucket', () => {
+  it('passes an object in the bucket and refuses a sibling', () => {
+    expect(() => assertOwnBucket(BASE, `${BASE}/avatars/abc.jpg`)).not.toThrow()
+    expect(() => assertOwnBucket(BASE, `${BASE}-evil/avatars/abc.jpg`)).toThrow(
+      /own storage bucket/,
+    )
+  })
+
+  /** Unconfigured storage is our problem, not the caller's: 500, not 400. */
+  it('says storage is unconfigured rather than blaming the URL', () => {
+    expect(() => assertOwnBucket(undefined, `${BASE}/avatars/abc.jpg`)).toThrow(
+      /Storage is not configured/,
+    )
+  })
+})

--- a/apps/api/src/lib/assertOwnBucket.ts
+++ b/apps/api/src/lib/assertOwnBucket.ts
@@ -2,6 +2,28 @@ import { ERROR_CODES } from '@langx/shared'
 import { ApiError } from './ApiError'
 
 /**
+ * Whether a URL lives inside our own bucket.
+ *
+ * **The separator is the whole check.** `url.startsWith(base)` on its own
+ * accepts every *sibling* of the bucket as well as the bucket itself: with
+ * `https://f003.backblazeb2.com/file/langx-media` configured — the form
+ * `.env.example` documents, and the one B2 and path-style S3 both hand out —
+ * `https://f003.backblazeb2.com/file/langx-media-anything/x.jpg` passes, and a
+ * bucket name on any of those providers is registerable by anybody who wants
+ * one. Comparing against the base *and its slash* is what makes the answer
+ * mean "under this bucket" rather than "starts with its name".
+ *
+ * `s3StorageProvider.keyFromPublicUrl` already reads URLs back this way; this
+ * is the same rule applied on the way in. Every stored URL is
+ * `${base}/${key}`, so nothing legitimate is lost by requiring the slash.
+ */
+export function isOwnBucketUrl(base: string | undefined, url: string): boolean {
+  if (!base) return false
+  const prefix = base.endsWith('/') ? base : `${base}/`
+  return url.startsWith(prefix)
+}
+
+/**
  * Refuses a media URL that does not live in our own bucket.
  *
  * A URL pointing anywhere else would break the account-deletion purge and any
@@ -15,7 +37,7 @@ import { ApiError } from './ApiError'
  */
 export function assertOwnBucket(base: string | undefined, url: string): void {
   if (!base) throw new ApiError(ERROR_CODES.INTERNAL, 'Storage is not configured')
-  if (!url.startsWith(base)) {
+  if (!isOwnBucketUrl(base, url)) {
     throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'URL must point into our own storage bucket')
   }
 }

--- a/apps/api/src/modules/media/assertMedia.ts
+++ b/apps/api/src/modules/media/assertMedia.ts
@@ -7,6 +7,7 @@ import {
   type MediaKind,
 } from '@langx/shared'
 import { ApiError } from '../../lib/ApiError'
+import { isOwnBucketUrl } from '../../lib/assertOwnBucket'
 
 export type { MediaKind }
 
@@ -69,7 +70,9 @@ export function assertMediaAllowed(
     }
   }
 
-  if (!storagePublicBaseUrl || !media.url.startsWith(storagePublicBaseUrl)) {
+  // `isOwnBucketUrl`, not a bare `startsWith`: the slash is what stops a
+  // sibling bucket from passing for ours. See that function.
+  if (!isOwnBucketUrl(storagePublicBaseUrl, media.url)) {
     throw new ApiError(
       ERROR_CODES.VALIDATION_FAILED,
       'Attachment must point into our own storage bucket',


### PR DESCRIPTION
## The bug

Three guards answered "is this media URL ours?" with `url.startsWith(base)`:

- `lib/assertOwnBucket.ts` — the avatar on onboarding, `POST /media/avatar/confirm`, `POST /media/photos`
- `modules/media/assertMedia.ts` — every chat and feed attachment, and feedback screenshots
- `email/avatars.ts` — the avatar this process **fetches** to inline into an email

A bare prefix test accepts every *sibling* of the bucket as well as the bucket. With `STORAGE_PUBLIC_BASE_URL=https://f003.backblazeb2.com/file/langx-media` — the form `.env.example` documents, and the one B2 and path-style S3 both hand out — this passes:

```
https://f003.backblazeb2.com/file/langx-media-anything/x.jpg
```

Bucket names on B2, R2 and S3 are global and registerable by whoever asks first, so `langx-media-anything` is a bucket a stranger can own. The guard that exists to stop someone pointing their profile at an arbitrary host stopped only the hosts that did not begin with ours: an avatar, a photo, a chat or post attachment or a feedback screenshot could live in a stranger's bucket, be served inside the app's UI, be fetched by the API and inlined into other people's mail, and be invisible to the account-deletion purge, which finds objects by key.

## The fix

`isOwnBucketUrl(base, url)` compares against the base **and its slash** — which is exactly what `s3StorageProvider.keyFromPublicUrl` has always done reading URLs back out; this is the same rule on the way in. All three call sites read that one rule now, instead of three copies of a comparison two of them got wrong.

Nothing legitimate changes: every stored URL is `${base}/${key}`, and the base may still be configured with or without a trailing slash.

## Tests

`lib/assertOwnBucket.test.ts` — new, and pure, so it runs without a database: an object in the bucket passes, `…-evil` and `…2` siblings do not, a slash-terminated base behaves identically, another host and the bare bucket root are refused, and an unconfigured bucket refuses everything (while `assertOwnBucket` still reports that as our 500 rather than the caller's 400).

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` — pass
- `apps/api` `src/lib`, `src/modules/media`, `src/email`: 16 files / 85 tests pass locally, including the 7 new ones. The two suites that fail there need `mongodb-memory-server`, which cannot reach `fastdl.mongodb.org` from this sandbox (the egress policy answers 403); they fail the same way on `main`, and CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aWL8Tzy8PMUpUdexJMXsF

---
_Generated by [Claude Code](https://claude.ai/code/session_018aWL8Tzy8PMUpUdexJMXsF)_