### PR TITLE
Close the share page while its owner is closed

### DIFF
--- a/apps/api/src/modules/cards/shareCards.ts
+++ b/apps/api/src/modules/cards/shareCards.ts
@@ -7,6 +7,8 @@ import { ERROR_CODES } from '@langx/shared'
 import { ApiError } from '../../lib/ApiError'
 import { supportsPut, type StorageProvider } from '../../storage/StorageProvider'
 import type { CardKind, CardShape } from '@langx/shared'
+import { notSuspended } from '../moderation/suspension'
+import type { Profile } from '../profiles/profiles'
 import { cardElement, type CardCopy } from './design'
 import { renderCard } from './render'
 
@@ -119,7 +121,31 @@ async function profileQr(handle: string): Promise<string | undefined> {
  * a card by its owner in order to be posted publicly. It carries no email, no
  * age, no location and no post text — the three things a card can be about are
  * the owner's own numbers.
+ *
+ * **While that owner is still someone the open internet may see.** This is the
+ * app's second unauthenticated read, and `getSharedProfile` — which calls
+ * itself the one that draws this line — is the first: a suspended account is
+ * closed to strangers, and so is one inside its deletion grace period. A card
+ * is the same surface by another address, carrying the same handle and a
+ * headline its owner wrote, so it answers the same way. Here rather than in
+ * the route because that is where access control lives in this codebase.
+ *
+ * Nothing is deleted and nothing is rewritten: the page stops answering and
+ * starts again by itself when a suspension runs out or a deletion is
+ * cancelled, which is what makes this safe to apply to a decision that is
+ * reversible for thirty days. What it cannot take back is a bucket URL
+ * somebody already has — the object is public, and removing it is the purge's
+ * job — but the page is the only thing that ever hands that URL out.
  */
 export async function readShareCard(db: Db, id: string): Promise<ShareCard | null> {
-  return db.collection<ShareCard>(COLLECTIONS.shareCards).findOne({ _id: id })
+  const card = await db.collection<ShareCard>(COLLECTIONS.shareCards).findOne({ _id: id })
+  if (!card) return null
+
+  const owner = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .findOne(
+      { _id: card.userId, deletedAt: { $exists: false }, ...notSuspended() },
+      { projection: { _id: 1 } },
+    )
+  return owner ? card : null
 }

--- a/apps/api/src/routes/shareCards.test.ts
+++ b/apps/api/src/routes/shareCards.test.ts
@@ -4,9 +4,11 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { buildApp } from '../app'
 import { createAuth } from '../auth'
 import { connectToDatabase, type DbHandle } from '../db/client'
+import { COLLECTIONS } from '../db/collections'
 import { ensureIndexes } from '../db/indexes'
 import { loadEnv } from '../env'
 import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
+import type { Profile } from '../modules/profiles/profiles'
 import { cardElement } from '../modules/cards/design'
 import { renderCard } from '../modules/cards/render'
 import type { StorageProviderWithPut, UploadUrl } from '../storage/StorageProvider'
@@ -179,6 +181,68 @@ describe('share cards', () => {
 
     const missing = await app.inject({ method: 'GET', url: '/public/share/deadbeefdeadbeef' })
     expect(missing.statusCode).toBe(404)
+  }, 60_000)
+
+  /**
+   * The line `getSharedProfile` draws, drawn here too. A card is the app's
+   * other unauthenticated read, at another address and carrying the same
+   * handle, and it used to answer for an account the profile page refuses to
+   * confirm exists.
+   *
+   * Both states are reversible, and the page comes back on its own for both:
+   * nothing is deleted, the read simply stops finding an owner it may show.
+   */
+  it('stops serving a card while its owner is suspended, and serves it again after', async () => {
+    const created = await make({
+      kind: 'streak',
+      shape: 'story',
+      headline: '9',
+      caption: 'day streak on LangX',
+    })
+    const { id } = created.json<{ id: string }>()
+    const page = () => app.inject({ method: 'GET', url: `/public/share/${id}` })
+    expect((await page()).statusCode).toBe(200)
+
+    const profiles = handle.db.collection<Profile>(COLLECTIONS.profiles)
+    await profiles.updateOne(
+      { handle: 'cardhaver' },
+      {
+        $set: {
+          suspension: {
+            at: new Date(),
+            until: new Date(Date.now() + 24 * 60 * 60 * 1000),
+            permanent: false,
+            reason: 'harassment',
+          },
+        },
+      },
+    )
+    // 404, not 403: a refusal that confirms the card exists is a refusal that
+    // answers the question it was meant to close.
+    expect((await page()).statusCode).toBe(404)
+
+    await profiles.updateOne({ handle: 'cardhaver' }, { $unset: { suspension: '' } })
+    expect((await page()).statusCode).toBe(200)
+  }, 60_000)
+
+  it('stops serving a card while its owner is inside the deletion grace period', async () => {
+    const created = await make({
+      kind: 'badge',
+      shape: 'wide',
+      headline: 'First Correction',
+      caption: 'badge earned',
+    })
+    const { id } = created.json<{ id: string }>()
+    const page = () => app.inject({ method: 'GET', url: `/public/share/${id}` })
+    expect((await page()).statusCode).toBe(200)
+
+    const profiles = handle.db.collection<Profile>(COLLECTIONS.profiles)
+    await profiles.updateOne({ handle: 'cardhaver' }, { $set: { deletedAt: new Date() } })
+    expect((await page()).statusCode).toBe(404)
+
+    // Signing back in is the cancel gesture, and the card is theirs again.
+    await profiles.updateOne({ handle: 'cardhaver' }, { $unset: { deletedAt: '' } })
+    expect((await page()).statusCode).toBe(200)
   }, 60_000)
 
   it('refuses a card for somebody who is not signed in', async () => {


### PR DESCRIPTION
## The bug

`sharedProfile.ts` says a suspended account is closed to the open internet, and calls itself "the one read that is". It is not the only one: `GET /public/share/:id` is the app's other unauthenticated read, and it answered for anybody at all — `readShareCard` was a bare `findOne` on the card id.

So a suspended account, or one inside its thirty-day deletion grace period, kept a public page up carrying the same handle the profile page refuses to confirm exists, under a headline and caption its owner typed. The image itself is rendered into our bucket from that text, and the page is what hands out its URL.

## The fix

`readShareCard` asks whether the owner is still someone the open internet may see — the same two conditions `getSharedProfile` applies, `deletedAt` and `notSuspended()` — as one keyed lookup after the card. In the repository function rather than the route, because that is where access control lives in this codebase; 404 rather than 403, for the reason the rest of the module gives.

Nothing is deleted and nothing is rewritten, which is what makes this safe against a decision that is reversible: the page stops answering and starts again by itself when a suspension runs out or a deletion is cancelled.

**What it does not do**, stated plainly: it cannot take back a bucket URL somebody already saved. The object is public and removing it is the purge's job. The page is the only thing that ever hands that URL out, so a link posted in public leads nowhere while its owner is closed.

## Tests

Two in `routes/shareCards.test.ts`, both round-trips on the same card: 200 → suspend the owner → 404 → lift the suspension → 200; and the same for `deletedAt`. They assert the reversibility as well as the refusal, which is the half a simpler test would miss.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` — pass
- `apps/api` tests need `mongodb-memory-server`, which cannot reach `fastdl.mongodb.org` from this sandbox (the egress policy answers 403), so the two new tests need CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aWL8Tzy8PMUpUdexJMXsF

---
_Generated by [Claude Code](https://claude.ai/code/session_018aWL8Tzy8PMUpUdexJMXsF)_