### PR TITLE
Hide a reported post from the report email

### DIFF
--- a/apps/api/src/email/templates.ts
+++ b/apps/api/src/email/templates.ts
@@ -1238,6 +1238,15 @@ export function reportEmail(input: {
   /** True only when this report is the one that crossed the threshold. */
   xpFrozen: boolean
   context: { conversationId: string | null; messageId: string | null; postId: string | null }
+  /**
+   * The reported post's own words, when it was raised from one.
+   *
+   * Worth the extra read the route makes for it: the alternative is a link
+   * that has to be opened, on an account that can see the post, before anyone
+   * knows whether the report is serious. Most of them can be judged from the
+   * sentence alone.
+   */
+  postBody: string | null
   /** The signed link that decides this report — see `reviewToken.ts`. */
   reviewUrl: string
 }): Email {
@@ -1275,6 +1284,10 @@ export function reportEmail(input: {
     ? `<p style="white-space: pre-wrap;">${escapeHtml(input.details)}</p>`
     : '<p style="color: #888;">No details were given.</p>'
 
+  const quoted = input.postBody
+    ? `<p style="margin:16px 0 8px;"><strong>The post</strong></p><blockquote style="white-space:pre-wrap;border-left:3px solid #ddd;margin:0 0 16px;padding:0 0 0 12px;color:#333;">${escapeHtml(input.postBody)}</blockquote>`
+    : ''
+
   return {
     subject,
     html: `<!doctype html>
@@ -1284,6 +1297,7 @@ export function reportEmail(input: {
     ${frozenLine}
     <p><strong>Reason</strong> ${escapeHtml(reason)}</p>
     ${details}
+    ${quoted}
     ${partyHtml('Reported', input.reported)}
     ${partyHtml('Reporter', input.reporter)}
     ${pointers.length ? `<p><strong>Raised from</strong></p><ul>${pointers.join('')}</ul>` : ''}
@@ -1306,6 +1320,7 @@ export function reportEmail(input: {
       '',
       input.details ?? 'No details were given.',
       '',
+      ...(input.postBody ? ['The post:', input.postBody, ''] : []),
       ...partyText('Reported', input.reported),
       ...partyText('Reporter', input.reporter),
       '',

--- a/apps/api/src/modules/feed/comments.ts
+++ b/apps/api/src/modules/feed/comments.ts
@@ -10,6 +10,7 @@ import { COLLECTIONS } from '../../db/collections'
 import { ApiError } from '../../lib/ApiError'
 import { decodeDateIdCursor, encodeDateIdCursor } from '../../lib/dateIdCursor'
 import { blockedUserIds } from '../moderation/blocks'
+import { notHidden } from './documents'
 import type { Post, PostCommentDoc } from './documents'
 import { commentDto, loadAuthors } from './dto'
 
@@ -69,7 +70,7 @@ export async function addComment(
   const _id = new ObjectId(postId)
 
   const [post, hidden] = await Promise.all([
-    db.collection<Post>(COLLECTIONS.posts).findOne({ _id }),
+    db.collection<Post>(COLLECTIONS.posts).findOne({ _id, ...notHidden() }),
     blockedUserIds(db, userId),
   ])
   if (!post) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Post not found')
@@ -107,7 +108,7 @@ export async function listPostComments(
   const _id = new ObjectId(postId)
 
   const [post, hidden] = await Promise.all([
-    db.collection<Post>(COLLECTIONS.posts).findOne({ _id }),
+    db.collection<Post>(COLLECTIONS.posts).findOne({ _id, ...notHidden() }),
     blockedUserIds(db, userId),
   ])
   if (!post) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Post not found')

--- a/apps/api/src/modules/feed/documents.ts
+++ b/apps/api/src/modules/feed/documents.ts
@@ -1,5 +1,5 @@
 import type { Media } from '@langx/shared'
-import type { ObjectId } from 'mongodb'
+import type { Document, ObjectId } from 'mongodb'
 
 /**
  * The shapes stored in the feed's four collections.
@@ -47,7 +47,36 @@ export interface Post {
   attachments?: Media[]
   /** The first of `attachments`, repeated for builds that predate the list. */
   media?: Media
+  /**
+   * When a moderator hid this post from the report email, or absent — which is
+   * almost every post, and why this is a missing field rather than a `false`.
+   *
+   * Hidden, not deleted: the row and its attachments stay exactly where they
+   * are and the same link puts it back. Every read that can surface a post to
+   * somebody filters on it, **including the author's own list** — the decision
+   * is silent, so a post that is still visible to the person who wrote it
+   * would be a different feature wearing this one's name.
+   *
+   * A date rather than a flag because "when" is the only question anyone asks
+   * afterwards, and it costs the same to store.
+   */
+  hiddenAt?: Date
   createdAt: Date
+}
+
+/**
+ * "Not hidden by a moderator", as a Mongo fragment — the one every read that
+ * can put a post in front of somebody spreads into its filter.
+ *
+ * `$exists: false` rather than `$ne: true`, and the difference is the same one
+ * `listFeed` makes over `kind`: a missing field has to pass, because that is
+ * every post there has ever been. It is a residual filter either way — the
+ * bounds still come from the compound index's leading keys — and that costs
+ * nothing worth naming, since the documents it rejects are a handful in the
+ * whole collection.
+ */
+export function notHidden(): Document {
+  return { hiddenAt: { $exists: false } }
 }
 
 export interface PostCorrectionDoc {

--- a/apps/api/src/modules/feed/feed.ts
+++ b/apps/api/src/modules/feed/feed.ts
@@ -30,6 +30,7 @@ import { assertAttachable, deleteObjects } from './attachments'
 import type { AttachmentNormalizer } from '../media/transcodeAudio'
 import { readCommentSummary } from './comments'
 import type { PostCommentDoc } from './documents'
+import { notHidden } from './documents'
 import type { Post, PostCorrectionDoc, PronunciationAnswerDoc } from './documents'
 import { correctionDto, loadAuthors, postDto } from './dto'
 import { readAnswerSummary } from './pronunciation'
@@ -203,7 +204,10 @@ export async function listFeed(db: Db, userId: string, query: ListFeedQuery): Pr
    * and cannot be bounded — it would quietly turn the main feed into a
    * collection scan, which nothing would fail to warn about.
    */
-  const base: Document = { kind: pronunciation ? 'pronunciation' : { $in: ['correction', null] } }
+  const base: Document = {
+    kind: pronunciation ? 'pronunciation' : { $in: ['correction', null] },
+    ...notHidden(),
+  }
   const sort: Document = { [countField]: 1, createdAt: -1, _id: -1 }
 
   /**
@@ -302,7 +306,9 @@ export async function listMyPosts(
   userId: string,
   query: ListMyPostsQuery,
 ): Promise<FeedPage> {
-  const filter: Document = { authorId: userId }
+  // Hidden posts are absent here too. Hiding is a silent decision, so the one
+  // list that would still show it is the one place the silence would break.
+  const filter: Document = { authorId: userId, ...notHidden() }
   if (query.cursor) {
     const { date, id } = decodeDateIdCursor(query.cursor)
     filter.$or = [{ createdAt: { $lt: date } }, { createdAt: date, _id: { $lt: id } }]
@@ -403,7 +409,10 @@ export async function correctPost(
   if (!ObjectId.isValid(postId)) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Post not found')
   const _id = new ObjectId(postId)
 
-  const post = await db.collection<Post>(COLLECTIONS.posts).findOne({ _id })
+  // A hidden post reads as a missing one, here and at every other site that
+  // looks one up to act on it: the 404 each of them already throws is the
+  // right answer, so the filter goes in rather than a branch beside it.
+  const post = await db.collection<Post>(COLLECTIONS.posts).findOne({ _id, ...notHidden() })
   if (!post) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Post not found')
   // The mirror of the guard in `answerPronunciation`. A request for a recording
   // is not a sentence to rewrite, and a correction on one would sit in a list
@@ -527,7 +536,7 @@ export async function listPostCorrections(
   // The correction summary only needs the post's id, which we already have, so
   // it rides along here rather than costing a second round trip below.
   const [post, hidden, { topByPost, viewerCorrected }, commentCounts] = await Promise.all([
-    db.collection<Post>(COLLECTIONS.posts).findOne({ _id }),
+    db.collection<Post>(COLLECTIONS.posts).findOne({ _id, ...notHidden() }),
     blockedUserIds(db, userId),
     readCorrectionSummary(db, userId, [_id]),
     // Carried here so the detail screen's header agrees with the card that
@@ -668,6 +677,32 @@ export async function deletePost(
     ...childCorrections.map((c) => c.media?.url),
     ...childAnswers.flatMap((a) => [a.media.url, a.slowMedia?.url]),
   ])
+}
+
+/**
+ * Hide a post from everybody, or put it back — the decision the report email's
+ * link makes about the thing reported, rather than about its author.
+ *
+ * No ownership filter, unlike `deletePost`: this is the one write in the feed
+ * that is deliberately somebody else's. What stands in for ownership is the
+ * signed link that reached it, which names the report, and the report names
+ * this post — see `email/reviewToken.ts`.
+ *
+ * Returns the post as it was *before* the write, so the caller can tell a
+ * decision from a no-op and say "already hidden" rather than claiming to have
+ * done something. `null` when there is no such post: a moderator can be
+ * reading a report about something its author deleted in the meantime.
+ */
+export async function setPostHidden(db: Db, postId: string, hidden: boolean): Promise<Post | null> {
+  if (!ObjectId.isValid(postId)) return null
+  const _id = new ObjectId(postId)
+  return db
+    .collection<Post>(COLLECTIONS.posts)
+    .findOneAndUpdate(
+      { _id },
+      hidden ? { $set: { hiddenAt: new Date() } } : { $unset: { hiddenAt: '' } },
+      { returnDocument: 'before' },
+    )
 }
 
 /**

--- a/apps/api/src/modules/feed/likes.ts
+++ b/apps/api/src/modules/feed/likes.ts
@@ -12,6 +12,7 @@ import { ApiError } from '../../lib/ApiError'
 import { decodeDateIdCursor, encodeDateIdCursor } from '../../lib/dateIdCursor'
 import { blockedUserIds } from '../moderation/blocks'
 import type { Profile } from '../profiles/profiles'
+import { notHidden } from './documents'
 import type { Post, PostCorrectionDoc, PronunciationAnswerDoc } from './documents'
 
 export interface Like {
@@ -130,7 +131,7 @@ async function resolveTarget(
   const hidden = await blockedUserIds(db, userId)
 
   if (target.targetType === 'post') {
-    const post = await db.collection<Post>(COLLECTIONS.posts).findOne({ _id })
+    const post = await db.collection<Post>(COLLECTIONS.posts).findOne({ _id, ...notHidden() })
     if (!post || hidden.includes(post.authorId)) {
       throw new ApiError(ERROR_CODES.NOT_FOUND, 'Nothing to like')
     }
@@ -150,7 +151,9 @@ async function resolveTarget(
     if (answer.authorId === userId) {
       throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'You cannot like your own answer')
     }
-    const parent = await db.collection<Post>(COLLECTIONS.posts).findOne({ _id: answer.postId })
+    const parent = await db
+      .collection<Post>(COLLECTIONS.posts)
+      .findOne({ _id: answer.postId, ...notHidden() })
     if (!parent || hidden.includes(parent.authorId)) {
       throw new ApiError(ERROR_CODES.NOT_FOUND, 'Nothing to like')
     }
@@ -166,7 +169,9 @@ async function resolveTarget(
   if (correction.authorId === userId) {
     throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'You cannot like your own correction')
   }
-  const post = await db.collection<Post>(COLLECTIONS.posts).findOne({ _id: correction.postId })
+  const post = await db
+    .collection<Post>(COLLECTIONS.posts)
+    .findOne({ _id: correction.postId, ...notHidden() })
   if (!post || hidden.includes(post.authorId)) {
     throw new ApiError(ERROR_CODES.NOT_FOUND, 'Nothing to like')
   }

--- a/apps/api/src/modules/feed/pronunciation.ts
+++ b/apps/api/src/modules/feed/pronunciation.ts
@@ -18,6 +18,7 @@ import { settleReferral } from '../referrals/settle'
 import { recordQualifyingAction } from '../tokens/streak'
 import { assertAttachable, deleteObjects } from './attachments'
 import type { AttachmentNormalizer } from '../media/transcodeAudio'
+import { notHidden } from './documents'
 import type { Post, PronunciationAnswerDoc } from './documents'
 import { answerDto, loadAuthors, postDto } from './dto'
 import { EMPTY_LIKE_SUMMARY, readLikeSummary } from './likes'
@@ -88,7 +89,7 @@ export async function answerPronunciation(
   if (!ObjectId.isValid(postId)) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Post not found')
   const _id = new ObjectId(postId)
 
-  const post = await db.collection<Post>(COLLECTIONS.posts).findOne({ _id })
+  const post = await db.collection<Post>(COLLECTIONS.posts).findOne({ _id, ...notHidden() })
   if (!post) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Post not found')
   // Without this the collection fills with rows no reader ever queries: the
   // pronunciation section is the only place answers are listed, and a
@@ -205,7 +206,7 @@ export async function listPronunciationAnswers(
   const _id = new ObjectId(postId)
 
   const [post, hidden, { topByPost, viewerAnswered }, commentCounts] = await Promise.all([
-    db.collection<Post>(COLLECTIONS.posts).findOne({ _id }),
+    db.collection<Post>(COLLECTIONS.posts).findOne({ _id, ...notHidden() }),
     blockedUserIds(db, userId),
     readAnswerSummary(db, userId, [_id]),
     readCommentSummary(db, [_id]),

--- a/apps/api/src/modules/moderation/suspension.ts
+++ b/apps/api/src/modules/moderation/suspension.ts
@@ -101,6 +101,17 @@ export async function dismissReport(db: Db, reportId: ObjectId): Promise<void> {
     .updateOne({ _id: reportId }, { $set: { status: 'dismissed' } })
 }
 
+/**
+ * Closes a report that was decided by something other than a suspension —
+ * today, hiding the post it named. `suspendUser` writes the same status
+ * inline, because there it is one line of the write it is already making.
+ */
+export async function actionReport(db: Db, reportId: ObjectId): Promise<void> {
+  await db
+    .collection<Report>(COLLECTIONS.reports)
+    .updateOne({ _id: reportId }, { $set: { status: 'actioned' } })
+}
+
 /** Moves the end date in, leaving everything else — the reason, the appeal — as it was. */
 export async function shortenSuspension(db: Db, userId: string, days: number): Promise<Date> {
   const until = new Date(Date.now() + days * 24 * 60 * 60 * 1000)

--- a/apps/api/src/routes/moderation.test.ts
+++ b/apps/api/src/routes/moderation.test.ts
@@ -1480,6 +1480,139 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
       expect((await decide(path, { action: 'suspend' })).statusCode).toBe(400)
       expect((await decide(path, { action: 'suspend', days: '400' })).statusCode).toBe(400)
     })
+
+    /**
+     * Hiding the post rather than suspending the person who wrote it — which
+     * is what most reports about a post actually want.
+     */
+    describe('hiding the reported post', () => {
+      /** A post by `author`, reported by somebody else, and the link that decides it. */
+      async function reportedPost(author: SignedUpUser, body = 'the reported sentence') {
+        const created = await post(author, '/posts', { body, language: 'en' })
+        expect(created.statusCode, created.body).toBe(201)
+        const postId = created.json<{ _id: string }>()._id
+
+        const reporter = await newUser()
+        emailSender.messages.length = 0
+        const filed = await post(reporter, '/reports', {
+          userId: author.userId,
+          reason: 'inappropriate_content',
+          postId,
+        })
+        expect(filed.statusCode, filed.body).toBe(201)
+        const mail = reportMails().at(-1)
+        if (!mail) throw new Error('no report mail')
+        return { postId, reporter, path: reviewPathFrom(mail.text), mail }
+      }
+
+      const feedIds = async (user: SignedUpUser) =>
+        (await get(user, '/feed')).json<{ items: { _id: string }[] }>().items.map((i) => i._id)
+
+      it('quotes the post in the mail, so the link need not be opened to judge it', async () => {
+        const author = await newUser()
+        const { mail } = await reportedPost(author, 'a sentence somebody objected to')
+        expect(mail.text).toContain('a sentence somebody objected to')
+      })
+
+      it('takes the post out of the feed, the thread and its author’s own list', async () => {
+        const author = await newUser()
+        const viewer = await newUser()
+        const { postId, path } = await reportedPost(author)
+
+        expect(await feedIds(viewer)).toContain(postId)
+        const page = await app.inject({ method: 'GET', url: path })
+        expect(page.statusCode).toBe(200)
+        expect(page.body).toContain('the reported sentence')
+        expect(page.body).toContain('Hide this post')
+
+        const hidden = await decide(path, { action: 'hide_post' })
+        expect(hidden.statusCode, hidden.body).toBe(200)
+        // The page turns around once the decision is made: the same link now
+        // offers the way back rather than the way in again.
+        const after = await app.inject({ method: 'GET', url: path })
+        expect(after.body).toContain('Show it again')
+        expect(after.body).not.toContain('Hide this post')
+
+        expect(await feedIds(viewer)).not.toContain(postId)
+        expect((await get(viewer, `/posts/${postId}/corrections`)).statusCode).toBe(404)
+        // The author's own list too: the decision is silent, and a post still
+        // sitting in the one place its writer looks would not be.
+        expect(await feedIds(author)).not.toContain(postId)
+        const mine = await get(author, '/me/posts')
+        expect(mine.json<{ items: { _id: string }[] }>().items.map((i) => i._id)).not.toContain(
+          postId,
+        )
+
+        const report = await handle.db
+          .collection<Report>(COLLECTIONS.reports)
+          .findOne({ postId: new ObjectId(postId) })
+        expect(report?.status).toBe('actioned')
+      })
+
+      it('refuses every write against a post nobody can see', async () => {
+        const author = await newUser()
+        const stranger = await newUser()
+        const { postId, path } = await reportedPost(author)
+        expect((await decide(path, { action: 'hide_post' })).statusCode).toBe(200)
+
+        // Each of these 404s because the lookup behind it now finds nothing —
+        // which is also what stops a hidden post from going on paying token.
+        expect(
+          (await post(stranger, `/posts/${postId}/corrections`, { corrected: 'fixed' })).statusCode,
+        ).toBe(404)
+        expect((await post(stranger, `/posts/${postId}/comments`, { body: 'hm' })).statusCode).toBe(
+          404,
+        )
+        expect(
+          (await post(stranger, '/likes', { targetType: 'post', targetId: postId })).statusCode,
+        ).toBe(404)
+      })
+
+      it('puts it back, and leaves the decided report decided', async () => {
+        const author = await newUser()
+        const viewer = await newUser()
+        const { postId, path } = await reportedPost(author)
+
+        expect((await decide(path, { action: 'hide_post' })).statusCode).toBe(200)
+        expect(await feedIds(viewer)).not.toContain(postId)
+
+        const shown = await decide(path, { action: 'unhide_post' })
+        expect(shown.statusCode, shown.body).toBe(200)
+        expect(await feedIds(viewer)).toContain(postId)
+
+        // Not back to `open`: showing it again corrects the first decision
+        // rather than handing the report to somebody as work still owed.
+        const report = await handle.db
+          .collection<Report>(COLLECTIONS.reports)
+          .findOne({ postId: new ObjectId(postId) })
+        expect(report?.status).toBe('actioned')
+      })
+
+      it('will not hide anything from an appeal link, or from a report with no post', async () => {
+        const author = await newUser()
+        const viewer = await newUser()
+        const { postId } = await reportedPost(author)
+
+        // A report raised from a profile names no post, so there is nothing
+        // for this decision to be about.
+        const { path: profileReport } = await reportAndReviewPath(author)
+        const refused = await decide(profileReport, { action: 'hide_post' })
+        expect(refused.statusCode).toBe(400)
+        expect(await feedIds(viewer)).toContain(postId)
+
+        // And the appeal link, which the kind check turns away before any of
+        // the above runs.
+        await decide(profileReport, { action: 'suspend', days: '3' })
+        const appeal = await post(author, '/me/suspension/appeal', {
+          text: 'I did not do the thing.',
+        })
+        expect(appeal.statusCode, appeal.body).toBe(202)
+        const appealMail = emailSender.messages.filter((m) => m.subject.includes('Appeal')).at(-1)
+        if (!appealMail) throw new Error('no appeal mail')
+        const crossed = await decide(appealPathFrom(appealMail.text), { action: 'hide_post' })
+        expect(crossed.statusCode).toBe(400)
+      })
+    })
   })
 
   describe('push registration', () => {

--- a/apps/api/src/routes/moderation.ts
+++ b/apps/api/src/routes/moderation.ts
@@ -2,6 +2,7 @@ import {
   REVIEW_ACTIONS_BY_KIND,
   SUSPENSION_MAX_DAYS,
   appealSchema,
+  attachmentsOf,
   blockSchema,
   moderationListQuerySchema,
   reportSchema,
@@ -22,11 +23,14 @@ import {
   signReviewToken,
   verifyReviewToken,
 } from '../email/reviewToken'
+import { COLLECTIONS } from '../db/collections'
 import { publicApiUrl } from '../env'
 import { requireAuth, requireMember } from '../middleware/requireAuth'
+import { setPostHidden, type Post } from '../modules/feed/feed'
 import { blockUser, listBlocked, reportUser, unblockUser } from '../modules/moderation/blocks'
 import { getViewers } from '../modules/moderation/profileViews'
 import {
+  actionReport,
   dismissReport,
   liftSuspension,
   shortenSuspension,
@@ -75,6 +79,31 @@ function actionForm(token: string, action: ReviewAction, label: string): string 
             <input type="hidden" name="action" value="${action}" />
             ${submitButton(label)}
           </form>`
+}
+
+/**
+ * The reported post, shown before the decisions about its author.
+ *
+ * Shown at all because the mail before it carries only an id and a link, and
+ * following that link means signing in as somebody who can see the post — the
+ * decision should not depend on being able to. The sentence is what is being
+ * judged, so it is on the page that judges it.
+ *
+ * Nothing here for a report raised from a profile or a message: a post-shaped
+ * empty box on those would suggest one is missing.
+ */
+function postSection(token: string, post: Post | null): string {
+  if (!post) return ''
+  const attachments = attachmentsOf(post).length
+  const files = attachments > 0 ? ` · ${attachments} attachment${attachments > 1 ? 's' : ''}` : ''
+  return `<p style="margin:24px 0 8px;"><strong>The post</strong> <span style="color:#888;">${escapeHtml(post.language)}${files}</span></p>
+          <blockquote style="white-space:pre-wrap;border-left:3px solid #ddd;margin:0 0 12px;padding:0 0 0 12px;color:#333;">${escapeHtml(post.body)}</blockquote>
+          ${
+            post.hiddenAt
+              ? `<p style="background:#fff3cd;padding:12px;border-radius:8px;">Hidden since <strong>${escapeHtml(post.hiddenAt.toISOString())}</strong>. Nobody can see it, its author included.</p>
+                 ${actionForm(token, 'unhide_post', 'Show it again')}`
+              : actionForm(token, 'hide_post', 'Hide this post')
+          }`
 }
 
 /**
@@ -146,9 +175,14 @@ export const moderationRoutes: FastifyPluginAsyncZod = async (app) => {
        * into a 500 would tell somebody their report of harassment failed when
        * it did not, and invite a retry that files it twice.
        */
-      const [reporter, reported] = await Promise.all([
+      const [reporter, reported, post] = await Promise.all([
         getProfile(app.mongo.db, request.userId),
         getProfile(app.mongo.db, request.body.userId),
+        result.report.postId
+          ? app.mongo.db
+              .collection<Post>(COLLECTIONS.posts)
+              .findOne({ _id: result.report.postId }, { projection: { body: 1 } })
+          : null,
       ])
       try {
         await app.email.send({
@@ -165,6 +199,7 @@ export const moderationRoutes: FastifyPluginAsyncZod = async (app) => {
               messageId: result.report.messageId?.toHexString() ?? null,
               postId: result.report.postId?.toHexString() ?? null,
             },
+            postBody: post?.body ?? null,
             reviewUrl: reviewUrl(
               publicApiUrl(app.env),
               signReviewToken(app.env.BETTER_AUTH_SECRET, {
@@ -254,9 +289,20 @@ export const moderationRoutes: FastifyPluginAsyncZod = async (app) => {
 
       const reportId = toObjectId(claim.reportId)
       const report = reportId
-        ? await app.mongo.db.collection('reports').findOne<{ reason: string; details?: string }>({
-            _id: reportId,
-          })
+        ? await app.mongo.db
+            .collection('reports')
+            .findOne<{ reason: string; details?: string; postId?: ObjectId }>({
+              _id: reportId,
+            })
+        : null
+
+      /*
+       * The post itself, when the report named one — read unfiltered, because
+       * this is the one reader that must still find a post it has already
+       * hidden. Everything else treats hidden as missing.
+       */
+      const post = report?.postId
+        ? await app.mongo.db.collection<Post>(COLLECTIONS.posts).findOne({ _id: report.postId })
         : null
 
       return html(
@@ -267,6 +313,14 @@ export const moderationRoutes: FastifyPluginAsyncZod = async (app) => {
             report ? ` for <strong>${escapeHtml(report.reason.replace(/_/g, ' '))}</strong>` : ''
           }.</p>
          ${report?.details ? `<blockquote style="white-space:pre-wrap;border-left:3px solid #ddd;margin:0 0 20px;padding:0 0 0 12px;color:#333;">${escapeHtml(report.details)}</blockquote>` : '<p style="color:#888;">No details were given.</p>'}
+         ${postSection(token, post)}
+         ${
+           /* Two groups of buttons now, and "hide this sentence" and "suspend
+              this person forever" are not things to mistake for each other. A
+              heading is what keeps the second from reading as more of the
+              first — but only when there is a first. */
+           post ? '<p style="margin:24px 0 8px;"><strong>The account</strong></p>' : ''
+         }
          ${inForce}
          ${daysForm(token, 'suspend', 'Suspend for N days', 7)}
          ${actionForm(token, 'permanent', 'Suspend permanently')}
@@ -309,6 +363,43 @@ export const moderationRoutes: FastifyPluginAsyncZod = async (app) => {
       }
       const name = escapeHtml(who(profile.handle, claim.userId))
       const reportId = toObjectId(claim.reportId)
+
+      /*
+       * The two decisions about the post rather than the account, handled
+       * before the address lookups below because neither needs one: hiding is
+       * silent, which is the whole shape of it.
+       */
+      if (action === 'hide_post' || action === 'unhide_post') {
+        const report = reportId
+          ? await app.mongo.db
+              .collection('reports')
+              .findOne<{ postId?: ObjectId }>({ _id: reportId })
+          : null
+        if (!report?.postId) {
+          return html(reply.code(400), page(REVIEW_TITLE, 'That report is not about a post.'))
+        }
+        const hide = action === 'hide_post'
+        const before = await setPostHidden(app.mongo.db, report.postId.toHexString(), hide)
+        if (!before) {
+          return html(reply.code(404), page(REVIEW_TITLE, 'That post no longer exists.'))
+        }
+        /*
+         * Hiding decides the report; showing it again does not reopen it. The
+         * second is a correction of the first, and a report that bounced back
+         * to `open` would arrive in the next list as work nobody owes.
+         */
+        if (hide && reportId) await actionReport(app.mongo.db, reportId)
+        const changed = Boolean(before.hiddenAt) !== hide
+        return html(
+          reply,
+          page(
+            REVIEW_TITLE,
+            hide
+              ? `<p>Hidden. Nobody can see it, ${name} included${changed ? '' : ' — it already was'}.</p>`
+              : `<p>Back in the feed${changed ? '' : ' — it was never hidden'}.</p>`,
+          ),
+        )
+      }
 
       /**
        * Telling the person is never fatal to the decision. The suspension is

--- a/apps/mobile/app/(app)/(tabs)/feed.tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed.tsx
@@ -27,6 +27,7 @@ import { PhotoViewer } from '../../../src/components/PhotoViewer'
 import { Avatar } from '../../../src/components/ui/Avatar'
 import { authClient } from '../../../src/lib/auth-client'
 import { reportWriteError } from '../../../src/lib/reportWriteError'
+import { chooseAlert } from '../../../src/lib/alert'
 import { requireAccount } from '../../../src/lib/requireAccount'
 import { unreadBadge } from '../../../src/lib/unreadBadge'
 import { LikeButton } from '../../../src/components/LikeButton'
@@ -202,6 +203,26 @@ export default function FeedScreen() {
       setUploadProgress(null)
     }
     return uploaded
+  }
+
+  /**
+   * The row's long-press, which reporting a post needed and did not have: the
+   * action lived only in the post screen's "more" sheet, so seeing something
+   * in the feed and reporting it cost a navigation first.
+   *
+   * Long-press rather than a button on the card, because that is what a list
+   * row does here already — see `chats.tsx` — and a fourth control on a card
+   * that is mostly somebody's sentence is a worse trade than a hidden one.
+   */
+  async function openMore(post: FeedPost): Promise<void> {
+    const choice = await chooseAlert(t('feed.post'), undefined, [
+      { label: t('common.report'), value: 'report' as const, destructive: true },
+    ])
+    if (choice !== 'report') return
+    router.push({
+      pathname: '/(app)/report',
+      params: { userId: post.author._id, postId: post._id },
+    })
   }
 
   function startCorrecting(post: FeedPost): void {
@@ -394,7 +415,13 @@ export default function FeedScreen() {
                 </Pressable>
 
                 {/* The sentence opens its thread; it is the one affordance every row has. */}
-                <Pressable accessibilityRole="button" onPress={open}>
+                <Pressable
+                  accessibilityRole="button"
+                  onPress={open}
+                  // Nothing to report on your own post, and the API says so
+                  // too — a sheet whose only item 400s is worse than no sheet.
+                  onLongPress={mine ? undefined : () => void openMore(item)}
+                >
                   <Text style={pronouncing ? styles.word : styles.body}>{item.body}</Text>
                 </Pressable>
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4422,3 +4422,33 @@ The row sits under the switch it explains, exactly where
 carries no live state for that row's stated reason: what the permission
 currently is takes an OS read and an `AppState` listener to stay true, and a
 row that goes stale in a list of switches reads as a switch that is wrong.
+
+## A reported post can be hidden from the mailbox, never deleted from it
+
+A report raised from the feed is usually about one sentence, not about the
+person who wrote it, and until now the report email could only decide the
+person: suspend for N days, suspend forever, dismiss. The proportionate answer
+— take that post down and leave the account alone — did not exist, so the
+choice was between doing too much and doing nothing.
+
+It exists now as `hide_post` / `unhide_post`, offered on the review page only
+when the report names a post. What it writes is `hiddenAt` on the post, and
+`notHidden()` is spread into every read that can put a post in front of
+somebody — the feed's two queries, the thread, the comments, the answers, the
+likes, and the author's own `/me/posts`.
+
+**There is deliberately no `delete_post`.** `email/reviewToken.ts` justifies
+treating a mailbox as authorisation by a single property: the worst a stolen or
+forwarded link can do is something a person can undo. A hard delete takes the
+post, its corrections, its answers and its attachments with it and breaks that
+property outright. Hiding is the reversible half of the same intent; a genuine
+deletion stays a script somebody runs by hand.
+
+The author's own list filters it too, which is the part worth stating because
+it looks like an oversight. Hiding is silent — nobody is emailed, nothing is
+labelled — so the one place the post stayed visible would be the one place the
+silence broke, and a writer watching their sentence sit in a list nobody else
+can reach is worse than either honest answer.
+
+Showing it again does not reopen the report. The second decision corrects the
+first rather than handing somebody work that is already done.

--- a/packages/shared/src/moderation.ts
+++ b/packages/shared/src/moderation.ts
@@ -147,8 +147,27 @@ export type SuspensionStatus = z.infer<typeof suspensionStatusSchema>
 export const REVIEW_KINDS = ['report', 'appeal'] as const
 export type ReviewKind = (typeof REVIEW_KINDS)[number]
 
-/** Deciding a report, and deciding an appeal against the decision. */
-export const REPORT_REVIEW_ACTIONS = ['suspend', 'permanent', 'dismiss'] as const
+/**
+ * Deciding a report, and deciding an appeal against the decision.
+ *
+ * `hide_post` and `unhide_post` act on the thing reported rather than on the
+ * account behind it, which is most of what a report about a post actually
+ * wants: one sentence is the problem and suspending its author is not
+ * proportionate. Both are offered only when the report names a post.
+ *
+ * There is deliberately no `delete_post`. The signed link's whole bargain —
+ * see `email/reviewToken.ts` — is that a forwarded or stolen one can do
+ * nothing a person cannot undo, and a hard delete takes the post, its
+ * corrections and its attachments with it. Hiding is the reversible half of
+ * the same intent; a genuine deletion stays a script run by hand.
+ */
+export const REPORT_REVIEW_ACTIONS = [
+  'suspend',
+  'permanent',
+  'dismiss',
+  'hide_post',
+  'unhide_post',
+] as const
 export const APPEAL_REVIEW_ACTIONS = ['shorten', 'lift', 'keep'] as const
 export const REVIEW_ACTIONS = [...REPORT_REVIEW_ACTIONS, ...APPEAL_REVIEW_ACTIONS] as const
 export type ReviewAction = (typeof REVIEW_ACTIONS)[number]
@@ -168,7 +187,7 @@ export const REVIEW_ACTIONS_BY_KIND = {
 export const reviewDecisionSchema = z
   .object({
     action: z.enum(REVIEW_ACTIONS),
-    /** Required by `suspend` and `shorten`, meaningless to the other four. */
+    /** Required by `suspend` and `shorten`, meaningless to the other six. */
     days: z.coerce.number().int().min(1).max(SUSPENSION_MAX_DAYS).optional(),
   })
   .refine((d) => !(d.action === 'suspend' || d.action === 'shorten') || d.days !== undefined, {


### PR DESCRIPTION
Reporting a post worked; deciding one did not. The report mail's signed link could only act on the **account** — suspend, suspend forever, dismiss — so the proportionate answer to "this one sentence is the problem" had to be borrowed from one of those.

## What changed

**The review page now decides the post.** When the report names one, the page shows the sentence and offers **Hide this post** — or **Show it again** if it is already hidden — above a labelled second group for the account decisions, so "hide a sentence" and "suspend a person forever" are not two adjacent unlabelled buttons.

**Hidden, not deleted.** `hiddenAt` on the post, and `notHidden()` spread into every read that can put a post in front of somebody: the feed's two queries, the thread, the comments, the answers, the likes, and the author's own `/me/posts`. The write paths inherit their 404s from lookups they already do — which is also what stops a hidden post from going on paying token.

**There is deliberately no `delete_post`.** `email/reviewToken.ts` justifies treating a mailbox as authorisation on one property: the worst a stolen or forwarded link can do is something a person can undo. A hard delete takes the post, its corrections, its answers and its attachments with it, and breaks that outright. A real deletion stays a script run by hand.

**The author's own list filters it too.** Hiding is silent — nobody is emailed, nothing is labelled — so the one place the post stayed visible would be the one place the silence broke.

**Reporting from the feed.** The action lived only in the post screen's "more" sheet, so seeing something in the feed and reporting it cost a navigation first. Long-press on the row, the pattern `chats.tsx` already uses, and never on your own post. No new user-facing strings, so no translation work.

**The mail quotes the post**, so most reports can be judged without opening the link at all.

## Verification

- Five new tests in `moderation.test.ts`: the post leaves the feed, the thread and its author's list at once; corrections, comments and likes against it 404; the same link puts it back and leaves the report `actioned`; an appeal link and a report with no post are both refused.
- `pnpm test` (2594), `pnpm -r typecheck`, `pnpm lint`, `prettier --check` all pass.
- The review page's rendered HTML was read in both states rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)