### PR TITLE
Keep unanswerable threads out of the unreplied tab

### DIFF
--- a/apps/api/src/modules/chat/messages.ts
+++ b/apps/api/src/modules/chat/messages.ts
@@ -23,7 +23,7 @@ import { ApiError } from '../../lib/ApiError'
 import { assertAttachmentsAllowed } from '../media/assertMedia'
 import type { AttachmentNormalizer } from '../media/transcodeAudio'
 import { blockedUserIds } from '../moderation/blocks'
-import { acceptsMessages } from '../official/accounts'
+import { acceptsMessages, unwritableOfficialIds } from '../official/accounts'
 import { awardForSend } from '../tokens/awards'
 import { assertConversationAccess, assertMediaUnlocked } from './access'
 import { toMessageView, type MessageView } from './messageView'
@@ -995,6 +995,15 @@ export async function listConversations(
   // `assertConversationAccess` already refuses to open it; without this the
   // thread would still sit in the list, unopenable — the worst of both.
   const hidden = await blockedUserIds(db, userId)
+  /*
+   * An account nobody can write to is hidden the same way, but from this one
+   * tab: `unreplied` is a to-do list, and a thread that takes no reply can
+   * never be crossed off it — @langx would announce once and sit at the top of
+   * the tab for good. Keyed on `OFFICIAL_WRITABLE` rather than on "is
+   * official", so @copilot leaves the tab today and joins it again on the day
+   * it opens.
+   */
+  if (filter === 'unreplied') hidden.push(...unwritableOfficialIds())
   // On an array field `$nin` means "contains none of these", so this reads as
   //: my threads, minus any whose participant list includes someone hidden.
   const base: Document = {

--- a/apps/api/src/modules/official/accounts.ts
+++ b/apps/api/src/modules/official/accounts.ts
@@ -90,6 +90,19 @@ export function officialHandleOf(id: string): OfficialHandle | null {
   return handlesById.get(id) ?? null
 }
 
+/**
+ * The same question as `acceptsMessages`, asked of the whole set rather than
+ * of an id already in hand — for a query that has to exclude these accounts
+ * before it knows which threads it is looking at.
+ *
+ * Empty before `ensureOfficialAccounts` has run, which is the same harmless
+ * shape the guards above take: a database with no official accounts has no
+ * threads with one either.
+ */
+export function unwritableOfficialIds(): string[] {
+  return [...handlesById].filter(([, handle]) => !OFFICIAL_WRITABLE[handle]).map(([id]) => id)
+}
+
 function isDuplicateKey(error: unknown): boolean {
   return error instanceof MongoServerError && error.code === 11000
 }

--- a/apps/api/src/modules/official/deliver.test.ts
+++ b/apps/api/src/modules/official/deliver.test.ts
@@ -4,6 +4,7 @@ import { connectToDatabase, type DbHandle } from '../../db/client'
 import { COLLECTIONS } from '../../db/collections'
 import { ensureIndexes } from '../../db/indexes'
 import type { Conversation } from '../chat/conversations'
+import { listConversations } from '../chat/messages'
 import type { Profile } from '../profiles/profiles'
 import { ensureOfficialAccounts } from './accounts'
 import { deliverOfficialMessage } from './deliver'
@@ -118,6 +119,26 @@ describe('a message from an official account', () => {
     expect(await handle.db.collection(COLLECTIONS.conversations).countDocuments()).toBe(1)
     expect(second?.conversation.messageCount).toBe(2)
     expect(second?.conversation.unread.ada).toBe(2)
+  })
+
+  /**
+   * The unreplied tab is a to-do list, and an announcement is not on it: the
+   * account takes no messages, so nothing the viewer could do would ever clear
+   * the thread from that tab. It belongs in the chat list and nowhere else.
+   */
+  it('stays out of the unreplied tab', async () => {
+    const delivered = await deliverOfficialMessage(handle.db, {
+      fromHandle: 'langx',
+      toUserId: 'ada',
+      body: 'hello',
+    })
+
+    const all = await listConversations(handle.db, 'ada', { limit: 20 })
+    expect(all.items.map((c) => c._id)).toEqual([delivered?.conversation._id.toHexString()])
+
+    const unreplied = await listConversations(handle.db, 'ada', { filter: 'unreplied', limit: 20 })
+    expect(unreplied.items).toHaveLength(0)
+    expect(unreplied.pinned).toHaveLength(0)
   })
 
   it('pays nobody for the exchange', async () => {


### PR DESCRIPTION
## What

`@langx` and `@copilot` showed up in the **Unreplied** tab. Neither takes a
message, so the thread has no move for the reader to make and nothing that
would ever clear it — the welcome sat at the top of that tab permanently.

`listConversations` now excludes the official accounts that take no messages
from the `unreplied` filter, the same way it already excludes a blocked
counterpart: one `$nin` on `participants`, applied to that tab only. The
threads still appear in **All**.

The exclusion is keyed on `OFFICIAL_WRITABLE`, not on "is official", so
`@copilot` leaves the tab today and joins it again on the day the assistant
opens — no second place to remember.

## Changes

- `apps/api/src/modules/official/accounts.ts` — `unwritableOfficialIds()`, the
  set form of the `acceptsMessages` question, for a query that has to exclude
  these accounts before it knows which threads it is looking at.
- `apps/api/src/modules/chat/messages.ts` — `listConversations` adds those ids
  to the hidden list when `filter === 'unreplied'`. Pinned threads go through
  the same base filter, so a pinned official thread is excluded too.
- `apps/api/src/modules/official/deliver.test.ts` — a delivered announcement is
  in the chat list and absent from the unreplied tab.

No client change: nothing renders the per-row `unreplied` flag, and the socket
cache only patches threads already in a loaded page, so it cannot put one back.

## Verification

- `pnpm -r typecheck`, `pnpm lint`, `pnpm format:check` — clean.
- `pnpm test` — 2596 tests across 245 files pass (api 1389, mobile 881,
  shared 326).
- The new test was checked against the bug: with the one line in
  `listConversations` reverted it fails on the delivered announcement still
  being in the tab, and passes with it.
- End to end against a local stack (mongod replica set, API on `:4000`, the
  Expo web build on `:8081`): a real sign-up → verify → onboarding, whose
  welcome from `@langx` arrives in **All** with one unread, while **Unreplied**
  renders its empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7iHig8nDmfuJZQ8RkFvaw