### PR TITLE
Add an admin-only user stats endpoint

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -15,6 +15,7 @@ import { ApiError } from './lib/ApiError'
 import type { AssistantProvider } from './modules/official/assistantProvider'
 import { registerMaintenanceGate } from './middleware/maintenance'
 import { accountRoutes } from './routes/account'
+import { adminRoutes } from './routes/admin'
 import { emailRoutes } from './routes/email'
 import { appConfigRoutes } from './routes/appConfig'
 import { registerAuthRoutes } from './routes/auth'
@@ -323,6 +324,7 @@ export async function buildApp({
   await app.register(accountRoutes)
   await app.register(emailRoutes)
   await app.register(feedbackRoutes)
+  await app.register(adminRoutes)
 
   // Attached last: Socket.io only needs `app.server` (Fastify creates the
   // underlying http.Server synchronously at construction) plus the

--- a/apps/api/src/middleware/requireAuth.ts
+++ b/apps/api/src/middleware/requireAuth.ts
@@ -158,3 +158,22 @@ export async function requireVerifiedEmail(
     return reply.code(ERROR_STATUS.EMAIL_NOT_VERIFIED).send(body)
   }
 }
+
+/**
+ * Layer on top of `requireAuth` for the operator-only routes, gated by the
+ * same `ADMIN_USER_IDS` the maintenance gate already reads — one list, so
+ * there is no second idea of who an admin is to keep in step.
+ *
+ * `FORBIDDEN`, not a 404 that hides the route: this repository is public, so
+ * the path is already known to anyone who wants it. Hiding would cost an
+ * operator a clear answer and buy nothing.
+ */
+export async function requireAdmin(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  await requireAuth(request, reply)
+  if (reply.sent) return
+
+  if (!request.server.env.ADMIN_USER_IDS.includes(request.userId)) {
+    const body: ApiErrorBody = { code: ERROR_CODES.FORBIDDEN, message: 'Admins only' }
+    return reply.code(ERROR_STATUS.FORBIDDEN).send(body)
+  }
+}

--- a/apps/api/src/modules/analytics/stats.ts
+++ b/apps/api/src/modules/analytics/stats.ts
@@ -1,0 +1,63 @@
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import type { Profile } from '../profiles/profiles'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * "How many users are there" does not have one answer, and the number that
+ * looks like the answer is the wrong one.
+ *
+ * `user` holds three populations at once: people who signed up, guests the
+ * anonymous plugin created for anyone who opened the app without an account,
+ * and the v1 addresses `legacyPrecreate` wrote ahead of their owners coming
+ * back. Counting the collection reports a migration table as growth, so each
+ * population is counted apart from the others.
+ *
+ * `onboarded` is the one to quote: a profile exists only once somebody picked
+ * their languages, so it counts people who arrived rather than rows.
+ */
+export interface UserStats {
+  /** Every `user` document, guests and precreated v1 addresses included. */
+  total: number
+  /** Anonymous sessions. They expire — see `purgeStaleGuests`. */
+  guests: number
+  /**
+   * Accounts whose origin is the v1 import. Claimed or not: the flag records
+   * where the row came from and is never cleared, so this is not a backlog.
+   */
+  fromV1: number
+  /** Real profiles: onboarded, not a guest, not deleted. */
+  onboarded: number
+  newLast24h: number
+  newLast7d: number
+  /** Null on an empty database, which is the only time there is no last one. */
+  lastSignUpAt: string | null
+}
+
+export async function getUserStats(db: Db, now: Date = new Date()): Promise<UserStats> {
+  const users = db.collection<{ createdAt: Date }>(COLLECTIONS.user)
+  const since = (ms: number) => ({ createdAt: { $gte: new Date(now.getTime() - ms) } })
+
+  const [total, guests, fromV1, onboarded, newLast24h, newLast7d, latest] = await Promise.all([
+    users.countDocuments(),
+    users.countDocuments({ isAnonymous: true }),
+    users.countDocuments({ precreatedFromV1: { $exists: true } }),
+    db
+      .collection<Profile>(COLLECTIONS.profiles)
+      .countDocuments({ guest: { $ne: true }, deletedAt: { $exists: false } }),
+    users.countDocuments(since(DAY_MS)),
+    users.countDocuments(since(7 * DAY_MS)),
+    users.findOne({}, { projection: { createdAt: 1 }, sort: { createdAt: -1 } }),
+  ])
+
+  return {
+    total,
+    guests,
+    fromV1,
+    onboarded,
+    newLast24h,
+    newLast7d,
+    lastSignUpAt: latest?.createdAt.toISOString() ?? null,
+  }
+}

--- a/apps/api/src/routes/admin.test.ts
+++ b/apps/api/src/routes/admin.test.ts
@@ -1,0 +1,155 @@
+import type { FastifyInstance } from 'fastify'
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import { ObjectId } from 'mongodb'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { buildApp } from '../app'
+import { createAuth } from '../auth'
+import { connectToDatabase, type DbHandle } from '../db/client'
+import { COLLECTIONS } from '../db/collections'
+import { ensureIndexes } from '../db/indexes'
+import { loadEnv } from '../env'
+import { createStorageProvider } from '../storage/createStorageProvider'
+import { createTranslationProvider } from '../translation/createTranslationProvider'
+import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
+import type { UserStats } from '../modules/analytics/stats'
+import { CapturingEmailSender, signUpAndSignIn } from '../testSupport/authFlow'
+
+const PASSWORD = 'correct horse battery staple'
+const DB = 'langx_admin_stats_test'
+
+describe('GET /admin/stats', () => {
+  let replSet: MongoMemoryReplSet
+  let handle: DbHandle
+  let app: FastifyInstance
+  let emailSender: CapturingEmailSender
+  let adminCookie: string
+  let memberCookie: string
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+    handle = await connectToDatabase(replSet.getUri(), DB)
+    await ensureIndexes(handle.db)
+
+    const env = loadEnv({
+      NODE_ENV: 'test',
+      MONGODB_URI: replSet.getUri(),
+      MONGODB_DB: DB,
+      LOG_LEVEL: 'silent',
+      BETTER_AUTH_SECRET: 'a'.repeat(32),
+      BETTER_AUTH_URL: 'http://localhost:4000',
+      LEGACY_EMAIL_HASH_SALT: 'test-legacy-salt',
+    })
+
+    emailSender = new CapturingEmailSender()
+    const auth = await createAuth({ env, db: handle.db, client: handle.client, emailSender })
+    app = await buildApp({
+      env,
+      client: handle.client,
+      db: handle.db,
+      auth,
+      storage: createStorageProvider(env),
+      translation: createTranslationProvider(env),
+      revenueCat: createRevenueCatClientFromEnv(env),
+    })
+    await app.ready()
+
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      const warmUp = await app.inject({
+        method: 'POST',
+        url: '/api/auth/sign-up/email',
+        payload: { email: `warmup-${attempt}@example.com`, password: PASSWORD, name: 'Warm Up' },
+      })
+      if (warmUp.statusCode === 200) break
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+    emailSender.messages.length = 0
+
+    const admin = await signUpAndSignIn(app, emailSender, {
+      email: 'admin@example.com',
+      password: PASSWORD,
+      name: 'Ad Min',
+    })
+    adminCookie = admin.cookie
+
+    const member = await signUpAndSignIn(app, emailSender, {
+      email: 'member@example.com',
+      password: PASSWORD,
+      name: 'Mem Ber',
+    })
+    memberCookie = member.cookie
+
+    /*
+     * Better Auth mints the id, so there is no id to configure before the
+     * sign-up that produces it. The guard reads the list per request, which is
+     * what lets the test name an admin after it has one.
+     */
+    app.env.ADMIN_USER_IDS = [admin.userId]
+
+    // The two populations that make the bare collection count a bad answer.
+    await handle.db.collection(COLLECTIONS.user).insertMany([
+      {
+        _id: new ObjectId(),
+        email: 'guest@example.com',
+        isAnonymous: true,
+        createdAt: new Date(),
+      },
+      {
+        _id: new ObjectId(),
+        email: 'from-v1@example.com',
+        createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+        precreatedFromV1: { at: new Date(), legacyUserId: 'appwrite-id' },
+      },
+    ])
+  }, 120_000)
+
+  afterAll(async () => {
+    await app?.close()
+    await handle?.close()
+    await replSet?.stop()
+  })
+
+  it('refuses a request with no session', async () => {
+    const response = await app.inject({ method: 'GET', url: '/admin/stats' })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toMatchObject({ code: 'UNAUTHENTICATED' })
+  })
+
+  it('refuses a signed-in user who is not an admin', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/admin/stats',
+      headers: { cookie: memberCookie },
+    })
+
+    expect(response.statusCode).toBe(403)
+    expect(response.json()).toMatchObject({ code: 'FORBIDDEN' })
+  })
+
+  /**
+   * The assertion that carries the endpoint's reason for existing: `total`
+   * counts rows, and the breakdown is what stops a guest session and a v1
+   * address nobody has claimed from being read as people who showed up.
+   */
+  it('counts each population apart for an admin', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/admin/stats',
+      headers: { cookie: adminCookie },
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<UserStats>()
+    const rows = await handle.db.collection(COLLECTIONS.user).countDocuments()
+
+    expect(body.total).toBe(rows)
+    expect(body.guests).toBe(1)
+    expect(body.fromV1).toBe(1)
+    // Nobody onboarded: every row here is a sign-up without a profile.
+    expect(body.onboarded).toBe(0)
+    // Everything but the 30-day-old v1 row was created by this test just now.
+    expect(body.newLast24h).toBe(rows - 1)
+    expect(body.newLast7d).toBe(rows - 1)
+    expect(body.lastSignUpAt).toEqual(expect.any(String))
+  })
+})

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,0 +1,35 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { z } from 'zod'
+import { requireAdmin } from '../middleware/requireAuth'
+import { getUserStats } from '../modules/analytics/stats'
+
+const userStatsSchema = z.object({
+  total: z.number(),
+  guests: z.number(),
+  fromV1: z.number(),
+  onboarded: z.number(),
+  newLast24h: z.number(),
+  newLast7d: z.number(),
+  lastSignUpAt: z.string().nullable(),
+})
+
+/**
+ * The operator's answer to "how many people are on this thing", without a
+ * database client and without anyone reading production by hand.
+ *
+ * Declared here rather than in `packages/shared` — unlike every DTO there,
+ * nothing in the app renders this. It is read by whoever is on the other end
+ * of a `curl`, which is the same reason `/health` keeps its schema local.
+ *
+ * Counted live on request. The numbers are small enough to count and rare
+ * enough to ask for that a cached aggregate would be a second thing to keep
+ * true for no gain; `getUserStats` says what each one actually means.
+ */
+// eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
+export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
+  app.get(
+    '/admin/stats',
+    { preHandler: requireAdmin, schema: { response: { 200: userStatsSchema } } },
+    async () => getUserStats(app.mongo.db),
+  )
+}


### PR DESCRIPTION
## Why

Answering "how many users are there right now" currently means opening a database client against Atlas. `GET /admin/stats` answers it over HTTPS instead, so an operator — or an agent that can only reach the API — can ask without production credentials.

## What

**`GET /admin/stats`** → `{ total, guests, fromV1, onboarded, newLast24h, newLast7d, lastSignUpAt }`

The counts are split rather than summed, which is the substance of the change. `user` holds three populations at once:

- people who signed up,
- guests the anonymous plugin creates for anyone who opens the app without an account,
- the v1 addresses `legacyPrecreate` wrote ahead of their owners coming back.

A bare `countDocuments()` on that collection reports the migration table as growth. So each population is counted apart, and `onboarded` — profiles, which exist only once somebody picked their languages — is the number worth quoting.

`fromV1` counts origin, not backlog: the flag is never cleared, so a returning user still carries it.

## Authorisation

`requireAdmin`, a new layer on `requireAuth`, gated by the existing `ADMIN_USER_IDS` env list that the maintenance gate already reads. No new secret and no second idea of who an admin is. It answers `FORBIDDEN` rather than a 404 that hides the route — this repository is public, so hiding the path buys nothing and costs an operator a clear answer.

`ADMIN_USER_IDS` is a comma-separated list of Better Auth user ids. It is unset by default, in which case the endpoint is closed to everyone.

## Shape of the change

| File | |
| --- | --- |
| `modules/analytics/stats.ts` | new — `getUserStats`, the repository function; no handler touches a collection |
| `middleware/requireAuth.ts` | `requireAdmin` added alongside the existing guards |
| `routes/admin.ts` | new — the one route. Response schema is local, as `/health`'s is: nothing in the app renders this |
| `routes/admin.test.ts` | new — no session → 401, non-admin → 403, admin → the breakdown |
| `app.ts` | registers the plugin |

Counted live per request. The numbers are small enough to count and rare enough to ask for that a cached aggregate would be a second thing to keep true for no gain.

## Verification

- `pnpm -r typecheck` — clean
- `pnpm lint` — clean
- `pnpm format:check` — clean
- `apps/api` suite — 115 files, 1391 tests, all passing (3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZFBfvUda3jLhmFm41jY8G


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZFBfvUda3jLhmFm41jY8G)_