### PR TITLE
Resolve the old handle on the three lookups that missed it

### DIFF
--- a/apps/api/src/modules/referrals/referrals.ts
+++ b/apps/api/src/modules/referrals/referrals.ts
@@ -19,9 +19,10 @@ export interface Referral {
   referrerId: string
   /**
    * The handle as it resolved at attach time, kept beside the id it points at.
-   * Handles cannot be renamed today, so this is redundant today — and it is
-   * what makes the row readable in a shell six months from now without a
-   * second lookup, which is what an audit row is for.
+   * A snapshot on purpose: a returning v1 account may trade its name once
+   * (`claimHandle`), and what this row is for is reading in a shell six months
+   * from now — which link was actually used — not naming the referrer today.
+   * Everything shown to a person re-reads the live profile; see `readReferralStatus`.
    */
   referrerHandle: string
   /** Where the code came from: a marked invite URL, or typed in at onboarding. */
@@ -70,10 +71,19 @@ export async function attachReferral(
   handle: string,
   source: Referral['source'],
 ): Promise<Referral | null> {
-  const bare = handle.startsWith('@') ? handle.slice(1) : handle
+  const bare = (handle.startsWith('@') ? handle.slice(1) : handle).toLowerCase()
   const profiles = db.collection<Profile>(COLLECTIONS.profiles)
   const referrer = await profiles.findOne(
-    { handle: bare.toLowerCase(), deletedAt: { $exists: false } },
+    {
+      // The old name resolves here too, for the same reason it resolves on the
+      // profile route: an invite link is the longest-lived thing a handle ends
+      // up inside — a QR on a sticker, a bio, a screenshot — and the accounts
+      // that may rename are precisely the ones whose links are years old. The
+      // failure would be silent (every failure here is), so the attribution
+      // would just quietly stop arriving.
+      $or: [{ handle: bare }, { previousHandle: bare }],
+      deletedAt: { $exists: false },
+    },
     { projection: { handle: 1 } },
   )
   if (!referrer) return null

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -10,7 +10,7 @@ import {
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { ApiError } from '../lib/ApiError'
 import { requireAuth } from '../middleware/requireAuth'
-import { getProfile } from '../modules/profiles/profiles'
+import { findProfileByHandleOrId, getProfile } from '../modules/profiles/profiles'
 import { blockedUserIds } from '../modules/moderation/blocks'
 import { getPublicSummary } from '../modules/tokens/publicSummary'
 import { listStreakDays, repairsInMonth } from '../modules/tokens/streakDays'
@@ -129,14 +129,11 @@ export const activityRoutes: FastifyPluginAsyncZod = async (app) => {
     { preHandler: requireAuth, schema: { querystring: activityRangeSchema } },
     async (request, reply) => {
       const { handle } = request.params as { handle: string }
-      const target = await app.mongo.db
-        .collection<{
-          _id: string
-          timezone?: string
-          streak?: { current: number; lastQualifiedDay: string | null }
-          privacy?: { activityMapVisible?: boolean }
-        }>('profiles')
-        .findOne({ handle })
+      // Through the repository, which is also what resolves a `previousHandle`:
+      // a v1 account that took a new name is still reachable at the old one
+      // everywhere else, and a map that 404s on the link in somebody's bio
+      // would be the one place it is not.
+      const target = await findProfileByHandleOrId(app.mongo.db, handle)
 
       // Blocked either way reads as "no such person", the same as the profile
       // itself — a 403 here would confirm the account exists.
@@ -174,9 +171,8 @@ export const activityRoutes: FastifyPluginAsyncZod = async (app) => {
    */
   app.get('/profiles/:handle/summary', { preHandler: requireAuth }, async (request, reply) => {
     const { handle } = request.params as { handle: string }
-    const target = await app.mongo.db
-      .collection<{ _id: string }>('profiles')
-      .findOne({ handle }, { projection: { _id: 1 } })
+    // The old name too — see the activity route above.
+    const target = await findProfileByHandleOrId(app.mongo.db, handle)
 
     const hidden = await blockedUserIds(app.mongo.db, request.userId)
     if (!target || hidden.includes(target._id)) {

--- a/apps/api/src/routes/claimHandle.test.ts
+++ b/apps/api/src/routes/claimHandle.test.ts
@@ -195,6 +195,50 @@ describe('POST /profiles/me/handle — the one rename, for v1 accounts', () => {
     expect(squat.json()).toMatchObject({ code: 'HANDLE_TAKEN' })
   })
 
+  it('answers the activity map and the summary at the old name too', async () => {
+    // The profile route resolved `previousHandle` from the start; these two
+    // read the same person by the same key and used not to, so a deep link
+    // carrying a v1 name opened a profile with its numbers missing.
+    const user = await newUser('v1-old-activity@example.com')
+    await asReturningV1User(user, 'langx_0114')
+    expect((await claim(user, 'deniz')).statusCode).toBe(200)
+
+    const viewer = await newUser('v1-old-activity-viewer@example.com')
+    const range = 'from=2026-01-01&to=2026-01-31'
+
+    for (const url of [`/profiles/langx_0114/activity?${range}`, '/profiles/langx_0114/summary']) {
+      const response = await app.inject({ method: 'GET', url, headers: { cookie: viewer.cookie } })
+      expect(response.statusCode, `${url} — ${response.body}`).toBe(200)
+    }
+  })
+
+  it('still attributes an invite link that carries the old name', async () => {
+    // Every failure in `attachReferral` is silent, so this one cost the
+    // referrer their tokens without anybody being told. Their links are years
+    // old by construction — they are the accounts that came back from v1.
+    const referrer = await newUser('v1-old-invite@example.com')
+    await asReturningV1User(referrer, 'langx_0125')
+    expect((await claim(referrer, 'yusuf')).statusCode).toBe(200)
+
+    const invitee = await signUpAndSignIn(app, emailSender, {
+      email: 'v1-old-invite-guest@example.com',
+      password: PASSWORD,
+      name: 'T',
+    })
+    const onboarded = await app.inject({
+      method: 'POST',
+      url: '/profiles',
+      headers: { cookie: invitee.cookie },
+      payload: onboardingBody({ referredByHandle: 'langx_0125', referredBySource: 'link' }),
+    })
+    expect(onboarded.statusCode, onboarded.body).toBe(201)
+
+    const row = await handle.db
+      .collection(COLLECTIONS.referrals)
+      .findOne({ _id: invitee.userId as never })
+    expect(row).toMatchObject({ referrerId: referrer.userId })
+  })
+
   it('allows exactly one claim', async () => {
     const user = await newUser('v1-twice@example.com')
     await asReturningV1User(user, 'langx_00a5')


### PR DESCRIPTION
Started as a question — when a username changes, does anything linked to it have to change too? — and the answer turned out to be "almost nothing, but three lookups are wrong."

## What had to be checked

Nothing denormalises a handle onto content. Posts, messages, conversations, follows, blocks, reports, notifications, profile views and both leaderboards key on the user id and read the name off `profiles` at request time, so a rename is already visible everywhere the moment it lands. There is no backfill to run and no migration to write.

Two places do store a handle, and both stay as they are on purpose:

- `referrals.referrerHandle` — an audit snapshot of which link was actually used. Everything a person sees (`readReferralStatus`) re-reads the live profile. Its comment claimed handles could not be renamed, which stopped being true when `POST /profiles/me/handle` shipped; that is corrected.
- `shareCards.handle`, and the rendered PNG beside it — a picture of a moment, and its QR points at a URL the old name still resolves.

## What was actually broken

A renamed v1 account keeps its old name in `previousHandle` so that links already out there keep working, and `docs/architecture.md` states that every lookup resolves through it. Three did not:

- `GET /profiles/:handle/activity` and `GET /profiles/:handle/summary` read `profiles` directly with `findOne({ handle })`. A deep link carrying a v1 name opened the profile — that route always resolved the old name — with the activity map and the stat tiles 404ing beside it. Both now go through `findProfileByHandleOrId`, which is also where the rule about handlers not querying a collection directly puts them.
- `attachReferral` looked the referrer up the same way, and every failure in it is silent by design. So an invite link carrying a v1 handle cost the referrer their tokens with nobody told. The accounts allowed to rename are precisely the ones whose links are years old: a QR on a sticker, a bio, a screenshot.

## Verification

Two regression tests in `claimHandle.test.ts`, beside the existing "keeps the old name working" case. Both fail on `main` (404 on the activity route; a null referral row) and pass here.

`pnpm -r typecheck`, `pnpm lint`, `prettier --check` and `pnpm test` (2597 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsaToeSdAryGWd4oesyyGU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsaToeSdAryGWd4oesyyGU)_