### PR TITLE
Accept a one-sided language match in discovery, temporarily

### DIFF
--- a/apps/api/src/modules/discovery/discovery.ts
+++ b/apps/api/src/modules/discovery/discovery.ts
@@ -6,6 +6,7 @@ import {
   DISCOVERY_BOOSTED_CANDIDATE_MAX,
   DISCOVERY_BOOSTED_LIMIT,
   DISCOVERY_BOOSTED_TIERS,
+  DISCOVERY_CROSS_MATCH_FALLBACK,
   DISCOVERY_PRO_FILTER_KEYS,
   ERROR_CODES,
   hasFeature,
@@ -200,6 +201,27 @@ async function resolveDiscoveryScope(
   // list, the leaderboard and profile views — see `blockedUserIds`.
   const excludedIds = [viewerId, ...(await blockedUserIds(db, viewerId))]
 
+  /**
+   * Mutual fit, both directions — the reason for the two split indexes.
+   *
+   * `DISCOVERY_CROSS_MATCH_FALLBACK` turns the `and` into an `or` while the
+   * app is small enough that the honest rule returns an empty screen; see the
+   * note on that constant. It applies to the **default** search only. Naming
+   * a language scope is asking a question about particular languages, and the
+   * answer to that question is the strict one — which is also why this reads
+   * `query`, not the resolved codes: those are the viewer's full set when the
+   * request named nothing, and indistinguishable at this point from a request
+   * that named all of them.
+   */
+  const namedLanguageScope =
+    query.learningLanguages !== undefined || query.nativeLanguages !== undefined
+  const theirNativeFits = { 'nativeLanguages.code': { $in: wantTheirNative } }
+  const theirLearningFits = { 'learning.code': { $in: myNativeCodes } }
+  const languageFit: Document =
+    DISCOVERY_CROSS_MATCH_FALLBACK && !namedLanguageScope
+      ? { $or: [theirNativeFits, theirLearningFits] }
+      : { ...theirNativeFits, ...theirLearningFits }
+
   const match: Document = {
     _id: { $nin: excludedIds },
     'settings.discoverable': true,
@@ -213,9 +235,7 @@ async function resolveDiscoveryScope(
     // profile still opens for somebody who has the link — see
     // `accountStatus` on `toPublicProfile` — but nothing proposes them.
     ...notSuspended(),
-    // Mutual fit, both directions — the reason for the two split indexes.
-    'nativeLanguages.code': { $in: wantTheirNative },
-    'learning.code': { $in: myNativeCodes },
+    ...languageFit,
   }
 
   if (query.gender) match.gender = query.gender
@@ -550,8 +570,18 @@ export async function boostedProfiles(
   const { match } = await resolveDiscoveryScope(db, viewerId, query)
   const now = new Date()
 
-  const boostedMatch: Document = {
-    ...match,
+  /*
+   * `$and` rather than a spread, and that is load-bearing.
+   *
+   * The scope's language fit is a top-level `$or` whenever the cross-match
+   * fallback is on, and so is the expiry check below. Spread into one object
+   * the second key wins and the first disappears — silently, since a `$match`
+   * with one condition missing is a valid query that returns more. The strip
+   * would have shown every paying member in the app regardless of language,
+   * and nothing would have failed. Both halves are named here instead, where
+   * neither can shadow the other.
+   */
+  const boostedConditions: Document = {
     'entitlement.tier': { $in: [...DISCOVERY_BOOSTED_TIERS] },
     /*
      * Absent means on. The flag is only ever written when somebody flips the
@@ -575,7 +605,7 @@ export async function boostedProfiles(
 
   const docs = await profiles
     .aggregate<Profile>([
-      { $match: boostedMatch },
+      { $match: { $and: [match, boostedConditions] } },
       {
         $addFields: {
           boostedRank: { $indexOfArray: [[...DISCOVERY_BOOSTED_TIERS], '$entitlement.tier'] },

--- a/apps/api/src/routes/discovery.test.ts
+++ b/apps/api/src/routes/discovery.test.ts
@@ -1132,16 +1132,24 @@ describe('Faz 3 — discovery aggregation', () => {
   })
 
   describe('sort presets and pagination', () => {
+    /*
+     * `af` / `am`, a pair no other fixture in this file uses on either side.
+     * It asserts an exact set, and the suite shares one database — which used
+     * to mean the pair had to be unique as a *pair*. Under the cross-match
+     * fallback either code on its own pulls a profile in, so each side has to
+     * be unique too. `ro` / `bg` was not, and this asserted five people while
+     * seven fitted.
+     */
     it('sort=active pages through by lastActiveAt with no duplicates or gaps', async () => {
       const viewer = await newUser('active-sort-viewer@example.com', {
-        nativeLanguages: [{ code: 'ro' }],
-        learning: [{ code: 'bg', level: 'intermediate', priority: 1 }],
+        nativeLanguages: [{ code: 'af' }],
+        learning: [{ code: 'am', level: 'intermediate', priority: 1 }],
       })
       const candidates = []
       for (let i = 0; i < 5; i++) {
         const c = await newUser(`active-sort-${i}@example.com`, {
-          nativeLanguages: [{ code: 'bg' }],
-          learning: [{ code: 'ro', level: 'intermediate', priority: 1 }],
+          nativeLanguages: [{ code: 'am' }],
+          learning: [{ code: 'af', level: 'intermediate', priority: 1 }],
         })
         await setLastActiveAt(c.userId, new Date(Date.now() - i * 1000))
         candidates.push(c)
@@ -1672,9 +1680,16 @@ describe('Faz 3 — discovery aggregation', () => {
     it("obeys the list's scope: no language fit and blocked are both absent", async () => {
       const viewer = await viewerFor('boost-scope-viewer@example.com')
       const blocked = await candidateFor('boost-blocked@example.com')
+      /*
+       * Outside the scope in *both* directions. It used to be native `rm` —
+       * the viewer's learning language — which was outside the mutual rule
+       * and inside the cross-match fallback, so the fixture named "no fit"
+       * became a fit. Neither side is one of the viewer's now, which is what
+       * the test always meant.
+       */
       const noFit = await newUser('boost-no-fit@example.com', {
-        nativeLanguages: [{ code: 'rm' }],
-        learning: [{ code: 'is', level: 'intermediate', priority: 1 }],
+        nativeLanguages: [{ code: 'is' }],
+        learning: [{ code: 'mt', level: 'intermediate', priority: 1 }],
       })
       await setTier(blocked.userId, 'pro_plus')
       await setTier(noFit.userId, 'pro_plus')

--- a/apps/api/src/routes/discovery.test.ts
+++ b/apps/api/src/routes/discovery.test.ts
@@ -176,18 +176,26 @@ describe('Faz 3 — discovery aggregation', () => {
   })
 
   describe('mutual-fit matching', () => {
-    it('returns a candidate whose native/learning mutually fit, and excludes one-directional and unrelated fits', async () => {
+    /**
+     * Written against `DISCOVERY_CROSS_MATCH_FALLBACK`, which is temporary.
+     * The assertions it changed are named in the comments below; when the
+     * flag goes, a one-directional fit is excluded here again and the
+     * `cross-match fallback` block further down is deleted whole.
+     */
+    it('returns a mutual fit and a one-sided one, and still excludes an unrelated profile', async () => {
       const viewer = await newUser('mutual-viewer@example.com')
       const mutual = await newUser('mutual-match@example.com', {
         nativeLanguages: [{ code: 'en' }],
         learning: [{ code: 'tr', level: 'intermediate', priority: 1 }],
       })
-      // Speaks what I'm learning, but isn't learning what I speak.
+      // Speaks what I'm learning, but isn't learning what I speak. Excluded
+      // until the fallback; a candidate while it is on.
       const oneDirectional = await newUser('one-directional@example.com', {
         nativeLanguages: [{ code: 'en' }],
         learning: [{ code: 'fr', level: 'intermediate', priority: 1 }],
       })
-      // Neither direction fits.
+      // Neither direction fits. Excluded either way — the fallback widens the
+      // match, it does not remove it.
       const unrelated = await newUser('unrelated@example.com', {
         nativeLanguages: [{ code: 'de' }],
         learning: [{ code: 'es', level: 'intermediate', priority: 1 }],
@@ -198,9 +206,12 @@ describe('Faz 3 — discovery aggregation', () => {
       const body = response.json<{ items: { handle: string }[] }>()
       const handles = body.items.map((i) => i.handle)
       expect(handles).toContain(mutual.handle)
-      expect(handles).not.toContain(oneDirectional.handle)
+      expect(handles).toContain(oneDirectional.handle)
       expect(handles).not.toContain(unrelated.handle)
-      expect(handles.length).toBe(1)
+      expect(handles.length).toBe(2)
+      // The one thing the fallback must not cost: a mutual fit still leads a
+      // one-sided one, because `recommended` scores both intersections.
+      expect(handles.indexOf(mutual.handle)).toBeLessThan(handles.indexOf(oneDirectional.handle))
     })
 
     it('never returns the viewer themselves', async () => {
@@ -531,6 +542,87 @@ describe('Faz 3 — discovery aggregation', () => {
       expect((await discover(viewer, 'learningLanguages=fr')).statusCode).toBe(400)
       expect((await discover(viewer, 'nativeLanguages=en')).statusCode).toBe(400)
       expect((await discover(viewer, 'learningLanguages=')).statusCode).toBe(400)
+    })
+  })
+
+  /**
+   * `DISCOVERY_CROSS_MATCH_FALLBACK`, and the whole of it — delete this block
+   * along with the flag.
+   */
+  describe('cross-match fallback', () => {
+    it('drops back to both directions as soon as the search names a language scope', async () => {
+      const viewer = await newUser('cross-scope-viewer@example.com', {
+        nativeLanguages: [{ code: 'ba' }],
+        learning: [{ code: 'av', level: 'intermediate', priority: 1 }],
+      })
+      const mutual = await newUser('cross-scope-mutual@example.com', {
+        nativeLanguages: [{ code: 'av' }],
+        learning: [{ code: 'ba', level: 'intermediate', priority: 1 }],
+      })
+      // Speaks what the viewer is learning, but is learning something else.
+      const oneSided = await newUser('cross-scope-one-sided@example.com', {
+        nativeLanguages: [{ code: 'av' }],
+        learning: [{ code: 'ay', level: 'intermediate', priority: 1 }],
+      })
+      const handlesOf = (response: Awaited<ReturnType<typeof discover>>) =>
+        response.json<{ items: { handle: string }[] }>().items.map((i) => i.handle)
+
+      const unfiltered = handlesOf(await discover(viewer))
+      expect(unfiltered).toEqual(expect.arrayContaining([mutual.handle, oneSided.handle]))
+
+      /*
+       * Naming either side asks about particular languages, and the answer to
+       * that is the strict one — in *both* directions, not only the side that
+       * was named. `nativeLanguages=ba` excluding the one-sided fit is the
+       * assertion that would fail if the fallback had been scoped to the side
+       * the request happened to narrow.
+       */
+      const byLearning = handlesOf(await discover(viewer, 'learningLanguages=av'))
+      expect(byLearning).toContain(mutual.handle)
+      expect(byLearning).not.toContain(oneSided.handle)
+
+      const byNative = handlesOf(await discover(viewer, 'nativeLanguages=ba'))
+      expect(byNative).toContain(mutual.handle)
+      expect(byNative).not.toContain(oneSided.handle)
+    })
+
+    /**
+     * A regression for the shape of the change rather than its behaviour.
+     * The scope's language fit is a top-level `$or` now and the strip adds an
+     * expiry `$or` of its own; spread into one object, one silently replaces
+     * the other and the strip shows every paying member in the app.
+     */
+    it('reaches the boosted strip without costing it the language fit or the expiry check', async () => {
+      const viewer = await newUser('cross-boost-viewer@example.com', {
+        nativeLanguages: [{ code: 'br' }],
+        learning: [{ code: 'eu', level: 'intermediate', priority: 1 }],
+      })
+      const oneSided = await newUser('cross-boost-one-sided@example.com', {
+        nativeLanguages: [{ code: 'eu' }],
+        learning: [{ code: 'bs', level: 'intermediate', priority: 1 }],
+      })
+      const lapsed = await newUser('cross-boost-lapsed@example.com', {
+        nativeLanguages: [{ code: 'eu' }],
+        learning: [{ code: 'bn', level: 'intermediate', priority: 1 }],
+      })
+      const unrelated = await newUser('cross-boost-unrelated@example.com', {
+        nativeLanguages: [{ code: 'my' }],
+        learning: [{ code: 'as', level: 'intermediate', priority: 1 }],
+      })
+      await setTier(oneSided.userId, 'pro')
+      await setTier(lapsed.userId, 'pro', new Date(Date.now() - 60_000))
+      await setTier(unrelated.userId, 'pro')
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/discovery/boosted',
+        headers: { cookie: viewer.cookie },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+      const handles = response.json<BoostedProfilesPage>().items.map((item) => item.handle)
+      expect(handles).toContain(oneSided.handle)
+      expect(handles).not.toContain(lapsed.handle)
+      expect(handles).not.toContain(unrelated.handle)
     })
   })
 
@@ -1682,24 +1774,44 @@ describe('Faz 3 — discovery aggregation', () => {
 
       // Mirrors the mutual-fit $match discoverProfiles builds — see its
       // comment on why this needs two indexes, not one.
-      const explainResult = await handle.db
-        .collection(COLLECTIONS.profiles)
-        .aggregate([
-          {
-            $match: {
-              _id: { $nin: [viewer.userId] },
-              'settings.discoverable': true,
-              deletedAt: { $exists: false },
-              'nativeLanguages.code': { $in: ['en'] },
-              'learning.code': { $in: ['tr'] },
-            },
-          },
-        ])
-        .explain('executionStats')
+      const common = {
+        _id: { $nin: [viewer.userId] },
+        'settings.discoverable': true,
+        deletedAt: { $exists: false },
+      }
+      const theirNativeFits = { 'nativeLanguages.code': { $in: ['en'] } }
+      const theirLearningFits = { 'learning.code': { $in: ['tr'] } }
 
-      const serialized = JSON.stringify(explainResult)
-      expect(serialized).toContain('IXSCAN')
-      expect(serialized).not.toContain('COLLSCAN')
+      /*
+       * Both shapes, because the cross-match fallback made them two. A
+       * filtered search still sends the conjunction; an unfiltered one now
+       * sends the `$or`, and *that* is the one every default request runs —
+       * an `$or` whose branches are not both indexed is a collection scan of
+       * the whole of `profiles`, which is the failure this criterion exists
+       * to catch. When the fallback goes, so does the second case.
+       */
+      for (const languageFit of [
+        { ...theirNativeFits, ...theirLearningFits },
+        { $or: [theirNativeFits, theirLearningFits] },
+      ]) {
+        const explainResult = await handle.db
+          .collection(COLLECTIONS.profiles)
+          .aggregate([{ $match: { ...common, ...languageFit } }])
+          .explain('executionStats')
+
+        /*
+         * `rejectedPlans` dropped, because it is not what runs. An `$or` is
+         * planned per branch and the loser of each is reported alongside the
+         * winner — a COLLSCAN the planner *considered and threw away* would
+         * fail an assertion about the query being index-driven, which is the
+         * opposite of what it means.
+         */
+        const serialized = JSON.stringify(explainResult, (key: string, value: unknown) =>
+          key === 'rejectedPlans' ? undefined : value,
+        )
+        expect(serialized, JSON.stringify(languageFit)).toContain('IXSCAN')
+        expect(serialized, JSON.stringify(languageFit)).not.toContain('COLLSCAN')
+      }
     })
     /**
      * Online-first used to be a chip that applied here too, and it is gone

--- a/apps/mobile/app/(app)/(tabs)/discover.tsx
+++ b/apps/mobile/app/(app)/(tabs)/discover.tsx
@@ -375,10 +375,10 @@ export default function DiscoverScreen() {
             </TourTarget>
           )}
         </View>
-        {/* Which direction this list is matched in. Every row below is
-            someone native in what you are learning and learning what you
-            speak, and without this the list looks unsorted rather than
-            matched. */}
+        {/* Which direction this list is matched in. Without it the list
+            looks unsorted rather than matched. Rows below are matched on
+            that pair — on both sides of it normally, on either side while
+            `DISCOVERY_CROSS_MATCH_FALLBACK` is on. */}
         {pair && !searching ? (
           <TourTarget id="discoverPair" style={styles.pairTarget}>
             <Pressable

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4483,3 +4483,56 @@ can reach is worse than either honest answer.
 
 Showing it again does not reopen the report. The second decision corrects the
 first rather than handing somebody work that is already done.
+
+## Discovery accepts a one-sided match while the app is this small — temporarily
+
+Mutual fit is the honest rule and the whole point of the product: their native
+is something I am learning **and** their learning is something I speak. With
+the number of profiles there are today that conjunction returns nothing for
+most people. Somebody signs up, finishes onboarding, opens Discover and sees an
+empty screen — which is not a list with no results, it is an app that looks
+broken, and it is the one first impression there is no recovering from.
+
+So `DISCOVERY_CROSS_MATCH_FALLBACK` in `packages/shared` turns the `and` into
+an `or` for the **default** search. A Turkish native learning English now sees
+an English native learning French: one side fits, the other does not, and a
+half-fit somebody can still talk to beats a blank screen. It is one constant
+and it is meant to be flipped back.
+
+Three boundaries, each of which is the thing the relaxation could easily have
+broken:
+
+**It widens the match, it does not remove it.** Somebody who shares no language
+at all in either direction is still not a candidate. The screen fills with
+people you have something in common with, not with everybody.
+
+**A named language scope restores both directions.** `learningLanguages` or
+`nativeLanguages` on the request is somebody asking about particular languages,
+and the answer to a question asked explicitly is the strict one. Note that
+_either_ side named restores _both_ — scoping the relaxation to the side the
+request happened to narrow would answer a question nobody asked.
+
+Other filters do not turn it off, deliberately. Age, country or gender narrow a
+pool that is already too small; a relaxation that exists to fill an empty
+screen must not switch itself off the moment somebody touches the filter
+sheet. The level band is the one that constrains the match anyway, because
+`$elemMatch` on `learning` re-imposes "their learning is one of my natives" by
+construction — that is consistent rather than accidental, and it is what a
+level filter means.
+
+**Ranking needed no rule.** `recommended` scores the two intersections and
+sums them, so a mutual fit scores 2 where a one-sided fit scores 1 and leads
+it without anything being added. `active` and `nearby` intermix them, which is
+correct: those sorts answer "who is here" and "who is close", not "who fits
+best".
+
+The one thing this cost is a shape. The language fit is a top-level `$or` now,
+and the boosted strip spreads the shared scope into an object where it adds an
+expiry `$or` of its own — the second key would have silently replaced the
+first, and the strip would have shown every paying member in the app
+regardless of language, with nothing failing anywhere. The strip composes the
+two halves with `$and` instead, and a test pins it.
+
+Reverting is the constant, the tests named `cross-match fallback`, and the
+second case in the index-usage test. Do it once there are enough profiles for
+the honest rule to fill a page.

--- a/packages/shared/src/discovery.ts
+++ b/packages/shared/src/discovery.ts
@@ -93,6 +93,32 @@ export function isOnlineAt(lastActiveAt: Date | string, now: Date = new Date()):
 export const DISCOVERY_PRO_FILTER_KEYS = ['gender', 'cityId'] as const
 
 /**
+ * **Temporary.** Whether an unfiltered discovery search accepts a one-sided
+ * language match.
+ *
+ * The honest rule is mutual fit — their native is something I am learning
+ * *and* their learning is something I speak — and with a user base this size
+ * that conjunction empties the screen. Somebody signs up, opens Discover and
+ * sees nothing, which is the one first impression there is no recovering
+ * from. So while this is on, either side on its own is enough: a Turkish
+ * native learning English sees an English native learning French.
+ *
+ * Two things it deliberately does not do. Someone who shares no language at
+ * all is still not a candidate — this widens the match, it does not remove
+ * it. And a search that named its own language scope keeps both sides:
+ * a relaxation that exists to fill an empty *default* must not overrule a
+ * question somebody asked explicitly.
+ *
+ * Nothing orders the two kinds apart, because nothing has to —
+ * `recommended`'s score already sums both intersections, so a mutual fit
+ * scores above a one-sided one on its own.
+ *
+ * Flip to `false` once there are enough profiles for the honest rule to fill
+ * a page, and delete the tests that pin the relaxed behaviour with it.
+ */
+export const DISCOVERY_CROSS_MATCH_FALLBACK: boolean = true
+
+/**
  * `en,ru` → `['en', 'ru']`. Capped at the largest allowance any tier has, so
  * a crafted query cannot post two hundred codes, and each code is a real one.
  */


### PR DESCRIPTION
## Why

Mutual fit — their native is something I am learning **and** their learning is something I speak — is the honest rule and the point of the product. At today's number of profiles it returns nothing for most people: somebody signs up, finishes onboarding, opens Discover and sees an empty screen. That is not a list with no results, it reads as a broken app, and it is the one first impression there is no recovering from.

## What

`DISCOVERY_CROSS_MATCH_FALLBACK` in `packages/shared` turns that `and` into an `or` for the **default** search. A Turkish native learning English now sees an English native learning French — one side fits, the other does not, and a half-fit somebody can still talk to beats a blank screen.

One constant, meant to be flipped back.

### Boundaries it keeps

- **It widens the match, it does not remove it.** Somebody who shares no language at all in either direction is still not a candidate.
- **A named language scope restores both directions.** `learningLanguages` or `nativeLanguages` on the request is a question about particular languages, and the answer to a question asked explicitly is the strict one. Either side named restores both — scoping the relaxation to the side the request happened to narrow would answer a question nobody asked.
- **Other filters do not turn it off**, deliberately: age, country and gender narrow a pool that is already too small. The level band constrains the match anyway, because `$elemMatch` on `learning` re-imposes "their learning is one of my natives" by construction.
- **Ranking needed no rule.** `recommended` sums the two intersections, so a mutual fit scores 2 against a one-sided fit's 1 and leads it without anything being added. `active` and `nearby` intermix them, which is correct — those sorts answer "who is here" and "who is close".

The feed is untouched: it carries no language filter at all, so there was nothing there to relax.

### The one thing it cost

The language fit is a top-level `$or` now, and `boostedProfiles` spread the shared scope into an object where it adds an expiry `$or` of its own. The second key would have silently replaced the first: the strip would have shown every paying member in the app regardless of language, with nothing failing anywhere. The strip composes the two halves with `$and` instead, and a test pins it.

## Tests

- The existing mutual-fit test now expects the one-directional profile to appear, the unrelated one still not to, and the mutual fit still to lead on score.
- A new `cross-match fallback` block: naming either side restores both directions; the fallback reaches the boosted strip without costing it the language fit or the expiry check.
- The Faz 3 index-usage criterion now runs both shapes. An `$or` whose branches are not both indexed is a collection scan of the whole of `profiles`, and the `$or` is what every default request now sends. `rejectedPlans` is dropped from the serialized explain — a plan the planner considered and threw away is not what runs.
- Two existing fixtures named a profile that is genuinely a candidate once either side is enough, and the second commit fixes them rather than loosening what they assert. `sort=active pages through …` compares an exact set over a shared database, so its language pair had to be unique in the file — under the fallback that has to hold for each *side*, not just the pair, and `ro` / `bg` were not. The boosted strip's "no language fit" fixture was a native `rm`, the viewer's own learning language.

## Reverting

The constant, the tests named `cross-match fallback`, and the second case in the index-usage test. Documented in `docs/decisions.md`.

## Verification

Green on `55132be`: `check` (typecheck, lint, format:check and the full 1390-test suite) and CodeQL all pass.

`apps/api`'s tests could not run in the session that wrote this — `mongodb-memory-server` downloads `mongod` from `fastdl.mongodb.org`, which that environment's network policy blocks — so the first CI run was the first real execution of them, and it caught the two fixtures described above. They are fixed and CI is green on the current head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ed8XWutqPMTXzndkNpPp6d