### PR TITLE
Say in architecture.md that mutual fit is temporarily an or

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -832,13 +832,27 @@ The language list and CEFR levels are constants in `packages/shared`.
 
 ```
 $match:    discoverable, !deleted, !blocked (either direction),
-           nativeLanguages.code ∈ my learning,      ← mutual fit
-           learning.code ∈ my nativeLanguages
+           nativeLanguages.code ∈ my learning,      ← mutual fit …
+           learning.code ∈ my nativeLanguages       … but see below
            country / age / CEFR / only-my-gender (free), [if Fluent] gender / city
 $addFields onlineBucket = active in the last 5 min AND not hiding it → 1/0
 $addFields score = language fit + shared interests + activity recency
 $sort:     onlineBucket desc, score desc, lastActiveAt desc  → cursor pagination
 ```
+
+**Mutual fit is temporarily an `or`.** `DISCOVERY_CROSS_MATCH_FALLBACK` in
+`packages/shared` is on, and while it is, the **default** search accepts either
+side on its own: a Turkish native learning English sees an English native
+learning French. The honest rule is the conjunction above, and at this number
+of profiles it returns nothing for most people — an empty Discover on the day
+somebody signs up reads as a broken app rather than a small one. Naming a
+language scope (`learningLanguages` / `nativeLanguages`) restores both
+directions, because a question asked explicitly gets the strict answer; other
+filters do not, since they narrow a pool that is already too small. Somebody
+who shares no language at all is still not a candidate, and the score above
+still sums both intersections, so a mutual fit outranks a one-sided one
+without a rule of its own. Flip the constant back once the honest rule fills a
+page — `decisions.md` has the entry and the revert steps.
 
 `onlineBucket` is an **ordering, not a filter** — everyone still comes back,
 the online ones lead. It was a chip once and is now unconditional, but only on


### PR DESCRIPTION
## Why

#1337 relaxed discovery's mutual-fit rule behind `DISCOVERY_CROSS_MATCH_FALLBACK` and recorded it in `docs/decisions.md`. It did not touch `docs/architecture.md`, whose `$match` pseudocode is the one place somebody reads to learn what discovery matches on — and it still showed the conjunction as the whole rule.

CLAUDE.md points a reader at `architecture.md` first. Leaving it describing a rule the code no longer runs by default is the kind of drift that gets rediscovered as a bug.

## What

Docs only, no code.

- The pseudocode's two mutual-fit lines now point at the paragraph below them rather than reading as the final word.
- A paragraph after the block: what the fallback does, that it applies to the **default** search only, that naming a language scope restores both directions while other filters do not, that somebody sharing no language at all is still excluded, that the score already ranks a mutual fit above a one-sided one, and where the revert steps live.

## Not touched

`architecture.md`'s boosted-strip paragraph says the strip "shares `resolveDiscoveryScope` with the feed". That is wrong and predates this change — it shares it with the discovery **list**; the feed has no language scope at all (`listFeed`'s `$match` is the section plus `notHidden()`). Left alone rather than folded into a docs change about something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ed8XWutqPMTXzndkNpPp6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ed8XWutqPMTXzndkNpPp6d)_