### PR TITLE
Deploy the API from CI instead of by hand

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,64 @@
+# Every merge to main that touches the API becomes the running process on
+# api.langx.io — the sibling of deploy-web.yml, which does the same for the
+# browser build. Until this file existed the API half was `fly deploy` from a
+# laptop, by hand, and it showed: the discovery cross-match flag sat merged on
+# main for hours while api.langx.io still served the release from the night
+# before. A deploy that depends on someone being at a computer is a deploy that
+# does not happen when they are not.
+#
+# The token is a repository secret. An app-scoped deploy token for `langx-api`
+# is enough: the image is built here on the runner, so nothing needs permission
+# to start a builder machine in the organisation.
+#
+# `flyctl deploy` is spelt as docs/repo-map.md documents the manual command, so
+# there is one definition of an API deploy whether it runs here or from a
+# laptop. The app name comes from fly.toml.
+#
+# No verification step follows it, unlike deploy-web.yml. That one checks
+# app.langx.io because a Pages upload can succeed onto a stale edge; here the
+# blue-green strategy in fly.toml already withholds traffic until /health
+# passes on the new machines, so a green run means the new version answered.
+name: Deploy API
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - apps/api/**
+      - packages/shared/**
+      - Dockerfile
+      - fly.toml
+      - pnpm-lock.yaml
+      - .github/workflows/deploy-api.yml
+      - '!**/*.md'
+  workflow_dispatch:
+
+# One deploy at a time, in order. Blue-green tolerates two versions of the app
+# running, but not two deploys racing to decide which one wins.
+concurrency:
+  group: deploy-api
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Installed from Fly's script rather than superfly/flyctl-actions, which
+      # CodeQL would want pinned to a commit for the same reason deploy-web.yml
+      # pins pnpm/action-setup — this job holds a deploy token. Pinning the
+      # version here is the same guarantee without a third-party action in the
+      # chain: 0.4.102 is the flyctl that built the last hand-made release.
+      - name: Install flyctl
+        run: |
+          curl -fsSL https://fly.io/install.sh | sh -s -- 0.4.102
+          echo "$HOME/.fly/bin" >> "$GITHUB_PATH"
+
+      - name: Deploy to Fly
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -48,7 +48,7 @@ the repos themselves.
 | Host             | Hosting                                                       | How a change gets there                                                    |
 | ---------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | `app.langx.io`   | Cloudflare Pages project `langx-web` (direct upload)          | push to `main` of this repo; `deploy-web.yml` exports, uploads and checks  |
-| `api.langx.io`   | Fly.io app `langx-api`, behind Cloudflare                     | `fly deploy -a langx-api` from this repo, by hand                          |
+| `api.langx.io`   | Fly.io app `langx-api`, behind Cloudflare                     | push to `main` of this repo; `deploy-api.yml` builds and runs `fly deploy` |
 | `langx.io`       | Cloudflare Pages project `website` (direct upload)            | push to `main` of `langx/website`; its workflow builds, uploads and purges |
 | `token.langx.io` | Cloudflare Pages project `token-website` (**Git-integrated**) | push to `main` of `langx/token-website`; Pages builds it                   |
 | `docs.langx.io`  | GitBook, Git Sync on `langx/docs`                             | push to `main` of `langx/docs`                                             |


### PR DESCRIPTION
## Why

`api.langx.io` was the last thing here deployed by hand. `docs/repo-map.md` said so plainly — `fly deploy -a langx-api` from a laptop — and today showed the cost: the discovery cross-match flag merged to `main` in #1337/#1338, and Fly kept serving release **v136**, built ~18 hours earlier. The flag is read only by the API (`apps/api/src/modules/discovery/discovery.ts:221`), so cross-match was not live anywhere, no matter what the OTA and web deploys did.

This is the same problem `deploy-web.yml` was written to solve for `app.langx.io` on 5 September, and its header comment describes it in the same words: the browser build "routinely sat a few merges behind the phones."

## What

`.github/workflows/deploy-api.yml`, built as the sibling of `deploy-web.yml`:

- Same trigger shape — push to `main`, path-filtered on `apps/api/**`, `packages/shared/**`, `Dockerfile`, `fly.toml`, `pnpm-lock.yaml` and the workflow itself, with `'!**/*.md'` so a docs-only merge does not redeploy.
- Same `concurrency` pattern: one deploy at a time, `cancel-in-progress: false`.
- `workflow_dispatch` as well, so a deploy can be triggered without a merge.
- `flyctl deploy` spelt as `repo-map.md` documents the manual command; the app name comes from `fly.toml`.

Two deliberate differences from `deploy-web.yml`, both explained in the file:

- **No third-party action.** `flyctl` is installed from Fly's own script pinned to `0.4.102` (the version that built v136). `deploy-web.yml`'s comment says CodeQL wants any third-party action pinned to a commit in a job holding a token; not adding one to the chain sidesteps that.
- **No verification step.** `deploy-web.yml` checks `app.langx.io` because a Pages upload can succeed onto a stale edge. Here `strategy = 'bluegreen'` in `fly.toml` already withholds traffic until `/health` passes on the new machines, so a green run already means the new version answered.

`docs/repo-map.md` is updated so the hosting table no longer claims the API goes out by hand.

## Before this can run

**The `FLY_API_TOKEN` repository secret has to be created** — no workflow references Fly today, so it does not exist yet. An app-scoped deploy token for `langx-api` is enough: the image is built on the runner, so nothing needs org permission to start a builder machine. Merging without the secret leaves the first run red; the deploy step is the only thing that needs it.

## The backlog this was written for is already cleared

`api.langx.io` was deployed by hand from this session after the workflow was written, so the cross-match change is **already live** — release **137**, image `deployment-20260912215900`, both `fra` machines passing their health check, `/health` answering `{"status":"ok","db":"up"}`. This PR is therefore not carrying that change; it only stops the next one from waiting.

That deploy needed a local workaround worth recording, because it is the reason the workflow builds on the runner rather than on Fly: inside this sandbox the build container does not trust the egress proxy's CA, so `npm install` fails with `SELF_SIGNED_CERT_IN_CHAIN`. The image was built from a throwaway copy of the `Dockerfile` that adds that CA to the build stages only — the runtime stage was left untouched and verified afterwards to contain neither the CA nor `NODE_EXTRA_CA_CERTS`. Neither the copy nor the certificate is part of this diff. A GitHub runner has no such proxy, so the workflow needs none of it.

## Testing

`check` (typecheck, lint, `format:check`, tests) and all three CodeQL runs are green on `f5d9a5f`; the hand-aligned markdown table passes `format:check`.

The workflow itself is **unverified end to end** — it has never run, because the `FLY_API_TOKEN` secret does not exist yet. `flyctl deploy` and the image it produces were exercised by hand as described above, but not through this job. The first `workflow_dispatch` run is the real test, and it is worth doing that deliberately rather than discovering it on a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUqmrCRxzYd5KJ5ybXRsqz