### PR TITLE
Install dependencies at web session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# A web session starts from a fresh clone: no node_modules, no mongod binary.
+# Both are the whole cost of the first `pnpm test`, and paying it here means the
+# session can typecheck, lint and test from its first message instead of
+# spending them on an install.
+set -euo pipefail
+
+# Local sessions have their own install and their own mongod; nothing here
+# applies to them.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(dirname "$0")/../..}"
+
+corepack enable >/dev/null 2>&1 || true
+
+pnpm install --frozen-lockfile
+
+# apps/api's test files each start their own MongoMemoryServer, and vitest runs
+# them in parallel workers. On a cold cache they race on the same binary's
+# download and lockfile, which reads exactly like a real test failure — the same
+# reason .github/workflows/ci.yml fetches it in its own step. The install's
+# postinstall usually has it already; this is a no-op then, and it also proves
+# the binary actually starts rather than only that it downloaded.
+# pnpm's layout is isolated, so the package resolves from apps/api and nowhere
+# else — running this from the root finds nothing.
+(cd apps/api && node --input-type=module -e "
+  import { MongoMemoryServer } from 'mongodb-memory-server'
+  const server = await MongoMemoryServer.create()
+  await server.stop()
+") >/dev/null
+
+# Outbound TCP 27017 is closed in web sessions, so MONGODB_URI — an Atlas
+# cluster — is unreachable here however valid its credentials are. Tests do not
+# care: they run against mongodb-memory-server. `pnpm dev` does, and fails with
+# a server-selection timeout that looks like a bad connection string.
+echo "Ready: pnpm test | pnpm -r typecheck | pnpm lint. No Atlas from here — tests use an in-memory mongod."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,5 +4,17 @@
   },
   "permissions": {
     "defaultMode": "plan"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
A Claude Code web session starts from a fresh clone: no `node_modules`, no mongod binary. The first `pnpm test` in a session pays for both before it runs a single test. This adds a `SessionStart` hook that pays it up front.

## What's here

- `.claude/hooks/session-start.sh` — runs `pnpm install --frozen-lockfile`, then fetches the `mongodb-memory-server` binary explicitly. That second step is there for the same reason `.github/workflows/ci.yml` has it: `apps/api`'s test files each start their own `MongoMemoryServer` and, on a cold cache, race on that download in parallel vitest workers. It doubles as proof the binary actually starts rather than only that it downloaded.
- `.claude/settings.json` — registers the hook alongside the existing `enabledPlugins` and `permissions` entries.

The hook exits immediately unless `CLAUDE_CODE_REMOTE=true`; a local checkout has its own install and its own mongod. It runs synchronously, so a session cannot start before dependencies are ready — that trades a slower session start for never racing an install.

## Validation

Ran from a wiped `node_modules` with `CLAUDE_CODE_REMOTE=true`: hook exits 0, `pnpm typecheck` passes on all three projects, `pnpm lint` passes, `pnpm format:check` passes, and the `cities` and `revenueCatClient` test files pass (24 tests).

## Two notes, neither addressed here

- **Outbound TCP 27017 is closed in web sessions**, so the Atlas cluster in `MONGODB_URI` is unreachable from one however valid its credentials are. Tests don't care — they use the in-memory mongod. `pnpm dev` does, and fails with a server-selection timeout that reads like a bad connection string. The hook's closing line says so.
- **The container runs Node 22**, while `engines` asks for `>=24` and CI uses 24. Every check above passes anyway, so the hook does not install a toolchain; `pnpm` prints an unsupported-engine warning on each command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGst7t9L9BH656AC5dPYS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGst7t9L9BH656AC5dPYS2)_