### PR TITLE
Play the tour over an empty Discover, not only a full one

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/discover.tsx
+++ b/apps/mobile/app/(app)/(tabs)/discover.tsx
@@ -302,12 +302,6 @@ export default function DiscoverScreen() {
   const tips = useTips()
   const { data: session } = authClient.useSession()
   /*
-   * Only over a list that has rows: the tour points at a card, and a run
-   * started over skeletons would highlight rectangles that are about to be
-   * replaced. Search closed for the same reason — half the targets are not
-   * rendered while the field is open.
-   */
-  /*
    * What the tour's last step offers. The first row, because that is the row
    * the step is pointing at — and re-registered whenever it changes, so a list
    * that refreshed mid-run offers whoever is at the top now.
@@ -321,8 +315,22 @@ export default function DiscoverScreen() {
     })
   }, [first])
 
+  /*
+   * Over a list that has settled, whatever it settled on — not only one with
+   * rows in it.
+   *
+   * `state === 'content'` was the condition, and it made the tour silently
+   * conditional on having matches: somebody whose Discover came back empty, or
+   * failed, or was waiting on a network, got no tour at first run and nothing
+   * at all from the Settings row that replays it. The screen it teaches is the
+   * same screen either way, and an empty one is where the explanation is worth
+   * the most.
+   *
+   * Skeletons still block it — those are rectangles about to be replaced — and
+   * so does an open search field, which is covering half the targets.
+   */
   const touring = useDiscoveryTour({
-    ready: !searching && state === 'content',
+    ready: !searching && state !== 'skeleton',
     guest: shouldGateGuest(session?.user),
     onFinished: () => {
       // The tour just taught both of these. A tip repeating one of them a

--- a/apps/mobile/src/hooks/useTour.ts
+++ b/apps/mobile/src/hooks/useTour.ts
@@ -57,9 +57,13 @@ export function useTourOpen(): boolean {
 
 interface DiscoveryTourOptions {
   /**
-   * Whether the screen is in a state worth touring: it has rendered at least
-   * one real card, and nothing is covering it. A tour over skeletons points at
-   * rectangles that are about to move.
+   * Whether the screen is in a state worth touring: its list has settled on
+   * something — rows, an empty panel, a failure — and nothing is covering it.
+   * A tour over skeletons points at rectangles that are about to move.
+   *
+   * Deliberately not "has rows": see the call site. A tour that only plays for
+   * people who already have matches skips the ones who most need telling what
+   * the screen is.
    */
   ready: boolean
   guest: boolean

--- a/apps/mobile/src/lib/tour.test.ts
+++ b/apps/mobile/src/lib/tour.test.ts
@@ -120,17 +120,44 @@ describe('walking the run', () => {
   })
 
   /**
-   * A step that names a tab is reachable by definition: the host switches to
-   * that tab before measuring, and the screen may never have been mounted
-   * before. Asking first is what made the run skip its whole tail the moment
-   * it left Discovery.
+   * A step waiting for a mount is reachable by definition: the host opens the
+   * screen its target lives on before measuring. Asking first is what made the
+   * run skip its whole tail the moment it left Discovery.
    */
-  it('lets a step with a tab through even when nothing is registered', () => {
+  it('lets a step through when it is waiting for a mount', () => {
     const resolved = resolveFrom(startTour({ guest: false }), () => false)
-    expect(resolved?.index).toBe(TOUR_STEPS.findIndex((step) => step.tab !== undefined))
+    expect(resolved?.index).toBe(TOUR_STEPS.findIndex((step) => step.awaitsMount))
   })
 
-  /** With no tabs and no targets there is no tour at all, not an empty overlay. */
+  /**
+   * Only the Feed's two steps wait. Everything else the run points at is
+   * mounted — the tab-bar icons whatever tab is showing, Discovery throughout
+   * — so "not registered" there means genuinely absent.
+   */
+  it('waits only for the screen the run itself opens', () => {
+    expect(TOUR_STEPS.filter((step) => step.awaitsMount).map((step) => step.target)).toEqual([
+      'feedAsk',
+      'feedKinds',
+    ])
+  })
+
+  /**
+   * The ending is an offer, and an empty list has nobody to offer. Left to the
+   * old rule — every step that names a tab gets through — it dimmed the screen
+   * for a second while the host asked eight times for a card that was never
+   * coming, then closed on nothing.
+   */
+  it('ends rather than waiting for a card that is not there', () => {
+    const beforeTheCard = {
+      steps: TOUR_STEPS,
+      index: TOUR_STEPS.findIndex((step) => step.target === 'discoverCard'),
+      guest: false,
+    }
+    expect(resolveFrom(beforeTheCard, (target) => target !== 'discoverCard')).toBeNull()
+    expect(resolveFrom(beforeTheCard, all)?.index).toBe(beforeTheCard.index)
+  })
+
+  /** With nothing mounted and nothing to wait for there is no tour at all. */
   it('ends the run when nothing is available and nothing navigates', () => {
     const only = { steps: [{ target: 'discoverPair' as const }], index: 0, guest: false }
     expect(resolveFrom(only, () => false)).toBeNull()

--- a/apps/mobile/src/lib/tour.ts
+++ b/apps/mobile/src/lib/tour.ts
@@ -82,6 +82,17 @@ export interface TourStep {
    * point at a card.
    */
   tab?: TourTab
+  /**
+   * Let the step through before anything has registered its target.
+   *
+   * Only true of a target on a screen the run itself opens: the Feed is not
+   * mounted until the tour switches to it, so asking whether its button is
+   * there is asking too early. Everywhere else the answer is trustworthy —
+   * the tab-bar icons are mounted whatever tab is showing, and Discovery is
+   * mounted throughout — so a step with nothing to point at is a step that
+   * must be skipped rather than one that must wait.
+   */
+  awaitsMount?: true
 }
 
 /**
@@ -104,11 +115,11 @@ export const TOUR_STEPS: readonly TourStep[] = [
   { target: 'discoverFilters' },
   { target: 'tabChats', tab: TOUR_TABS.chats },
   { target: 'tabFeed', tab: TOUR_TABS.feed },
-  // Standing on the Feed already, but still naming the tab: the host treats a
-  // step with a tab as reachable whether or not its target has ever been
-  // mounted, which is exactly the case for a screen the run just opened.
-  { target: 'feedAsk', tab: TOUR_TABS.feed },
-  { target: 'feedKinds', tab: TOUR_TABS.feed },
+  // Standing on the Feed already, but still naming the tab — and the only two
+  // steps that wait for a mount, because the Feed is the one screen the run
+  // opens that nothing had rendered before.
+  { target: 'feedAsk', tab: TOUR_TABS.feed, awaitsMount: true },
+  { target: 'feedKinds', tab: TOUR_TABS.feed, awaitsMount: true },
   { target: 'tabMe', tab: TOUR_TABS.me },
   { target: 'discoverCard', tab: TOUR_TABS.discover },
 ]
@@ -167,7 +178,7 @@ export function isLastStep(state: TourState): boolean {
  * step. A step with nothing to highlight is skipped; it must never be able to
  * hold the overlay open on an empty rectangle.
  *
- * The exception is a step that names a tab; see below.
+ * The exception is a step that says it is waiting for a mount; see below.
  */
 export function resolveFrom(
   state: TourState,
@@ -177,14 +188,19 @@ export function resolveFrom(
     const step = state.steps[index]
     if (!step) continue
     /*
-     * A step that names a tab is always allowed through, even when its target
-     * is not registered yet: the host is about to switch to that tab, and the
-     * screen it wants may not have been mounted until now. Asking first is how
-     * the run learned to skip every remaining step the moment it left
+     * A step marked `awaitsMount` is allowed through with nothing registered:
+     * the host is about to open the screen its target lives on, and asking
+     * first is how the run learned to skip its whole tail the moment it left
      * Discovery — three steps and the ending, gone in a second, with nobody
      * having touched anything.
+     *
+     * Naming a tab is *not* enough on its own, and that distinction is the
+     * ending: `discoverCard` names Discovery, but Discovery has been mounted
+     * since the run began, so "no card registered" means the list is empty
+     * rather than late. Waiting for it dimmed the screen for a second and
+     * closed on nothing.
      */
-    if (step.tab || isAvailable(step.target)) return { ...state, index }
+    if (step.awaitsMount || isAvailable(step.target)) return { ...state, index }
   }
   return null
 }


### PR DESCRIPTION
## Ne oldu

The first-run tour was gated on `state === 'content'` — a Discover list with rows in it. Anyone whose Discover came back **empty**, **failed**, or was **waiting on a network** got:

- no tour on first run, and
- nothing at all from **Settings → About → Replay the tour** — the row cleared the flag and navigated to Discovery, Discovery looked at the flag, found no rows, and stayed silent.

Two buttons that looked dead, one cause. Reproduced with an empty Discover (a country filter nobody matches): before, nothing happened; after, the run plays.

## Ne değişti

**`app/(app)/(tabs)/discover.tsx`** — `ready` is now `!searching && state !== 'skeleton'`. The screen the tour teaches is the same screen whether or not it has rows, and an empty one is where the explanation is worth the most. Skeletons still block it, which was the real thing the gate was for.

**`src/lib/tour.ts`** — letting the run start over an empty list exposed the ending. `resolveFrom` let *every* step that named a tab through with nothing registered, so the final `discoverCard` step waited out eight measurements for a card that was never coming, then closed on a dimmed screen. Replaced with an explicit `awaitsMount` on the two Feed steps — the one screen the run opens that nothing had rendered before. The tab-bar icons are mounted whatever tab is showing and Discovery is mounted throughout, so "not registered" there means genuinely absent, and the run ends on "Yours" instead.

## Doğrulama

- Full run over an **empty** Discover, entry path: 9 steps, no dead frames.
- Full run over a **populated** Discover, entry path and Settings replay: unchanged, still ends on "Say hi to X".
- Three new tests in `tour.test.ts`, including one that pins the ending to `awaitsMount` rather than to `tab`.
- `pnpm -r typecheck`, `pnpm lint`, `prettier --check`, `pnpm test` (2602 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)