### PR TITLE
An operator panel, in the app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,10 @@ comes from `src/i18n/messages/en.ts` through `t('some.key')`; the other seven
 locales are typed against English, so adding a key without translating it does
 not compile. A count takes a plural entry, not `count === 1 ? … : …` — Russian
 and Arabic do not split there. See `docs/decisions.md` → _The app speaks eight
-languages_.
+languages_. The one exception is `app/(app)/admin/**`, the operator panel,
+which is read by us rather than by the person it is about and is English by
+design — its words are in `src/lib/adminStrings.ts`, and a lint rule refuses
+the i18n import there.
 
 **Optional services degrade, they do not crash.** No email credentials means
 verification links are logged; no storage means the upload endpoint fails with

--- a/apps/api/scripts/grant-admin.ts
+++ b/apps/api/scripts/grant-admin.ts
@@ -1,0 +1,163 @@
+/**
+ * The account that can open the operator panel.
+ *
+ *   ADMIN_PASSWORD=... pnpm --filter @langx/api exec tsx --env-file=../../.env \
+ *     scripts/grant-admin.ts --email <address> [--handle h] [--confirm]
+ *
+ * Two paths, and which one runs depends on whether the address already has an
+ * account:
+ *
+ * - **It does.** Nothing is created and no password is touched. The profile
+ *   gets `admin: true` and you sign in the way you always did. This is the
+ *   common case and the better one: no second credential to store.
+ * - **It does not.** The rows are written directly, already verified — the
+ *   same reason `create-review-account.ts` does it. `emailAndPassword` runs
+ *   with `requireEmailVerification: true` and `autoSignIn: false`, so an
+ *   account made through the sign-up form returns no session and stays
+ *   unusable until a link is clicked in an inbox.
+ *
+ * The password is read from `ADMIN_PASSWORD`, or generated and printed once if
+ * that is not set. Deliberately **not** an argv flag.
+ * `create-review-account.ts` allows one and justifies it as "a throwaway
+ * credential typed into a store console, not a person's password — acceptable
+ * here and nowhere else". A moderator's password is the nowhere else: argv is
+ * readable by every process on the machine and lands in shell history.
+ *
+ * `--revoke` takes the flag away again. Idempotent either way.
+ *
+ * It prints the database it is about to write to and refuses to touch one that
+ * is not `*_dev` without `--confirm`.
+ */
+import { randomBytes } from 'node:crypto'
+import { hashPassword } from 'better-auth/crypto'
+import { ObjectId } from 'mongodb'
+import { PASSWORD_MIN_LENGTH, type OnboardingProfileInput } from '@langx/shared'
+import { connectToDatabase } from '../src/db/client'
+import { loadEnv } from '../src/env'
+import { COLLECTIONS } from '../src/db/collections'
+import { recordTermsAcceptance } from '../src/modules/account/terms'
+import { createProfile, type Profile } from '../src/modules/profiles/profiles'
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`)
+  return i === -1 ? undefined : process.argv[i + 1]
+}
+
+const email = arg('email')?.trim().toLowerCase()
+const handle = arg('handle') ?? 'langx_admin'
+const displayName = arg('name') ?? 'LangX Admin'
+const revoke = process.argv.includes('--revoke')
+
+if (!email) {
+  throw new Error('usage: --email <address> [--handle h] [--name n] [--revoke] [--confirm]')
+}
+
+const env = loadEnv()
+const dbName = arg('db') ?? env.MONGODB_DB
+
+if (!dbName.endsWith('_dev') && !process.argv.includes('--confirm')) {
+  throw new Error(
+    `Refusing to write to "${dbName}" without --confirm. This is a live database; ` +
+      `re-run with --confirm if that is what you mean.`,
+  )
+}
+
+/**
+ * Only used when the address has no account yet. Boring on purpose: this
+ * profile is a door, not a person, and nothing about it should end up in
+ * anybody's Discover as a surprise.
+ */
+const PERSON: OnboardingProfileInput = {
+  handle,
+  displayName,
+  birthDate: '1990-01-01',
+  gender: 'undisclosed',
+  nativeLanguages: [{ code: 'en' }],
+  learning: [{ code: 'tr', level: 'beginner', priority: 1 }],
+  country: 'CA',
+  bio: 'Moderation account.',
+  interests: ['books'],
+}
+
+const { db, close } = await connectToDatabase(env.MONGODB_URI, dbName)
+
+try {
+  console.log(`db     ${dbName}`)
+  console.log(`email  ${email}`)
+
+  const users = db.collection(COLLECTIONS.user)
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  const now = new Date()
+
+  const existing = await users.findOne({ email })
+
+  if (revoke) {
+    if (!existing) throw new Error('No account with that address; nothing to revoke.')
+    const result = await profiles.updateOne(
+      { _id: String(existing._id) },
+      { $unset: { admin: '' }, $set: { updatedAt: now } },
+    )
+    console.log(result.modifiedCount ? 'admin  revoked' : 'admin  was not set — nothing to do')
+    process.exit(0)
+  }
+
+  let userId: ObjectId
+  let created = false
+
+  if (existing) {
+    userId = new ObjectId(String(existing._id))
+    console.log('user   already exists — password left alone')
+  } else {
+    userId = new ObjectId()
+    const password = process.env.ADMIN_PASSWORD ?? randomBytes(18).toString('base64url')
+    if (password.length < PASSWORD_MIN_LENGTH) {
+      throw new Error(`ADMIN_PASSWORD must be at least ${PASSWORD_MIN_LENGTH} characters.`)
+    }
+
+    await users.insertOne({
+      _id: userId,
+      name: displayName,
+      email,
+      // Nobody can click a link for this address in time to be useful, so the
+      // flag is set here rather than left to a flow that would never complete.
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    /*
+     * Mirrors the shape Better Auth's mongo adapter writes for a credential
+     * account — `userId` as an ObjectId, `accountId` the same value as a
+     * string.
+     */
+    await db.collection(COLLECTIONS.account).updateOne(
+      { userId, providerId: 'credential' },
+      {
+        $set: { password: await hashPassword(password), updatedAt: now },
+        $setOnInsert: { accountId: String(userId), issuer: 'local:credential', createdAt: now },
+      },
+      { upsert: true },
+    )
+
+    // Every other route into an account passes through the Better Auth create
+    // hook that stamps this; writing the rows directly skips it.
+    await recordTermsAcceptance(db, String(userId))
+    created = true
+    console.log('user   created, verified')
+    console.log(`\n  password  ${password}`)
+    console.log('  Printed once. It is not stored anywhere else and cannot be shown again.\n')
+  }
+
+  if (!(await profiles.findOne({ _id: String(userId) }))) {
+    await createProfile(db, String(userId), null, PERSON, env.STORAGE_PUBLIC_BASE_URL)
+    console.log(`profile created as @${handle}`)
+  } else if (created) {
+    console.log('profile already existed — left alone')
+  }
+
+  await profiles.updateOne({ _id: String(userId) }, { $set: { admin: true, updatedAt: now } })
+  console.log('admin  granted')
+  console.log(`\nuserId ${String(userId)}`)
+} finally {
+  await close()
+}

--- a/apps/api/scripts/send-announcement.ts
+++ b/apps/api/scripts/send-announcement.ts
@@ -1,171 +1,101 @@
 /**
- * Sends one message from @langx to everybody, as a message in their chat list.
+ * Queues one message from @langx to everybody, as a message in their chat list.
  *
  * Not an email and not a push-only broadcast: an announcement lands in the
- * same thread the welcome did, so it is still there next week and can be
- * replied to. The push is only the knock on the door — `send-campaign.ts` is
- * the tool for something that has to arrive in an inbox, and it carries the
- * consent rules and the warm-up ramp that mail needs.
+ * same thread the welcome did, so it is still there next week. The push is
+ * only the knock on the door — `send-campaign.ts` is the tool for something
+ * that has to arrive in an inbox, and it carries the consent rules and the
+ * warm-up ramp that mail needs.
  *
- * **Nobody is messaged twice.** Each recipient's message carries
- * `announcement:<slug>:<userId>`, and `messages.sender_client_id_unique` is on
- * `{senderId, clientId}` — so a second write for that person is refused while
- * everybody else's goes through. A run that died halfway can simply be run
- * again: there is no cursor to keep and no ledger to reconcile.
+ * **This no longer sends anything itself.** It writes a row to
+ * `broadcastQueue` and the API works through it, half an hour at a time — so
+ * the laptop does not have to stay awake, the send is paced, and it can be
+ * stopped from the operator panel once it has started. The loop that used to
+ * be here, and everything it knew about not messaging anybody twice, is in
+ * `modules/admin/broadcastQueue.ts`.
  *
- * The id has to carry the recipient. Without it the first person is messaged
- * and every other write is refused as a duplicate, which looks like success
- * from here because `deliverOfficialMessage` returns the message it found.
- *
- * The body is one file per locale in a directory, and each recipient gets the
- * one for their native language (`localeFor`), falling back to `en.txt`. Not
- * the server catalogue: an announcement is written once for one occasion, and
- * putting it in a typed catalogue would mean a code change and a deploy for
- * every sentence anybody wants to say.
+ * The body stays one file per locale in a directory, and each recipient gets
+ * the one for their native language, falling back to `en.txt`. The panel can
+ * write a broadcast too; this exists because an announcement in eight
+ * languages is authored in files, reviewed in a diff, and not typed into a
+ * textarea.
  *
  * Usage:
  *   pnpm --filter @langx/api exec tsx --env-file=../../.env \
  *     scripts/send-announcement.ts --id 2026-09-copilot --body announcements/copilot [--confirm]
  *
- * Without `--confirm` it counts and prints and sends nothing.
+ * Without `--confirm` it writes the draft and stops there — which is a real
+ * preview now rather than a printed one: the row is in the panel, where it can
+ * be sent to yourself before it is armed.
  */
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { SUPPORTED_LOCALES, type Locale } from '@langx/shared'
 import { connectToDatabase } from '../src/db/client'
-import { COLLECTIONS } from '../src/db/collections'
 import { loadEnv, publicApiUrl } from '../src/env'
-import { deliverOfficialMessage } from '../src/modules/official/deliver'
+import { createBroadcast, getBroadcast, setBroadcastStatus } from '../src/modules/admin/broadcast'
 import { ensureOfficialAccounts } from '../src/modules/official/accounts'
-import { localeFor } from '../src/modules/profiles/localeFor'
-import type { Profile } from '../src/modules/profiles/profiles'
-import { ExpoPushSender, sendPush, tokensFor } from '../src/modules/push/devices'
 
 function flag(name: string): string | undefined {
   const index = process.argv.indexOf(`--${name}`)
   return index === -1 ? undefined : process.argv[index + 1]
 }
 
-function has(name: string): boolean {
-  return process.argv.includes(`--${name}`)
-}
-
 /** `<dir>/<locale>.txt`, or English. A missing English file is fatal. */
-function loadBodies(dir: string): Map<Locale, string> {
-  const bodies = new Map<Locale, string>()
-  for (const locale of SUPPORTED_LOCALES) {
+function loadBodies(dir: string): Record<string, string> {
+  const bodies: Record<string, string> = {}
+  for (const locale of SUPPORTED_LOCALES as readonly Locale[]) {
     const path = join(dir, `${locale}.txt`)
-    if (existsSync(path)) bodies.set(locale, readFileSync(path, 'utf8').trim())
+    if (existsSync(path)) bodies[locale] = readFileSync(path, 'utf8').trim()
   }
-  if (!bodies.has('en')) throw new Error(`${dir}/en.txt is required — it is the fallback`)
+  if (!bodies.en) throw new Error(`${dir}/en.txt is required — it is the fallback`)
   return bodies
 }
 
 async function main(): Promise<void> {
   const slug = flag('id')
   const dir = flag('body')
-  if (!slug || !dir) {
-    throw new Error('usage: --id <slug> --body <dir> [--confirm]')
-  }
+  if (!slug || !dir) throw new Error('usage: --id <slug> --body <dir> [--confirm]')
 
-  /*
-   * No separate refusal for a live database. There was one, and it fired
-   * *before* the dry run — so the only way to preview an announcement against
-   * production was to arm the send at the same time, which is the opposite of
-   * what a preview is for. `--confirm` already gates every write; a second
-   * gate on the same flag only took the safe path away.
-   */
   const env = loadEnv()
-
   const bodies = loadBodies(dir)
   const { db, close } = await connectToDatabase(env.MONGODB_URI, env.MONGODB_DB)
 
   try {
-    // Fills the id cache `deliverOfficialMessage` reads. The API does this at
-    // boot; a script is its own process and has had no boot.
+    // Fills the id cache the queue reads. The API does this at boot; a script
+    // is its own process and has had no boot.
     const accounts = await ensureOfficialAccounts(db, publicApiUrl(env))
-    if (accounts.find((a) => a.handle === 'langx')?.outcome === 'conflict') {
+    if (accounts.find((account) => account.handle === 'langx')?.outcome === 'conflict') {
       throw new Error('@langx is held by a real account — nothing to send from')
     }
 
-    const recipients = await db
-      .collection<Profile>(COLLECTIONS.profiles)
-      .find(
-        { deletedAt: { $exists: false }, guest: { $exists: false }, official: { $exists: false } },
-        { projection: { _id: 1 } },
-      )
-      .toArray()
+    const existing = await getBroadcast(db, slug)
+    const job =
+      existing ??
+      (await createBroadcast(db, {
+        id: slug,
+        bodies,
+        pushTitle: 'LangX',
+        createdBy: 'script:send-announcement',
+      }))
 
     console.log(`announcement ${slug} on ${env.MONGODB_DB}`)
-    console.log(`  recipients: ${recipients.length}`)
-    console.log(`  locales: ${[...bodies.keys()].join(', ')}`)
-    console.log(`\n  en.txt:\n${bodies.get('en')!.slice(0, 300)}\n`)
+    console.log(`  status:     ${job.status}${existing ? ' (already queued — left as it is)' : ''}`)
+    console.log(`  recipients: ${job.total}`)
+    console.log(`  locales:    ${Object.keys(job.bodies).join(', ')}`)
+    console.log(`\n  en.txt:\n${job.bodies.en?.slice(0, 300) ?? ''}\n`)
 
-    if (!has('confirm')) {
-      console.log('(dry run — re-run with --confirm to send it)')
+    if (!process.argv.includes('--confirm')) {
+      console.log('(draft written — re-run with --confirm to arm it, or start it from the panel)')
       return
     }
 
-    const push = new ExpoPushSender(env.EXPO_ACCESS_TOKEN)
-    let sent = 0
-    let failed = 0
-
-    for (const recipient of recipients) {
-      try {
-        const locale = await localeFor(db, recipient._id)
-        const body = bodies.get(locale) ?? bodies.get('en')!
-        const delivered = await deliverOfficialMessage(db, {
-          fromHandle: 'langx',
-          toUserId: recipient._id,
-          body,
-          // Per recipient. `sender_client_id_unique` is on `{senderId,
-          // clientId}`, so one id for the whole announcement means the first
-          // person gets it and every other write is refused as a duplicate —
-          // and `deliverOfficialMessage` hands back the existing message, so
-          // it all looks like it worked. It did that once, to 25 people.
-          clientId: `announcement:${slug}:${recipient._id}`,
-        })
-        if (!delivered) continue
-        sent += 1
-
-        /*
-         * The knock, not the message. No socket broadcast beside it: whoever
-         * has the app open sees the thread on the next focus, and a script
-         * outside the API process has no `io` to emit on anyway.
-         *
-         * **One language for both**, and it is the reader's native one, not
-         * the phone's. `tokensByLocale` groups by device locale and is right
-         * for a streak nudge — that is a sentence written for the screen it
-         * appears on and nothing else. This one is a preview of a message
-         * sitting in a thread, and a Turkish notification opening a Russian
-         * message reads like two different senders. So the push follows
-         * `localeFor`, like the message and the welcome before it.
-         *
-         * Best-effort — a phone that cannot be reached does not undo a message
-         * that is already in the thread.
-         */
-        const tokens = await tokensFor(db, recipient._id)
-        if (tokens.length > 0) {
-          await sendPush(db, push, {
-            to: tokens,
-            title: 'LangX',
-            // The same words as the message, in the same language.
-            body: body.slice(0, 120),
-            data: {
-              kind: 'message',
-              conversationId: delivered.conversation._id.toHexString(),
-              senderId: delivered.message.senderId,
-            },
-          })
-        }
-      } catch (error) {
-        failed += 1
-        console.error(`  ${recipient._id}: ${String(error)}`)
-      }
-      if ((sent + failed) % 200 === 0) console.log(`  …${sent + failed}/${recipients.length}`)
-    }
-
-    console.log(`\nsent ${sent}, failed ${failed}. Re-running is safe: ${slug} is idempotent.`)
+    const armed = await setBroadcastStatus(db, slug, 'queued')
+    console.log(
+      armed
+        ? `armed. The API sends it from here, in batches, inside its send window.`
+        : `already past draft (${job.status}) — nothing to arm.`,
+    )
   } finally {
     await close()
   }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -24,6 +24,7 @@ import { cityRoutes } from './routes/cities'
 import { conversationRoutes } from './routes/conversations'
 import { discoveryRoutes } from './routes/discovery'
 import { feedRoutes } from './routes/feed'
+import { adminRoutes } from './routes/admin'
 import { feedbackRoutes } from './routes/feedback'
 import { followRoutes } from './routes/follows'
 import { likeRoutes } from './routes/likes'
@@ -320,6 +321,7 @@ export async function buildApp({
   await app.register(activityRoutes)
   await app.register(leaderboardRoutes)
   await app.register(moderationRoutes)
+  await app.register(adminRoutes)
   await app.register(accountRoutes)
   await app.register(emailRoutes)
   await app.register(feedbackRoutes)

--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -154,6 +154,12 @@ export const COLLECTIONS = {
   // ops
   /** A single document (`_id: 'current'`) — maintenance, min versions, feature flags. */
   appConfig: 'appConfig',
+  /**
+   * One document per in-app broadcast from `@langx`, worked through by the
+   * scheduler. No claim collection beside it — the message row is the claim.
+   * See `modules/admin/broadcast.ts`.
+   */
+  broadcastQueue: 'broadcastQueue',
   jobRuns: 'jobRuns',
   /**
    * One document per scheduled pass, holding its last run. A record, not a

--- a/apps/api/src/db/collections.ts
+++ b/apps/api/src/db/collections.ts
@@ -55,6 +55,13 @@ export const COLLECTIONS = {
    */
   follows: 'follows',
   reports: 'reports',
+  /**
+   * Bug reports and feature requests, as the queue the operator panel works
+   * through. The `_id` is the uuid `feedback/submit.ts` already mints for the
+   * emailed bounty link, so the row, the link and the ledger's `refId` are one
+   * string rather than three that have to be kept in step.
+   */
+  feedback: 'feedback',
   devices: 'devices',
   profileViews: 'profileViews',
   translationCache: 'translationCache',
@@ -148,6 +155,14 @@ export const COLLECTIONS = {
   /** A single document (`_id: 'current'`) — maintenance, min versions, feature flags. */
   appConfig: 'appConfig',
   jobRuns: 'jobRuns',
+  /**
+   * One document per scheduled pass, holding its last run. A record, not a
+   * lock — `jobRuns` is the lock, and the two must not be confused. See
+   * `modules/admin/jobHealth.ts`.
+   */
+  jobHealth: 'jobHealth',
+  /** Every mutating decision an operator made in the panel, append-only. */
+  adminActions: 'adminActions',
   /**
    * Socket.io's bus between API instances. Every emit is written here and
    * every instance tails it with a change stream, which is how a message sent

--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -790,6 +790,19 @@ export const INDEXES: Partial<IndexSpec> = {
     { key: { userId: 1 }, name: 'device_owner' },
   ],
 
+  [COLLECTIONS.feedback]: [
+    /*
+     * The triage queue, and **ascending** — the opposite of every other list
+     * here. Those are feeds, where the newest row is the interesting one; this
+     * is a queue, where the interesting row is the one that has been waiting
+     * longest. Sorting it the other way is how the oldest open report becomes
+     * the one nobody ever sees.
+     */
+    { key: { status: 1, createdAt: 1 }, name: 'status_created' },
+    // "What else has this person sent", and the path the account purge takes.
+    { key: { userId: 1, createdAt: -1 }, name: 'user_created' },
+  ],
+
   [COLLECTIONS.adminActions]: [
     /*
      * "What has been done to this account", which is the only question this

--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -126,6 +126,17 @@ export const INDEXES: Partial<IndexSpec> = {
      * scan every half hour.
      */
     { key: { 'stats.lastActiveAt': 1 }, name: 'last_active' },
+    /*
+     * "How many people joined today?" — the number the operator dashboard is
+     * opened for, and until this existed the only way to answer it was a
+     * collection scan. Nothing in `profiles` led with `createdAt`: the text
+     * index, the two discovery compounds and `last_active` all lead with
+     * something else, and Mongo will not skip-scan to reach a later field.
+     *
+     * It pays for itself twice. `publicStats.perDay` runs three of those scans
+     * every ten minutes for the public counters, and they land here now too.
+     */
+    { key: { createdAt: -1 }, name: 'joined' },
     /**
      * The Pro city filter, on the canonical id.
      *

--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -137,6 +137,16 @@ export const INDEXES: Partial<IndexSpec> = {
      * every ten minutes for the public counters, and they land here now too.
      */
     { key: { createdAt: -1 }, name: 'joined' },
+    /*
+     * The appeal queue. Partial because almost nobody has ever appealed, and
+     * an index entry per profile that never will is the whole collection for
+     * one screen.
+     */
+    {
+      key: { 'suspension.appeal.at': -1 },
+      name: 'appeal_recent',
+      partialFilterExpression: { 'suspension.appeal.at': { $exists: true } },
+    },
     /**
      * The Pro city filter, on the canonical id.
      *
@@ -780,6 +790,16 @@ export const INDEXES: Partial<IndexSpec> = {
     { key: { userId: 1 }, name: 'device_owner' },
   ],
 
+  [COLLECTIONS.adminActions]: [
+    /*
+     * "What has been done to this account", which is the only question this
+     * collection is ever asked and the whole reason it is written. No TTL: a
+     * suspension has to stay explicable long after the person has stopped
+     * asking, and a decision is not the subject's data to expire.
+     */
+    { key: { subjectUserId: 1, at: -1 }, name: 'subject_recent' },
+    { key: { at: -1 }, name: 'recent' },
+  ],
   [COLLECTIONS.jobRuns]: [
     // The only defence against a double-run cron distributing the pool twice.
     { key: { job: 1, periodKey: 1 }, name: 'job_period_unique', unique: true },

--- a/apps/api/src/db/indexes.ts
+++ b/apps/api/src/db/indexes.ts
@@ -790,6 +790,15 @@ export const INDEXES: Partial<IndexSpec> = {
     { key: { userId: 1 }, name: 'device_owner' },
   ],
 
+  [COLLECTIONS.broadcastQueue]: [
+    /*
+     * "Is anything waiting?", asked twice a minute by the scheduler. The slug
+     * is the `_id`, so the uniqueness that matters — one broadcast per slug —
+     * needs no index of its own.
+     */
+    { key: { status: 1, createdAt: 1 }, name: 'status_created' },
+  ],
+
   [COLLECTIONS.feedback]: [
     /*
      * The triage queue, and **ascending** — the opposite of every other list

--- a/apps/api/src/email/bountyToken.ts
+++ b/apps/api/src/email/bountyToken.ts
@@ -5,11 +5,12 @@ import { createHmac, timingSafeEqual } from 'node:crypto'
  * finder.
  *
  * Signed rather than stored, unlike `deletionTokens.ts`, because there is
- * nothing to store: a report leaves no row, and the thing that must not
- * happen twice — the payout — is already made impossible twice over by the
- * ledger's unique `{userId, kind, refId}` index. `reportId` is that `refId`,
- * so opening the link again pays nothing and says so, and a forwarded mail
- * cannot pay a second time either.
+ * nothing to store *about the token*: the thing that must not happen twice —
+ * the payout — is already impossible twice over through the ledger's unique
+ * `{userId, kind, refId}` index. `reportId` is that `refId`, and it is also
+ * the `_id` of the report's row in `feedback`, so opening the link again pays
+ * nothing and says so, a forwarded mail cannot pay a second time, and neither
+ * can the operator panel, which reaches the same ledger row by the same id.
  *
  * **It is a capability: whoever holds the link can pay this one reporter, once,
  * within the range in `BOUNTY_MIN`/`MAX`.** That is the same trade the

--- a/apps/api/src/middleware/requireAuth.ts
+++ b/apps/api/src/middleware/requireAuth.ts
@@ -21,6 +21,12 @@ declare module 'fastify' {
     emailVerified: boolean
     /** Set by requireAuth. A guest browsing without an account of their own. */
     isGuest: boolean
+    /**
+     * Set by requireAuth, from the same projected read the suspension check
+     * already makes. Always defined on a route behind that guard, and always
+     * `false` on the two a suspended account may still reach.
+     */
+    isAdmin: boolean
   }
 }
 
@@ -53,6 +59,12 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply):
   // `isAnonymous` is declared by the plugin with `input: false`, so a client
   // cannot assert it — it is only ever true because Better Auth made the user.
   request.isGuest = (session.user as { isAnonymous?: boolean }).isAnonymous === true
+  /*
+   * Set before the early return below, so the two routes a suspended account
+   * may reach leave it defined rather than undefined. Neither is an admin
+   * route, and a suspended admin is refused by the branch under it anyway.
+   */
+  request.isAdmin = false
 
   /*
    * Suspension is enforced here rather than route by route, because "every
@@ -72,8 +84,15 @@ export async function requireAuth(request: FastifyRequest, reply: FastifyReply):
 
   const profile = await request.server.mongo.db
     .collection<Profile>(COLLECTIONS.profiles)
-    .findOne({ _id: request.userId }, { projection: { suspension: 1 } })
+    .findOne({ _id: request.userId }, { projection: { suspension: 1, admin: 1 } })
   const suspension = profile?.suspension
+  /*
+   * One more field on a read that was already being made, rather than a
+   * lookup of its own in `requireAdmin`: the panel costs no extra round trip,
+   * and the flag cannot be true for an account this guard has not just seen.
+   */
+  request.isAdmin = profile?.admin === true
+
   if (suspension && isSuspended(profile)) {
     const body: ApiErrorBody = {
       code: ERROR_CODES.ACCOUNT_SUSPENDED,
@@ -156,5 +175,30 @@ export async function requireVerifiedEmail(
       message: 'Verify your email first',
     }
     return reply.code(ERROR_STATUS.EMAIL_NOT_VERIFIED).send(body)
+  }
+}
+
+/**
+ * Layer on top of `requireAuth` for the operator panel.
+ *
+ * The order the three refusals come in is the point. Unauthenticated is
+ * answered first, then suspension — so a suspended moderator is told they are
+ * suspended and cannot moderate their way out of it — and only then this. A
+ * guest reaches it and is answered with `ADMIN_REQUIRED` rather than
+ * `GUEST_ACCOUNT`: that code is an offer ("create an account"), and there is
+ * nothing here to offer.
+ *
+ * `ADMIN_USER_IDS` is deliberately not consulted. That env var lets an id
+ * through the maintenance gate when the database may itself be the problem
+ * (`middleware/maintenance.ts`); it is not an authorisation primitive, and
+ * reading it here would make who can moderate depend on a redeploy.
+ */
+export async function requireAdmin(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  await requireAuth(request, reply)
+  if (reply.sent) return
+
+  if (!request.isAdmin) {
+    const body: ApiErrorBody = { code: ERROR_CODES.ADMIN_REQUIRED, message: 'Not available' }
+    return reply.code(ERROR_STATUS.ADMIN_REQUIRED).send(body)
   }
 }

--- a/apps/api/src/modules/account/deletion.ts
+++ b/apps/api/src/modules/account/deletion.ts
@@ -242,11 +242,11 @@ export async function purgeExpiredAccounts(
     }
 
     /*
-     * The one kind of file no row points at. A bug report goes to an email
-     * and into no table of ours — see `routes/feedback.ts` for why — so the
-     * sweep above cannot reach its attachments however carefully it reads.
-     * The prefix is the only handle the upload kept, which is why it chose
-     * one — and until this, nothing had ever used it.
+     * The one kind of file the sweep above cannot reach. A bug report's row
+     * does carry its attachment URLs, but that row is deleted by this same
+     * purge and the ordering between the two is not worth depending on — so
+     * the handle this uses is the prefix the upload chose, which is why it
+     * chose one.
      *
      * Its own capability check, outside the block above: listing objects and
      * writing them are separate things a provider may or may not do.

--- a/apps/api/src/modules/account/deletion.ts
+++ b/apps/api/src/modules/account/deletion.ts
@@ -368,6 +368,10 @@ export async function purgeExpiredAccounts(
       // Better Auth's own rows. Deleting the `user` document is what makes the
       // email reusable and the account genuinely gone rather than orphaned.
       db.collection(COLLECTIONS.session).deleteMany({ userId: authId(userId) }),
+      // A bug report carries its author's prose, so it goes with them. The
+      // `adminActions` rows about this account deliberately do not: those are
+      // the record of a decision we made, not data we hold about a person.
+      db.collection(COLLECTIONS.feedback).deleteMany({ userId }),
       db.collection(COLLECTIONS.account).deleteMany({ userId: authId(userId) }),
       db.collection(COLLECTIONS.user).deleteOne({ _id: authId(userId) as unknown as never }),
       // In the same breath as the rows, because after this there is no

--- a/apps/api/src/modules/account/purgeScheduler.ts
+++ b/apps/api/src/modules/account/purgeScheduler.ts
@@ -5,6 +5,7 @@ import type { PersonDeleter } from '../analytics/personDeleter'
 import { drainAnalyticsDeletions } from './analyticsDeletions'
 import { purgeExpiredAccounts } from './deletion'
 import { purgeStaleGuests } from '../profiles/purgeGuests'
+import { withJobHealth } from '../admin/jobHealth'
 
 /** Hourly is plenty — the grace period is 30 days, nothing here is urgent. */
 export const PURGE_INTERVAL_MS = 60 * 60 * 1000
@@ -29,39 +30,45 @@ export function startPurgeScheduler(
     if (running) return
     running = true
     try {
-      const result = await purgeExpiredAccounts(db, {
-        ...(options.storage ? { storage: options.storage } : {}),
-      })
-      if (result.purged > 0) {
-        logger.info(
-          { purged: result.purged, objectsDeleted: result.objectsDeleted },
-          'expired accounts purged',
-        )
-      }
-
-      // Guest sessions ride the same tick rather than a second scheduler: the
-      // question is the same shape ("is anything past its cutoff?") and neither
-      // is urgent.
-      const guests = await purgeStaleGuests(db)
-      if (guests.purged > 0) {
-        logger.info({ purged: guests.purged }, 'stale guest sessions purged')
-      }
-
-      /*
-       * The deletions the purge above recorded, plus anything an earlier tick
-       * could not send. Last in the tick and after the accounts, so a PostHog
-       * outage delays the analytics half and never the account half — the
-       * queue exists precisely so those two can fail apart.
-       *
-       * Unconfigured means leave it alone, not "nothing to do": an instance
-       * that gains a key later still owes what it recorded without one.
-       */
-      if (options.analytics) {
-        const analytics = await drainAnalyticsDeletions(db, options.analytics)
-        if (analytics.deleted > 0 || analytics.failed > 0) {
-          logger.info(analytics, 'analytics person deletions drained')
+      // One record for the whole tick. Its three halves fail apart on purpose
+      // (see the note on the analytics drain below), but they run or do not
+      // run together, and that is what a health row is asked about.
+      await withJobHealth(db, 'purge', async () => {
+        const result = await purgeExpiredAccounts(db, {
+          ...(options.storage ? { storage: options.storage } : {}),
+        })
+        if (result.purged > 0) {
+          logger.info(
+            { purged: result.purged, objectsDeleted: result.objectsDeleted },
+            'expired accounts purged',
+          )
         }
-      }
+
+        // Guest sessions ride the same tick rather than a second scheduler: the
+        // question is the same shape ("is anything past its cutoff?") and neither
+        // is urgent.
+        const guests = await purgeStaleGuests(db)
+        if (guests.purged > 0) {
+          logger.info({ purged: guests.purged }, 'stale guest sessions purged')
+        }
+
+        /*
+         * The deletions the purge above recorded, plus anything an earlier tick
+         * could not send. Last in the tick and after the accounts, so a PostHog
+         * outage delays the analytics half and never the account half — the
+         * queue exists precisely so those two can fail apart.
+         *
+         * Unconfigured means leave it alone, not "nothing to do": an instance
+         * that gains a key later still owes what it recorded without one.
+         */
+        if (options.analytics) {
+          const analytics = await drainAnalyticsDeletions(db, options.analytics)
+          if (analytics.deleted > 0 || analytics.failed > 0) {
+            logger.info(analytics, 'analytics person deletions drained')
+          }
+        }
+        return { purged: result.purged, guests: guests.purged }
+      })
     } catch (error) {
       logger.error({ err: error }, 'account purge failed')
     } finally {

--- a/apps/api/src/modules/admin/auditLog.ts
+++ b/apps/api/src/modules/admin/auditLog.ts
@@ -1,0 +1,74 @@
+import type { AdminActionName } from '@langx/shared'
+import type { Db, ObjectId } from 'mongodb'
+import type { FastifyBaseLogger } from 'fastify'
+import { COLLECTIONS } from '../../db/collections'
+
+/**
+ * What an operator did, kept.
+ *
+ * The emailed flow left a trace by accident: the decision, the reasoning and
+ * the person were all in a mail thread that nobody deletes. A panel replaces
+ * that with nothing at all, so the trace has to be written on purpose or a
+ * suspension becomes unexplainable a year later — which is exactly when
+ * somebody asks.
+ *
+ * Append-only, no TTL, and **not purged when the subject deletes their
+ * account**. What is stored about them is an opaque id; the row is the record
+ * of a decision we made, not data we hold about a person.
+ */
+export interface AdminAction {
+  _id: ObjectId
+  adminId: string
+  action: AdminActionName
+  /** Who it was about, when it was about somebody. */
+  subjectUserId?: string
+  /** The report, feedback row or broadcast it concerned. */
+  refId?: string
+  /** Days, amounts, reasons — never a message body. */
+  payload?: Record<string, unknown>
+  at: Date
+}
+
+/**
+ * Records an action **after** it succeeded, and never fails the route.
+ *
+ * Best-effort on purpose, and the reason is worth keeping in front of whoever
+ * changes this: the repository functions underneath are shared with the
+ * emailed flow, which has no admin to name. By the time this is called the
+ * suspension is already written. An audit write that could throw would turn a
+ * decision that landed into a 500 that invites the button being pressed again.
+ */
+export async function recordAdminAction(
+  db: Db,
+  log: FastifyBaseLogger,
+  entry: Omit<AdminAction, '_id' | 'at'>,
+): Promise<void> {
+  try {
+    await db.collection<AdminAction>(COLLECTIONS.adminActions).insertOne({
+      ...entry,
+      at: new Date(),
+    } as AdminAction)
+  } catch (error) {
+    log.warn({ err: error, action: entry.action }, 'admin action not recorded')
+  }
+}
+
+/**
+ * What has been done to one account, newest first.
+ *
+ * Read by the user screen, because an audit log nobody reads is theatre —
+ * the point of writing it is that the next question about this account has an
+ * answer on the same screen as the account.
+ */
+export async function readAdminActions(
+  db: Db,
+  subjectUserId: string,
+  limit = 20,
+): Promise<AdminAction[]> {
+  return db
+    .collection<AdminAction>(COLLECTIONS.adminActions)
+    .find({ subjectUserId })
+    .sort({ at: -1 })
+    .limit(limit)
+    .toArray()
+}

--- a/apps/api/src/modules/admin/broadcast.ts
+++ b/apps/api/src/modules/admin/broadcast.ts
@@ -1,0 +1,139 @@
+import type { BroadcastStatus, Locale } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { notSuspended } from '../moderation/suspension'
+import type { Profile } from '../profiles/profiles'
+
+/**
+ * One message from `@langx` to everybody, as a queued job the API works
+ * through rather than a loop on somebody's laptop.
+ *
+ * `scripts/send-announcement.ts` did this well enough to keep its doctrine
+ * whole — the idempotency, the per-locale bodies, the push as a knock rather
+ * than the message — and badly in exactly two ways: the machine had to stay
+ * awake, and there was no pacing at all. This is the same send, moved into the
+ * scheduler.
+ *
+ * **No claim collection**, unlike `campaignQueue`. That one needs
+ * `emailCampaigns` because an SMTP send leaves no row we own, so there is
+ * nothing to ask afterwards whether a person was already written to. A chat
+ * message *is* the row: `messages.sender_client_id_unique` on
+ * `{senderId, clientId}` refuses the second write for a recipient and lets
+ * every other one through. The cursor below paces the work; that index is what
+ * makes it exactly once.
+ */
+export interface BroadcastJob {
+  /** The slug. Being the primary key is what stops the same one running twice. */
+  _id: string
+  /** One body per locale; `en` is required and is the fallback. */
+  bodies: Record<string, string>
+  pushTitle: string
+  status: BroadcastStatus
+  createdAt: Date
+  createdBy: string
+  startedAt?: Date
+  finishedAt?: Date
+  /** The audience counted at create — a number to watch progress against. */
+  total: number
+  sent: number
+  failed: number
+  /**
+   * The highest profile `_id` delivered to. Paging by primary key needs no
+   * index and resumes after a crash; the batch that was in flight is simply
+   * retried, and the clientId index refuses its duplicates.
+   */
+  cursorUserId?: string
+}
+
+/**
+ * Who a broadcast goes to.
+ *
+ * The script's filter plus `notSuspended()`, which it did not have. Pushing an
+ * announcement at somebody we suspended last week is the wrong call, and
+ * `requireAuth` would refuse them the app it invited them into.
+ */
+export function broadcastAudience(now: Date = new Date()) {
+  return {
+    deletedAt: { $exists: false },
+    guest: { $exists: false },
+    official: { $exists: false },
+    ...notSuspended(now),
+  }
+}
+
+export function broadcasts(db: Db) {
+  return db.collection<BroadcastJob>(COLLECTIONS.broadcastQueue)
+}
+
+export async function countBroadcastAudience(db: Db, now: Date = new Date()): Promise<number> {
+  return db.collection<Profile>(COLLECTIONS.profiles).countDocuments(broadcastAudience(now))
+}
+
+export async function createBroadcast(
+  db: Db,
+  input: { id: string; bodies: Record<string, string>; pushTitle: string; createdBy: string },
+  now: Date = new Date(),
+): Promise<BroadcastJob> {
+  const job: BroadcastJob = {
+    _id: input.id,
+    bodies: input.bodies,
+    pushTitle: input.pushTitle,
+    // A draft sends nothing. Starting it is a second, separate request — which
+    // is the only reason a back button or a double tap cannot broadcast.
+    status: 'draft',
+    createdAt: now,
+    createdBy: input.createdBy,
+    total: await countBroadcastAudience(db, now),
+    sent: 0,
+    failed: 0,
+  }
+  await broadcasts(db).insertOne(job)
+  return job
+}
+
+export async function listBroadcasts(db: Db, limit = 20): Promise<BroadcastJob[]> {
+  return broadcasts(db).find({}).sort({ createdAt: -1 }).limit(limit).toArray()
+}
+
+export async function getBroadcast(db: Db, id: string): Promise<BroadcastJob | null> {
+  return broadcasts(db).findOne({ _id: id })
+}
+
+/**
+ * The state machine, as a table rather than a pile of conditionals.
+ *
+ * `done` is terminal and only the queue writes it. Everything else is the
+ * operator: arm a draft, stop a send, let it go again.
+ */
+const ALLOWED: Record<string, BroadcastStatus[]> = {
+  draft: ['queued'],
+  queued: ['paused'],
+  sending: ['paused'],
+  paused: ['queued'],
+}
+
+export async function setBroadcastStatus(
+  db: Db,
+  id: string,
+  next: BroadcastStatus,
+): Promise<BroadcastJob | null> {
+  const job = await getBroadcast(db, id)
+  if (!job) return null
+  if (!ALLOWED[job.status]?.includes(next)) return null
+  return broadcasts(db).findOneAndUpdate(
+    { _id: id, status: job.status },
+    { $set: { status: next } },
+    { returnDocument: 'after' },
+  )
+}
+
+/** Only while it is a draft: once it has been armed there may be messages out. */
+export async function deleteBroadcast(db: Db, id: string): Promise<boolean> {
+  const { deletedCount } = await broadcasts(db).deleteOne({ _id: id, status: 'draft' })
+  return deletedCount > 0
+}
+
+/** The body for one reader, in their own language, falling back to English. */
+export function bodyFor(job: BroadcastJob, locale: Locale): string {
+  return job.bodies[locale] ?? job.bodies.en ?? ''
+}

--- a/apps/api/src/modules/admin/broadcastQueue.test.ts
+++ b/apps/api/src/modules/admin/broadcastQueue.test.ts
@@ -1,0 +1,223 @@
+import { SUSPENSION_FOREVER } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { connectToDatabase, type DbHandle } from '../../db/client'
+import { COLLECTIONS } from '../../db/collections'
+import { ensureIndexes } from '../../db/indexes'
+import { createBroadcast, broadcasts, setBroadcastStatus } from './broadcast'
+import { runBroadcastQueuePass } from './broadcastQueue'
+import { ensureOfficialAccounts } from '../official/accounts'
+import type { Profile } from '../profiles/profiles'
+import type { PushSender } from '../push/devices'
+
+/** Nothing is registered for push in here, so this is never asked to send. */
+const push: PushSender = {
+  send: () => Promise.resolve({ invalidTokens: [] }),
+}
+
+/** Inside `BROADCAST_SEND_WINDOW_UTC`, which is the only clock this cares about. */
+const NOON = new Date('2026-09-13T12:00:00.000Z')
+const HALF_PAST = new Date('2026-09-13T12:30:00.000Z')
+
+describe('the in-app broadcast queue', () => {
+  let replSet: MongoMemoryReplSet
+  let handle: DbHandle
+  let db: Db
+
+  /**
+   * Profiles written straight in rather than onboarded: this exercises the
+   * queue, and a page of real sign-ups would be a minute of setup for a fact
+   * none of these tests are about.
+   */
+  async function member(id: string, overrides: Partial<Profile> = {}): Promise<string> {
+    await db.collection<Profile>(COLLECTIONS.profiles).insertOne({
+      _id: id,
+      handle: id,
+      displayName: id,
+      gender: 'undisclosed',
+      nativeLanguages: [{ code: 'en' }],
+      learning: [{ code: 'tr', level: 'beginner', priority: 1 }],
+      settings: { discoverable: true },
+      stats: { lastActiveAt: NOON, messagesSent: 0 },
+      createdAt: NOON,
+      updatedAt: NOON,
+      ...overrides,
+    } as Profile)
+    return id
+  }
+
+  const messagesSent = () =>
+    db.collection(COLLECTIONS.messages).countDocuments({ type: { $ne: 'system' } })
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+    handle = await connectToDatabase(replSet.getUri(), 'langx_broadcast_test')
+    db = handle.db
+    await ensureIndexes(db)
+    await ensureOfficialAccounts(db, 'http://localhost:4000')
+  }, 120_000)
+
+  afterAll(async () => {
+    await handle?.close()
+    await replSet?.stop()
+  })
+
+  beforeEach(async () => {
+    await Promise.all([
+      broadcasts(db).deleteMany({}),
+      db.collection(COLLECTIONS.jobRuns).deleteMany({}),
+      db.collection(COLLECTIONS.messages).deleteMany({}),
+      db.collection(COLLECTIONS.conversations).deleteMany({}),
+      db.collection<Profile>(COLLECTIONS.profiles).deleteMany({ official: { $exists: false } }),
+    ])
+  })
+
+  it('sends to everybody once, and only once, however often the pass runs', async () => {
+    await Promise.all([member('anna'), member('bruno'), member('carla')])
+    await createBroadcast(db, {
+      id: 'hello',
+      bodies: { en: 'Something new' },
+      pushTitle: 'LangX',
+      createdBy: 'test',
+    })
+    await setBroadcastStatus(db, 'hello', 'queued')
+
+    expect(await runBroadcastQueuePass(db, push, NOON)).toEqual({ sent: 3 })
+    expect(await messagesSent()).toBe(3)
+
+    /*
+     * The same tick again. The `jobRuns` lock is what refuses it — two API
+     * instances reach this together and only one does the work.
+     */
+    expect(await runBroadcastQueuePass(db, push, NOON)).toEqual({ sent: 0 })
+    expect(await messagesSent()).toBe(3)
+
+    // A later tick finds nobody past the cursor and finishes.
+    expect(await runBroadcastQueuePass(db, push, HALF_PAST)).toEqual({ sent: 0 })
+    expect(await messagesSent()).toBe(3)
+    expect((await broadcasts(db).findOne({ _id: 'hello' }))?.status).toBe('done')
+  })
+
+  it('is exactly once even when a batch is replayed from the start', async () => {
+    await Promise.all([member('dora'), member('emil')])
+    await createBroadcast(db, {
+      id: 'replay',
+      bodies: { en: 'Twice would be wrong' },
+      pushTitle: 'LangX',
+      createdBy: 'test',
+    })
+    await setBroadcastStatus(db, 'replay', 'queued')
+    await runBroadcastQueuePass(db, push, NOON)
+    expect(await messagesSent()).toBe(2)
+
+    /*
+     * A crash between the sends and the cursor write, simulated: the cursor is
+     * rolled back and the next tick walks the same people again. Every write is
+     * refused by `messages.sender_client_id_unique`, so this is the assertion
+     * that the clientId carries the recipient — with one shared id the first
+     * person would be messaged and the rest silently skipped, which is what
+     * happened once, to 25 people.
+     *
+     * Asserted on the message count rather than on what the pass returned:
+     * `deliverOfficialMessage` hands back the message it found, so a duplicate
+     * looks like a success from the caller's side.
+     */
+    await broadcasts(db).updateOne(
+      { _id: 'replay' },
+      { $unset: { cursorUserId: '' }, $set: { sent: 0 } },
+    )
+    await runBroadcastQueuePass(db, push, HALF_PAST)
+    expect(await messagesSent()).toBe(2)
+  })
+
+  it('leaves out guests, suspended, deleted and official accounts', async () => {
+    await Promise.all([
+      member('real'),
+      member('guest', { guest: true }),
+      member('gone', { deletedAt: NOON }),
+      member('banned', {
+        suspension: {
+          at: NOON,
+          until: new Date(SUSPENSION_FOREVER),
+          permanent: true,
+          reason: 'spam',
+        },
+      }),
+    ])
+    await createBroadcast(db, {
+      id: 'narrow',
+      bodies: { en: 'Only for the living' },
+      pushTitle: 'LangX',
+      createdBy: 'test',
+    })
+    await setBroadcastStatus(db, 'narrow', 'queued')
+
+    expect(await runBroadcastQueuePass(db, push, NOON)).toEqual({ sent: 1 })
+    const recipients = await db
+      .collection<{ participants?: string[] }>(COLLECTIONS.conversations)
+      .find({})
+      .toArray()
+    expect(recipients.flatMap((row) => row.participants ?? []).includes('banned')).toBe(false)
+  })
+
+  it('sends nothing while it is a draft, and nothing once it is paused', async () => {
+    await member('frida')
+    await createBroadcast(db, {
+      id: 'held',
+      bodies: { en: 'Not yet' },
+      pushTitle: 'LangX',
+      createdBy: 'test',
+    })
+
+    // A draft is invisible to the queue: arming it is a separate request, which
+    // is the whole reason a stray tap cannot broadcast.
+    expect(await runBroadcastQueuePass(db, push, NOON)).toEqual({ sent: 0 })
+    expect(await messagesSent()).toBe(0)
+
+    await setBroadcastStatus(db, 'held', 'queued')
+    await setBroadcastStatus(db, 'held', 'paused')
+    expect(await runBroadcastQueuePass(db, push, HALF_PAST)).toEqual({ sent: 0 })
+    expect(await messagesSent()).toBe(0)
+  })
+
+  it('sends nothing outside the window, without consuming the tick', async () => {
+    await member('greta')
+    await createBroadcast(db, {
+      id: 'night',
+      bodies: { en: 'Not at 3am' },
+      pushTitle: 'LangX',
+      createdBy: 'test',
+    })
+    await setBroadcastStatus(db, 'night', 'queued')
+
+    const threeAm = new Date('2026-09-13T03:00:00.000Z')
+    expect(await runBroadcastQueuePass(db, push, threeAm)).toEqual({ sent: 0 })
+    expect(await db.collection(COLLECTIONS.jobRuns).countDocuments({ job: 'broadcastQueue' })).toBe(
+      0,
+    )
+    expect(await runBroadcastQueuePass(db, push, NOON)).toEqual({ sent: 1 })
+  })
+
+  it('writes each recipient the body in their own language, English otherwise', async () => {
+    await Promise.all([
+      member('turk', { nativeLanguages: [{ code: 'tr' }] }),
+      member('greek', { nativeLanguages: [{ code: 'el' }] }),
+    ])
+    await createBroadcast(db, {
+      id: 'localised',
+      bodies: { en: 'Hello', tr: 'Merhaba' },
+      pushTitle: 'LangX',
+      createdBy: 'test',
+    })
+    await setBroadcastStatus(db, 'localised', 'queued')
+    await runBroadcastQueuePass(db, push, NOON)
+
+    const bodies = await db
+      .collection<{ body: string }>(COLLECTIONS.messages)
+      .find({})
+      .map((row) => row.body)
+      .toArray()
+    expect(bodies.sort()).toEqual(['Hello', 'Merhaba'])
+  })
+})

--- a/apps/api/src/modules/admin/broadcastQueue.ts
+++ b/apps/api/src/modules/admin/broadcastQueue.ts
@@ -1,0 +1,198 @@
+import { broadcastTickShare, utcDayKey } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { bodyFor, broadcastAudience, broadcasts, type BroadcastJob } from './broadcast'
+import { deliverOfficialMessage } from '../official/deliver'
+import { localeFor } from '../profiles/localeFor'
+import type { Profile } from '../profiles/profiles'
+import { sendPush, tokensFor, type PushSender } from '../push/devices'
+import type { SchedulerLogger } from '../tokens/poolScheduler'
+import type { JobRun } from '../tokens/pool'
+
+/**
+ * One tick of the in-app broadcast queue.
+ *
+ * The loop is `scripts/send-announcement.ts`'s, comments and all, with three
+ * things the script could not have: a pace, a cursor, and somewhere to stop.
+ *
+ * **The idempotency is the clientId and nothing else.** Each recipient's
+ * message carries `broadcast:<slug>:<userId>`, and
+ * `messages.sender_client_id_unique` is on `{senderId, clientId}` — so a
+ * second write for that person is refused while everybody else's goes
+ * through. The id has to carry the recipient: without it the first person is
+ * messaged and every other write is refused as a duplicate, which looks like
+ * success from here because `deliverOfficialMessage` hands back the message it
+ * found. It did that once, to 25 people.
+ */
+export async function runBroadcastQueuePass(
+  db: Db,
+  push: PushSender,
+  now: Date = new Date(),
+  options: { logger?: SchedulerLogger } = {},
+): Promise<{ sent: number; failed?: number }> {
+  // Whatever is already going, before whatever is waiting: two half-sent
+  // broadcasts would each take half the pace and both arrive late.
+  const job =
+    (await broadcasts(db).findOne({ status: 'sending' }, { sort: { createdAt: 1 } })) ??
+    (await broadcasts(db).findOne({ status: 'queued' }, { sort: { createdAt: 1 } }))
+  if (!job) return { sent: 0 }
+
+  const share = broadcastTickShare(now)
+  if (share <= 0) return { sent: 0 } // outside the sending window
+
+  /*
+   * The tick lock, on the collection that already is one. Two API instances
+   * reach this at the same moment; the first to insert owns the tick and the
+   * second returns having done nothing. Note that this is a *pace* lock, not a
+   * correctness one — correctness is the clientId index, which is why a lost
+   * lock costs nothing but a slower minute.
+   */
+  const tickKey = `${job._id}:${utcDayKey(now)}:${now.getUTCHours()}:${now.getUTCMinutes() < 30 ? '00' : '30'}`
+  try {
+    await db
+      .collection<JobRun>(COLLECTIONS.jobRuns)
+      .insertOne({ job: 'broadcastQueue', periodKey: tickKey, startedAt: now })
+  } catch (error) {
+    if ((error as { code?: number }).code === 11000) return { sent: 0 }
+    throw error
+  }
+
+  if (job.status !== 'sending') {
+    await broadcasts(db).updateOne(
+      { _id: job._id, status: 'queued' },
+      { $set: { status: 'sending', startedAt: job.startedAt ?? now } },
+    )
+  }
+
+  const recipients = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .find(
+      {
+        ...broadcastAudience(now),
+        ...(job.cursorUserId ? { _id: { $gt: job.cursorUserId } } : {}),
+      },
+      { projection: { _id: 1 }, sort: { _id: 1 }, limit: share },
+    )
+    .toArray()
+
+  if (recipients.length === 0) {
+    await broadcasts(db).updateOne({ _id: job._id }, { $set: { status: 'done', finishedAt: now } })
+    options.logger?.info({ broadcast: job._id, sent: job.sent }, 'broadcast finished')
+    return { sent: 0 }
+  }
+
+  let sent = 0
+  let failed = 0
+  for (const recipient of recipients) {
+    try {
+      if (await deliver(db, push, job, recipient._id)) sent += 1
+    } catch (error) {
+      failed += 1
+      options.logger?.warn(
+        { err: error, broadcast: job._id, userId: recipient._id },
+        'broadcast delivery failed',
+      )
+    }
+  }
+
+  /*
+   * The cursor moves once the batch is done rather than per recipient. A crash
+   * mid-batch therefore re-sends that batch on the next tick, and every
+   * message in it is refused as a duplicate — which is the cheap half of the
+   * trade, and the reason there is no ledger here.
+   */
+  const last = recipients.at(-1)?._id
+  await broadcasts(db).updateOne(
+    { _id: job._id },
+    {
+      $inc: { sent, failed },
+      ...(last ? { $set: { cursorUserId: last } } : {}),
+    },
+  )
+  return { sent, ...(failed > 0 ? { failed } : {}) }
+}
+
+async function deliver(
+  db: Db,
+  push: PushSender,
+  job: BroadcastJob,
+  userId: string,
+): Promise<boolean> {
+  const body = bodyFor(job, await localeFor(db, userId))
+  const delivered = await deliverOfficialMessage(db, {
+    fromHandle: 'langx',
+    toUserId: userId,
+    body,
+    clientId: `broadcast:${job._id}:${userId}`,
+  })
+  if (!delivered) return false
+
+  /*
+   * The knock, not the message. Deliberately not `fanOutMessage`: that calls
+   * `respondAsOfficial` — which would hand @langx its own announcement to
+   * reply to — and does a cross-instance `fetchSockets` per recipient, five
+   * hundred of those a tick with a five-second adapter timeout each. Whoever
+   * has the app open sees the thread on the next focus, which is what the
+   * script did too.
+   *
+   * **One language for both**, and it is the reader's native one rather than
+   * the phone's: a Turkish notification opening a Russian message reads like
+   * two different senders.
+   *
+   * Best-effort — a phone that cannot be reached does not undo a message that
+   * is already in the thread.
+   */
+  const tokens = await tokensFor(db, userId)
+  if (tokens.length > 0) {
+    await sendPush(db, push, {
+      to: tokens,
+      title: job.pushTitle,
+      body: body.slice(0, 120),
+      data: {
+        kind: 'message',
+        conversationId: delivered.conversation._id.toHexString(),
+        senderId: delivered.message.senderId,
+      },
+    })
+  }
+  return true
+}
+
+/**
+ * Sends one broadcast to one person — the operator, before arming it.
+ *
+ * The only preview that catches a broken line break in the Turkish body
+ * before five thousand people get it: the real font, the real thread, the real
+ * push. Its own clientId, so testing does not consume the recipient's real
+ * copy when the broadcast goes out for real.
+ */
+export async function sendBroadcastTest(
+  db: Db,
+  push: PushSender,
+  job: BroadcastJob,
+  toUserId: string,
+): Promise<boolean> {
+  const body = bodyFor(job, await localeFor(db, toUserId))
+  const delivered = await deliverOfficialMessage(db, {
+    fromHandle: 'langx',
+    toUserId,
+    body,
+    clientId: `broadcast:${job._id}:test:${toUserId}`,
+  })
+  if (!delivered) return false
+
+  const tokens = await tokensFor(db, toUserId)
+  if (tokens.length > 0) {
+    await sendPush(db, push, {
+      to: tokens,
+      title: job.pushTitle,
+      body: body.slice(0, 120),
+      data: {
+        kind: 'message',
+        conversationId: delivered.conversation._id.toHexString(),
+        senderId: delivered.message.senderId,
+      },
+    })
+  }
+  return true
+}

--- a/apps/api/src/modules/admin/jobHealth.ts
+++ b/apps/api/src/modules/admin/jobHealth.ts
@@ -1,0 +1,103 @@
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+
+/**
+ * When each scheduled pass last ran, and whether it worked.
+ *
+ * Two of the schedulers already leave a trace — `dailyPool` and
+ * `campaignQueue` write to `jobRuns` — but that collection's unique
+ * `{job, periodKey}` is a **lock**: the first inserter owns the tick. Giving
+ * the other passes a row there would hand them lock semantics they were never
+ * written for, and quietly change which instance runs what.
+ *
+ * So this is a record and only a record. One document per job, keyed by its
+ * name, overwritten every run. It grants nothing, guards nothing, and cannot
+ * change behaviour by being absent — which is the point, because it wraps
+ * passes that must keep working if this write fails.
+ *
+ * It exists because the alternative is what we had: a pass that stops firing
+ * says nothing at all, and the first sign is somebody asking why they stopped
+ * getting streak reminders.
+ */
+export interface JobHealth {
+  /** The pass's name, as the scheduler calls it. */
+  _id: string
+  lastStartedAt: Date
+  lastFinishedAt?: Date
+  lastDurationMs?: number
+  /** Whatever the pass returned, when that was an object — usually `{ sent }`. */
+  lastResult?: Record<string, unknown>
+  /** The message from the last run that threw, cleared by the next that does not. */
+  lastError?: string | null
+  /** Runs since this collection existed, failed ones included. */
+  runs: number
+  failures: number
+}
+
+/**
+ * Runs a pass and records what happened to it.
+ *
+ * Rethrows, so the caller's own error handling is unchanged — every scheduler
+ * already catches, logs and carries on, and this must not take that over. Its
+ * own writes are swallowed: a health record that could fail a healthy job
+ * would be worse than no health record at all.
+ */
+export async function withJobHealth<T>(db: Db, job: string, pass: () => Promise<T>): Promise<T> {
+  const startedAt = new Date()
+
+  try {
+    const result = await pass()
+    await record(db, job, startedAt, {
+      lastResult: isRecord(result) ? result : {},
+      // Cleared rather than left behind: this describes the last run, and a
+      // stale error beside a fresh success reads as a job still broken.
+      lastError: null,
+    })
+    return result
+  } catch (error) {
+    await record(db, job, startedAt, {
+      lastError: error instanceof Error ? error.message : String(error),
+    })
+    throw error
+  }
+}
+
+async function record(
+  db: Db,
+  job: string,
+  startedAt: Date,
+  outcome: { lastResult?: Record<string, unknown>; lastError: string | null },
+): Promise<void> {
+  const finishedAt = new Date()
+  try {
+    await db.collection<JobHealth>(COLLECTIONS.jobHealth).updateOne(
+      { _id: job },
+      {
+        $set: {
+          lastStartedAt: startedAt,
+          lastFinishedAt: finishedAt,
+          lastDurationMs: finishedAt.getTime() - startedAt.getTime(),
+          ...(outcome.lastResult ? { lastResult: outcome.lastResult } : {}),
+          lastError: outcome.lastError,
+        },
+        $inc: { runs: 1, failures: outcome.lastError === null ? 0 : 1 },
+      },
+      { upsert: true },
+    )
+  } catch {
+    // Deliberately silent. See the note above the interface.
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Every job that has ever run, stalest first. */
+export async function readJobHealth(db: Db): Promise<JobHealth[]> {
+  return db
+    .collection<JobHealth>(COLLECTIONS.jobHealth)
+    .find({})
+    .sort({ lastFinishedAt: 1 })
+    .toArray()
+}

--- a/apps/api/src/modules/admin/reports.ts
+++ b/apps/api/src/modules/admin/reports.ts
@@ -1,0 +1,254 @@
+import type { AdminReportListQuery, ReportStatus } from '@langx/shared'
+import { ObjectId, type Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import type { Report } from '../moderation/blocks'
+import type { Post } from '../feed/feed'
+import type { Profile } from '../profiles/profiles'
+
+/**
+ * The two queues the panel works through: reports, and appeals against what
+ * was decided about them.
+ *
+ * Reads only. Every decision goes through `moderation/decide.ts`, which the
+ * emailed link uses too — a list that could also decide things would be the
+ * second implementation this whole arrangement exists to avoid.
+ */
+
+/** As much of somebody as a queue row needs. */
+export interface AdminParty {
+  userId: string
+  handle: string | null
+  displayName: string | null
+  avatarUrl: string | null
+  suspended: boolean
+}
+
+export interface AdminReportRow {
+  id: string
+  reason: string
+  details: string | null
+  status: ReportStatus
+  createdAt: string
+  reported: AdminParty
+  reporter: AdminParty
+  /** Whether the report named a post, so the list can say so without loading it. */
+  aboutPost: boolean
+}
+
+export interface AdminReportDetail extends AdminReportRow {
+  /**
+   * The post, read unfiltered — this is the one reader that must still find a
+   * post it has already hidden. Everything else treats hidden as missing.
+   */
+  post: { id: string; body: string; language: string; hiddenAt: string | null } | null
+  /** What is in force on the reported account right now. */
+  suspension: Profile['suspension'] | null
+  /** Other reports against the same account still waiting, this one excluded. */
+  otherOpenReports: number
+}
+
+export interface AdminAppealRow {
+  userId: string
+  handle: string | null
+  displayName: string | null
+  text: string
+  appealedAt: string
+  until: string | null
+  permanent: boolean
+  reason: string
+  /** The report the suspension was decided from, when there was one. */
+  reportId: string | null
+}
+
+export interface Page<T> {
+  items: T[]
+  nextCursor: string | null
+}
+
+function party(userId: string, profile: Profile | null, now: Date): AdminParty {
+  const until = profile?.suspension?.until
+  return {
+    userId,
+    handle: profile?.handle ?? null,
+    displayName: profile?.displayName ?? null,
+    avatarUrl: profile?.avatarUrl ?? null,
+    suspended: until !== undefined && new Date(until).getTime() > now.getTime(),
+  }
+}
+
+/**
+ * Both people on every row, in one query rather than two per row.
+ *
+ * A page is thirty reports, which is sixty ids and — before this — sixty point
+ * reads. The same `$in` shape `pool.ts` was rewritten into for the same
+ * reason.
+ */
+async function partiesFor(db: Db, ids: string[], now: Date): Promise<Map<string, AdminParty>> {
+  const unique = [...new Set(ids)]
+  const rows = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .find(
+      { _id: { $in: unique } },
+      { projection: { handle: 1, displayName: 1, avatarUrl: 1, suspension: 1 } },
+    )
+    .toArray()
+  const byId = new Map(rows.map((row) => [row._id, row]))
+  return new Map(unique.map((id) => [id, party(id, byId.get(id) ?? null, now)]))
+}
+
+/**
+ * One status at a time, newest first — served by the `status_created` index
+ * that has been on `reports` since the collection existed and had no reader.
+ *
+ * The cursor is the `_id` of the last row, which for an ObjectId sorts the
+ * same way `createdAt` does.
+ */
+export async function listReports(
+  db: Db,
+  query: AdminReportListQuery,
+  now: Date = new Date(),
+): Promise<Page<AdminReportRow>> {
+  const cursor = query.cursor ? toObjectId(query.cursor) : null
+  const rows = await db
+    .collection<Report>(COLLECTIONS.reports)
+    .find({
+      status: query.status,
+      ...(cursor ? { _id: { $lt: cursor } } : {}),
+    })
+    .sort({ _id: -1 })
+    .limit(query.limit + 1)
+    .toArray()
+
+  const page = rows.slice(0, query.limit)
+  const parties = await partiesFor(
+    db,
+    page.flatMap((row) => [row.reportedId, row.reporterId]),
+    now,
+  )
+
+  return {
+    items: page.map((row) => toRow(row, parties)),
+    nextCursor: rows.length > query.limit ? (page.at(-1)?._id.toHexString() ?? null) : null,
+  }
+}
+
+export async function getReport(
+  db: Db,
+  id: string,
+  now: Date = new Date(),
+): Promise<AdminReportDetail | null> {
+  const reportId = toObjectId(id)
+  if (!reportId) return null
+  const report = await db.collection<Report>(COLLECTIONS.reports).findOne({ _id: reportId })
+  if (!report) return null
+
+  const [parties, post, reported, otherOpenReports] = await Promise.all([
+    partiesFor(db, [report.reportedId, report.reporterId], now),
+    report.postId
+      ? db.collection<Post>(COLLECTIONS.posts).findOne({ _id: report.postId })
+      : Promise.resolve(null),
+    db.collection<Profile>(COLLECTIONS.profiles).findOne({ _id: report.reportedId }),
+    db.collection<Report>(COLLECTIONS.reports).countDocuments({
+      reportedId: report.reportedId,
+      status: { $in: ['open', 'reviewing'] },
+      _id: { $ne: reportId },
+    }),
+  ])
+
+  return {
+    ...toRow(report, parties),
+    post: post
+      ? {
+          id: post._id.toHexString(),
+          body: post.body,
+          language: post.language,
+          hiddenAt: post.hiddenAt ? post.hiddenAt.toISOString() : null,
+        }
+      : null,
+    suspension: reported?.suspension ?? null,
+    otherOpenReports,
+  }
+}
+
+/**
+ * Appeals nobody has answered.
+ *
+ * `decidedAt` is what takes a row out of this list, and until `closeAppeal`
+ * existed nothing wrote it — so an appeal that was read and refused looked
+ * exactly like one that had never been opened. Served by the partial
+ * `appeal_recent` index.
+ */
+export async function listAppeals(
+  db: Db,
+  query: AdminReportListQuery,
+): Promise<Page<AdminAppealRow>> {
+  const rows = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .find(
+      {
+        'suspension.appeal.at': { $exists: true },
+        'suspension.appeal.decidedAt': { $exists: false },
+        ...(query.cursor ? { 'suspension.appeal.at': { $lt: new Date(query.cursor) } } : {}),
+      },
+      { projection: { handle: 1, displayName: 1, suspension: 1 } },
+    )
+    .sort({ 'suspension.appeal.at': -1 })
+    .limit(query.limit + 1)
+    .toArray()
+
+  const page = rows.slice(0, query.limit)
+  return {
+    items: page.flatMap((row) => {
+      const suspension = row.suspension
+      const appeal = suspension?.appeal
+      if (!suspension || !appeal) return []
+      return [
+        {
+          userId: row._id,
+          handle: row.handle ?? null,
+          displayName: row.displayName ?? null,
+          text: appeal.text,
+          appealedAt: new Date(appeal.at).toISOString(),
+          until: suspension.permanent ? null : new Date(suspension.until).toISOString(),
+          permanent: suspension.permanent,
+          reason: suspension.reason,
+          reportId: suspension.reportId?.toHexString() ?? null,
+        },
+      ]
+    }),
+    nextCursor:
+      rows.length > query.limit
+        ? (page.at(-1)?.suspension?.appeal?.at.toISOString() ?? null)
+        : null,
+  }
+}
+
+function toRow(report: Report, parties: Map<string, AdminParty>): AdminReportRow {
+  const unknown = (userId: string): AdminParty => ({
+    userId,
+    handle: null,
+    displayName: null,
+    avatarUrl: null,
+    suspended: false,
+  })
+  return {
+    id: report._id.toHexString(),
+    reason: report.reason,
+    details: report.details ?? null,
+    status: report.status,
+    createdAt: report.createdAt.toISOString(),
+    reported: parties.get(report.reportedId) ?? unknown(report.reportedId),
+    reporter: parties.get(report.reporterId) ?? unknown(report.reporterId),
+    aboutPost: report.postId !== undefined,
+  }
+}
+
+/** An id that came out of a URL. `new ObjectId` throws on anything else. */
+export function toObjectId(value: string | null | undefined): ObjectId | null {
+  if (!value) return null
+  try {
+    return new ObjectId(value)
+  } catch {
+    return null
+  }
+}

--- a/apps/api/src/modules/admin/stats.ts
+++ b/apps/api/src/modules/admin/stats.ts
@@ -1,0 +1,304 @@
+import { shiftDayKey, utcDayKey, type AppConfig } from '@langx/shared'
+import type { Db, Document } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { getAppConfig } from '../appConfig/appConfig'
+import { readJobHealth, type JobHealth } from './jobHealth'
+import { countActiveToday } from '../tokens/dailyActivity'
+import { DAILY_POOL_JOB, type JobRun, type PoolResult } from '../tokens/pool'
+import { readPublicStats, type PublicStats } from '../insight/publicStats'
+import type { EmailSuppression } from '../notifications/suppressions'
+import type { Profile } from '../profiles/profiles'
+
+/**
+ * The numbers the operator panel opens on.
+ *
+ * **Separate from `insight/publicStats.ts` on purpose, and nothing here may
+ * move there.** That module is served unauthenticated from `/public/stats` to
+ * anybody who asks, and `docs/insight.md` draws the line it lives behind:
+ * members, messages, corrections, languages and streaks are publishable;
+ * revenue, subscriptions, plan mix, conversion and retention are not. This is
+ * the private half. It *reads* the public one rather than recomputing it —
+ * that function already caches for ten minutes and already runs the three
+ * expensive scans.
+ *
+ * What is here was chosen by what it costs. Totals come from
+ * `estimatedDocumentCount`, which reads collection metadata rather than
+ * counting; daily grain comes from `dailyActivity` and `tokenLedger`, both of
+ * which have a bare `day` index; the pool's history is one keyed `jobRuns`
+ * read per day. What is deliberately absent is "messages / conversations /
+ * subscriptions / referrals in the last seven days": none of those
+ * collections has a bare `createdAt` index, so each would be a collection
+ * scan on every open of the dashboard, and this is a screen that gets opened.
+ */
+
+/** How many days the strips across the dashboard cover. */
+export const STATS_DAYS = 7
+
+/**
+ * Long enough that opening the panel twice does not recompute, short enough
+ * that "how many signed up today" is worth reading. The public stats behind it
+ * keep their own ten-minute memory.
+ */
+export const ADMIN_STATS_TTL_MS = 60 * 1000
+
+export interface DayCount {
+  day: string
+  count: number
+}
+
+export interface AdminStats {
+  generatedAt: string
+  queue: {
+    reports: number
+    appeals: number
+    feedback: number
+  }
+  audience: {
+    /** Metadata counts, not scans — close enough for a headline, free to read. */
+    profiles: number
+    messages: number
+    activeToday: number
+    activeDaily: DayCount[]
+    seenLastWeek: number
+    joinedToday: number
+    joinedLastWeek: number
+    builds: { platform: string; version: string; count: number }[]
+  }
+  money: {
+    tiers: { total: number; pro: number; proPlus: number; free: number }
+    pool: PoolResult | null
+    tokensDaily: DayCount[]
+  }
+  system: {
+    jobs: JobHealth[]
+    suppressions: { total: number; unsubscribed: number; bounced: number; complained: number }
+    purge: { accounts: number; analytics: number }
+    assistantCallsToday: number
+    campaigns: { id: string; status: string; sent: number; total: number }[]
+    config: AppConfig
+  }
+  public: PublicStats
+}
+
+let memory: { at: number; stats: AdminStats } | null = null
+
+export async function readAdminStats(db: Db, now: Date = new Date()): Promise<AdminStats> {
+  if (memory && now.getTime() - memory.at < ADMIN_STATS_TTL_MS) return memory.stats
+  const stats = await computeAdminStats(db, now)
+  memory = { at: now.getTime(), stats }
+  return stats
+}
+
+/** For the tests, and for anything that has just written what it wants to read. */
+export function forgetAdminStats(): void {
+  memory = null
+}
+
+async function computeAdminStats(db: Db, now: Date): Promise<AdminStats> {
+  const today = utcDayKey(now)
+  const days = Array.from({ length: STATS_DAYS }, (_, i) => shiftDayKey(today, -i)).reverse()
+  const weekAgo = new Date(now.getTime() - STATS_DAYS * 24 * 60 * 60 * 1000)
+
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  const midnight = new Date(`${today}T00:00:00.000Z`)
+
+  const [
+    reports,
+    appeals,
+    feedback,
+    profileCount,
+    messageCount,
+    activeDaily,
+    seenLastWeek,
+    joinedToday,
+    joinedLastWeek,
+    builds,
+    tiers,
+    pool,
+    tokensDaily,
+    jobs,
+    suppressions,
+    purgeAccounts,
+    purgeAnalytics,
+    assistantCallsToday,
+    campaigns,
+    config,
+    publicStats,
+  ] = await Promise.all([
+    db.collection(COLLECTIONS.reports).countDocuments({ status: { $in: ['open', 'reviewing'] } }),
+    profiles.countDocuments({
+      'suspension.appeal.at': { $exists: true },
+      'suspension.appeal.decidedAt': { $exists: false },
+    }),
+    db.collection(COLLECTIONS.feedback).countDocuments({ status: 'open' }),
+    profiles.estimatedDocumentCount(),
+    db.collection(COLLECTIONS.messages).estimatedDocumentCount(),
+    Promise.all(
+      days.map(async (day) => ({
+        day,
+        count: await countActiveToday(db, new Date(`${day}T12:00:00.000Z`)),
+      })),
+    ),
+    profiles.countDocuments({ 'stats.lastActiveAt': { $gte: weekAgo } }),
+    profiles.countDocuments({ createdAt: { $gte: midnight }, guest: { $exists: false } }),
+    profiles.countDocuments({ createdAt: { $gte: weekAgo }, guest: { $exists: false } }),
+    countBuilds(db),
+    countTiers(db, now),
+    lastPool(db, today),
+    tokensPerDay(db, days),
+    readJobHealth(db),
+    countSuppressions(db),
+    profiles.countDocuments({ deletedAt: { $exists: true } }),
+    db.collection(COLLECTIONS.analyticsDeletions).countDocuments({}),
+    assistantCalls(db, today),
+    listCampaignProgress(db),
+    getAppConfig(db),
+    readPublicStats(db, now),
+  ])
+
+  return {
+    generatedAt: now.toISOString(),
+    queue: { reports, appeals, feedback },
+    audience: {
+      profiles: profileCount,
+      messages: messageCount,
+      activeToday: activeDaily[activeDaily.length - 1]?.count ?? 0,
+      activeDaily,
+      seenLastWeek,
+      joinedToday,
+      joinedLastWeek,
+      builds,
+    },
+    money: { tiers, pool, tokensDaily },
+    system: {
+      jobs,
+      suppressions,
+      purge: { accounts: purgeAccounts, analytics: purgeAnalytics },
+      assistantCallsToday,
+      campaigns,
+      config,
+    },
+    public: publicStats,
+  }
+}
+
+/**
+ * The plan mix, live rather than ever-sold.
+ *
+ * `live` is the same expression `scripts/count-paid-subscribers.ts` uses: an
+ * entitlement with no expiry, or one that has not passed yet. A lapsed Pro is
+ * a free account with a row about last month in it.
+ */
+async function countTiers(db: Db, now: Date): Promise<AdminStats['money']['tiers']> {
+  const live: Document = {
+    $or: [
+      { 'entitlement.expiresAt': { $exists: false } },
+      { 'entitlement.expiresAt': { $gt: now } },
+    ],
+  }
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  const member = { guest: { $exists: false }, deletedAt: { $exists: false } }
+  const [total, pro, proPlus] = await Promise.all([
+    profiles.countDocuments(member),
+    profiles.countDocuments({ ...member, 'entitlement.tier': 'pro', ...live }),
+    profiles.countDocuments({ ...member, 'entitlement.tier': 'pro_plus', ...live }),
+  ])
+  return { total, pro, proPlus, free: total - pro - proPlus }
+}
+
+/** Which builds people are actually on — see `Profile.stats.appVersion`. */
+async function countBuilds(db: Db): Promise<AdminStats['audience']['builds']> {
+  return db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .aggregate<{ platform: string; version: string; count: number }>([
+      { $match: { 'stats.appVersion': { $exists: true } } },
+      {
+        $group: {
+          _id: { platform: '$stats.appPlatform', version: '$stats.appVersion' },
+          count: { $sum: 1 },
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          platform: '$_id.platform',
+          version: '$_id.version',
+          count: 1,
+        },
+      },
+      { $sort: { count: -1 } },
+      { $limit: 20 },
+    ])
+    .toArray()
+}
+
+/**
+ * Yesterday's pool, or the newest one that actually ran.
+ *
+ * One keyed read per day against `jobRuns`'s unique `{job, periodKey}`. The
+ * run record is operational rather than ledger — it can be absent for a day
+ * nobody paid — so this walks back until it finds one, and gives up rather
+ * than scanning.
+ */
+async function lastPool(db: Db, today: string): Promise<PoolResult | null> {
+  const runs = db.collection<JobRun>(COLLECTIONS.jobRuns)
+  for (let back = 1; back <= STATS_DAYS; back++) {
+    const run = await runs.findOne({ job: DAILY_POOL_JOB, periodKey: shiftDayKey(today, -back) })
+    if (run?.result) return run.result
+  }
+  return null
+}
+
+/** Tokens awarded per day. `tokenLedger` carries a bare `day` index. */
+async function tokensPerDay(db: Db, days: string[]): Promise<DayCount[]> {
+  const rows = await db
+    .collection(COLLECTIONS.tokenLedger)
+    .aggregate<{ _id: string; count: number }>([
+      { $match: { day: { $in: days } } },
+      { $group: { _id: '$day', count: { $sum: '$amount' } } },
+    ])
+    .toArray()
+  const byDay = new Map(rows.map((row) => [row._id, row.count]))
+  // Zeros included: a chart needs the gaps, and a missing day reads as missing
+  // data rather than as a quiet one.
+  return days.map((day) => ({ day, count: byDay.get(day) ?? 0 }))
+}
+
+async function countSuppressions(db: Db): Promise<AdminStats['system']['suppressions']> {
+  const rows = await db
+    .collection<EmailSuppression>(COLLECTIONS.emailSuppressions)
+    .aggregate<{ _id: string; count: number }>([{ $group: { _id: '$reason', count: { $sum: 1 } } }])
+    .toArray()
+  const of = (reason: string) => rows.find((row) => row._id === reason)?.count ?? 0
+  return {
+    total: rows.reduce((sum, row) => sum + row.count, 0),
+    unsubscribed: of('unsubscribed'),
+    bounced: of('bounced'),
+    complained: of('complained'),
+  }
+}
+
+async function assistantCalls(db: Db, today: string): Promise<number> {
+  const usage = await db
+    .collection<{ _id: string; calls: number }>(COLLECTIONS.assistantUsage)
+    .findOne({ _id: today })
+  return usage?.calls ?? 0
+}
+
+/** Email campaigns that are not finished, so a stuck drip is visible. */
+async function listCampaignProgress(db: Db): Promise<AdminStats['system']['campaigns']> {
+  const rows = await db
+    .collection<{ _id: string; status: string; sent?: number; total?: number }>(
+      COLLECTIONS.campaignQueue,
+    )
+    .find({ status: { $ne: 'done' } })
+    .sort({ createdAt: -1 })
+    .limit(10)
+    .toArray()
+  return rows.map((row) => ({
+    id: row._id,
+    status: row.status,
+    sent: row.sent ?? 0,
+    total: row.total ?? 0,
+  }))
+}

--- a/apps/api/src/modules/admin/users.ts
+++ b/apps/api/src/modules/admin/users.ts
@@ -1,0 +1,268 @@
+import {
+  NOTIFICATION_TYPES,
+  notificationsAllowed,
+  type NotificationType,
+  type PlanTier,
+} from '@langx/shared'
+import type { Db, Document } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { readAdminActions, type AdminAction } from './auditLog'
+import { blockedUserIds } from '../moderation/blocks'
+import { resolveDiscoveryScope } from '../discovery/discovery'
+import { effectiveTier } from '../profiles/entitlement'
+import type { Device } from '../push/devices'
+import type { EmailSuppression } from '../notifications/suppressions'
+import { emailFor } from '../profiles/emailFor'
+import { findProfileByHandleOrId, type Profile } from '../profiles/profiles'
+
+/**
+ * One account, as the person answering a support thread needs to see it.
+ *
+ * The support mailbox asks the same four questions over and over — "my
+ * Discover is empty", "I get no notifications", "my mail never arrives", "my
+ * old data did not come back" — and every one of them is answerable from this
+ * database with an indexed read. Until now answering meant opening a shell and
+ * writing the query by hand, which is why they mostly went unanswered.
+ */
+
+/**
+ * Built by naming fields, the way `toPublicProfile` is, rather than by
+ * removing them: a field added to `Profile` later is private here by default
+ * instead of being published by an omission nobody noticed.
+ */
+export interface AdminUserView {
+  userId: string
+  handle: string
+  previousHandle: string | null
+  displayName: string
+  avatarUrl: string | null
+  bio: string | null
+  country: string | null
+  cityName: string | null
+  birthDate: string | null
+  gender: string
+  createdAt: string
+  lastActiveAt: string | null
+  build: { version: string; platform: string } | null
+  tier: PlanTier
+  official: boolean
+  admin: boolean
+  guest: boolean
+  /** The point of a support lookup, and the reason this view is admin-only. */
+  email: string | null
+  emailVerified: boolean
+  deletedAt: string | null
+  tokenFrozenAt: string | null
+  suspension: Profile['suspension'] | null
+  counts: { reportsAgainst: number; reportsFiled: number; blockedBy: number }
+  /** What has been done to this account, and by whom. */
+  actions: AdminAction[]
+}
+
+export interface DiscoveryDiagnosis {
+  /** What Discover would return for them right now. */
+  matches: number
+  /**
+   * The same filter built up one clause at a time, so the step where the
+   * number collapses is the answer. Cumulative, in the order Discover applies
+   * them.
+   */
+  steps: { filter: string; remaining: number }[]
+  discoverable: boolean
+  nativeLanguages: string[]
+  learning: string[]
+}
+
+export interface PushDiagnosis {
+  devices: {
+    platform: string
+    pushEnabled: boolean
+    hasDeviceId: boolean
+    locale: string | null
+    updatedAt: string | null
+  }[]
+  /** Per kind, per channel, resolved through the one reader — see `notificationsAllowed`. */
+  prefs: { type: NotificationType; push: boolean; email: boolean }[]
+  /** Why no mail can reach them, when that is the answer. */
+  suppression: { reason: string; at: string } | null
+}
+
+export interface LegacyDiagnosis {
+  /** A v1 row staged by the ETL under a handle they may not have claimed yet. */
+  staged: boolean
+  reserved: boolean
+  restored: boolean
+  previousHandle: string | null
+}
+
+export interface AdminUserDetail {
+  user: AdminUserView
+  discovery: DiscoveryDiagnosis
+  push: PushDiagnosis
+  legacy: LegacyDiagnosis
+}
+
+/** Handle, previous handle, user id, or the email address a support thread came from. */
+export async function findAdminUser(db: Db, q: string): Promise<Profile | null> {
+  const direct = await findProfileByHandleOrId(db, q, { includeDeleted: true })
+  if (direct) return direct
+
+  const user = await db
+    .collection<{ _id: unknown; email: string }>(COLLECTIONS.user)
+    .findOne({ email: q.trim().toLowerCase() })
+  if (!user) return null
+  return db.collection<Profile>(COLLECTIONS.profiles).findOne({ _id: String(user._id) })
+}
+
+export async function getAdminUser(db: Db, profile: Profile): Promise<AdminUserDetail> {
+  const [user, discovery, push, legacy] = await Promise.all([
+    toAdminUserView(db, profile),
+    diagnoseDiscovery(db, profile),
+    diagnosePush(db, profile),
+    diagnoseLegacy(db, profile),
+  ])
+  return { user, discovery, push, legacy }
+}
+
+async function toAdminUserView(db: Db, profile: Profile): Promise<AdminUserView> {
+  const [address, reportsAgainst, reportsFiled, blockedBy, actions] = await Promise.all([
+    emailFor(db, profile._id),
+    db.collection(COLLECTIONS.reports).countDocuments({ reportedId: profile._id }),
+    db.collection(COLLECTIONS.reports).countDocuments({ reporterId: profile._id }),
+    db.collection(COLLECTIONS.blocks).countDocuments({ blockedId: profile._id }),
+    readAdminActions(db, profile._id),
+  ])
+
+  return {
+    userId: profile._id,
+    handle: profile.handle,
+    previousHandle: profile.previousHandle ?? null,
+    displayName: profile.displayName,
+    avatarUrl: profile.avatarUrl ?? null,
+    bio: profile.bio ?? null,
+    country: profile.country ?? null,
+    cityName: profile.cityName ?? null,
+    birthDate: profile.birthDate ?? null,
+    gender: profile.gender,
+    createdAt: profile.createdAt.toISOString(),
+    lastActiveAt: profile.stats?.lastActiveAt
+      ? new Date(profile.stats.lastActiveAt).toISOString()
+      : null,
+    build: profile.stats?.appVersion
+      ? { version: profile.stats.appVersion, platform: profile.stats.appPlatform ?? 'unknown' }
+      : null,
+    tier: effectiveTier(profile),
+    official: profile.official === true,
+    admin: profile.admin === true,
+    guest: profile.guest === true,
+    email: address?.email ?? null,
+    emailVerified: address?.verified === true,
+    deletedAt: profile.deletedAt ? profile.deletedAt.toISOString() : null,
+    tokenFrozenAt: profile.tokenFrozenAt ? new Date(profile.tokenFrozenAt).toISOString() : null,
+    suspension: profile.suspension ?? null,
+    counts: { reportsAgainst, reportsFiled, blockedBy },
+    actions,
+  }
+}
+
+/**
+ * Why Discover is empty for this person.
+ *
+ * The last number is the real one: it comes from `resolveDiscoveryScope`, the
+ * same function the feature itself calls, so a diagnosis cannot quietly
+ * disagree with the screen it is explaining. The steps before it are that same
+ * filter built up a clause at a time — the first big drop is the cause, and in
+ * practice it is either the language pair or the size of the app.
+ */
+export async function diagnoseDiscovery(db: Db, profile: Profile): Promise<DiscoveryDiagnosis> {
+  const profiles = db.collection<Profile>(COLLECTIONS.profiles)
+  /*
+   * The default search, which is what somebody means when they say Discover is
+   * empty: no filters, the sort the app opens on. Naming a language scope
+   * would change the answer — see the cross-match note in `resolveDiscoveryScope`.
+   */
+  const scope = await resolveDiscoveryScope(db, profile._id, {
+    sort: 'recommended',
+    limit: 1,
+  })
+  const excluded = [profile._id, ...(await blockedUserIds(db, profile._id))]
+
+  const steps: DiscoveryDiagnosis['steps'] = []
+  let filter: Document = {}
+  const add = async (name: string, clause: Document) => {
+    filter = { ...filter, ...clause }
+    steps.push({ filter: name, remaining: await profiles.countDocuments(filter) })
+  }
+
+  await add('everybody', { guest: { $exists: false }, deletedAt: { $exists: false } })
+  await add('discoverable', { 'settings.discoverable': true })
+  await add('not suspended', { 'suspension.until': { $not: { $gt: new Date() } } })
+  await add('not blocked either way', { _id: { $nin: excluded } })
+
+  const matches = await profiles.countDocuments(scope.match)
+  steps.push({ filter: 'language fit', remaining: matches })
+
+  return {
+    matches,
+    steps,
+    discoverable: profile.settings?.discoverable === true,
+    nativeLanguages: profile.nativeLanguages.map((language) => language.code),
+    learning: profile.learning.map((language) => language.code),
+  }
+}
+
+/** Why no notification arrives: the phones, the switches, or the mail itself. */
+async function diagnosePush(db: Db, profile: Profile): Promise<PushDiagnosis> {
+  const [devices, address] = await Promise.all([
+    db.collection<Device>(COLLECTIONS.devices).find({ userId: profile._id }).toArray(),
+    emailFor(db, profile._id),
+  ])
+
+  const suppression = address
+    ? await db
+        .collection<EmailSuppression>(COLLECTIONS.emailSuppressions)
+        .findOne({ _id: address.email.trim().toLowerCase() })
+    : null
+
+  return {
+    devices: devices.map((device) => ({
+      platform: device.platform,
+      pushEnabled: device.pushEnabled !== false,
+      hasDeviceId: device.deviceId !== undefined,
+      locale: device.locale ?? null,
+      updatedAt: device.updatedAt ? new Date(device.updatedAt).toISOString() : null,
+    })),
+    /*
+     * Read through `notificationsAllowed` rather than printed raw. The field
+     * holds three historical shapes — one boolean for everything, a bare
+     * boolean per kind, and the current per-channel object — and only that
+     * function knows what each means. A panel that showed the stored value
+     * would be showing something nobody can act on.
+     */
+    prefs: NOTIFICATION_TYPES.map((type) => ({
+      type,
+      push: notificationsAllowed(profile.settings?.notifications, type, 'push'),
+      email: notificationsAllowed(profile.settings?.notifications, type, 'email'),
+    })),
+    suppression: suppression
+      ? { reason: suppression.reason, at: suppression.at.toISOString() }
+      : null,
+  }
+}
+
+/** Whether a returning v1 account actually came back, and how far it got. */
+async function diagnoseLegacy(db: Db, profile: Profile): Promise<LegacyDiagnosis> {
+  const handles = [profile.handle, profile.previousHandle].filter(
+    (handle): handle is string => typeof handle === 'string',
+  )
+  const [staged, reserved] = await Promise.all([
+    db.collection(COLLECTIONS.legacyProfiles).countDocuments({ handle: { $in: handles } }),
+    db.collection(COLLECTIONS.handleReservations).countDocuments({ handle: { $in: handles } }),
+  ])
+  return {
+    staged: staged > 0,
+    reserved: reserved > 0,
+    restored: profile.restoredFromV1 !== undefined,
+    previousHandle: profile.previousHandle ?? null,
+  }
+}

--- a/apps/api/src/modules/discovery/discovery.ts
+++ b/apps/api/src/modules/discovery/discovery.ts
@@ -163,7 +163,13 @@ interface DiscoveryScope {
   myLearningCodes: string[]
 }
 
-async function resolveDiscoveryScope(
+/*
+ * Exported for one reader beyond this file: the operator panel's "why is
+ * Discover empty for this person" diagnosis, which has to evaluate the filter
+ * the feature actually uses. A diagnosis built from a copy of these clauses
+ * would answer confidently and be wrong the first time one of them changed.
+ */
+export async function resolveDiscoveryScope(
   db: Db,
   viewerId: string,
   query: DiscoveryQuery,

--- a/apps/api/src/modules/feedback/awardBounty.ts
+++ b/apps/api/src/modules/feedback/awardBounty.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify'
 import { notifyBountyPaid } from './bountyNotice'
+import { markFeedbackPaid } from './reports'
 import { awardTokens } from '../tokens/ledger'
 
 /**
@@ -36,6 +37,12 @@ export async function payBounty(
    * one.
    */
   if (result.awarded) {
+    /*
+     * `triaged`, not `closed`: paying says the report was real, not that the
+     * fix has shipped. And only on the award that happened, so the row cannot
+     * gain a second, later `bounty.at` from a press that paid nothing.
+     */
+    await markFeedbackPaid(app.mongo.db, input.refId, result.amount)
     await notifyBountyPaid(
       app.mongo.db,
       { push: app.push, email: app.email },

--- a/apps/api/src/modules/feedback/awardBounty.ts
+++ b/apps/api/src/modules/feedback/awardBounty.ts
@@ -1,0 +1,48 @@
+import type { FastifyInstance } from 'fastify'
+import { notifyBountyPaid } from './bountyNotice'
+import { awardTokens } from '../tokens/ledger'
+
+/**
+ * Paying for a confirmed report, from either door.
+ *
+ * The emailed link and the admin panel both land here, so "paid once" is one
+ * fact rather than two implementations of it. `refId` is the report's id, and
+ * the ledger's unique `{userId, kind, refId}` index — not a check in here — is
+ * what makes a second press, a refresh, a forwarded mail, or the panel and the
+ * mail both being used worth nothing.
+ */
+export interface PayBountyInput {
+  userId: string
+  /** The feedback report's id, which is also the ledger's `refId`. */
+  refId: string
+  amount: number
+}
+
+export async function payBounty(
+  app: FastifyInstance,
+  input: PayBountyInput,
+): Promise<{ awarded: boolean; amount: number }> {
+  const result = await awardTokens(app.mongo.db, {
+    userId: input.userId,
+    kind: 'bounty',
+    amount: input.amount,
+    refId: input.refId,
+  })
+
+  /*
+   * Only on the award that actually happened. The unique index makes that
+   * exactly once per report, so a second attempt pays nothing and says nothing
+   * either — no second notification, and no need for a claim row to prevent
+   * one.
+   */
+  if (result.awarded) {
+    await notifyBountyPaid(
+      app.mongo.db,
+      { push: app.push, email: app.email },
+      { userId: input.userId, amount: result.amount },
+      (err, message) => app.log.warn({ err, userId: input.userId }, message),
+    )
+  }
+
+  return { awarded: result.awarded, amount: result.amount }
+}

--- a/apps/api/src/modules/feedback/reports.ts
+++ b/apps/api/src/modules/feedback/reports.ts
@@ -1,0 +1,162 @@
+import type { AdminFeedbackListQuery, FeedbackKind } from '@langx/shared'
+import type { Db } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import type { Profile } from '../profiles/profiles'
+
+/**
+ * A bug report or an idea, as a row somebody can close.
+ *
+ * `routes/feedback.ts` argued against this collection, and the argument was
+ * right at the time: *"a copy of a decision taken in an inbox, with no screen
+ * in the app able to close a row and nobody looking at the ones left open"*.
+ * Three things answer it now.
+ *
+ * The row is not a copy — the decision is made in the panel, and the mailbox
+ * is the fallback. The row and the emailed link are the **same object**: the
+ * `_id` here is the `randomUUID()` `submit.ts` already minted, which is also
+ * the bounty token's `reportId` and the ledger's `refId`, so paying from the
+ * panel and paying from a six-week-old forwarded mail are physically the same
+ * payment — enforced by `tokenLedger`'s unique index, not by a check. And the
+ * queue is ordered oldest-open-first, so the thing nobody has closed is the
+ * first thing the screen shows.
+ *
+ * No TTL. A bug report is evidence; expiring it on a timer is how the oldest
+ * open one disappears instead of getting fixed.
+ */
+export interface FeedbackReport {
+  /** The uuid `submit.ts` mints — also the bounty token's `reportId`. */
+  _id: string
+  userId: string
+  kind: FeedbackKind
+  body: string
+  attachmentUrls: string[]
+  /**
+   * The prefilled GitHub new-issue link at submit; replaced with the real
+   * issue's URL once somebody files it.
+   */
+  issueUrl?: string
+  status: FeedbackStatus
+  /** A mirror of the ledger row, never the authority on whether it paid. */
+  bounty?: { amount: number; at: Date }
+  closedAt?: Date
+  closedBy?: string
+  closeReason?: FeedbackCloseReason
+  note?: string
+  createdAt: Date
+}
+
+export type FeedbackStatus = 'open' | 'triaged' | 'closed'
+export type FeedbackCloseReason = 'fixed' | 'shipped' | 'wontfix' | 'duplicate' | 'invalid'
+
+export interface FeedbackRow extends Omit<FeedbackReport, 'createdAt' | 'bounty' | 'closedAt'> {
+  createdAt: string
+  bounty: { amount: number; at: string } | null
+  closedAt: string | null
+  sender: { userId: string; handle: string | null; displayName: string | null }
+}
+
+export async function recordFeedback(
+  db: Db,
+  report: Omit<FeedbackReport, 'status' | 'createdAt'>,
+): Promise<void> {
+  await db
+    .collection<FeedbackReport>(COLLECTIONS.feedback)
+    .insertOne({ ...report, status: 'open', createdAt: new Date() })
+}
+
+/**
+ * Oldest first, deliberately.
+ *
+ * Every other list in this codebase is newest-first because every other list
+ * is a feed. This one is a queue, and the row that matters most is the one
+ * that has been waiting longest — which is also why the index is ascending.
+ */
+export async function listFeedback(
+  db: Db,
+  query: AdminFeedbackListQuery,
+): Promise<{ items: FeedbackRow[]; nextCursor: string | null }> {
+  const rows = await db
+    .collection<FeedbackReport>(COLLECTIONS.feedback)
+    .find({
+      status: query.status,
+      ...(query.cursor ? { createdAt: { $gt: new Date(query.cursor) } } : {}),
+    })
+    .sort({ createdAt: 1 })
+    .limit(query.limit + 1)
+    .toArray()
+
+  const page = rows.slice(0, query.limit)
+  return {
+    items: await withSenders(db, page),
+    nextCursor: rows.length > query.limit ? (page.at(-1)?.createdAt.toISOString() ?? null) : null,
+  }
+}
+
+export async function getFeedback(db: Db, id: string): Promise<FeedbackRow | null> {
+  const row = await db.collection<FeedbackReport>(COLLECTIONS.feedback).findOne({ _id: id })
+  if (!row) return null
+  return (await withSenders(db, [row]))[0] ?? null
+}
+
+export interface FeedbackUpdate {
+  status?: FeedbackStatus
+  issueUrl?: string
+  closeReason?: FeedbackCloseReason
+  note?: string
+}
+
+export async function updateFeedback(
+  db: Db,
+  id: string,
+  update: FeedbackUpdate,
+  byAdminId: string,
+): Promise<FeedbackReport | null> {
+  const closing = update.status === 'closed'
+  return db.collection<FeedbackReport>(COLLECTIONS.feedback).findOneAndUpdate(
+    { _id: id },
+    {
+      $set: {
+        ...update,
+        ...(closing ? { closedAt: new Date(), closedBy: byAdminId } : {}),
+      },
+    },
+    { returnDocument: 'after' },
+  )
+}
+
+/**
+ * Marks a report as paid for.
+ *
+ * Called only when the ledger says the award actually happened, so a second
+ * press of either door changes nothing here either. `triaged` rather than
+ * `closed`: paying says the report was real, not that the fix has shipped.
+ */
+export async function markFeedbackPaid(db: Db, id: string, amount: number): Promise<void> {
+  await db
+    .collection<FeedbackReport>(COLLECTIONS.feedback)
+    .updateOne({ _id: id }, { $set: { status: 'triaged', bounty: { amount, at: new Date() } } })
+}
+
+async function withSenders(db: Db, rows: FeedbackReport[]): Promise<FeedbackRow[]> {
+  const ids = [...new Set(rows.map((row) => row.userId))]
+  const profiles = await db
+    .collection<Profile>(COLLECTIONS.profiles)
+    .find({ _id: { $in: ids } }, { projection: { handle: 1, displayName: 1 } })
+    .toArray()
+  const byId = new Map(profiles.map((profile) => [profile._id, profile]))
+
+  return rows.map((row) => {
+    const profile = byId.get(row.userId)
+    return {
+      ...row,
+      createdAt: row.createdAt.toISOString(),
+      bounty: row.bounty ? { amount: row.bounty.amount, at: row.bounty.at.toISOString() } : null,
+      closedAt: row.closedAt ? row.closedAt.toISOString() : null,
+      sender: {
+        userId: row.userId,
+        handle: profile?.handle ?? null,
+        displayName: profile?.displayName ?? null,
+      },
+    }
+  })
+}

--- a/apps/api/src/modules/feedback/submit.ts
+++ b/apps/api/src/modules/feedback/submit.ts
@@ -8,6 +8,7 @@ import { assertAttachmentsAllowed } from '../media/assertMedia'
 import { emailFor } from '../profiles/emailFor'
 import { getProfile } from '../profiles/profiles'
 import { newIssueUrl } from './githubIssue'
+import { recordFeedback } from './reports'
 
 /**
  * A bug or an idea, on its way to the support mailbox.
@@ -51,9 +52,10 @@ export async function submitFeedback(
   })
 
   /*
-   * The report's own id, and the only place it is ever written down is the
-   * link below — which is enough, because the one thing it has to be is the
-   * ledger's `refId`, and the ledger is what remembers it after that.
+   * The report's own id, and one string in three places: the row below, the
+   * bounty link, and the ledger's `refId`. That identity is what makes paying
+   * from the panel and paying from a forwarded mail the same payment rather
+   * than two that have to be reconciled.
    */
   const reportId = randomUUID()
   const awardUrl = bountyAwardUrl(
@@ -78,11 +80,31 @@ export async function submitFeedback(
     newIssueUrl: issueUrl,
   })
 
-  await app.email.send({
-    to: app.env.SUPPORT_EMAIL,
-    ...mail,
-    // So that confirming a report — or asking for the step that is missing —
-    // is a reply rather than a lookup.
-    ...(address ? { headers: { 'Reply-To': address.email } } : {}),
+  /*
+   * The row first, and it is the one write here that may fail the request.
+   * Until it existed the mail *was* the record, so a failed send had to be a
+   * 500; now the record is this, and a mail provider's bad minute must not
+   * tell somebody their bug report did not go — the same shape `POST /reports`
+   * already uses for the same reason.
+   */
+  await recordFeedback(app.mongo.db, {
+    _id: reportId,
+    userId,
+    kind: input.kind,
+    body: input.body,
+    attachmentUrls,
+    issueUrl,
   })
+
+  try {
+    await app.email.send({
+      to: app.env.SUPPORT_EMAIL,
+      ...mail,
+      // So that confirming a report — or asking for the step that is missing —
+      // is a reply rather than a lookup.
+      ...(address ? { headers: { 'Reply-To': address.email } } : {}),
+    })
+  } catch (error) {
+    app.log.warn({ err: error, reportId }, 'feedback notification email failed')
+  }
 }

--- a/apps/api/src/modules/handles/legacyImportScheduler.ts
+++ b/apps/api/src/modules/handles/legacyImportScheduler.ts
@@ -1,6 +1,7 @@
 import type { Db } from 'mongodb'
 import type { SchedulerLogger } from '../tokens/poolScheduler'
 import { sweepLegacyImports } from './legacyConversations'
+import { withJobHealth } from '../admin/jobHealth'
 
 /**
  * Slow on purpose. The fast path is the restore hook, which imports a
@@ -27,9 +28,11 @@ export function startLegacyImportScheduler(
     if (running) return
     running = true
     try {
-      const result = await sweepLegacyImports(db, {
-        ...(options.limit !== undefined ? { limit: options.limit } : {}),
-      })
+      const result = await withJobHealth(db, 'legacy import', () =>
+        sweepLegacyImports(db, {
+          ...(options.limit !== undefined ? { limit: options.limit } : {}),
+        }),
+      )
       if (result.conversationsImported > 0) {
         logger.info(
           {

--- a/apps/api/src/modules/moderation/decide.ts
+++ b/apps/api/src/modules/moderation/decide.ts
@@ -14,6 +14,7 @@ import { localeFor } from '../profiles/localeFor'
 import { getProfile } from '../profiles/profiles'
 import {
   actionReport,
+  closeAppeal,
   dismissReport,
   liftSuspension,
   shortenSuspension,
@@ -62,13 +63,25 @@ export interface ReviewDecisionInput extends ReviewDecision {
   userId: string
   /** The report being decided, or `null` for an appeal with none behind it. */
   reportId: ObjectId | null
+  /**
+   * Who decided, when that is knowable. The panel knows; the emailed link does
+   * not, because it authorises whoever holds it.
+   */
+  byAdminId?: string
+  /**
+   * The reason to record, for a suspension with no report behind it — the
+   * panel's search-box path, where there is nothing to read one from. A
+   * report's own reason always wins: this decision is about *that* report, and
+   * the person is about to be told which one it was.
+   */
+  reason?: string
 }
 
 export async function applyReviewDecision(
   app: FastifyInstance,
   input: ReviewDecisionInput,
 ): Promise<ReviewDecisionResult> {
-  const { kind, userId, reportId, action, days } = input
+  const { kind, userId, reportId, action, days, byAdminId } = input
 
   /*
    * The token (or the route) says *which* report or appeal; this says what may
@@ -131,6 +144,9 @@ export async function applyReviewDecision(
   }
 
   if (action === 'keep') {
+    // Refusing an appeal still answers it. Without this the appeal queue never
+    // empties — see `closeAppeal`.
+    await closeAppeal(app.mongo.db, userId, byAdminId)
     return { ok: true, handle, outcome: { action } }
   }
 
@@ -149,12 +165,13 @@ export async function applyReviewDecision(
           .collection(COLLECTIONS.reports)
           .findOne<{ reason: string }>({ _id: reportId })
       : null
-    const reason = report?.reason ?? profile.suspension?.reason ?? 'other'
+    const reason = report?.reason ?? input.reason ?? profile.suspension?.reason ?? 'other'
     const until = await suspendUser(app.mongo.db, {
       userId,
       reason,
       ...(permanent ? { permanent: true } : { days: days ?? 1 }),
       ...(reportId ? { reportId } : {}),
+      ...(byAdminId ? { byAdminId } : {}),
     })
     if (address?.verified) {
       await tell(() =>
@@ -170,6 +187,9 @@ export async function applyReviewDecision(
   // `shorten` and `lift` — the two an appeal can drive.
   const until =
     action === 'shorten' ? await shortenSuspension(app.mongo.db, userId, days ?? 1) : null
+  // Shortening answers the appeal; lifting removes the sub-document the appeal
+  // lives in, so it needs no stamp and must not be given one after the fact.
+  if (action === 'shorten') await closeAppeal(app.mongo.db, userId, byAdminId)
   if (action === 'lift') await liftSuspension(app.mongo.db, userId)
   if (address?.verified) {
     await tell(() =>

--- a/apps/api/src/modules/moderation/decide.ts
+++ b/apps/api/src/modules/moderation/decide.ts
@@ -1,0 +1,182 @@
+import {
+  REVIEW_ACTIONS_BY_KIND,
+  type ReviewAction,
+  type ReviewDecision,
+  type ReviewKind,
+} from '@langx/shared'
+import type { FastifyInstance } from 'fastify'
+import type { ObjectId } from 'mongodb'
+import { COLLECTIONS } from '../../db/collections'
+import { suspendedEmail, suspensionUpdatedEmail } from '../../email/templates'
+import { setPostHidden } from '../feed/feed'
+import { emailFor } from '../profiles/emailFor'
+import { localeFor } from '../profiles/localeFor'
+import { getProfile } from '../profiles/profiles'
+import {
+  actionReport,
+  dismissReport,
+  liftSuspension,
+  shortenSuspension,
+  suspendUser,
+} from './suspension'
+
+/**
+ * One moderation decision, with no page around it.
+ *
+ * This is the body of `POST /moderation/review` lifted out of the route so
+ * that the signed link in the report email and the admin panel are the same
+ * decision rather than two that drift. Everything that made the emailed
+ * version safe is here — the kind check, the reversible post actions, the
+ * best-effort notice — and the callers differ only in what they render:
+ * a sentence of HTML for the mailbox, JSON for the panel.
+ *
+ * It writes nothing itself. The five repository functions in `suspension.ts`
+ * already did all of it, and adding a sixth here would have been the drift
+ * this exists to prevent.
+ */
+
+export type ReviewOutcome =
+  | { action: 'hide_post' | 'unhide_post'; hidden: boolean; changed: boolean }
+  | { action: 'dismiss' }
+  | { action: 'keep' }
+  | { action: 'suspend' | 'permanent'; until: Date; permanent: boolean; reason: string }
+  | { action: 'shorten'; until: Date }
+  | { action: 'lift' }
+
+/**
+ * Why a decision could not be made. Each maps to a different sentence and a
+ * different status code, so the callers word them rather than this.
+ */
+export type ReviewRefusal = 'action_not_allowed' | 'account_gone' | 'not_a_post' | 'post_gone'
+
+export type ReviewDecisionResult =
+  | { ok: false; refusal: ReviewRefusal }
+  | { ok: true; handle: string | null; outcome: ReviewOutcome }
+
+/**
+ * The decision itself is `reviewDecisionSchema`'s own shape — the same object
+ * the emailed form posts and the panel sends — plus who it is about.
+ */
+export interface ReviewDecisionInput extends ReviewDecision {
+  kind: ReviewKind
+  userId: string
+  /** The report being decided, or `null` for an appeal with none behind it. */
+  reportId: ObjectId | null
+}
+
+export async function applyReviewDecision(
+  app: FastifyInstance,
+  input: ReviewDecisionInput,
+): Promise<ReviewDecisionResult> {
+  const { kind, userId, reportId, action, days } = input
+
+  /*
+   * The token (or the route) says *which* report or appeal; this says what may
+   * be done with it. Both halves are checked, so a report link cannot lift a
+   * suspension it was never shown, and an appeal link cannot open a new one.
+   */
+  if (!(REVIEW_ACTIONS_BY_KIND[kind] as readonly ReviewAction[]).includes(action)) {
+    return { ok: false, refusal: 'action_not_allowed' }
+  }
+
+  const profile = await getProfile(app.mongo.db, userId)
+  if (!profile) return { ok: false, refusal: 'account_gone' }
+  const handle = profile.handle ?? null
+
+  /*
+   * The two decisions about the post rather than the account, handled before
+   * the address lookups below because neither needs one: hiding is silent,
+   * which is the whole shape of it.
+   */
+  if (action === 'hide_post' || action === 'unhide_post') {
+    const report = reportId
+      ? await app.mongo.db
+          .collection(COLLECTIONS.reports)
+          .findOne<{ postId?: ObjectId }>({ _id: reportId })
+      : null
+    if (!report?.postId) return { ok: false, refusal: 'not_a_post' }
+
+    const hidden = action === 'hide_post'
+    const before = await setPostHidden(app.mongo.db, report.postId.toHexString(), hidden)
+    if (!before) return { ok: false, refusal: 'post_gone' }
+    /*
+     * Hiding decides the report; showing it again does not reopen it. The
+     * second is a correction of the first, and a report that bounced back to
+     * `open` would arrive in the next list as work nobody owes.
+     */
+    if (hidden && reportId) await actionReport(app.mongo.db, reportId)
+    return {
+      ok: true,
+      handle,
+      outcome: { action, hidden, changed: Boolean(before.hiddenAt) !== hidden },
+    }
+  }
+
+  /**
+   * Telling the person is never fatal to the decision. The suspension is
+   * already written; a mail provider's bad minute must not turn it into a 500
+   * that invites the same button being pressed again.
+   */
+  const tell = async (send: () => Promise<void>) => {
+    try {
+      await send()
+    } catch (error) {
+      app.log.warn({ err: error, userId }, 'suspension email failed')
+    }
+  }
+
+  if (action === 'dismiss') {
+    if (reportId) await dismissReport(app.mongo.db, reportId)
+    return { ok: true, handle, outcome: { action } }
+  }
+
+  if (action === 'keep') {
+    return { ok: true, handle, outcome: { action } }
+  }
+
+  const address = await emailFor(app.mongo.db, userId)
+  const locale = await localeFor(app.mongo.db, userId)
+
+  if (action === 'suspend' || action === 'permanent') {
+    const permanent = action === 'permanent'
+    /*
+     * The reason comes from the report being decided, not from whatever a
+     * previous decision stored: this decision is about *this* report, and the
+     * person is about to be told which one it was.
+     */
+    const report = reportId
+      ? await app.mongo.db
+          .collection(COLLECTIONS.reports)
+          .findOne<{ reason: string }>({ _id: reportId })
+      : null
+    const reason = report?.reason ?? profile.suspension?.reason ?? 'other'
+    const until = await suspendUser(app.mongo.db, {
+      userId,
+      reason,
+      ...(permanent ? { permanent: true } : { days: days ?? 1 }),
+      ...(reportId ? { reportId } : {}),
+    })
+    if (address?.verified) {
+      await tell(() =>
+        app.email.send({
+          to: address.email,
+          ...suspendedEmail(locale, { until: permanent ? null : until, reason }),
+        }),
+      )
+    }
+    return { ok: true, handle, outcome: { action, until, permanent, reason } }
+  }
+
+  // `shorten` and `lift` — the two an appeal can drive.
+  const until =
+    action === 'shorten' ? await shortenSuspension(app.mongo.db, userId, days ?? 1) : null
+  if (action === 'lift') await liftSuspension(app.mongo.db, userId)
+  if (address?.verified) {
+    await tell(() =>
+      app.email.send({ to: address.email, ...suspensionUpdatedEmail(locale, { until }) }),
+    )
+  }
+  return until
+    ? { ok: true, handle, outcome: { action: 'shorten', until } }
+    : { ok: true, handle, outcome: { action: 'lift' } }
+}

--- a/apps/api/src/modules/moderation/suspension.ts
+++ b/apps/api/src/modules/moderation/suspension.ts
@@ -19,9 +19,13 @@ import type { Profile } from '../profiles/profiles'
  * it — see the note on that constant for why permanence is a date here rather
  * than a flag.
  *
- * Decisions arrive from the signed link in the report email
- * (`email/reviewToken.ts`), never from a route with a session behind it: there
- * is no moderation console, and this does not build one.
+ * Decisions reach these functions two ways and write the same thing either
+ * way: the signed link in the report email (`email/reviewToken.ts`), which
+ * needs no session and works when nobody can sign in, and the operator panel
+ * (`routes/admin.ts`). Both go through `applyReviewDecision`, which is what
+ * keeps them one decision rather than two. Nothing below knows which door it
+ * came through, except that `byAdminId` is absent for the link — the mailbox
+ * authorises whoever holds it and can name nobody.
  */
 
 /** The suspension a profile is under right now, or none. */
@@ -54,6 +58,13 @@ export interface SuspendInput {
   permanent?: boolean
   reason: string
   reportId?: ObjectId
+  /**
+   * The moderator who decided it, when one is known. Absent for the emailed
+   * link, which authorises whoever holds it and can name nobody — so this
+   * answers "who suspended this account" without a join, for the decisions
+   * that can answer it at all.
+   */
+  byAdminId?: string
 }
 
 /**
@@ -82,6 +93,7 @@ export async function suspendUser(db: Db, input: SuspendInput): Promise<Date> {
           permanent,
           reason: input.reason,
           ...(input.reportId ? { reportId: input.reportId } : {}),
+          ...(input.byAdminId ? { by: input.byAdminId } : {}),
         },
       },
     },
@@ -122,6 +134,30 @@ export async function shortenSuspension(db: Db, userId: string, days: number): P
       { $set: { 'suspension.until': until, 'suspension.permanent': false } },
     )
   return until
+}
+
+/**
+ * Marks an appeal as answered, whatever the answer was.
+ *
+ * Without this the appeal queue never empties. `lift` has always cleared it by
+ * removing the whole sub-document, but `keep` and `shorten` leave the appeal
+ * exactly as they found it — so an appeal that was read and refused is
+ * indistinguishable from one nobody has looked at, and the emailed flow has
+ * had that hole since it shipped.
+ *
+ * Filtered on the appeal existing rather than read first, so answering twice
+ * does not move the date.
+ */
+export async function closeAppeal(db: Db, userId: string, byAdminId?: string): Promise<void> {
+  await db.collection<Profile>(COLLECTIONS.profiles).updateOne(
+    { _id: userId, 'suspension.appeal': { $exists: true } },
+    {
+      $set: {
+        'suspension.appeal.decidedAt': new Date(),
+        ...(byAdminId ? { 'suspension.appeal.decidedBy': byAdminId } : {}),
+      },
+    },
+  )
 }
 
 /**

--- a/apps/api/src/modules/notifications/scheduler.ts
+++ b/apps/api/src/modules/notifications/scheduler.ts
@@ -1,6 +1,7 @@
 import type { Db } from 'mongodb'
 import type { NotificationEmailContext } from '../../email/notify'
 import type { PushSender } from '../push/devices'
+import { runBroadcastQueuePass } from '../admin/broadcastQueue'
 import { withJobHealth } from '../admin/jobHealth'
 import type { SchedulerLogger } from '../tokens/poolScheduler'
 import { runBadgeRoundUpPass } from './badges'
@@ -89,6 +90,13 @@ export function startNotificationScheduler(
             logger,
           }),
         ),
+        /*
+         * The in-app half of the same idea, and a pass like the others. It
+         * needs no `tickMinutes`: an announcement has no day budget to spread,
+         * only a ceiling per tick — see `BROADCAST_PER_TICK` for why this is
+         * not a warm-up ramp.
+         */
+        run('broadcast queue', () => runBroadcastQueuePass(db, senders.push, now, { logger })),
       ])
     } finally {
       running = false

--- a/apps/api/src/modules/notifications/scheduler.ts
+++ b/apps/api/src/modules/notifications/scheduler.ts
@@ -1,6 +1,7 @@
 import type { Db } from 'mongodb'
 import type { NotificationEmailContext } from '../../email/notify'
 import type { PushSender } from '../push/devices'
+import { withJobHealth } from '../admin/jobHealth'
 import type { SchedulerLogger } from '../tokens/poolScheduler'
 import { runBadgeRoundUpPass } from './badges'
 import { runCampaignQueuePass } from './campaignQueue'
@@ -94,13 +95,18 @@ export function startNotificationScheduler(
     }
   }
 
-  /** Each pass on its own, so one throwing does not starve the two after it. */
+  /**
+   * Each pass on its own, so one throwing does not starve the two after it —
+   * and each one's outcome recorded, which is the only reason the operator
+   * panel can say a pass stopped firing. `withJobHealth` rethrows, so the
+   * catch below is unchanged.
+   */
   async function run(
     name: string,
     pass: () => Promise<{ sent: number; failed?: number }>,
   ): Promise<void> {
     try {
-      const { sent, failed } = await pass()
+      const { sent, failed } = await withJobHealth(db, name, pass)
       if (sent > 0) logger.info({ sent, pass: name }, 'notifications sent')
       if (failed) logger.warn({ failed, pass: name }, 'notifications skipped')
     } catch (error) {

--- a/apps/api/src/modules/presence/presence.ts
+++ b/apps/api/src/modules/presence/presence.ts
@@ -1,4 +1,4 @@
-import { PRESENCE_WRITE_MIN_GAP_MS } from '@langx/shared'
+import { APP_PLATFORM_HEADER, APP_VERSION_HEADER, PRESENCE_WRITE_MIN_GAP_MS } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
 import type { Profile } from '../profiles/profiles'
@@ -13,10 +13,56 @@ import type { Profile } from '../profiles/profiles'
  * stayed online for five minutes after their last message rather than after
  * they left.
  */
-export async function touchPresence(db: Db, userId: string, at: Date): Promise<void> {
-  await db
-    .collection<Profile>(COLLECTIONS.profiles)
-    .updateOne({ _id: userId }, { $set: { 'stats.lastActiveAt': at } })
+export async function touchPresence(
+  db: Db,
+  userId: string,
+  at: Date,
+  client: ClientBuild | null = null,
+): Promise<void> {
+  await db.collection<Profile>(COLLECTIONS.profiles).updateOne(
+    { _id: userId },
+    {
+      $set: {
+        'stats.lastActiveAt': at,
+        ...(client
+          ? { 'stats.appVersion': client.appVersion, 'stats.appPlatform': client.appPlatform }
+          : {}),
+      },
+    },
+  )
+}
+
+/** Which build somebody is on, when the headers said something we recognise. */
+export interface ClientBuild {
+  appVersion: string
+  appPlatform: 'ios' | 'android' | 'web'
+}
+
+const PLATFORMS = new Set<ClientBuild['appPlatform']>(['ios', 'android', 'web'])
+
+/** Three numbers and two dots, at most — nothing else is a version of ours. */
+const VERSION = /^\d{1,3}(\.\d{1,3}){0,2}$/
+
+/**
+ * The build behind a connection, from the two headers every request already
+ * carries (`app-config.ts` reads the same pair to decide whether an update is
+ * required).
+ *
+ * Validated rather than stored as sent. These are client headers, so anything
+ * at all can arrive in them, and what this feeds is a `$group` on the admin
+ * dashboard — an unbounded string there is an unbounded number of rows in a
+ * chart, written by whoever felt like it. Anything unrecognised is simply not
+ * recorded, which leaves the field as it was.
+ */
+export function clientBuildOf(
+  headers: Record<string, string | string[] | undefined>,
+): ClientBuild | null {
+  const first = (value: string | string[] | undefined): string =>
+    (Array.isArray(value) ? value[0] : value)?.trim().toLowerCase() ?? ''
+  const appVersion = first(headers[APP_VERSION_HEADER])
+  const appPlatform = first(headers[APP_PLATFORM_HEADER]) as ClientBuild['appPlatform']
+  if (!VERSION.test(appVersion) || !PLATFORMS.has(appPlatform)) return null
+  return { appVersion, appPlatform }
 }
 
 /**

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -287,6 +287,18 @@ export interface Profile {
     lastActiveAt: Date
     messagesSent: number
     /**
+     * The build this account was last seen on, from the two headers every
+     * client already sends — validated in `clientBuildOf` before it is stored,
+     * because a header is whatever the sender says it is.
+     *
+     * Here rather than on `devices` because `devices` holds only the accounts
+     * that registered for push, and "how many people are still on the old
+     * build" is a question about everybody. Absent until the next connection
+     * after this shipped.
+     */
+    appVersion?: string
+    appPlatform?: 'ios' | 'android' | 'web'
+    /**
      * Which badges this account has already been *told* about.
      *
      * Not a second copy of the badges — those stay derived, and this cannot

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -394,7 +394,15 @@ export interface Profile {
     reason: string
     reportId?: ObjectId
     /** The one appeal. Its presence is what refuses a second. */
-    appeal?: { at: Date; text: string }
+    /** The moderator who decided it, when the decision came from the panel. */
+    by?: string
+    /**
+     * `decidedAt` is what takes an appeal out of the queue. Answering with
+     * `lift` removes this whole sub-document and needs nothing; `keep` and
+     * `shorten` leave the appeal where it was, so without a stamp a refused
+     * appeal is indistinguishable from an unread one.
+     */
+    appeal?: { at: Date; text: string; decidedAt?: Date; decidedBy?: string }
   }
   deletedAt?: Date
   createdAt: Date

--- a/apps/api/src/modules/profiles/profiles.ts
+++ b/apps/api/src/modules/profiles/profiles.ts
@@ -75,6 +75,19 @@ export interface Profile {
    * was renamed would silently stop being official.
    */
   official?: true
+  /**
+   * A moderator. Set only by `scripts/grant-admin.ts`, never by a form —
+   * `updateProfileSchema` is a closed object and no route `$set`s a
+   * client-supplied shape onto a profile, so there is no path from a request
+   * body to this field.
+   *
+   * Read by `requireAuth`, which folds it into the projection it already makes
+   * for the suspension check. It reaches its owner through `GET /profiles/me`,
+   * which sends the stored document, and nobody else: `toPublicProfile` and
+   * `getSharedProfile` are both allow-lists, so a field added here is private
+   * until somebody names it.
+   */
+  admin?: true
   handle: string
   /**
    * The handle this account held before its owner swapped v1's name for one

--- a/apps/api/src/modules/push/meetingReminders.ts
+++ b/apps/api/src/modules/push/meetingReminders.ts
@@ -1,5 +1,6 @@
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
+import { withJobHealth } from '../admin/jobHealth'
 import { notificationsAllowed } from '@langx/shared'
 import type { Conversation, Message } from '../chat/conversations'
 import type { Profile } from '../profiles/profiles'
@@ -115,7 +116,9 @@ export function startMeetingReminderScheduler(
     if (running) return
     running = true
     try {
-      const { pushed } = await runMeetingReminderTick(db, sender, new Date())
+      const { pushed } = await withJobHealth(db, 'meeting reminder', () =>
+        runMeetingReminderTick(db, sender, new Date()),
+      )
       if (pushed > 0) logger.info({ pushed }, 'meeting reminders sent')
     } catch (error) {
       logger.error({ err: error }, 'meeting reminder run failed')

--- a/apps/api/src/modules/push/reminderScheduler.ts
+++ b/apps/api/src/modules/push/reminderScheduler.ts
@@ -1,6 +1,7 @@
 import { localDayKey, type Locale } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { COLLECTIONS } from '../../db/collections'
+import { withJobHealth } from '../admin/jobHealth'
 import { streakReminderSection } from '../../email/templates'
 import type { DigestCandidate } from '../notifications/digest'
 import type { Profile } from '../profiles/profiles'
@@ -138,7 +139,9 @@ export function startStreakReminderScheduler(
     if (running) return
     running = true
     try {
-      const { pushed } = await runStreakReminderTick(db, sender, new Date())
+      const { pushed } = await withJobHealth(db, 'streak reminder', () =>
+        runStreakReminderTick(db, sender, new Date()),
+      )
       if (pushed > 0) logger.info({ pushed }, 'streak reminders sent')
     } catch (error) {
       logger.error({ err: error }, 'streak reminder run failed')

--- a/apps/api/src/modules/tokens/poolScheduler.ts
+++ b/apps/api/src/modules/tokens/poolScheduler.ts
@@ -1,6 +1,7 @@
 import { newestPayableDay, shiftDayKey, utcDayKey } from '@langx/shared'
 import type { Db } from 'mongodb'
 import { runDailyPool } from './pool'
+import { withJobHealth } from '../admin/jobHealth'
 
 export interface SchedulerLogger {
   info: (obj: object, msg: string) => void
@@ -51,19 +52,30 @@ export function startDailyPoolScheduler(
     if (running) return // a slow run must not overlap itself
     running = true
     try {
-      const now = new Date()
-      const today = utcDayKey(now)
-      const newestPayable = newestPayableDay(now)
-      // Oldest first, so a catch-up pays days out in the order they happened.
-      for (let back = catchUpDays; back >= 1; back--) {
-        const day = shiftDayKey(today, -back)
-        // Day keys are `YYYY-MM-DD`, so this compares chronologically.
-        if (day > newestPayable) continue // closed, but its payout hour has not come
-        const outcome = await runDailyPool(db, { day })
-        if (outcome.ran) {
-          logger.info({ ...outcome.result }, 'daily token pool distributed')
+      /*
+       * The health record is of the tick, not of a day: a tick that walks five
+       * days and pays none of them still ran, and that is the fact worth being
+       * able to see. What each *day* did stays on its `jobRuns` row, which is
+       * the ledger-shaped half and outlives this.
+       */
+      await withJobHealth(db, 'daily pool', async () => {
+        const now = new Date()
+        const today = utcDayKey(now)
+        const newestPayable = newestPayableDay(now)
+        let paid = 0
+        // Oldest first, so a catch-up pays days out in the order they happened.
+        for (let back = catchUpDays; back >= 1; back--) {
+          const day = shiftDayKey(today, -back)
+          // Day keys are `YYYY-MM-DD`, so this compares chronologically.
+          if (day > newestPayable) continue // closed, but its payout hour has not come
+          const outcome = await runDailyPool(db, { day })
+          if (outcome.ran) {
+            paid += 1
+            logger.info({ ...outcome.result }, 'daily token pool distributed')
+          }
         }
-      }
+        return { daysPaid: paid }
+      })
     } catch (error) {
       // Never let a bad day kill the timer — the next tick retries, and the
       // `jobRuns` row for a day that failed mid-flight is what needs a human.

--- a/apps/api/src/routes/admin.test.ts
+++ b/apps/api/src/routes/admin.test.ts
@@ -1,4 +1,4 @@
-import { ERROR_CODES, SUSPENSION_FOREVER } from '@langx/shared'
+import { ERROR_CODES, REPORTS_TO_FREEZE_XP, SUSPENSION_FOREVER } from '@langx/shared'
 import type { FastifyInstance } from 'fastify'
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
@@ -10,6 +10,7 @@ import { ensureIndexes } from '../db/indexes'
 import { loadEnv } from '../env'
 import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
 import { withJobHealth, type JobHealth } from '../modules/admin/jobHealth'
+import { signReviewToken } from '../email/reviewToken'
 import { forgetAdminStats, type AdminStats } from '../modules/admin/stats'
 import type { Profile } from '../modules/profiles/profiles'
 import { createStorageProvider } from '../storage/createStorageProvider'
@@ -56,6 +57,17 @@ describe('the operator panel', () => {
   async function makeAdmin(user: SignedUpUser): Promise<void> {
     await profiles().updateOne({ _id: user.userId }, { $set: { admin: true } })
   }
+
+  // Always a payload, even an empty one: a conditional spread makes `inject`
+  // resolve to a union of its overloads, and `.json<T>()` on that union is an
+  // error type rather than a response. The routes with no body schema ignore it.
+  const post = (user: SignedUpUser, url: string, payload: unknown = {}) =>
+    app.inject({
+      method: 'POST',
+      url,
+      headers: { cookie: user.cookie },
+      payload: payload as Record<string, unknown>,
+    })
 
   const get = (user: SignedUpUser | null, url: string) =>
     app.inject({
@@ -248,6 +260,224 @@ describe('the operator panel', () => {
       await makeAdmin(admin)
       const jobs = (await get(admin, '/admin/stats')).json<AdminStats>().system.jobs
       expect(jobs.map((job) => job._id)).toContain('test pass')
+    })
+  })
+
+  describe('reports', () => {
+    it('is the same decision through the panel as through the emailed link', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+
+      // Two reports, two targets, so the two decisions cannot interfere.
+      const viaPanel = await newUser()
+      const viaLink = await newUser()
+      const reporter = await newUser()
+      for (const target of [viaPanel, viaLink]) {
+        expect(
+          (await post(reporter, '/reports', { userId: target.userId, reason: 'spam' })).statusCode,
+        ).toBe(201)
+      }
+
+      const queue = (await get(admin, '/admin/reports?status=open')).json<{
+        items: { id: string; reported: { userId: string } }[]
+      }>()
+      expect(queue.items).toHaveLength(2)
+      const reportFor = (user: SignedUpUser) =>
+        queue.items.find((item) => item.reported.userId === user.userId)!.id
+
+      // The panel.
+      const decided = await post(admin, `/admin/reports/${reportFor(viaPanel)}/decision`, {
+        action: 'suspend',
+        days: 3,
+      })
+      expect(decided.statusCode).toBe(200)
+
+      // The emailed form, which posts urlencoded and carries a signed token.
+      const token = signReviewToken('a'.repeat(32), {
+        kind: 'report',
+        userId: viaLink.userId,
+        reportId: reportFor(viaLink),
+        expiresAt: Date.now() + 60_000,
+      })
+      const page = await app.inject({
+        method: 'POST',
+        url: `/moderation/review?token=${encodeURIComponent(token)}`,
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        payload: 'action=suspend&days=3',
+      })
+      expect(page.statusCode).toBe(200)
+
+      const [a, b] = await Promise.all([
+        profiles().findOne({ _id: viaPanel.userId }),
+        profiles().findOne({ _id: viaLink.userId }),
+      ])
+      // Identical but for `by`, which only the panel can know: the mailbox
+      // authorises whoever holds the link and can name nobody.
+      expect(a?.suspension?.by).toBe(admin.userId)
+      expect(b?.suspension?.by).toBeUndefined()
+      expect(a?.suspension?.permanent).toBe(b?.suspension?.permanent)
+      expect(a?.suspension?.reason).toBe(b?.suspension?.reason)
+      expect(a?.suspension?.reportId).toBeDefined()
+      expect(b?.suspension?.reportId).toBeDefined()
+
+      // Both reports are closed, and both people were told the same thing.
+      const closed = (await get(admin, '/admin/reports?status=actioned')).json<{
+        items: unknown[]
+      }>()
+      expect(closed.items).toHaveLength(2)
+    })
+
+    it('writes what it did, and shows it on the account it did it to', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const target = await newUser()
+      const reporter = await newUser()
+      await post(reporter, '/reports', { userId: target.userId, reason: 'harassment' })
+
+      const queue = (await get(admin, '/admin/reports?status=open')).json<{
+        items: { id: string }[]
+      }>()
+      await post(admin, `/admin/reports/${queue.items[0]!.id}/decision`, { action: 'dismiss' })
+
+      const detail = (await get(admin, `/admin/users/${target.userId}`)).json<{
+        user: { actions: { action: string; adminId: string }[] }
+      }>()
+      expect(detail.user.actions[0]).toMatchObject({
+        action: 'report.decide',
+        adminId: admin.userId,
+      })
+    })
+  })
+
+  describe('appeals', () => {
+    it('leaves the queue when it is answered, however it is answered', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const target = await newUser()
+
+      await post(admin, `/admin/users/${target.userId}/suspend`, { reason: 'spam', days: 7 })
+      expect(
+        (
+          await post(target, '/me/suspension/appeal', {
+            text: 'It was not me, and I would like this looked at again.',
+          })
+        ).statusCode,
+      ).toBe(202)
+
+      const waiting = () =>
+        get(admin, '/admin/appeals').then((response) =>
+          response.json<{ items: { userId: string }[] }>(),
+        )
+      expect((await waiting()).items.map((item) => item.userId)).toContain(target.userId)
+
+      // `keep` is the one that used to leave it behind: `lift` removes the
+      // whole sub-document and always looked answered.
+      const kept = await post(admin, `/admin/appeals/${target.userId}/decision`, { action: 'keep' })
+      expect(kept.statusCode).toBe(200)
+      expect((await waiting()).items.map((item) => item.userId)).not.toContain(target.userId)
+
+      const profile = await profiles().findOne({ _id: target.userId })
+      expect(profile?.suspension?.appeal?.decidedBy).toBe(admin.userId)
+      // Still suspended — answering an appeal is not lifting one.
+      expect(profile?.suspension?.until).toBeDefined()
+    })
+  })
+
+  describe('the two things a report was the only way to reach', () => {
+    it('thaws an account whose earning three reports froze', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const target = await newUser()
+
+      for (let i = 0; i < REPORTS_TO_FREEZE_XP; i++) {
+        const reporter = await newUser()
+        await post(reporter, '/reports', { userId: target.userId, reason: 'spam' })
+      }
+      expect((await profiles().findOne({ _id: target.userId }))?.tokenFrozenAt).toBeDefined()
+
+      const thawed = await post(admin, `/admin/users/${target.userId}/unfreeze-tokens`)
+      expect(thawed.json<{ thawed: boolean }>().thawed).toBe(true)
+      expect((await profiles().findOne({ _id: target.userId }))?.tokenFrozenAt).toBeUndefined()
+    })
+
+    it('hides a post nobody reported, and can put it back', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const author = await newUser()
+      const created = await post(author, '/posts', {
+        body: 'something worth hiding',
+        language: 'en',
+      })
+      expect(created.statusCode).toBe(201)
+      const postId = created.json<{ _id: string }>()._id
+
+      const hidden = await post(admin, `/admin/posts/${postId}/hide`)
+      expect(hidden.json<{ hidden: boolean; changed: boolean }>()).toEqual({
+        hidden: true,
+        changed: true,
+      })
+      // Hiding it twice changes nothing and says so.
+      expect(
+        (await post(admin, `/admin/posts/${postId}/hide`)).json<{ changed: boolean }>().changed,
+      ).toBe(false)
+      expect(
+        (await post(admin, `/admin/posts/${postId}/unhide`)).json<{ hidden: boolean }>().hidden,
+      ).toBe(false)
+    })
+  })
+
+  describe('the support questions', () => {
+    it("says which filter empties this person's Discover", async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const lonely = await newUser()
+
+      const { discovery } = (await get(admin, `/admin/users/${lonely.userId}`)).json<{
+        discovery: { matches: number; steps: { filter: string; remaining: number }[] }
+      }>()
+
+      // Cumulative and in order, so the step where it collapses is the answer.
+      expect(discovery.steps.map((step) => step.filter)).toEqual([
+        'everybody',
+        'discoverable',
+        'not suspended',
+        'not blocked either way',
+        'language fit',
+      ])
+      expect(discovery.steps.at(-1)!.remaining).toBe(discovery.matches)
+      for (let i = 1; i < discovery.steps.length; i++) {
+        expect(discovery.steps[i]!.remaining).toBeLessThanOrEqual(discovery.steps[i - 1]!.remaining)
+      }
+    })
+
+    it('resolves the notification switches rather than printing what is stored', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const target = await newUser()
+
+      // The oldest of the three stored shapes: one boolean for everything.
+      await profiles().updateOne(
+        { _id: target.userId },
+        { $set: { 'settings.notifications': false } },
+      )
+
+      const { push } = (await get(admin, `/admin/users/${target.userId}`)).json<{
+        push: { prefs: { type: string; push: boolean; email: boolean }[] }
+      }>()
+      expect(push.prefs.length).toBeGreaterThan(0)
+      expect(push.prefs.every((pref) => !pref.push && !pref.email)).toBe(true)
+    })
+
+    it('finds somebody by the address a support thread came from', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const target = await newUser()
+
+      const found = await get(admin, `/admin/users?q=${encodeURIComponent(target.email)}`)
+      expect(found.statusCode).toBe(200)
+      expect(found.json<{ user: { userId: string; email: string } }>().user.userId).toBe(
+        target.userId,
+      )
     })
   })
 })

--- a/apps/api/src/routes/admin.test.ts
+++ b/apps/api/src/routes/admin.test.ts
@@ -14,6 +14,7 @@ import { verifyBountyToken } from '../email/bountyToken'
 import { signReviewToken } from '../email/reviewToken'
 import { forgetAdminStats, type AdminStats } from '../modules/admin/stats'
 import type { Profile } from '../modules/profiles/profiles'
+import { ensureOfficialAccounts } from '../modules/official/accounts'
 import { createStorageProvider } from '../storage/createStorageProvider'
 import { CapturingEmailSender, signUpAndSignIn, type SignedUpUser } from '../testSupport/authFlow'
 import { createTranslationProvider } from '../translation/createTranslationProvider'
@@ -102,6 +103,9 @@ describe('the operator panel', () => {
       revenueCat: createRevenueCatClientFromEnv(env),
     })
     await app.ready()
+    // `index.ts` does this at boot; `buildApp` does not, and the panel can
+    // send from @langx.
+    await ensureOfficialAccounts(handle.db, 'http://localhost:4000')
     for (let attempt = 1; attempt <= 5; attempt++) {
       const warmUp = await app.inject({
         method: 'POST',
@@ -553,6 +557,89 @@ describe('the operator panel', () => {
         items: { body: string }[]
       }>()
       expect(queue.items[0]?.body).toBe('The first thing that went wrong.')
+    })
+  })
+
+  describe('speaking as @langx', () => {
+    it('delivers one message, which the person cannot reply to', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const recipient = await newUser()
+
+      const sent = await post(admin, `/admin/users/${recipient.userId}/message`, {
+        body: 'Your report was received. Replies go to hi@langx.io.',
+      })
+      expect(sent.statusCode).toBe(201)
+      const conversationId = sent.json<{ conversationId: string }>().conversationId
+
+      /*
+       * It lands in the thread the welcome is already in — one conversation per
+       * pair, forever, which is what `pairKey` is for. So this looks through
+       * the thread rather than at the top of it.
+       */
+      const thread = await get(recipient, `/conversations/${conversationId}/messages`)
+      expect(thread.statusCode).toBe(200)
+      const bodies = thread.json<{ items: { body: string }[] }>().items.map((item) => item.body)
+      expect(bodies.some((body) => body.includes('Your report was received'))).toBe(true)
+
+      /*
+       * And it is one way. `OFFICIAL_WRITABLE.langx` is false, so
+       * `recordMessage` refuses anything addressed back — a deliberate product
+       * decision, asserted here so that turning @langx into a support inbox
+       * becomes a choice somebody makes rather than something that happens.
+       *
+       * Against the repository rather than a route because text messages are
+       * sent over the socket, and the guard is below both.
+       */
+      const { sendTextMessage } = await import('../modules/chat/messages')
+      await expect(
+        sendTextMessage(handle.db, recipient.userId, {
+          conversationId,
+          body: 'thanks!',
+          clientId: 'reply-attempt',
+        }),
+      ).rejects.toThrow(/does not take messages/i)
+    })
+  })
+
+  describe('broadcasts', () => {
+    it('is a draft first, and the slug cannot be used twice', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+
+      const created = await post(admin, '/admin/broadcasts', {
+        id: 'autumn-news',
+        bodies: { en: 'Something new is here.' },
+      })
+      expect(created.statusCode).toBe(201)
+      expect(created.json<{ status: string; total: number }>().status).toBe('draft')
+      expect(created.json<{ total: number }>().total).toBeGreaterThan(0)
+
+      // Sent to the operator alone, before anybody else can see it.
+      const tested = await post(admin, '/admin/broadcasts/autumn-news/test')
+      expect(tested.json<{ delivered: boolean }>().delivered).toBe(true)
+
+      const armed = await post(admin, '/admin/broadcasts/autumn-news/start')
+      expect(armed.json<{ status: string }>().status).toBe('queued')
+
+      // Starting it again is refused rather than silently ignored.
+      expect((await post(admin, '/admin/broadcasts/autumn-news/start')).statusCode).toBe(400)
+
+      const again = await post(admin, '/admin/broadcasts', {
+        id: 'autumn-news',
+        bodies: { en: 'A different message under the same name.' },
+      })
+      expect(again.statusCode).toBe(400)
+    })
+
+    it('refuses a broadcast with no English body, because English is the fallback', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const created = await post(admin, '/admin/broadcasts', {
+        id: 'turkish-only',
+        bodies: { tr: 'Sadece Türkçe' },
+      })
+      expect(created.statusCode).toBe(400)
     })
   })
 })

--- a/apps/api/src/routes/admin.test.ts
+++ b/apps/api/src/routes/admin.test.ts
@@ -591,6 +591,13 @@ describe('the operator panel', () => {
        * Against the repository rather than a route because text messages are
        * sent over the socket, and the guard is below both.
        */
+      // A typo in the URL opens no conversation with a participant who is not
+      // there — the id that reaches the write is the one the lookup returned.
+      expect(
+        (await post(admin, '/admin/users/nobody-by-that-id/message', { body: 'hello?' }))
+          .statusCode,
+      ).toBe(404)
+
       const { sendTextMessage } = await import('../modules/chat/messages')
       await expect(
         sendTextMessage(handle.db, recipient.userId, {

--- a/apps/api/src/routes/admin.test.ts
+++ b/apps/api/src/routes/admin.test.ts
@@ -1,4 +1,4 @@
-import { ERROR_CODES, REPORTS_TO_FREEZE_XP, SUSPENSION_FOREVER } from '@langx/shared'
+import { BOUNTY_MIN, ERROR_CODES, REPORTS_TO_FREEZE_XP, SUSPENSION_FOREVER } from '@langx/shared'
 import type { FastifyInstance } from 'fastify'
 import { MongoMemoryReplSet } from 'mongodb-memory-server'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
@@ -10,6 +10,7 @@ import { ensureIndexes } from '../db/indexes'
 import { loadEnv } from '../env'
 import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
 import { withJobHealth, type JobHealth } from '../modules/admin/jobHealth'
+import { verifyBountyToken } from '../email/bountyToken'
 import { signReviewToken } from '../email/reviewToken'
 import { forgetAdminStats, type AdminStats } from '../modules/admin/stats'
 import type { Profile } from '../modules/profiles/profiles'
@@ -478,6 +479,80 @@ describe('the operator panel', () => {
       expect(found.json<{ user: { userId: string; email: string } }>().user.userId).toBe(
         target.userId,
       )
+    })
+  })
+
+  describe('bug reports', () => {
+    it('is the same object as the link in the mail, and pays once across both', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const finder = await newUser()
+
+      const sent = await post(finder, '/feedback', {
+        kind: 'bug',
+        body: 'The compose button does nothing on a cold start.',
+      })
+      expect(sent.statusCode).toBe(202)
+
+      const queue = (await get(admin, '/admin/feedback?status=open')).json<{
+        items: { _id: string; kind: string; sender: { userId: string } }[]
+      }>()
+      expect(queue.items).toHaveLength(1)
+      const row = queue.items[0]!
+      expect(row.kind).toBe('bug')
+      expect(row.sender.userId).toBe(finder.userId)
+
+      /*
+       * The row's id is the id the emailed bounty link carries. This is the
+       * assertion the whole design rests on: if these two ever differ, paying
+       * from the panel and paying from the mail become two payments.
+       */
+      const mail = emailSender.messages.find((message) =>
+        message.subject.startsWith('Bug report from'),
+      )
+      expect(mail).toBeDefined()
+      const token = decodeURIComponent(
+        /\/feedback\/award\?token=([^"'&\s]+)/.exec(mail?.html ?? '')?.[1] ?? '',
+      )
+      expect(verifyBountyToken('a'.repeat(32), token)?.reportId).toBe(row._id)
+
+      const paid = await post(admin, `/admin/feedback/${row._id}/award`, { amount: BOUNTY_MIN })
+      expect(paid.json<{ awarded: boolean; amount: number }>()).toEqual({
+        awarded: true,
+        amount: BOUNTY_MIN,
+      })
+
+      // Paying again — from either door — pays nothing and says so.
+      const again = await post(admin, `/admin/feedback/${row._id}/award`, { amount: BOUNTY_MIN })
+      expect(again.json<{ awarded: boolean }>().awarded).toBe(false)
+
+      const ledger = await handle.db
+        .collection(COLLECTIONS.tokenLedger)
+        .countDocuments({ userId: finder.userId, kind: 'bounty', refId: row._id })
+      expect(ledger).toBe(1)
+
+      // Paying moves it to `triaged`, not `closed`: it says the report was
+      // real, not that the fix shipped.
+      const triaged = (await get(admin, '/admin/feedback?status=triaged')).json<{
+        items: { _id: string; bounty: { amount: number } | null }[]
+      }>()
+      expect(triaged.items[0]?._id).toBe(row._id)
+      expect(triaged.items[0]?.bounty?.amount).toBe(BOUNTY_MIN)
+    })
+
+    it('shows the oldest open report first, because it is a queue and not a feed', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const sender = await newUser()
+
+      for (const body of ['The first thing that went wrong.', 'The second thing.']) {
+        await post(sender, '/feedback', { kind: 'bug', body })
+      }
+
+      const queue = (await get(admin, '/admin/feedback?status=open')).json<{
+        items: { body: string }[]
+      }>()
+      expect(queue.items[0]?.body).toBe('The first thing that went wrong.')
     })
   })
 })

--- a/apps/api/src/routes/admin.test.ts
+++ b/apps/api/src/routes/admin.test.ts
@@ -1,0 +1,253 @@
+import { ERROR_CODES, SUSPENSION_FOREVER } from '@langx/shared'
+import type { FastifyInstance } from 'fastify'
+import { MongoMemoryReplSet } from 'mongodb-memory-server'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { buildApp } from '../app'
+import { createAuth } from '../auth'
+import { connectToDatabase, type DbHandle } from '../db/client'
+import { COLLECTIONS } from '../db/collections'
+import { ensureIndexes } from '../db/indexes'
+import { loadEnv } from '../env'
+import { createRevenueCatClientFromEnv } from '../modules/billing/createRevenueCatClient'
+import { withJobHealth, type JobHealth } from '../modules/admin/jobHealth'
+import { forgetAdminStats, type AdminStats } from '../modules/admin/stats'
+import type { Profile } from '../modules/profiles/profiles'
+import { createStorageProvider } from '../storage/createStorageProvider'
+import { CapturingEmailSender, signUpAndSignIn, type SignedUpUser } from '../testSupport/authFlow'
+import { createTranslationProvider } from '../translation/createTranslationProvider'
+
+const PASSWORD = 'correct horse battery staple'
+
+describe('the operator panel', () => {
+  let replSet: MongoMemoryReplSet
+  let handle: DbHandle
+  let app: FastifyInstance
+  let emailSender: CapturingEmailSender
+  let seq = 0
+
+  async function newUser(): Promise<SignedUpUser> {
+    seq++
+    const user = await signUpAndSignIn(app, emailSender, {
+      email: `admin-${seq}@example.com`,
+      password: PASSWORD,
+      name: 'Test',
+    })
+    const response = await app.inject({
+      method: 'POST',
+      url: '/profiles',
+      headers: { cookie: user.cookie },
+      payload: {
+        handle: `adminuser${seq}`,
+        displayName: `User ${seq}`,
+        birthDate: '1995-06-15',
+        gender: 'undisclosed',
+        nativeLanguages: [{ code: 'tr' }],
+        learning: [{ code: 'en', level: 'intermediate', priority: 1 }],
+      },
+    })
+    if (response.statusCode !== 201) {
+      throw new Error(`onboarding failed (${response.statusCode}): ${response.body}`)
+    }
+    return user
+  }
+
+  const profiles = () => handle.db.collection<Profile>(COLLECTIONS.profiles)
+
+  async function makeAdmin(user: SignedUpUser): Promise<void> {
+    await profiles().updateOne({ _id: user.userId }, { $set: { admin: true } })
+  }
+
+  const get = (user: SignedUpUser | null, url: string) =>
+    app.inject({
+      method: 'GET',
+      url,
+      ...(user ? { headers: { cookie: user.cookie } } : {}),
+    })
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+    handle = await connectToDatabase(replSet.getUri(), 'langx_admin_test')
+    const env = loadEnv({
+      NODE_ENV: 'test',
+      MONGODB_URI: replSet.getUri(),
+      MONGODB_DB: 'langx_admin_test',
+      LOG_LEVEL: 'silent',
+      BETTER_AUTH_SECRET: 'a'.repeat(32),
+      BETTER_AUTH_URL: 'http://localhost:4000',
+    })
+    await ensureIndexes(handle.db)
+    emailSender = new CapturingEmailSender()
+    const auth = await createAuth({ env, db: handle.db, client: handle.client, emailSender })
+    app = await buildApp({
+      env,
+      client: handle.client,
+      db: handle.db,
+      auth,
+      email: emailSender,
+      storage: createStorageProvider(env),
+      translation: createTranslationProvider(env),
+      revenueCat: createRevenueCatClientFromEnv(env),
+    })
+    await app.ready()
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      const warmUp = await app.inject({
+        method: 'POST',
+        url: '/api/auth/sign-up/email',
+        payload: { email: `warmup-${attempt}@example.com`, password: PASSWORD, name: 'Warm Up' },
+      })
+      if (warmUp.statusCode === 200) break
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+    emailSender.messages.length = 0
+  }, 120_000)
+
+  afterAll(async () => {
+    await app?.close()
+    await handle?.close()
+    await replSet?.stop()
+  })
+
+  // The stats endpoint memoises for a minute, which is right in production and
+  // wrong inside a test that has just written the thing it is about to read.
+  beforeEach(() => {
+    forgetAdminStats()
+  })
+
+  describe('the guard', () => {
+    it('refuses in the right order: unauthenticated, then suspended, then not an admin', async () => {
+      expect((await get(null, '/admin/stats')).statusCode).toBe(401)
+
+      const member = await newUser()
+      const refused = await get(member, '/admin/stats')
+      expect(refused.statusCode).toBe(403)
+      expect(refused.json<{ code: string }>().code).toBe(ERROR_CODES.ADMIN_REQUIRED)
+
+      const admin = await newUser()
+      await makeAdmin(admin)
+      expect((await get(admin, '/admin/stats')).statusCode).toBe(200)
+
+      /*
+       * A suspended moderator is told they are suspended rather than being let
+       * in to moderate their way out of it. This is the assertion that pins the
+       * order of the two 403s; without it either arrangement passes.
+       */
+      await profiles().updateOne(
+        { _id: admin.userId },
+        {
+          $set: {
+            suspension: {
+              at: new Date(),
+              until: new Date(SUSPENSION_FOREVER),
+              permanent: true,
+              reason: 'spam',
+            },
+          },
+        },
+      )
+      const suspended = await get(admin, '/admin/stats')
+      expect(suspended.statusCode).toBe(403)
+      expect(suspended.json<{ code: string }>().code).toBe(ERROR_CODES.ACCOUNT_SUSPENDED)
+
+      await profiles().updateOne({ _id: admin.userId }, { $unset: { suspension: '' } })
+    })
+
+    it('answers a guest with ADMIN_REQUIRED, not the offer to create an account', async () => {
+      const guest = await app.inject({ method: 'POST', url: '/api/auth/sign-in/anonymous' })
+      const cookie = guest.headers['set-cookie']
+      const refused = await app.inject({
+        method: 'GET',
+        url: '/admin/stats',
+        headers: { cookie: Array.isArray(cookie) ? cookie.join('; ') : (cookie ?? '') },
+      })
+      expect(refused.statusCode).toBe(403)
+      expect(refused.json<{ code: string }>().code).toBe(ERROR_CODES.ADMIN_REQUIRED)
+    })
+  })
+
+  describe('the flag', () => {
+    it('reaches its owner and nobody else', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const other = await newUser()
+
+      expect((await get(admin, '/profiles/me')).json<{ admin?: true }>().admin).toBe(true)
+
+      const asMember = await get(other, `/profiles/${admin.userId}`)
+      expect(asMember.statusCode).toBe(200)
+      expect(asMember.json()).not.toHaveProperty('admin')
+
+      const adminProfile = await profiles().findOne({ _id: admin.userId })
+      const signedOut = await get(null, `/public/profiles/${adminProfile?.handle}`)
+      expect(signedOut.statusCode).toBe(200)
+      expect(signedOut.json()).not.toHaveProperty('admin')
+    })
+  })
+
+  describe('the dashboard', () => {
+    it('counts what it says it counts, and survives a database with nothing in it', async () => {
+      const admin = await newUser()
+      await makeAdmin(admin)
+
+      const stats = (await get(admin, '/admin/stats')).json<AdminStats>()
+
+      // Every profile made in this file joined today, so the two agree.
+      expect(stats.audience.joinedToday).toBeGreaterThan(0)
+      expect(stats.audience.joinedToday).toBe(stats.audience.joinedLastWeek)
+      expect(stats.audience.profiles).toBeGreaterThan(0)
+      expect(stats.audience.seenLastWeek).toBeGreaterThan(0)
+
+      // Seven days of strip, oldest first, zeros included rather than absent —
+      // a missing day in a chart reads as missing data, not as a quiet one.
+      expect(stats.audience.activeDaily).toHaveLength(7)
+      expect(stats.money.tokensDaily).toHaveLength(7)
+      expect(stats.audience.activeDaily.at(-1)!.day > stats.audience.activeDaily[0]!.day).toBe(true)
+
+      // Nothing has been reported, appealed, sent, suspended or paid here.
+      expect(stats.queue).toEqual({ reports: 0, appeals: 0, feedback: 0 })
+      expect(stats.money.pool).toBeNull()
+      expect(stats.system.suppressions.total).toBe(0)
+      expect(stats.system.campaigns).toEqual([])
+
+      // The plan mix adds up, which is the only thing that can be asserted
+      // about it without pinning the tier of every fixture in the file.
+      const { total, pro, proPlus, free } = stats.money.tiers
+      expect(pro + proPlus + free).toBe(total)
+
+      // Read from the public module rather than recomputed beside it.
+      expect(stats.public.totals.members).toBeGreaterThan(0)
+    })
+  })
+
+  describe('job health', () => {
+    it('records a pass that worked, a pass that threw, and clears the error after', async () => {
+      const health = () =>
+        handle.db.collection<JobHealth>(COLLECTIONS.jobHealth).findOne({ _id: 'test pass' })
+
+      await withJobHealth(handle.db, 'test pass', () => Promise.resolve({ sent: 3 }))
+      expect(await health()).toMatchObject({ lastResult: { sent: 3 }, lastError: null, runs: 1 })
+
+      // It rethrows: every scheduler already catches and carries on, and this
+      // must not take that over.
+      await expect(
+        withJobHealth(handle.db, 'test pass', () =>
+          Promise.reject(new Error('the pass fell over')),
+        ),
+      ).rejects.toThrow('the pass fell over')
+      expect(await health()).toMatchObject({
+        lastError: 'the pass fell over',
+        runs: 2,
+        failures: 1,
+      })
+
+      // A stale error beside a fresh success would read as a job still broken.
+      await withJobHealth(handle.db, 'test pass', () => Promise.resolve({ sent: 0 }))
+      expect(await health()).toMatchObject({ lastError: null, runs: 3, failures: 1 })
+
+      forgetAdminStats()
+      const admin = await newUser()
+      await makeAdmin(admin)
+      const jobs = (await get(admin, '/admin/stats')).json<AdminStats>().system.jobs
+      expect(jobs.map((job) => job._id)).toContain('test pass')
+    })
+  })
+})

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -448,9 +448,20 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
       config: { rateLimit: limit(60, '1 minute') },
     },
     async (request, reply) => {
+      /*
+       * The profile is looked up rather than trusted, and the id that goes
+       * into the write is the one that came back. Without it a typo in the URL
+       * opens a conversation with a participant who does not exist — and
+       * `deliverOfficialMessage` builds `unread` and `messageCountBy` as
+       * objects keyed by that id, which is a route parameter reaching a
+       * property name. CodeQL says so too (`js/remote-property-injection`).
+       */
+      const recipient = await getProfile(app.mongo.db, request.params.userId)
+      if (!recipient) throw new ApiError(ERROR_CODES.NOT_FOUND, 'No such account')
+
       const delivered = await deliverOfficialMessage(app.mongo.db, {
         fromHandle: 'langx',
-        toUserId: request.params.userId,
+        toUserId: recipient._id,
         body: request.body.body,
         // Unique per send rather than per subject: the same words twice are
         // two messages here, unlike a broadcast, which must never repeat.
@@ -466,7 +477,7 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
       await recordAdminAction(app.mongo.db, request.log, {
         adminId: request.userId,
         action: 'user.message',
-        subjectUserId: request.params.userId,
+        subjectUserId: recipient._id,
         // The body is deliberately not stored here: it is already a message
         // row, and the audit log is a record of decisions rather than a second
         // copy of everything anybody was told.

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,23 +1,355 @@
+import {
+  ERROR_CODES,
+  adminListQuerySchema,
+  adminReportListQuerySchema,
+  adminSuspendSchema,
+  adminUserSearchSchema,
+  reviewDecisionSchema,
+} from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { z } from 'zod'
+import { COLLECTIONS } from '../db/collections'
+import { ApiError } from '../lib/ApiError'
+import { authId } from '../lib/authId'
 import { requireAdmin } from '../middleware/requireAuth'
+import { recordAdminAction } from '../modules/admin/auditLog'
+import { getReport, listAppeals, listReports, toObjectId } from '../modules/admin/reports'
 import { readAdminStats } from '../modules/admin/stats'
+import { findAdminUser, getAdminUser } from '../modules/admin/users'
+import { setPostHidden } from '../modules/feed/feed'
+import { applyReviewDecision, type ReviewRefusal } from '../modules/moderation/decide'
+import { getProfile, type Profile } from '../modules/profiles/profiles'
+import { userRoom } from '../ws/types'
 
 /**
  * The operator panel's API.
  *
- * Everything here is behind `requireAdmin`, which is a flag on a profile and
- * not an env var — see the note on that guard for why `ADMIN_USER_IDS` is not
- * what authorises this.
+ * Everything here is behind `requireAdmin`, which reads a flag on a profile —
+ * see the note on that guard for why `ADMIN_USER_IDS` is not what authorises
+ * it.
  *
- * It is JSON and nothing else. The two server-rendered pages in
- * `moderation.ts` and `feedback.ts` stay exactly where they are: a signed link
- * in a mailbox is the path that still works when nobody can sign in, and it is
- * the one somebody else can be handed without an account. The panel is the
- * surface you reach for; those are the one you fall back to.
+ * JSON and nothing else. The two server-rendered pages in `moderation.ts` and
+ * `feedback.ts` stay exactly where they are: a signed link in a mailbox is the
+ * path that still works when nobody can sign in, and the one somebody can be
+ * handed without an account. The panel is the surface you reach for; those are
+ * the one you fall back to. Both drive `applyReviewDecision`, so neither can
+ * drift from the other.
+ *
+ * Every mutating route records what it did *after* it did it, through
+ * `recordAdminAction`, which never throws — see the note there.
  */
+
+/** What a refusal from `applyReviewDecision` becomes over JSON. */
+const REFUSALS: Record<ReviewRefusal, [code: string, status: number, message: string]> = {
+  action_not_allowed: [ERROR_CODES.VALIDATION_FAILED, 400, 'That decision does not belong here'],
+  account_gone: [ERROR_CODES.NOT_FOUND, 404, 'That account no longer exists'],
+  not_a_post: [ERROR_CODES.VALIDATION_FAILED, 400, 'That report is not about a post'],
+  post_gone: [ERROR_CODES.NOT_FOUND, 404, 'That post no longer exists'],
+}
+
 // eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
 export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
+  /**
+   * Ceilings rather than anti-abuse limits: one person holds this flag, and
+   * what these guard against is a stuck client or a slipped keypress. Disabled
+   * under test, the way `moderation.ts` and `feedback.ts` both do it.
+   */
+  const limit = (max: number, timeWindow: string) =>
+    app.env.NODE_ENV === 'test' ? false : { max, timeWindow }
+
   app.get('/admin/stats', { preHandler: requireAdmin }, async (_request, reply) => {
     return reply.send(await readAdminStats(app.mongo.db))
   })
+
+  // ── reports ──────────────────────────────────────────────────────────────
+
+  app.get(
+    '/admin/reports',
+    { preHandler: requireAdmin, schema: { querystring: adminReportListQuerySchema } },
+    async (request, reply) => {
+      return reply.send(await listReports(app.mongo.db, request.query))
+    },
+  )
+
+  app.get(
+    '/admin/reports/:id',
+    { preHandler: requireAdmin, schema: { params: z.object({ id: z.string() }) } },
+    async (request, reply) => {
+      const report = await getReport(app.mongo.db, request.params.id)
+      if (!report) throw new ApiError(ERROR_CODES.NOT_FOUND, 'No such report')
+      return reply.send(report)
+    },
+  )
+
+  app.post(
+    '/admin/reports/:id/decision',
+    {
+      preHandler: requireAdmin,
+      schema: { params: z.object({ id: z.string() }), body: reviewDecisionSchema },
+      config: { rateLimit: limit(60, '1 minute') },
+    },
+    async (request, reply) => {
+      const reportId = toObjectId(request.params.id)
+      const report = reportId
+        ? await app.mongo.db
+            .collection<{ reportedId: string }>(COLLECTIONS.reports)
+            .findOne({ _id: reportId })
+        : null
+      if (!report || !reportId) throw new ApiError(ERROR_CODES.NOT_FOUND, 'No such report')
+
+      const result = await applyReviewDecision(app, {
+        kind: 'report',
+        userId: report.reportedId,
+        reportId,
+        action: request.body.action,
+        ...(request.body.days === undefined ? {} : { days: request.body.days }),
+        byAdminId: request.userId,
+      })
+      if (!result.ok) return refuse(reply, result.refusal)
+
+      await recordAdminAction(app.mongo.db, request.log, {
+        adminId: request.userId,
+        action: 'report.decide',
+        subjectUserId: report.reportedId,
+        refId: request.params.id,
+        payload: { ...request.body },
+      })
+      return reply.send(result.outcome)
+    },
+  )
+
+  // ── appeals ──────────────────────────────────────────────────────────────
+
+  app.get(
+    '/admin/appeals',
+    { preHandler: requireAdmin, schema: { querystring: adminListQuerySchema } },
+    async (request, reply) => {
+      return reply.send(await listAppeals(app.mongo.db, { ...request.query, status: 'open' }))
+    },
+  )
+
+  app.post(
+    '/admin/appeals/:userId/decision',
+    {
+      preHandler: requireAdmin,
+      schema: { params: z.object({ userId: z.string() }), body: reviewDecisionSchema },
+      config: { rateLimit: limit(60, '1 minute') },
+    },
+    async (request, reply) => {
+      const profile = await getProfile(app.mongo.db, request.params.userId)
+      if (!profile) throw new ApiError(ERROR_CODES.NOT_FOUND, 'No such account')
+
+      const result = await applyReviewDecision(app, {
+        kind: 'appeal',
+        userId: request.params.userId,
+        reportId: profile.suspension?.reportId ?? null,
+        action: request.body.action,
+        ...(request.body.days === undefined ? {} : { days: request.body.days }),
+        byAdminId: request.userId,
+      })
+      if (!result.ok) return refuse(reply, result.refusal)
+
+      await recordAdminAction(app.mongo.db, request.log, {
+        adminId: request.userId,
+        action: 'appeal.decide',
+        subjectUserId: request.params.userId,
+        payload: { ...request.body },
+      })
+      return reply.send(result.outcome)
+    },
+  )
+
+  // ── one account ──────────────────────────────────────────────────────────
+
+  app.get(
+    '/admin/users',
+    { preHandler: requireAdmin, schema: { querystring: adminUserSearchSchema } },
+    async (request, reply) => {
+      const profile = await findAdminUser(app.mongo.db, request.query.q)
+      if (!profile) throw new ApiError(ERROR_CODES.NOT_FOUND, 'Nobody by that name or address')
+      return reply.send(await getAdminUser(app.mongo.db, profile))
+    },
+  )
+
+  app.get(
+    '/admin/users/:userId',
+    { preHandler: requireAdmin, schema: { params: z.object({ userId: z.string() }) } },
+    async (request, reply) => {
+      const profile = await getProfile(app.mongo.db, request.params.userId)
+      if (!profile) throw new ApiError(ERROR_CODES.NOT_FOUND, 'No such account')
+      return reply.send(await getAdminUser(app.mongo.db, profile))
+    },
+  )
+
+  /**
+   * Suspending somebody the panel found rather than somebody a report named.
+   *
+   * Through `applyReviewDecision` with no report, so the notice, the stamp and
+   * the shape of the sub-document are identical to a decision taken from a
+   * report. `adminSuspendSchema` offers no `permanent`: a suspension that
+   * never ends should be reached from the evidence that justifies it.
+   */
+  app.post(
+    '/admin/users/:userId/suspend',
+    {
+      preHandler: requireAdmin,
+      schema: { params: z.object({ userId: z.string() }), body: adminSuspendSchema },
+      config: { rateLimit: limit(60, '1 minute') },
+    },
+    async (request, reply) => {
+      const result = await applyReviewDecision(app, {
+        kind: 'report',
+        userId: request.params.userId,
+        reportId: null,
+        action: 'suspend',
+        days: request.body.days,
+        // There is no report to read a reason from, so the one typed here is it.
+        reason: request.body.reason,
+        byAdminId: request.userId,
+      })
+      if (!result.ok) return refuse(reply, result.refusal)
+
+      await recordAdminAction(app.mongo.db, request.log, {
+        adminId: request.userId,
+        action: 'user.suspend',
+        subjectUserId: request.params.userId,
+        payload: { ...request.body },
+      })
+      return reply.send(result.outcome)
+    },
+  )
+
+  app.post(
+    '/admin/users/:userId/lift',
+    {
+      preHandler: requireAdmin,
+      schema: { params: z.object({ userId: z.string() }) },
+      config: { rateLimit: limit(60, '1 minute') },
+    },
+    async (request, reply) => {
+      const result = await applyReviewDecision(app, {
+        kind: 'appeal',
+        userId: request.params.userId,
+        reportId: null,
+        action: 'lift',
+        byAdminId: request.userId,
+      })
+      if (!result.ok) return refuse(reply, result.refusal)
+
+      await recordAdminAction(app.mongo.db, request.log, {
+        adminId: request.userId,
+        action: 'user.lift',
+        subjectUserId: request.params.userId,
+      })
+      return reply.send(result.outcome)
+    },
+  )
+
+  /**
+   * Thaws an account's earning.
+   *
+   * `reportUser` freezes it once three distinct people have reported somebody
+   * (`REPORTS_TO_FREEZE_XP`), and until this route existed **nothing in the
+   * codebase ever cleared it** — a report that turned out to be wrong left
+   * that person unable to earn a token, permanently and silently. This is the
+   * other half of dismissing a report.
+   */
+  app.post(
+    '/admin/users/:userId/unfreeze-tokens',
+    {
+      preHandler: requireAdmin,
+      schema: { params: z.object({ userId: z.string() }) },
+      config: { rateLimit: limit(60, '1 minute') },
+    },
+    async (request, reply) => {
+      const result = await app.mongo.db
+        .collection<Profile>(COLLECTIONS.profiles)
+        .updateOne({ _id: request.params.userId }, { $unset: { tokenFrozenAt: '' } })
+      if (result.matchedCount === 0) throw new ApiError(ERROR_CODES.NOT_FOUND, 'No such account')
+
+      await recordAdminAction(app.mongo.db, request.log, {
+        adminId: request.userId,
+        action: 'user.unfreeze',
+        subjectUserId: request.params.userId,
+      })
+      return reply.send({ thawed: result.modifiedCount > 0 })
+    },
+  )
+
+  /**
+   * Signs one account out everywhere — for the compromised account, where the
+   * answer is not a suspension.
+   *
+   * Two halves, because a session and a socket are revoked by different
+   * things. Deleting the rows shuts REST immediately; a socket that is already
+   * open authenticated at its handshake and would not notice, so it is
+   * disconnected here rather than left until its next reconnect.
+   *
+   * `authId` because Better Auth's collections store ids as ObjectId and ours
+   * store the string — a string against `session` matches nothing and reports
+   * success.
+   */
+  app.post(
+    '/admin/users/:userId/sign-out',
+    {
+      preHandler: requireAdmin,
+      schema: { params: z.object({ userId: z.string() }) },
+      config: { rateLimit: limit(30, '1 minute') },
+    },
+    async (request, reply) => {
+      const { deletedCount } = await app.mongo.db
+        .collection(COLLECTIONS.session)
+        .deleteMany({ userId: authId(request.params.userId) })
+      app.io.in(userRoom(request.params.userId)).disconnectSockets(true)
+
+      await recordAdminAction(app.mongo.db, request.log, {
+        adminId: request.userId,
+        action: 'user.signOut',
+        subjectUserId: request.params.userId,
+        payload: { sessions: deletedCount },
+      })
+      return reply.send({ sessions: deletedCount })
+    },
+  )
+
+  // ── one post ─────────────────────────────────────────────────────────────
+
+  /**
+   * Hiding a post nobody reported.
+   *
+   * `setPostHidden` has existed since the feed did, and the only way to reach
+   * it was a report — so a post you found yourself could not be hidden until
+   * somebody else complained about it. Reversible, and deliberately still no
+   * delete: see `REPORT_REVIEW_ACTIONS` for why that stays a script.
+   */
+  for (const hidden of [true, false]) {
+    app.post(
+      `/admin/posts/:postId/${hidden ? 'hide' : 'unhide'}`,
+      {
+        preHandler: requireAdmin,
+        schema: { params: z.object({ postId: z.string() }) },
+        config: { rateLimit: limit(60, '1 minute') },
+      },
+      async (request, reply) => {
+        const before = await setPostHidden(app.mongo.db, request.params.postId, hidden)
+        if (!before) throw new ApiError(ERROR_CODES.NOT_FOUND, 'No such post')
+
+        await recordAdminAction(app.mongo.db, request.log, {
+          adminId: request.userId,
+          action: hidden ? 'post.hide' : 'post.unhide',
+          subjectUserId: before.authorId,
+          refId: request.params.postId,
+        })
+        return reply.send({ hidden, changed: Boolean(before.hiddenAt) !== hidden })
+      },
+    )
+  }
+}
+
+function refuse(
+  reply: { code: (status: number) => { send: (body: unknown) => unknown } },
+  refusal: ReviewRefusal,
+) {
+  const [code, status, message] = REFUSALS[refusal]
+  return reply.code(status).send({ code, message })
 }

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -2,8 +2,10 @@ import {
   ERROR_CODES,
   adminListQuerySchema,
   adminReportListQuerySchema,
+  adminFeedbackListQuerySchema,
   adminSuspendSchema,
   adminUserSearchSchema,
+  bountyAwardSchema,
   reviewDecisionSchema,
 } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
@@ -16,6 +18,8 @@ import { recordAdminAction } from '../modules/admin/auditLog'
 import { getReport, listAppeals, listReports, toObjectId } from '../modules/admin/reports'
 import { readAdminStats } from '../modules/admin/stats'
 import { findAdminUser, getAdminUser } from '../modules/admin/users'
+import { payBounty } from '../modules/feedback/awardBounty'
+import { getFeedback, listFeedback, updateFeedback } from '../modules/feedback/reports'
 import { setPostHidden } from '../modules/feed/feed'
 import { applyReviewDecision, type ReviewRefusal } from '../modules/moderation/decide'
 import { getProfile, type Profile } from '../modules/profiles/profiles'
@@ -309,6 +313,104 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
         payload: { sessions: deletedCount },
       })
       return reply.send({ sessions: deletedCount })
+    },
+  )
+
+  // ── bug reports and ideas ────────────────────────────────────────────────
+
+  app.get(
+    '/admin/feedback',
+    { preHandler: requireAdmin, schema: { querystring: adminFeedbackListQuerySchema } },
+    async (request, reply) => {
+      return reply.send(await listFeedback(app.mongo.db, request.query))
+    },
+  )
+
+  app.get(
+    '/admin/feedback/:id',
+    { preHandler: requireAdmin, schema: { params: z.object({ id: z.string() }) } },
+    async (request, reply) => {
+      const row = await getFeedback(app.mongo.db, request.params.id)
+      if (!row) throw new ApiError(ERROR_CODES.NOT_FOUND, 'No such report')
+      return reply.send(row)
+    },
+  )
+
+  app.patch(
+    '/admin/feedback/:id',
+    {
+      preHandler: requireAdmin,
+      schema: {
+        params: z.object({ id: z.string() }),
+        body: z.object({
+          status: z.enum(['open', 'triaged', 'closed']).optional(),
+          issueUrl: z.url().optional(),
+          closeReason: z.enum(['fixed', 'shipped', 'wontfix', 'duplicate', 'invalid']).optional(),
+          note: z.string().trim().max(1000).optional(),
+        }),
+      },
+      config: { rateLimit: limit(60, '1 minute') },
+    },
+    async (request, reply) => {
+      const row = await updateFeedback(
+        app.mongo.db,
+        request.params.id,
+        {
+          ...(request.body.status ? { status: request.body.status } : {}),
+          ...(request.body.issueUrl ? { issueUrl: request.body.issueUrl } : {}),
+          ...(request.body.closeReason ? { closeReason: request.body.closeReason } : {}),
+          ...(request.body.note === undefined ? {} : { note: request.body.note }),
+        },
+        request.userId,
+      )
+      if (!row) throw new ApiError(ERROR_CODES.NOT_FOUND, 'No such report')
+
+      await recordAdminAction(app.mongo.db, request.log, {
+        adminId: request.userId,
+        action: 'feedback.update',
+        subjectUserId: row.userId,
+        refId: request.params.id,
+        payload: { ...request.body },
+      })
+      return reply.send(row)
+    },
+  )
+
+  /**
+   * Paying for a confirmed report.
+   *
+   * Through `payBounty`, which the emailed link also calls — so the ledger's
+   * unique `{userId, kind, refId}` index makes it paid once *across both
+   * doors*, not once per door. A second press of either says so and changes
+   * nothing.
+   */
+  app.post(
+    '/admin/feedback/:id/award',
+    {
+      preHandler: requireAdmin,
+      schema: { params: z.object({ id: z.string() }), body: bountyAwardSchema },
+      config: { rateLimit: limit(30, '1 hour') },
+    },
+    async (request, reply) => {
+      const row = await getFeedback(app.mongo.db, request.params.id)
+      if (!row) throw new ApiError(ERROR_CODES.NOT_FOUND, 'No such report')
+
+      const result = await payBounty(app, {
+        userId: row.userId,
+        refId: row._id,
+        amount: request.body.amount,
+      })
+
+      if (result.awarded) {
+        await recordAdminAction(app.mongo.db, request.log, {
+          adminId: request.userId,
+          action: 'feedback.award',
+          subjectUserId: row.userId,
+          refId: row._id,
+          payload: { amount: result.amount },
+        })
+      }
+      return reply.send(result)
     },
   )
 

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,11 +1,13 @@
 import {
   ERROR_CODES,
   adminListQuerySchema,
+  adminMessageSchema,
   adminReportListQuerySchema,
   adminFeedbackListQuerySchema,
   adminSuspendSchema,
   adminUserSearchSchema,
   bountyAwardSchema,
+  broadcastCreateSchema,
   reviewDecisionSchema,
 } from '@langx/shared'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
@@ -15,6 +17,15 @@ import { ApiError } from '../lib/ApiError'
 import { authId } from '../lib/authId'
 import { requireAdmin } from '../middleware/requireAuth'
 import { recordAdminAction } from '../modules/admin/auditLog'
+import {
+  countBroadcastAudience,
+  createBroadcast,
+  deleteBroadcast,
+  getBroadcast,
+  listBroadcasts,
+  setBroadcastStatus,
+} from '../modules/admin/broadcast'
+import { sendBroadcastTest } from '../modules/admin/broadcastQueue'
 import { getReport, listAppeals, listReports, toObjectId } from '../modules/admin/reports'
 import { readAdminStats } from '../modules/admin/stats'
 import { findAdminUser, getAdminUser } from '../modules/admin/users'
@@ -22,7 +33,9 @@ import { payBounty } from '../modules/feedback/awardBounty'
 import { getFeedback, listFeedback, updateFeedback } from '../modules/feedback/reports'
 import { setPostHidden } from '../modules/feed/feed'
 import { applyReviewDecision, type ReviewRefusal } from '../modules/moderation/decide'
+import { deliverOfficialMessage } from '../modules/official/deliver'
 import { getProfile, type Profile } from '../modules/profiles/profiles'
+import { fanOutMessage } from '../ws/fanOut'
 import { userRoom } from '../ws/types'
 
 /**
@@ -411,6 +424,178 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
         })
       }
       return reply.send(result)
+    },
+  )
+
+  // ── one message, and a message to everybody ──────────────────────────────
+
+  /**
+   * A message from `@langx` to one person.
+   *
+   * **One way.** `OFFICIAL_WRITABLE.langx` is false, so `recordMessage`
+   * refuses anything addressed back and the chat screen draws no composer —
+   * which is a deliberate product decision (a broadcast account that sometimes
+   * replies is a promise about attention nobody can keep) and is not being
+   * undone here. So this is right for "your report was received", "the bounty
+   * is paid", "your suspension was lifted", and wrong for a conversation: what
+   * is written should say where a reply goes.
+   */
+  app.post(
+    '/admin/users/:userId/message',
+    {
+      preHandler: requireAdmin,
+      schema: { params: z.object({ userId: z.string() }), body: adminMessageSchema },
+      config: { rateLimit: limit(60, '1 minute') },
+    },
+    async (request, reply) => {
+      const delivered = await deliverOfficialMessage(app.mongo.db, {
+        fromHandle: 'langx',
+        toUserId: request.params.userId,
+        body: request.body.body,
+        // Unique per send rather than per subject: the same words twice are
+        // two messages here, unlike a broadcast, which must never repeat.
+        clientId: `admin:${request.userId}:${Date.now()}`,
+      })
+      if (!delivered) {
+        throw new ApiError(ERROR_CODES.NOT_FOUND, 'There is no @langx account to send from')
+      }
+      await fanOutMessage(app, app.io, delivered.conversation, delivered.message, {
+        pushWhenAway: true,
+      })
+
+      await recordAdminAction(app.mongo.db, request.log, {
+        adminId: request.userId,
+        action: 'user.message',
+        subjectUserId: request.params.userId,
+        // The body is deliberately not stored here: it is already a message
+        // row, and the audit log is a record of decisions rather than a second
+        // copy of everything anybody was told.
+        refId: delivered.message._id.toHexString(),
+      })
+      return reply.code(201).send({ conversationId: delivered.conversation._id.toHexString() })
+    },
+  )
+
+  app.get('/admin/broadcasts', { preHandler: requireAdmin }, async (_request, reply) => {
+    return reply.send({
+      items: await listBroadcasts(app.mongo.db),
+      audience: await countBroadcastAudience(app.mongo.db),
+    })
+  })
+
+  app.post(
+    '/admin/broadcasts',
+    {
+      preHandler: requireAdmin,
+      schema: { body: broadcastCreateSchema },
+      config: { rateLimit: limit(30, '1 hour') },
+    },
+    async (request, reply) => {
+      if (await getBroadcast(app.mongo.db, request.body.id)) {
+        throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'That slug has already been used')
+      }
+      const job = await createBroadcast(app.mongo.db, {
+        id: request.body.id,
+        bodies: request.body.bodies,
+        pushTitle: request.body.pushTitle,
+        createdBy: request.userId,
+      })
+
+      await recordAdminAction(app.mongo.db, request.log, {
+        adminId: request.userId,
+        action: 'broadcast.create',
+        refId: job._id,
+        payload: { total: job.total, locales: Object.keys(job.bodies) },
+      })
+      return reply.code(201).send(job)
+    },
+  )
+
+  app.get(
+    '/admin/broadcasts/:id',
+    { preHandler: requireAdmin, schema: { params: z.object({ id: z.string() }) } },
+    async (request, reply) => {
+      const job = await getBroadcast(app.mongo.db, request.params.id)
+      if (!job) throw new ApiError(ERROR_CODES.NOT_FOUND, 'No such broadcast')
+      return reply.send(job)
+    },
+  )
+
+  /** To the operator and nobody else — see `sendBroadcastTest`. */
+  app.post(
+    '/admin/broadcasts/:id/test',
+    {
+      preHandler: requireAdmin,
+      schema: { params: z.object({ id: z.string() }) },
+      config: { rateLimit: limit(30, '1 hour') },
+    },
+    async (request, reply) => {
+      const job = await getBroadcast(app.mongo.db, request.params.id)
+      if (!job) throw new ApiError(ERROR_CODES.NOT_FOUND, 'No such broadcast')
+
+      const delivered = await sendBroadcastTest(app.mongo.db, app.push, job, request.userId)
+      await recordAdminAction(app.mongo.db, request.log, {
+        adminId: request.userId,
+        action: 'broadcast.test',
+        refId: job._id,
+      })
+      return reply.send({ delivered })
+    },
+  )
+
+  /*
+   * Arming, stopping and letting go again. The transitions live in
+   * `setBroadcastStatus` as a table; a refused one is a 409 rather than a
+   * silent no-op, because "I pressed Start and nothing happened" is the one
+   * thing this screen must never do.
+   */
+  for (const [path, next, action] of [
+    ['start', 'queued', 'broadcast.start'],
+    ['pause', 'paused', 'broadcast.pause'],
+    ['resume', 'queued', 'broadcast.resume'],
+  ] as const) {
+    app.post(
+      `/admin/broadcasts/:id/${path}`,
+      {
+        preHandler: requireAdmin,
+        schema: { params: z.object({ id: z.string() }) },
+        // Five an hour on the irreversible one. Not anti-abuse — one person
+        // holds this flag — but a bound on the blast radius of a stuck client.
+        config: { rateLimit: limit(path === 'start' ? 5 : 30, '1 hour') },
+      },
+      async (request, reply) => {
+        const job = await setBroadcastStatus(app.mongo.db, request.params.id, next)
+        if (!job) {
+          throw new ApiError(
+            ERROR_CODES.VALIDATION_FAILED,
+            'That broadcast is not in a state this can change',
+          )
+        }
+        await recordAdminAction(app.mongo.db, request.log, {
+          adminId: request.userId,
+          action,
+          refId: job._id,
+          payload: { status: job.status, sent: job.sent, total: job.total },
+        })
+        return reply.send(job)
+      },
+    )
+  }
+
+  /** Only a draft: once it has been armed there may be messages out. */
+  app.delete(
+    '/admin/broadcasts/:id',
+    { preHandler: requireAdmin, schema: { params: z.object({ id: z.string() }) } },
+    async (request, reply) => {
+      if (!(await deleteBroadcast(app.mongo.db, request.params.id))) {
+        throw new ApiError(ERROR_CODES.VALIDATION_FAILED, 'Only a draft can be deleted')
+      }
+      await recordAdminAction(app.mongo.db, request.log, {
+        adminId: request.userId,
+        action: 'broadcast.delete',
+        refId: request.params.id,
+      })
+      return reply.code(204).send()
     },
   )
 

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,0 +1,23 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { requireAdmin } from '../middleware/requireAuth'
+import { readAdminStats } from '../modules/admin/stats'
+
+/**
+ * The operator panel's API.
+ *
+ * Everything here is behind `requireAdmin`, which is a flag on a profile and
+ * not an env var — see the note on that guard for why `ADMIN_USER_IDS` is not
+ * what authorises this.
+ *
+ * It is JSON and nothing else. The two server-rendered pages in
+ * `moderation.ts` and `feedback.ts` stay exactly where they are: a signed link
+ * in a mailbox is the path that still works when nobody can sign in, and it is
+ * the one somebody else can be handed without an account. The panel is the
+ * surface you reach for; those are the one you fall back to.
+ */
+// eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
+export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
+  app.get('/admin/stats', { preHandler: requireAdmin }, async (_request, reply) => {
+    return reply.send(await readAdminStats(app.mongo.db))
+  })
+}

--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -13,11 +13,10 @@ import { ApiError } from '../lib/ApiError'
 import { verifyBountyToken } from '../email/bountyToken'
 import { requireVerifiedEmail } from '../middleware/requireAuth'
 import { escapeHtml, html, page, submitButton, who } from './operatorPage'
-import { notifyBountyPaid } from '../modules/feedback/bountyNotice'
+import { payBounty } from '../modules/feedback/awardBounty'
 import { submitFeedback } from '../modules/feedback/submit'
 import { objectExtension } from '../modules/media/objectExtension'
 import { getProfile } from '../modules/profiles/profiles'
-import { awardTokens } from '../modules/tokens/ledger'
 
 /**
  * Bug reports and feature requests from inside the app — and, in the email
@@ -184,27 +183,11 @@ export const feedbackRoutes: FastifyPluginAsyncZod = async (app) => {
         )
       }
 
-      const result = await awardTokens(app.mongo.db, {
+      const result = await payBounty(app, {
         userId: claim.userId,
-        kind: 'bounty',
-        amount: parsed.data.amount,
         refId: claim.reportId,
+        amount: parsed.data.amount,
       })
-
-      /*
-       * Only on the award that actually happened. The ledger's unique index on
-       * `{userId, kind, refId}` makes that exactly once per report, so a
-       * second press of the same link pays nothing and says nothing either —
-       * no second notification, and no need for a claim row to prevent one.
-       */
-      if (result.awarded) {
-        await notifyBountyPaid(
-          app.mongo.db,
-          { push: app.push, email: app.email },
-          { userId: claim.userId, amount: result.amount },
-          (err, message) => request.log.warn({ err, userId: claim.userId }, message),
-        )
-      }
 
       return html(
         reply,

--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -22,14 +22,19 @@ import { getProfile } from '../modules/profiles/profiles'
  * Bug reports and feature requests from inside the app — and, in the email
  * each one becomes, paying for it.
  *
- * A report goes two places and into no table of ours: an email to
- * `SUPPORT_EMAIL`, and a public issue on the repository. That is the design,
- * not a shortcut. A confirmed report is paid for, and both halves of that —
- * whether it is real and what it is worth — are one person's judgement made
- * while reading the mail; the tracker is where the work then lives. A
- * collection here would hold a copy of a decision taken in an inbox, with no
- * screen in the app able to close a row and nobody looking at the ones left
- * open.
+ * A report goes three places: a row in `feedback`, an email to
+ * `SUPPORT_EMAIL`, and a prefilled link that opens a public issue on the
+ * repository. A confirmed report is paid for, and both halves of that —
+ * whether it is real and what it is worth — are one person's judgement; the
+ * tracker is where the work then lives.
+ *
+ * The row came last, and the objection it answers is worth keeping in view:
+ * a collection here would be a copy of a decision taken in an inbox, with no
+ * screen able to close a row and nobody looking at the ones left open. The
+ * operator panel is that screen, its queue is ordered oldest-open-first so the
+ * ones left open are the ones it shows, and the row's `_id` is the id the
+ * bounty link already carried — so it is the same object as the link rather
+ * than a copy of it.
  *
  * `requireVerifiedEmail` on both of the routes the app calls. A signed URL is a
  * capability, so the upload route needs the same guard the feed's does — and
@@ -77,10 +82,10 @@ export const feedbackRoutes: FastifyPluginAsyncZod = async (app) => {
         )
       }
 
-      // Its own prefix, keyed by user, and load-bearing rather than tidy: a
-      // report is written to no table of ours, so this prefix is the only
-      // thing that can find the file again. The account purge sweeps it with
-      // `deleteByPrefix` — proof of a bug is still their file.
+      // Its own prefix, keyed by user, and load-bearing rather than tidy: the
+      // report's row carries the URLs but the storage does not know about it,
+      // so this prefix is what can still find the files. The account purge
+      // sweeps it with `deleteByPrefix` — proof of a bug is still their file.
       const extension = objectExtension(contentType)
       const key = `feedback/${request.userId}/${randomUUID()}.${extension}`
       return reply.send(await app.storage.getUploadUrl(key, contentType))

--- a/apps/api/src/routes/moderation.test.ts
+++ b/apps/api/src/routes/moderation.test.ts
@@ -1216,8 +1216,10 @@ describe('Faz 10 — blocking, reports, profile views, deletion and export', () 
   /**
    * Suspension, end to end from the link in the report email.
    *
-   * There is no admin route to drive here, which is the design: the decision
-   * happens in the mailbox the report already arrives in.
+   * The operator panel decides the same reports through the same function
+   * (`moderation/decide.ts`); what is pinned here is the door that needs no
+   * session, which is the one that has to keep working when nobody can sign
+   * in. `routes/admin.test.ts` asserts the two write the same thing.
    */
   describe('suspension', () => {
     /** The `Review:` line the report mail carries, as a path this app can be injected with. */

--- a/apps/api/src/routes/moderation.ts
+++ b/apps/api/src/routes/moderation.ts
@@ -1,5 +1,4 @@
 import {
-  REVIEW_ACTIONS_BY_KIND,
   SUSPENSION_MAX_DAYS,
   appealSchema,
   attachmentsOf,
@@ -11,12 +10,7 @@ import {
 } from '@langx/shared'
 import { ObjectId } from 'mongodb'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
-import {
-  appealEmail,
-  reportEmail,
-  suspendedEmail,
-  suspensionUpdatedEmail,
-} from '../email/templates'
+import { appealEmail, reportEmail } from '../email/templates'
 import {
   REVIEW_TOKEN_TTL_MS,
   reviewUrl,
@@ -26,20 +20,15 @@ import {
 import { COLLECTIONS } from '../db/collections'
 import { publicApiUrl } from '../env'
 import { requireAuth, requireMember } from '../middleware/requireAuth'
-import { setPostHidden, type Post } from '../modules/feed/feed'
+import type { Post } from '../modules/feed/feed'
 import { blockUser, listBlocked, reportUser, unblockUser } from '../modules/moderation/blocks'
-import { getViewers } from '../modules/moderation/profileViews'
 import {
-  actionReport,
-  dismissReport,
-  liftSuspension,
-  shortenSuspension,
-  submitAppeal,
-  suspendUser,
-  suspensionStatus,
-} from '../modules/moderation/suspension'
-import { emailFor } from '../modules/profiles/emailFor'
-import { localeFor } from '../modules/profiles/localeFor'
+  applyReviewDecision,
+  type ReviewOutcome,
+  type ReviewRefusal,
+} from '../modules/moderation/decide'
+import { getViewers } from '../modules/moderation/profileViews'
+import { submitAppeal, suspensionStatus } from '../modules/moderation/suspension'
 import { getProfile, type Profile } from '../modules/profiles/profiles'
 import { escapeHtml, html, page, submitButton, who } from './operatorPage'
 
@@ -104,6 +93,39 @@ function postSection(token: string, post: Post | null): string {
                  ${actionForm(token, 'unhide_post', 'Show it again')}`
               : actionForm(token, 'hide_post', 'Hide this post')
           }`
+}
+
+/** Why a decision could not be made, as this page says it. */
+const REFUSALS: Record<ReviewRefusal, [number, string]> = {
+  action_not_allowed: [400, 'That link cannot make that decision.'],
+  account_gone: [404, 'That account no longer exists.'],
+  not_a_post: [400, 'That report is not about a post.'],
+  post_gone: [404, 'That post no longer exists.'],
+}
+
+/** What was decided, in the one sentence this page answers with. */
+function decided(outcome: ReviewOutcome, name: string): string {
+  switch (outcome.action) {
+    case 'hide_post':
+      return `<p>Hidden. Nobody can see it, ${name} included${outcome.changed ? '' : ' — it already was'}.</p>`
+    case 'unhide_post':
+      return `<p>Back in the feed${outcome.changed ? '' : ' — it was never hidden'}.</p>`
+    case 'dismiss':
+      return `<p>Dismissed. Nothing changes on ${name}.</p>`
+    case 'keep':
+      return `<p>Kept as it is. ${name} was not told.</p>`
+    case 'suspend':
+    case 'permanent':
+      return `<p>${name} is suspended ${
+        outcome.permanent
+          ? '<strong>permanently</strong>'
+          : `until <strong>${escapeHtml(outcome.until.toISOString())}</strong>`
+      }.</p>`
+    case 'shorten':
+      return `<p>${name} is now suspended until <strong>${escapeHtml(outcome.until.toISOString())}</strong>.</p>`
+    case 'lift':
+      return `<p>Lifted. ${name} can use the app again.</p>`
+  }
 }
 
 /**
@@ -347,135 +369,22 @@ export const moderationRoutes: FastifyPluginAsyncZod = async (app) => {
           page(REVIEW_TITLE, 'That is not a decision this page can make.'),
         )
       }
-      const { action, days } = parsed.data
-      /*
-       * The token says *which* report or appeal; this says what may be done
-       * with it. Both halves are checked, so a report link cannot lift a
-       * suspension it was never shown, and an appeal link cannot open a new one.
-       */
-      if (!(REVIEW_ACTIONS_BY_KIND[claim.kind] as readonly ReviewAction[]).includes(action)) {
-        return html(reply.code(400), page(REVIEW_TITLE, 'That link cannot make that decision.'))
+
+      const result = await applyReviewDecision(app, {
+        kind: claim.kind,
+        userId: claim.userId,
+        reportId: toObjectId(claim.reportId),
+        action: parsed.data.action,
+        days: parsed.data.days,
+      })
+      if (!result.ok) {
+        const [status, sentence] = REFUSALS[result.refusal]
+        return html(reply.code(status), page(REVIEW_TITLE, sentence))
       }
 
-      const profile = await getProfile(app.mongo.db, claim.userId)
-      if (!profile) {
-        return html(reply.code(404), page(REVIEW_TITLE, 'That account no longer exists.'))
-      }
-      const name = escapeHtml(who(profile.handle, claim.userId))
-      const reportId = toObjectId(claim.reportId)
-
-      /*
-       * The two decisions about the post rather than the account, handled
-       * before the address lookups below because neither needs one: hiding is
-       * silent, which is the whole shape of it.
-       */
-      if (action === 'hide_post' || action === 'unhide_post') {
-        const report = reportId
-          ? await app.mongo.db
-              .collection('reports')
-              .findOne<{ postId?: ObjectId }>({ _id: reportId })
-          : null
-        if (!report?.postId) {
-          return html(reply.code(400), page(REVIEW_TITLE, 'That report is not about a post.'))
-        }
-        const hide = action === 'hide_post'
-        const before = await setPostHidden(app.mongo.db, report.postId.toHexString(), hide)
-        if (!before) {
-          return html(reply.code(404), page(REVIEW_TITLE, 'That post no longer exists.'))
-        }
-        /*
-         * Hiding decides the report; showing it again does not reopen it. The
-         * second is a correction of the first, and a report that bounced back
-         * to `open` would arrive in the next list as work nobody owes.
-         */
-        if (hide && reportId) await actionReport(app.mongo.db, reportId)
-        const changed = Boolean(before.hiddenAt) !== hide
-        return html(
-          reply,
-          page(
-            REVIEW_TITLE,
-            hide
-              ? `<p>Hidden. Nobody can see it, ${name} included${changed ? '' : ' — it already was'}.</p>`
-              : `<p>Back in the feed${changed ? '' : ' — it was never hidden'}.</p>`,
-          ),
-        )
-      }
-
-      /**
-       * Telling the person is never fatal to the decision. The suspension is
-       * already written; a mail provider's bad minute must not turn it into a
-       * 500 that invites the same button being pressed again.
-       */
-      const tell = async (send: () => Promise<void>) => {
-        try {
-          await send()
-        } catch (error) {
-          request.log.warn({ err: error, userId: claim.userId }, 'suspension email failed')
-        }
-      }
-      const address = await emailFor(app.mongo.db, claim.userId)
-      const locale = await localeFor(app.mongo.db, claim.userId)
-
-      if (action === 'dismiss') {
-        if (reportId) await dismissReport(app.mongo.db, reportId)
-        return html(reply, page(REVIEW_TITLE, `<p>Dismissed. Nothing changes on ${name}.</p>`))
-      }
-
-      if (action === 'keep') {
-        return html(reply, page(REVIEW_TITLE, `<p>Kept as it is. ${name} was not told.</p>`))
-      }
-
-      if (action === 'suspend' || action === 'permanent') {
-        const permanent = action === 'permanent'
-        /*
-         * The reason comes from the report being decided, not from whatever a
-         * previous decision stored: this link is about *this* report, and the
-         * person is about to be told which one it was.
-         */
-        const report = reportId
-          ? await app.mongo.db.collection('reports').findOne<{ reason: string }>({ _id: reportId })
-          : null
-        const reason = report?.reason ?? profile.suspension?.reason ?? 'other'
-        const until = await suspendUser(app.mongo.db, {
-          userId: claim.userId,
-          reason,
-          ...(permanent ? { permanent: true } : { days: days ?? 1 }),
-          ...(reportId ? { reportId } : {}),
-        })
-        if (address?.verified) {
-          await tell(() =>
-            app.email.send({
-              to: address.email,
-              ...suspendedEmail(locale, { until: permanent ? null : until, reason }),
-            }),
-          )
-        }
-        return html(
-          reply,
-          page(
-            REVIEW_TITLE,
-            `<p>${name} is suspended ${permanent ? '<strong>permanently</strong>' : `until <strong>${escapeHtml(until.toISOString())}</strong>`}.</p>`,
-          ),
-        )
-      }
-
-      // `shorten` and `lift` — the two an appeal link can drive.
-      const until =
-        action === 'shorten' ? await shortenSuspension(app.mongo.db, claim.userId, days ?? 1) : null
-      if (action === 'lift') await liftSuspension(app.mongo.db, claim.userId)
-      if (address?.verified) {
-        await tell(() =>
-          app.email.send({ to: address.email, ...suspensionUpdatedEmail(locale, { until }) }),
-        )
-      }
       return html(
         reply,
-        page(
-          REVIEW_TITLE,
-          until
-            ? `<p>${name} is now suspended until <strong>${escapeHtml(until.toISOString())}</strong>.</p>`
-            : `<p>Lifted. ${name} can use the app again.</p>`,
-        ),
+        page(REVIEW_TITLE, decided(result.outcome, escapeHtml(who(result.handle, claim.userId)))),
       )
     },
   )

--- a/apps/api/src/routes/moderation.ts
+++ b/apps/api/src/routes/moderation.ts
@@ -131,11 +131,16 @@ function decided(outcome: ReviewOutcome, name: string): string {
 /**
  * Blocks, reports, and what a report can lead to.
  *
- * Suspension is decided from the signed link in the report email, not from a
- * route with a session behind it. There is no moderation console and this
- * does not build one: the review happens in the mailbox where the report
- * already arrives, which is the same trade `feedback.ts` makes for a bounty.
- * See `email/reviewToken.ts` for what authorises those two routes.
+ * The two routes at the bottom are decided from the signed link in the report
+ * email rather than from a session — see `email/reviewToken.ts` for what
+ * authorises them, and `feedback.ts` for the same trade made for a bounty.
+ * They are **not** the only way any more: `routes/admin.ts` decides the same
+ * reports from the operator panel. This one stays because it is the path that
+ * still works when nobody can sign in, and the one that can be handed to
+ * somebody without an account.
+ *
+ * Both call `applyReviewDecision`. Nothing about a decision lives in this
+ * file except the sentence it is rendered as.
  */
 // eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin signature
 export const moderationRoutes: FastifyPluginAsyncZod = async (app) => {

--- a/apps/api/src/storage/StorageProvider.ts
+++ b/apps/api/src/storage/StorageProvider.ts
@@ -59,10 +59,11 @@ export interface StorageProviderWithPut extends StorageProvider {
  *
  * The purge finds a person's files through the documents that reference them,
  * which works for everything the app stores a URL for. A bug report's
- * attachment is the exception: it goes to an email and into no table of ours,
- * so the only handle we kept on it is the prefix the upload chose. Without
- * this it stays in the bucket forever, publicly fetchable, after the account
- * that sent it is gone.
+ * attachment is the exception. Its row does hold the URLs, but the row is
+ * deleted by the same purge and the ordering between the two is not something
+ * to rely on — so the handle that has always worked, the prefix the upload
+ * chose, is still what this sweeps. Without it an attachment stays in the
+ * bucket forever, publicly fetchable, after the account that sent it is gone.
  *
  * Its own interface rather than another method on `StorageProviderWithPut`,
  * for the reason that one is separate from `StorageProvider`: a provider that

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -48,7 +48,7 @@ import {
   sendTextMessage,
 } from '../modules/chat/messages'
 import { fanOutConversationPinned, fanOutMessage, fanOutMessageUpdate } from './fanOut'
-import { PresenceThrottle, touchPresence } from '../modules/presence/presence'
+import { PresenceThrottle, clientBuildOf, touchPresence } from '../modules/presence/presence'
 import { SocketRateLimiter } from './rateLimit'
 import { userRoom, type AppServer, type AppSocket } from './types'
 
@@ -281,7 +281,14 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
      * missed presence write decays away by itself, a rejection here would
      * take down a working connection.
      */
-    void touchPresence(app.mongo.db, userId, new Date()).catch((error: unknown) =>
+    /*
+     * The build, read once per connection rather than per write: the headers
+     * cannot change while a socket is open, and re-parsing them on every
+     * heartbeat would be work for an answer that is already known.
+     */
+    const build = clientBuildOf(socket.handshake.headers)
+
+    void touchPresence(app.mongo.db, userId, new Date(), build).catch((error: unknown) =>
       app.log.warn({ err: error }, 'presence write on connect failed'),
     )
 
@@ -593,7 +600,7 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
       // Throttled: a heartbeat is cheap to send and not cheap to store, and
       // without a floor every connected tab is a write per interval.
       if (socket.data.presence.shouldWrite()) {
-        void touchPresence(app.mongo.db, userId, new Date()).catch((error: unknown) =>
+        void touchPresence(app.mongo.db, userId, new Date(), build).catch((error: unknown) =>
           app.log.warn({ err: error }, 'presence heartbeat write failed'),
         )
       }
@@ -610,7 +617,7 @@ export function attachSocketServer(app: FastifyInstance): AppServer {
      * boolean left `true` by a crashed process marks everyone online forever.
      */
     socket.on('disconnect', () => {
-      void touchPresence(app.mongo.db, userId, new Date()).catch((error: unknown) =>
+      void touchPresence(app.mongo.db, userId, new Date(), build).catch((error: unknown) =>
         app.log.warn({ err: error }, 'presence write on disconnect failed'),
       )
     })

--- a/apps/mobile/app/(app)/admin/broadcast/[id].tsx
+++ b/apps/mobile/app/(app)/admin/broadcast/[id].tsx
@@ -81,11 +81,11 @@ export default function AdminBroadcastDetailScreen() {
             </Card>
 
             <View style={styles.tiles}>
-              <StatTile value={String(data.total)} label={ADMIN.home.reports} />
-              <StatTile value={String(data.sent)} label={ADMIN.broadcast.status.sending} />
+              <StatTile value={String(data.total)} label={ADMIN.broadcast.people} />
+              <StatTile value={String(data.sent)} label={ADMIN.broadcast.sent} />
               <StatTile
                 value={ADMIN.broadcast.status[data.status]}
-                label={ADMIN.broadcast.title}
+                label={ADMIN.broadcast.state}
                 valueSize={16}
               />
             </View>
@@ -97,7 +97,9 @@ export default function AdminBroadcastDetailScreen() {
               />
             ) : null}
             {data.failed > 0 ? (
-              <Callout tone="error">{ADMIN.broadcast.failed(data.failed)}</Callout>
+              <Callout tone="error">
+                <Text style={styles.calloutBody}>{ADMIN.broadcast.failed(data.failed)}</Text>
+              </Callout>
             ) : null}
 
             {data.status === 'draft' ? (
@@ -129,7 +131,9 @@ export default function AdminBroadcastDetailScreen() {
 
             {data.status === 'queued' || data.status === 'sending' ? (
               <>
-                <Callout tone="warning">{ADMIN.broadcast.stoppedNote}</Callout>
+                <Callout tone="warning">
+                  <Text style={styles.calloutBody}>{ADMIN.broadcast.stoppedNote}</Text>
+                </Callout>
                 <Button
                   label={ADMIN.broadcast.pause}
                   variant="neutral"
@@ -154,6 +158,7 @@ export default function AdminBroadcastDetailScreen() {
 
 const useStyles = makeStyles((theme) => ({
   loading: { gap: 12, marginTop: 16 },
+  calloutBody: { fontSize: 14, color: theme.colors.text, lineHeight: 20 },
   body: { fontSize: 15, color: theme.colors.text, lineHeight: 22 },
   tiles: { flexDirection: 'row', gap: 24, marginVertical: 20 },
   actions: { gap: 12, marginVertical: 16 },

--- a/apps/mobile/app/(app)/admin/broadcast/[id].tsx
+++ b/apps/mobile/app/(app)/admin/broadcast/[id].tsx
@@ -1,0 +1,161 @@
+import { useLocalSearchParams } from 'expo-router'
+import { useState } from 'react'
+import { Text, View } from 'react-native'
+import { useAdminBroadcast, useAdminBroadcastAction } from '../../../../src/api/queries'
+import { AdminGate } from '../../../../src/components/AdminGate'
+import { Button } from '../../../../src/components/ui/Button'
+import { Callout } from '../../../../src/components/ui/Callout'
+import { Card } from '../../../../src/components/ui/Card'
+import { FormField } from '../../../../src/components/ui/FormField'
+import { ProgressBar } from '../../../../src/components/ui/ProgressBar'
+import { Screen } from '../../../../src/components/ui/Screen'
+import { ScreenHeader } from '../../../../src/components/ui/ScreenHeader'
+import { Skeleton } from '../../../../src/components/ui/Skeleton'
+import { StatTile } from '../../../../src/components/ui/StatTile'
+import { useScreenInteractive } from '../../../../src/hooks/useScreenInteractive'
+import { ADMIN } from '../../../../src/lib/adminStrings'
+import { confirmAlert } from '../../../../src/lib/alert'
+import { goBackTo } from '../../../../src/lib/navigation'
+import { makeStyles } from '../../../../src/lib/theme'
+import { showToast } from '../../../../src/lib/toast'
+
+/**
+ * Arming a broadcast, and watching it go.
+ *
+ * Four things stand between this screen and five thousand people, and all four
+ * are here on purpose:
+ *
+ * 1. It is already a draft — writing it and sending it were separate requests.
+ * 2. `Send it to me first` delivers the real message, in the real font, with
+ *    the real push. It is the only preview that catches a broken line break in
+ *    a translated body before everybody gets it.
+ * 3. The confirmation is the **recipient count**, typed. "SEND" is muscle
+ *    memory; a number proves the preview above it was read, and it does not
+ *    depend on what language the operator thinks in.
+ * 4. Stop works between batches, and says honestly that what has gone cannot
+ *    be recalled.
+ */
+export default function AdminBroadcastDetailScreen() {
+  useScreenInteractive()
+  const styles = useStyles()
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const job = useAdminBroadcast(id)
+  const act = useAdminBroadcastAction()
+  const [typed, setTyped] = useState('')
+
+  const data = job.data
+  const armed = typed.trim() === String(data?.total ?? -1)
+
+  async function run(action: 'test' | 'start' | 'pause' | 'resume') {
+    if (action === 'start') {
+      const ok = await confirmAlert({
+        title: ADMIN.broadcast.confirmStart(data?.total ?? 0),
+        confirmLabel: ADMIN.broadcast.start,
+        destructive: true,
+      })
+      if (!ok) return
+    }
+    try {
+      await act.mutateAsync({ id, action })
+      if (action === 'test') showToast(ADMIN.broadcast.tested)
+      if (action === 'pause') showToast(ADMIN.broadcast.stoppedNote)
+    } catch {
+      showToast(ADMIN.common.failed)
+    }
+  }
+
+  return (
+    <AdminGate>
+      <Screen scroll fluid>
+        <ScreenHeader title={id} onBack={() => goBackTo('/(app)/admin/broadcast')} />
+
+        {job.isPending || !data ? (
+          <View style={styles.loading}>
+            <Skeleton height={40} />
+            <Skeleton height={120} />
+          </View>
+        ) : (
+          <>
+            <Card>
+              <Text style={styles.body}>{data.bodies.en}</Text>
+            </Card>
+
+            <View style={styles.tiles}>
+              <StatTile value={String(data.total)} label={ADMIN.home.reports} />
+              <StatTile value={String(data.sent)} label={ADMIN.broadcast.status.sending} />
+              <StatTile
+                value={ADMIN.broadcast.status[data.status]}
+                label={ADMIN.broadcast.title}
+                valueSize={16}
+              />
+            </View>
+
+            {data.status === 'sending' || data.status === 'done' ? (
+              <ProgressBar
+                value={data.total > 0 ? data.sent / data.total : 0}
+                accessibilityLabel={ADMIN.broadcast.progress(data.sent, data.total)}
+              />
+            ) : null}
+            {data.failed > 0 ? (
+              <Callout tone="error">{ADMIN.broadcast.failed(data.failed)}</Callout>
+            ) : null}
+
+            {data.status === 'draft' ? (
+              <>
+                <View style={styles.actions}>
+                  <Button
+                    label={ADMIN.broadcast.test}
+                    variant="secondary"
+                    onPress={() => run('test')}
+                    loading={act.isPending}
+                  />
+                </View>
+
+                <FormField
+                  label={ADMIN.broadcast.confirmPrompt(data.total)}
+                  value={typed}
+                  onChangeText={setTyped}
+                  keyboardType="number-pad"
+                />
+                <Text style={styles.hint}>{ADMIN.broadcast.confirmHint}</Text>
+                <Button
+                  label={ADMIN.broadcast.start}
+                  variant="danger"
+                  disabled={!armed}
+                  onPress={() => run('start')}
+                />
+              </>
+            ) : null}
+
+            {data.status === 'queued' || data.status === 'sending' ? (
+              <>
+                <Callout tone="warning">{ADMIN.broadcast.stoppedNote}</Callout>
+                <Button
+                  label={ADMIN.broadcast.pause}
+                  variant="neutral"
+                  onPress={() => run('pause')}
+                />
+              </>
+            ) : null}
+
+            {data.status === 'paused' ? (
+              <Button
+                label={ADMIN.broadcast.resume}
+                variant="secondary"
+                onPress={() => run('resume')}
+              />
+            ) : null}
+          </>
+        )}
+      </Screen>
+    </AdminGate>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  loading: { gap: 12, marginTop: 16 },
+  body: { fontSize: 15, color: theme.colors.text, lineHeight: 22 },
+  tiles: { flexDirection: 'row', gap: 24, marginVertical: 20 },
+  actions: { gap: 12, marginVertical: 16 },
+  hint: { fontSize: 13, color: theme.colors.textMuted, marginBottom: 16 },
+}))

--- a/apps/mobile/app/(app)/admin/broadcast/index.tsx
+++ b/apps/mobile/app/(app)/admin/broadcast/index.tsx
@@ -49,7 +49,9 @@ export default function AdminBroadcastScreen() {
         <ScreenHeader title={ADMIN.broadcast.title} onBack={() => goBackTo('/(app)/admin')} />
 
         <Callout tone="warning" icon="users">
-          {ADMIN.broadcast.audience(list.data?.audience ?? 0)}
+          <Text style={styles.calloutBody}>
+            {ADMIN.broadcast.audience(list.data?.audience ?? 0)}
+          </Text>
         </Callout>
 
         <Text style={styles.heading}>{ADMIN.broadcast.newTitle}</Text>
@@ -78,7 +80,7 @@ export default function AdminBroadcastScreen() {
           loading={create.isPending}
         />
 
-        <Text style={styles.heading}>{ADMIN.broadcast.title}</Text>
+        <Text style={styles.heading}>{ADMIN.broadcast.history}</Text>
         {list.data?.items.length ? (
           <View>
             {list.data.items.map((item, index) => (
@@ -110,4 +112,5 @@ const useStyles = makeStyles((theme) => ({
     textTransform: 'uppercase',
   },
   hint: { fontSize: 13, color: theme.colors.textMuted, marginBottom: 16 },
+  calloutBody: { fontSize: 14, color: theme.colors.text, lineHeight: 20 },
 }))

--- a/apps/mobile/app/(app)/admin/broadcast/index.tsx
+++ b/apps/mobile/app/(app)/admin/broadcast/index.tsx
@@ -1,0 +1,113 @@
+import { router } from 'expo-router'
+import { useState } from 'react'
+import { Text, View } from 'react-native'
+import { useAdminBroadcasts, useAdminCreateBroadcast } from '../../../../src/api/queries'
+import { AdminGate } from '../../../../src/components/AdminGate'
+import { Button } from '../../../../src/components/ui/Button'
+import { Callout } from '../../../../src/components/ui/Callout'
+import { FormField } from '../../../../src/components/ui/FormField'
+import { ListRow } from '../../../../src/components/ui/ListRow'
+import { Screen } from '../../../../src/components/ui/Screen'
+import { ScreenHeader } from '../../../../src/components/ui/ScreenHeader'
+import { useScreenInteractive } from '../../../../src/hooks/useScreenInteractive'
+import { ADMIN } from '../../../../src/lib/adminStrings'
+import { goBackTo } from '../../../../src/lib/navigation'
+import { makeStyles } from '../../../../src/lib/theme'
+import { showToast } from '../../../../src/lib/toast'
+
+/**
+ * Writing a broadcast, which is deliberately not sending one.
+ *
+ * This screen's only button makes a draft. Arming it is a second request on a
+ * second screen — which is the whole reason a back gesture, a double tap or a
+ * deep link cannot message five thousand people.
+ */
+export default function AdminBroadcastScreen() {
+  useScreenInteractive()
+  const styles = useStyles()
+  const list = useAdminBroadcasts()
+  const create = useAdminCreateBroadcast()
+  const [slug, setSlug] = useState('')
+  const [body, setBody] = useState('')
+
+  const ready = /^[a-z0-9][a-z0-9-]{2,}$/.test(slug) && body.trim().length > 0
+
+  async function onCreate() {
+    try {
+      const job = await create.mutateAsync({ id: slug, bodies: { en: body.trim() } })
+      setSlug('')
+      setBody('')
+      router.push(`/(app)/admin/broadcast/${job._id}`)
+    } catch {
+      showToast(ADMIN.common.failed)
+    }
+  }
+
+  return (
+    <AdminGate>
+      <Screen scroll fluid>
+        <ScreenHeader title={ADMIN.broadcast.title} onBack={() => goBackTo('/(app)/admin')} />
+
+        <Callout tone="warning" icon="users">
+          {ADMIN.broadcast.audience(list.data?.audience ?? 0)}
+        </Callout>
+
+        <Text style={styles.heading}>{ADMIN.broadcast.newTitle}</Text>
+        <FormField
+          label={ADMIN.broadcast.slug}
+          value={slug}
+          onChangeText={(next) => setSlug(next.toLowerCase().replace(/[^a-z0-9-]/g, '-'))}
+          autoCapitalize="none"
+        />
+        <Text style={styles.hint}>{ADMIN.broadcast.slugHint}</Text>
+
+        <FormField
+          label={ADMIN.broadcast.body}
+          value={body}
+          onChangeText={setBody}
+          multiline
+          numberOfLines={6}
+          maxLength={4000}
+        />
+        <Text style={styles.hint}>{ADMIN.broadcast.bodyHint}</Text>
+
+        <Button
+          label={ADMIN.broadcast.createDraft}
+          onPress={onCreate}
+          disabled={!ready}
+          loading={create.isPending}
+        />
+
+        <Text style={styles.heading}>{ADMIN.broadcast.title}</Text>
+        {list.data?.items.length ? (
+          <View>
+            {list.data.items.map((item, index) => (
+              <ListRow
+                key={item._id}
+                title={item._id}
+                subtitle={ADMIN.broadcast.progress(item.sent, item.total)}
+                value={ADMIN.broadcast.status[item.status]}
+                onPress={() => router.push(`/(app)/admin/broadcast/${item._id}`)}
+                last={index === list.data.items.length - 1}
+              />
+            ))}
+          </View>
+        ) : (
+          <Text style={styles.hint}>{ADMIN.broadcast.empty}</Text>
+        )}
+      </Screen>
+    </AdminGate>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  heading: {
+    marginTop: 24,
+    marginBottom: 8,
+    fontSize: 13,
+    fontWeight: '700',
+    color: theme.colors.textMuted,
+    textTransform: 'uppercase',
+  },
+  hint: { fontSize: 13, color: theme.colors.textMuted, marginBottom: 16 },
+}))

--- a/apps/mobile/app/(app)/admin/feedback/index.tsx
+++ b/apps/mobile/app/(app)/admin/feedback/index.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react'
+import { FlatList, Linking, Text, View } from 'react-native'
+import { BOUNTY_MAX, BOUNTY_MIN } from '@langx/shared'
+import {
+  useAdminCloseFeedback,
+  useAdminFeedback,
+  useAdminPayBounty,
+  type AdminFeedbackDto,
+} from '../../../../src/api/queries'
+import { AdminGate } from '../../../../src/components/AdminGate'
+import { Button } from '../../../../src/components/ui/Button'
+import { Card } from '../../../../src/components/ui/Card'
+import { EmptyState } from '../../../../src/components/ui/EmptyState'
+import { FormField } from '../../../../src/components/ui/FormField'
+import { Screen } from '../../../../src/components/ui/Screen'
+import { ScreenHeader } from '../../../../src/components/ui/ScreenHeader'
+import { SegmentedControl } from '../../../../src/components/ui/SegmentedControl'
+import { Skeleton } from '../../../../src/components/ui/Skeleton'
+import { useScreenInteractive } from '../../../../src/hooks/useScreenInteractive'
+import { ADMIN } from '../../../../src/lib/adminStrings'
+import { chooseAlert, confirmAlert } from '../../../../src/lib/alert'
+import { goBackTo } from '../../../../src/lib/navigation'
+import { makeStyles } from '../../../../src/lib/theme'
+import { showToast } from '../../../../src/lib/toast'
+
+type Tab = 'open' | 'triaged' | 'closed'
+
+const TABS: readonly { value: Tab; label: string }[] = [
+  { value: 'open', label: ADMIN.feedback.tabs.open },
+  { value: 'triaged', label: ADMIN.feedback.tabs.triaged },
+  { value: 'closed', label: ADMIN.feedback.tabs.closed },
+]
+
+const CLOSE_REASONS = [
+  { value: 'fixed', label: ADMIN.feedback.closeReasons.fixed },
+  { value: 'shipped', label: ADMIN.feedback.closeReasons.shipped },
+  { value: 'wontfix', label: ADMIN.feedback.closeReasons.wontfix },
+  { value: 'duplicate', label: ADMIN.feedback.closeReasons.duplicate },
+  { value: 'invalid', label: ADMIN.feedback.closeReasons.invalid },
+] as const
+
+/**
+ * The bug and idea queue, oldest first — the server sorts it that way because
+ * it is a queue and not a feed, and the row that matters is the one nobody has
+ * closed for longest.
+ *
+ * The whole report is in the row rather than behind a tap. They are short, the
+ * decision is "is this real and what is it worth", and a list of first lines
+ * would mean opening every one of them to find that out.
+ */
+export default function AdminFeedbackScreen() {
+  useScreenInteractive()
+  const styles = useStyles()
+  const [tab, setTab] = useState<Tab>('open')
+  const feedback = useAdminFeedback(tab)
+
+  return (
+    <AdminGate>
+      <Screen fluid>
+        <ScreenHeader title={ADMIN.feedback.title} onBack={() => goBackTo('/(app)/admin')} />
+
+        <View style={styles.tabs}>
+          <SegmentedControl
+            options={TABS}
+            selected={[tab]}
+            onToggle={setTab}
+            accessibilityLabel={ADMIN.feedback.title}
+          />
+        </View>
+
+        {feedback.isPending ? (
+          <View style={styles.loading}>
+            <Skeleton height={120} />
+            <Skeleton height={120} />
+          </View>
+        ) : (
+          <FlatList
+            data={feedback.data?.items ?? []}
+            keyExtractor={(item) => item._id}
+            contentContainerStyle={styles.list}
+            ListEmptyComponent={<EmptyState icon="inbox" title={ADMIN.feedback.empty} body="" />}
+            renderItem={({ item }) => <Row row={item} />}
+          />
+        )}
+      </Screen>
+    </AdminGate>
+  )
+}
+
+function Row({ row }: { row: AdminFeedbackDto }) {
+  const styles = useStyles()
+  const pay = useAdminPayBounty()
+  const close = useAdminCloseFeedback()
+  const [amount, setAmount] = useState(String(BOUNTY_MIN))
+
+  const who = row.sender.handle ? `@${row.sender.handle}` : row.sender.userId
+  const tokens = Math.min(BOUNTY_MAX, Math.max(BOUNTY_MIN, Number.parseInt(amount, 10) || 0))
+
+  async function onPay() {
+    // The amount is in the button's own label as well as the dialog: a
+    // confirmation that only says "pay?" hides the number that is wrong.
+    const ok = await confirmAlert({
+      title: ADMIN.feedback.confirmPay(tokens, who),
+      confirmLabel: ADMIN.feedback.pay(tokens),
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      const result = await pay.mutateAsync({ id: row._id, amount: tokens })
+      showToast(result.awarded ? ADMIN.feedback.paid(result.amount) : ADMIN.feedback.alreadyPaid)
+    } catch {
+      showToast(ADMIN.common.failed)
+    }
+  }
+
+  async function onClose() {
+    const reason = await chooseAlert(ADMIN.feedback.closeReason, undefined, [...CLOSE_REASONS])
+    if (!reason) return
+    try {
+      await close.mutateAsync({ id: row._id, closeReason: reason })
+    } catch {
+      showToast(ADMIN.common.failed)
+    }
+  }
+
+  return (
+    <Card style={styles.card}>
+      <Text style={styles.meta}>
+        {row.kind} · {ADMIN.feedback.from} {who} · {row.createdAt.slice(0, 10)}
+      </Text>
+      <Text style={styles.body}>{row.body}</Text>
+
+      {row.attachmentUrls.length > 0 ? (
+        <Text style={styles.meta}>
+          {ADMIN.feedback.attachments}: {row.attachmentUrls.length}
+        </Text>
+      ) : null}
+
+      {row.bounty ? (
+        <Text style={styles.paid}>{ADMIN.feedback.paid(row.bounty.amount)}</Text>
+      ) : (
+        <>
+          <FormField
+            label={ADMIN.feedback.amount}
+            value={amount}
+            onChangeText={setAmount}
+            keyboardType="number-pad"
+          />
+          <View style={styles.actions}>
+            <Button label={ADMIN.feedback.pay(tokens)} onPress={onPay} loading={pay.isPending} />
+            <Button
+              label={ADMIN.feedback.close}
+              variant="neutral"
+              onPress={onClose}
+              loading={close.isPending}
+            />
+          </View>
+        </>
+      )}
+
+      {row.issueUrl ? (
+        <Button
+          label={ADMIN.feedback.openIssue}
+          variant="neutral"
+          size="small"
+          onPress={() => void Linking.openURL(row.issueUrl ?? '')}
+        />
+      ) : null}
+    </Card>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  tabs: { marginVertical: 12 },
+  loading: { gap: 12 },
+  list: { gap: 12, paddingBottom: 32 },
+  card: { gap: 10 },
+  meta: { fontSize: 13, color: theme.colors.textMuted },
+  body: { fontSize: 15, color: theme.colors.text, lineHeight: 22 },
+  paid: { fontSize: 15, fontWeight: '700', color: theme.colors.text },
+  actions: { gap: 10 },
+}))

--- a/apps/mobile/app/(app)/admin/index.tsx
+++ b/apps/mobile/app/(app)/admin/index.tsx
@@ -36,7 +36,7 @@ export default function AdminHomeScreen() {
         <ScreenHeader title={ADMIN.home.title} onBack={() => goBackTo('/(app)/settings')} />
 
         <Callout tone="warning" icon="shield">
-          {ADMIN.warning}
+          <Text style={styles.calloutBody}>{ADMIN.warning}</Text>
         </Callout>
 
         {stats.isPending ? (
@@ -45,7 +45,9 @@ export default function AdminHomeScreen() {
             <Skeleton height={200} />
           </View>
         ) : stats.isError ? (
-          <Callout tone="error">{ADMIN.home.failedToLoad}</Callout>
+          <Callout tone="error">
+            <Text style={styles.calloutBody}>{ADMIN.home.failedToLoad}</Text>
+          </Callout>
         ) : (
           <>
             <View style={styles.group}>
@@ -125,6 +127,7 @@ export default function AdminHomeScreen() {
 
 const useStyles = makeStyles((theme) => ({
   loading: { gap: 12, marginTop: 16 },
+  calloutBody: { fontSize: 14, color: theme.colors.text, lineHeight: 20 },
   group: { marginTop: 16 },
   heading: {
     marginTop: 24,

--- a/apps/mobile/app/(app)/admin/index.tsx
+++ b/apps/mobile/app/(app)/admin/index.tsx
@@ -1,0 +1,140 @@
+import { router } from 'expo-router'
+import { Text, View } from 'react-native'
+import { useAdminStats } from '../../../src/api/queries'
+import { AdminGate } from '../../../src/components/AdminGate'
+import { Callout } from '../../../src/components/ui/Callout'
+import { ListRow } from '../../../src/components/ui/ListRow'
+import { Screen } from '../../../src/components/ui/Screen'
+import { ScreenHeader } from '../../../src/components/ui/ScreenHeader'
+import { Skeleton } from '../../../src/components/ui/Skeleton'
+import { StatTile } from '../../../src/components/ui/StatTile'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
+import { ADMIN } from '../../../src/lib/adminStrings'
+import { goBackTo } from '../../../src/lib/navigation'
+import { makeStyles } from '../../../src/lib/theme'
+
+/**
+ * The operator's first screen: what is waiting, and whether anything is wrong.
+ *
+ * The numbers come from one request (`GET /admin/stats`), which is one
+ * `Promise.all` with a minute of memory behind it — see `modules/admin/stats.ts`
+ * for why each of them is cheap and why the obvious ones that are not (messages
+ * this week, new subscriptions this week) are deliberately absent.
+ */
+export default function AdminHomeScreen() {
+  useScreenInteractive()
+  const styles = useStyles()
+  const stats = useAdminStats()
+
+  const queue = stats.data?.queue
+  const audience = stats.data?.audience
+  const money = stats.data?.money
+
+  return (
+    <AdminGate>
+      <Screen scroll fluid>
+        <ScreenHeader title={ADMIN.home.title} onBack={() => goBackTo('/(app)/settings')} />
+
+        <Callout tone="warning" icon="shield">
+          {ADMIN.warning}
+        </Callout>
+
+        {stats.isPending ? (
+          <View style={styles.loading}>
+            <Skeleton height={80} />
+            <Skeleton height={200} />
+          </View>
+        ) : stats.isError ? (
+          <Callout tone="error">{ADMIN.home.failedToLoad}</Callout>
+        ) : (
+          <>
+            <View style={styles.group}>
+              <ListRow
+                title={ADMIN.home.reports}
+                value={String(queue?.reports ?? 0)}
+                onPress={() => router.push('/(app)/admin/reports')}
+              />
+              <ListRow
+                title={ADMIN.home.appeals}
+                value={String(queue?.appeals ?? 0)}
+                onPress={() => router.push('/(app)/admin/reports?tab=appeals')}
+              />
+              <ListRow
+                title={ADMIN.home.feedback}
+                value={String(queue?.feedback ?? 0)}
+                onPress={() => router.push('/(app)/admin/feedback')}
+              />
+              <ListRow
+                title={ADMIN.home.broadcast}
+                onPress={() => router.push('/(app)/admin/broadcast')}
+              />
+              <ListRow title={ADMIN.home.users} onPress={() => router.push('/(app)/admin/users')} />
+              <ListRow
+                title={ADMIN.home.system}
+                onPress={() => router.push('/(app)/admin/system')}
+                last
+              />
+            </View>
+
+            <Text style={styles.heading}>{ADMIN.home.sections.audience}</Text>
+            <View style={styles.tiles}>
+              <StatTile value={String(audience?.joinedToday ?? 0)} label={ADMIN.home.joinedToday} />
+              <StatTile
+                value={String(audience?.joinedLastWeek ?? 0)}
+                label={ADMIN.home.joinedWeek}
+              />
+              <StatTile value={String(audience?.activeToday ?? 0)} label={ADMIN.home.activeToday} />
+              <StatTile value={String(audience?.seenLastWeek ?? 0)} label={ADMIN.home.seenWeek} />
+              <StatTile value={String(audience?.profiles ?? 0)} label={ADMIN.home.profiles} />
+              <StatTile value={String(audience?.messages ?? 0)} label={ADMIN.home.messages} />
+            </View>
+
+            <Text style={styles.heading}>{ADMIN.home.sections.money}</Text>
+            <View style={styles.tiles}>
+              <StatTile value={String(money?.tiers.pro ?? 0)} label={ADMIN.home.pro} />
+              <StatTile value={String(money?.tiers.proPlus ?? 0)} label={ADMIN.home.proPlus} />
+              <StatTile value={String(money?.tiers.free ?? 0)} label={ADMIN.home.free} />
+            </View>
+
+            <Text style={styles.heading}>{ADMIN.home.poolYesterday}</Text>
+            {money?.pool ? (
+              <Text style={styles.line}>
+                {money.pool.paid} {ADMIN.home.poolPaid} · {money.pool.distributed}{' '}
+                {ADMIN.home.poolDistributed}
+              </Text>
+            ) : (
+              <Text style={styles.muted}>{ADMIN.home.poolNone}</Text>
+            )}
+
+            {audience?.builds.length ? (
+              <>
+                <Text style={styles.heading}>{ADMIN.home.builds}</Text>
+                {audience.builds.map((build) => (
+                  <Text key={`${build.platform}-${build.version}`} style={styles.line}>
+                    {build.platform} {build.version} · {build.count}
+                  </Text>
+                ))}
+              </>
+            ) : null}
+          </>
+        )}
+      </Screen>
+    </AdminGate>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  loading: { gap: 12, marginTop: 16 },
+  group: { marginTop: 16 },
+  heading: {
+    marginTop: 24,
+    marginBottom: 8,
+    fontSize: 13,
+    fontWeight: '700',
+    color: theme.colors.textMuted,
+    textTransform: 'uppercase',
+  },
+  tiles: { flexDirection: 'row', flexWrap: 'wrap', gap: 20 },
+  line: { fontSize: 15, color: theme.colors.text, marginBottom: 4 },
+  muted: { fontSize: 15, color: theme.colors.textMuted },
+}))

--- a/apps/mobile/app/(app)/admin/reports/[id].tsx
+++ b/apps/mobile/app/(app)/admin/reports/[id].tsx
@@ -1,0 +1,241 @@
+import { useLocalSearchParams } from 'expo-router'
+import { useState } from 'react'
+import { Text, View } from 'react-native'
+import {
+  useAdminAppeals,
+  useAdminDecision,
+  useAdminReport,
+  type AdminAppealDto,
+} from '../../../../src/api/queries'
+import { AdminGate } from '../../../../src/components/AdminGate'
+import { Button } from '../../../../src/components/ui/Button'
+import { Callout } from '../../../../src/components/ui/Callout'
+import { Card } from '../../../../src/components/ui/Card'
+import { FormField } from '../../../../src/components/ui/FormField'
+import { Screen } from '../../../../src/components/ui/Screen'
+import { ScreenHeader } from '../../../../src/components/ui/ScreenHeader'
+import { Skeleton } from '../../../../src/components/ui/Skeleton'
+import { useScreenInteractive } from '../../../../src/hooks/useScreenInteractive'
+import { ADMIN } from '../../../../src/lib/adminStrings'
+import { confirmAlert } from '../../../../src/lib/alert'
+import { goBackTo } from '../../../../src/lib/navigation'
+import { makeStyles } from '../../../../src/lib/theme'
+import { showToast } from '../../../../src/lib/toast'
+
+/**
+ * One case, and the decisions it can take.
+ *
+ * A report and an appeal are one screen because they are one judgement seen
+ * from two sides — what the suspension is for, and whether it should stand.
+ * The route tells them apart by prefix: `appeal:<userId>` against a plain
+ * report id, which keeps the two queues in one stack without a second folder.
+ *
+ * The buttons are in two groups with a heading between them, exactly as the
+ * emailed page does it: hiding one sentence and suspending a person for good
+ * are not things to mistake for each other at a glance.
+ */
+export default function AdminCaseScreen() {
+  useScreenInteractive()
+  const styles = useStyles()
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const isAppeal = id.startsWith('appeal:')
+  const userId = isAppeal ? id.slice('appeal:'.length) : ''
+
+  const report = useAdminReport(isAppeal ? '' : id)
+  const appeals = useAdminAppeals()
+  const appeal = isAppeal
+    ? appeals.data?.items.find((item: AdminAppealDto) => item.userId === userId)
+    : undefined
+
+  const decide = useAdminDecision()
+  const [days, setDays] = useState('7')
+
+  async function run(
+    action: string,
+    options: { confirm: string; days?: number } = { confirm: '' },
+  ) {
+    const ok = await confirmAlert({
+      title: options.confirm,
+      confirmLabel: ADMIN.common.confirm,
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await decide.mutateAsync({
+        kind: isAppeal ? 'appeal' : 'report',
+        id: isAppeal ? userId : id,
+        action,
+        ...(options.days === undefined ? {} : { days: options.days }),
+      })
+      showToast(ADMIN.reports.done)
+      goBackTo('/(app)/admin/reports')
+    } catch {
+      showToast(ADMIN.common.failed)
+    }
+  }
+
+  const numberOfDays = Math.max(1, Number.parseInt(days, 10) || 1)
+  const subject = isAppeal
+    ? (appeal?.handle ?? userId)
+    : (report.data?.reported.handle ?? report.data?.reported.userId ?? '')
+  const shown = isAppeal ? `@${subject}` : subject ? `@${subject}` : ''
+
+  return (
+    <AdminGate>
+      <Screen scroll fluid>
+        <ScreenHeader
+          title={isAppeal ? ADMIN.appeals.title : ADMIN.reports.title}
+          onBack={() => goBackTo('/(app)/admin/reports')}
+        />
+
+        {(isAppeal ? appeals.isPending : report.isPending) ? (
+          <View style={styles.loading}>
+            <Skeleton height={40} />
+            <Skeleton height={120} />
+          </View>
+        ) : isAppeal ? (
+          appeal ? (
+            <>
+              <Text style={styles.subject}>{shown}</Text>
+              <Callout tone="warning">
+                {appeal.permanent
+                  ? `${ADMIN.reports.inForce} (∞, ${appeal.reason})`
+                  : `${ADMIN.reports.inForce} (${appeal.until ?? ''}, ${appeal.reason})`}
+              </Callout>
+
+              <Text style={styles.heading}>{ADMIN.appeals.said}</Text>
+              <Card>
+                <Text style={styles.quote}>{appeal.text}</Text>
+              </Card>
+
+              <FormField
+                label={ADMIN.reports.days}
+                value={days}
+                onChangeText={setDays}
+                keyboardType="number-pad"
+              />
+              <View style={styles.actions}>
+                <Button
+                  label={ADMIN.appeals.shorten}
+                  variant="secondary"
+                  onPress={() =>
+                    run('shorten', {
+                      confirm: ADMIN.reports.confirmSuspend(shown, numberOfDays),
+                      days: numberOfDays,
+                    })
+                  }
+                />
+                <Button
+                  label={ADMIN.appeals.lift}
+                  variant="secondary"
+                  onPress={() => run('lift', { confirm: ADMIN.appeals.confirmLift(shown) })}
+                />
+                <Button
+                  label={ADMIN.appeals.keep}
+                  variant="neutral"
+                  onPress={() => run('keep', { confirm: ADMIN.appeals.confirmKeep })}
+                />
+              </View>
+            </>
+          ) : (
+            <Callout tone="info">{ADMIN.appeals.empty}</Callout>
+          )
+        ) : report.data ? (
+          <>
+            <Text style={styles.subject}>{shown}</Text>
+            <Text style={styles.muted}>{report.data.reason.replace(/_/g, ' ')}</Text>
+
+            {report.data.otherOpenReports ? (
+              <Callout tone="warning">
+                {ADMIN.reports.otherReports(report.data.otherOpenReports)}
+              </Callout>
+            ) : null}
+            {report.data.suspension ? (
+              <Callout tone="warning">{ADMIN.reports.inForce}</Callout>
+            ) : null}
+
+            <Text style={styles.heading}>{ADMIN.reports.details}</Text>
+            <Card>
+              <Text style={styles.quote}>{report.data.details ?? ADMIN.reports.noDetails}</Text>
+            </Card>
+
+            {report.data.post ? (
+              <>
+                <Text style={styles.heading}>{ADMIN.reports.post}</Text>
+                <Card>
+                  <Text style={styles.quote}>{report.data.post.body}</Text>
+                </Card>
+                {report.data.post.hiddenAt ? (
+                  <Callout tone="warning">{ADMIN.reports.postHidden}</Callout>
+                ) : null}
+                <View style={styles.actions}>
+                  <Button
+                    label={report.data.post.hiddenAt ? ADMIN.reports.unhide : ADMIN.reports.hide}
+                    variant="secondary"
+                    onPress={() =>
+                      run(report.data?.post?.hiddenAt ? 'unhide_post' : 'hide_post', {
+                        confirm: report.data?.post?.hiddenAt
+                          ? ADMIN.reports.unhide
+                          : ADMIN.reports.hide,
+                      })
+                    }
+                  />
+                </View>
+              </>
+            ) : null}
+
+            {/* The account, and the heading is what keeps it from reading as
+                more of the post's buttons. */}
+            <Text style={styles.heading}>{ADMIN.reports.account}</Text>
+            <FormField
+              label={ADMIN.reports.days}
+              value={days}
+              onChangeText={setDays}
+              keyboardType="number-pad"
+            />
+            <View style={styles.actions}>
+              <Button
+                label={ADMIN.reports.suspendDays}
+                variant="secondary"
+                onPress={() =>
+                  run('suspend', {
+                    confirm: ADMIN.reports.confirmSuspend(shown, numberOfDays),
+                    days: numberOfDays,
+                  })
+                }
+              />
+              <Button
+                label={ADMIN.reports.suspendPermanent}
+                variant="danger"
+                onPress={() => run('permanent', { confirm: ADMIN.reports.confirmPermanent(shown) })}
+              />
+              <Button
+                label={ADMIN.reports.dismiss}
+                variant="neutral"
+                onPress={() => run('dismiss', { confirm: ADMIN.reports.confirmDismiss })}
+              />
+            </View>
+          </>
+        ) : (
+          <Callout tone="info">{ADMIN.reports.empty}</Callout>
+        )}
+      </Screen>
+    </AdminGate>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  loading: { gap: 12, marginTop: 16 },
+  subject: { fontSize: 22, fontWeight: '700', color: theme.colors.text, marginTop: 12 },
+  muted: { fontSize: 15, color: theme.colors.textMuted, marginBottom: 8 },
+  heading: {
+    marginTop: 24,
+    marginBottom: 8,
+    fontSize: 13,
+    fontWeight: '700',
+    color: theme.colors.textMuted,
+    textTransform: 'uppercase',
+  },
+  quote: { fontSize: 15, color: theme.colors.text, lineHeight: 22 },
+  actions: { gap: 12, marginTop: 16 },
+}))

--- a/apps/mobile/app/(app)/admin/reports/[id].tsx
+++ b/apps/mobile/app/(app)/admin/reports/[id].tsx
@@ -98,9 +98,11 @@ export default function AdminCaseScreen() {
             <>
               <Text style={styles.subject}>{shown}</Text>
               <Callout tone="warning">
-                {appeal.permanent
-                  ? `${ADMIN.reports.inForce} (∞, ${appeal.reason})`
-                  : `${ADMIN.reports.inForce} (${appeal.until ?? ''}, ${appeal.reason})`}
+                <Text style={styles.calloutBody}>
+                  {appeal.permanent
+                    ? `${ADMIN.reports.inForce} (∞, ${appeal.reason})`
+                    : `${ADMIN.reports.inForce} (${appeal.until ?? ''}, ${appeal.reason})`}
+                </Text>
               </Callout>
 
               <Text style={styles.heading}>{ADMIN.appeals.said}</Text>
@@ -138,7 +140,9 @@ export default function AdminCaseScreen() {
               </View>
             </>
           ) : (
-            <Callout tone="info">{ADMIN.appeals.empty}</Callout>
+            <Callout tone="info">
+              <Text style={styles.calloutBody}>{ADMIN.appeals.empty}</Text>
+            </Callout>
           )
         ) : report.data ? (
           <>
@@ -147,11 +151,15 @@ export default function AdminCaseScreen() {
 
             {report.data.otherOpenReports ? (
               <Callout tone="warning">
-                {ADMIN.reports.otherReports(report.data.otherOpenReports)}
+                <Text style={styles.calloutBody}>
+                  {ADMIN.reports.otherReports(report.data.otherOpenReports)}
+                </Text>
               </Callout>
             ) : null}
             {report.data.suspension ? (
-              <Callout tone="warning">{ADMIN.reports.inForce}</Callout>
+              <Callout tone="warning">
+                <Text style={styles.calloutBody}>{ADMIN.reports.inForce}</Text>
+              </Callout>
             ) : null}
 
             <Text style={styles.heading}>{ADMIN.reports.details}</Text>
@@ -166,7 +174,9 @@ export default function AdminCaseScreen() {
                   <Text style={styles.quote}>{report.data.post.body}</Text>
                 </Card>
                 {report.data.post.hiddenAt ? (
-                  <Callout tone="warning">{ADMIN.reports.postHidden}</Callout>
+                  <Callout tone="warning">
+                    <Text style={styles.calloutBody}>{ADMIN.reports.postHidden}</Text>
+                  </Callout>
                 ) : null}
                 <View style={styles.actions}>
                   <Button
@@ -217,7 +227,9 @@ export default function AdminCaseScreen() {
             </View>
           </>
         ) : (
-          <Callout tone="info">{ADMIN.reports.empty}</Callout>
+          <Callout tone="info">
+            <Text style={styles.calloutBody}>{ADMIN.reports.empty}</Text>
+          </Callout>
         )}
       </Screen>
     </AdminGate>
@@ -226,6 +238,7 @@ export default function AdminCaseScreen() {
 
 const useStyles = makeStyles((theme) => ({
   loading: { gap: 12, marginTop: 16 },
+  calloutBody: { fontSize: 14, color: theme.colors.text, lineHeight: 20 },
   subject: { fontSize: 22, fontWeight: '700', color: theme.colors.text, marginTop: 12 },
   muted: { fontSize: 15, color: theme.colors.textMuted, marginBottom: 8 },
   heading: {

--- a/apps/mobile/app/(app)/admin/reports/index.tsx
+++ b/apps/mobile/app/(app)/admin/reports/index.tsx
@@ -1,0 +1,110 @@
+import { router, useLocalSearchParams } from 'expo-router'
+import { useState } from 'react'
+import { FlatList, View } from 'react-native'
+import { useAdminAppeals, useAdminReports } from '../../../../src/api/queries'
+import { AdminGate } from '../../../../src/components/AdminGate'
+import { EmptyState } from '../../../../src/components/ui/EmptyState'
+import { ListRow } from '../../../../src/components/ui/ListRow'
+import { Screen } from '../../../../src/components/ui/Screen'
+import { ScreenHeader } from '../../../../src/components/ui/ScreenHeader'
+import { SegmentedControl } from '../../../../src/components/ui/SegmentedControl'
+import { Skeleton } from '../../../../src/components/ui/Skeleton'
+import { useScreenInteractive } from '../../../../src/hooks/useScreenInteractive'
+import { ADMIN } from '../../../../src/lib/adminStrings'
+import { goBackTo } from '../../../../src/lib/navigation'
+import { makeStyles } from '../../../../src/lib/theme'
+
+type Tab = 'open' | 'reviewing' | 'actioned' | 'dismissed' | 'appeals'
+
+const TABS: readonly { value: Tab; label: string }[] = [
+  { value: 'open', label: ADMIN.reports.tabs.open },
+  { value: 'appeals', label: ADMIN.appeals.title },
+  { value: 'actioned', label: ADMIN.reports.tabs.actioned },
+  { value: 'dismissed', label: ADMIN.reports.tabs.dismissed },
+]
+
+/** Who a row is about, as whoever is deciding would recognise them. */
+function who(handle: string | null, userId: string): string {
+  return handle ? `@${handle}` : userId
+}
+
+/**
+ * The two queues, on one screen with a switch.
+ *
+ * They are separate collections and separate decisions, but they are the same
+ * job done in the same sitting, and two screens would have meant two places to
+ * remember to look.
+ */
+export default function AdminReportsScreen() {
+  useScreenInteractive()
+  const styles = useStyles()
+  const params = useLocalSearchParams<{ tab?: string }>()
+  const [tab, setTab] = useState<Tab>(params.tab === 'appeals' ? 'appeals' : 'open')
+
+  const reports = useAdminReports(tab === 'appeals' ? 'open' : tab)
+  const appeals = useAdminAppeals()
+  const showing = tab === 'appeals'
+  const pending = showing ? appeals.isPending : reports.isPending
+
+  return (
+    <AdminGate>
+      <Screen fluid>
+        <ScreenHeader title={ADMIN.reports.title} onBack={() => goBackTo('/(app)/admin')} />
+
+        <View style={styles.tabs}>
+          <SegmentedControl
+            options={TABS}
+            selected={[tab]}
+            onToggle={setTab}
+            accessibilityLabel={ADMIN.reports.title}
+          />
+        </View>
+
+        {pending ? (
+          <View style={styles.loading}>
+            <Skeleton height={64} />
+            <Skeleton height={64} />
+          </View>
+        ) : showing ? (
+          <FlatList
+            data={appeals.data?.items ?? []}
+            keyExtractor={(item) => item.userId}
+            ListEmptyComponent={<EmptyState icon="shield" title={ADMIN.appeals.empty} body="" />}
+            renderItem={({ item, index }) => (
+              <ListRow
+                title={who(item.handle, item.userId)}
+                subtitle={item.text.slice(0, 90)}
+                value={item.permanent ? '∞' : undefined}
+                onPress={() => router.push(`/(app)/admin/reports/appeal:${item.userId}`)}
+                last={index === (appeals.data?.items.length ?? 0) - 1}
+              />
+            )}
+          />
+        ) : (
+          <FlatList
+            data={reports.data?.items ?? []}
+            keyExtractor={(item) => item.id}
+            ListEmptyComponent={<EmptyState icon="shield" title={ADMIN.reports.empty} body="" />}
+            renderItem={({ item, index }) => (
+              <ListRow
+                title={who(item.reported.handle, item.reported.userId)}
+                subtitle={`${item.reason.replace(/_/g, ' ')} · ${ADMIN.reports.reportedBy} ${who(
+                  item.reporter.handle,
+                  item.reporter.userId,
+                )}`}
+                value={item.aboutPost ? ADMIN.reports.aboutPost : undefined}
+                onPress={() => router.push(`/(app)/admin/reports/${item.id}`)}
+                last={index === (reports.data?.items.length ?? 0) - 1}
+              />
+            )}
+          />
+        )}
+      </Screen>
+    </AdminGate>
+  )
+}
+
+const useStyles = makeStyles(() => ({
+  tabs: { marginVertical: 12 },
+  loading: { gap: 12 },
+}))

--- a/apps/mobile/app/(app)/admin/system.tsx
+++ b/apps/mobile/app/(app)/admin/system.tsx
@@ -105,7 +105,9 @@ export default function AdminSystemScreen() {
                   .join(' · ')}
               </Text>
             </Card>
-            <Callout tone="info">{ADMIN.system.readOnly}</Callout>
+            <Callout tone="info">
+              <Text style={styles.calloutBody}>{ADMIN.system.readOnly}</Text>
+            </Callout>
           </>
         )}
       </Screen>
@@ -115,6 +117,7 @@ export default function AdminSystemScreen() {
 
 const useStyles = makeStyles((theme) => ({
   loading: { gap: 12, marginTop: 16 },
+  calloutBody: { fontSize: 14, color: theme.colors.text, lineHeight: 20 },
   heading: {
     marginTop: 24,
     marginBottom: 8,

--- a/apps/mobile/app/(app)/admin/system.tsx
+++ b/apps/mobile/app/(app)/admin/system.tsx
@@ -1,0 +1,129 @@
+import { Text, View } from 'react-native'
+import { useAdminStats } from '../../../src/api/queries'
+import { AdminGate } from '../../../src/components/AdminGate'
+import { Callout } from '../../../src/components/ui/Callout'
+import { Card } from '../../../src/components/ui/Card'
+import { Screen } from '../../../src/components/ui/Screen'
+import { ScreenHeader } from '../../../src/components/ui/ScreenHeader'
+import { Skeleton } from '../../../src/components/ui/Skeleton'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
+import { ADMIN } from '../../../src/lib/adminStrings'
+import { goBackTo } from '../../../src/lib/navigation'
+import { makeStyles } from '../../../src/lib/theme'
+
+/**
+ * Whether anything is quietly broken.
+ *
+ * The job table is the part that earns this screen. Two of the schedulers used
+ * to leave a trace in `jobRuns` and the other eight left nothing at all, so a
+ * pass that stopped firing said nothing — the first sign was somebody asking
+ * why their streak reminders had stopped. `jobHealth` records every pass now,
+ * and this is what reads it.
+ *
+ * Everything here is read only, and the config block most deliberately of all.
+ * `scripts/maintenance.ts` explains why the kill switch is a script: it is the
+ * control you reach for when something is wrong, and it must not depend on the
+ * API being healthy enough to authenticate you. A panel served *by* that API
+ * cannot be the thing that turns it off.
+ */
+export default function AdminSystemScreen() {
+  useScreenInteractive()
+  const styles = useStyles()
+  const stats = useAdminStats()
+  const system = stats.data?.system
+
+  return (
+    <AdminGate>
+      <Screen scroll fluid>
+        <ScreenHeader title={ADMIN.system.title} onBack={() => goBackTo('/(app)/admin')} />
+
+        {stats.isPending || !system ? (
+          <View style={styles.loading}>
+            <Skeleton height={120} />
+            <Skeleton height={120} />
+          </View>
+        ) : (
+          <>
+            <Text style={styles.heading}>{ADMIN.system.jobs}</Text>
+            <Card>
+              {system.jobs.length === 0 ? (
+                <Text style={styles.muted}>{ADMIN.system.jobNever}</Text>
+              ) : (
+                system.jobs.map((job) => (
+                  <Text key={job._id} style={job.lastError ? styles.bad : styles.row}>
+                    {job._id} · {job.lastFinishedAt?.slice(5, 16).replace('T', ' ') ?? '—'} ·{' '}
+                    {job.lastError ? ADMIN.system.jobFailed : ADMIN.system.runs(job.runs)}
+                  </Text>
+                ))
+              )}
+            </Card>
+
+            <Text style={styles.heading}>{ADMIN.system.suppressions}</Text>
+            <Text style={styles.row}>
+              {system.suppressions.total} · bounced {system.suppressions.bounced} · complained{' '}
+              {system.suppressions.complained} · unsubscribed {system.suppressions.unsubscribed}
+            </Text>
+
+            <Text style={styles.heading}>{ADMIN.system.purge}</Text>
+            <Text style={styles.row}>
+              {system.purge.accounts} {ADMIN.system.purgeAccounts} · {system.purge.analytics}{' '}
+              {ADMIN.system.purgeAnalytics}
+            </Text>
+
+            <Text style={styles.heading}>{ADMIN.system.assistant}</Text>
+            <Text style={styles.row}>{system.assistantCallsToday}</Text>
+
+            <Text style={styles.heading}>{ADMIN.system.campaigns}</Text>
+            {system.campaigns.length === 0 ? (
+              <Text style={styles.muted}>—</Text>
+            ) : (
+              <Card>
+                {system.campaigns.map((campaign) => (
+                  <Text key={campaign.id} style={styles.row}>
+                    {campaign.id} · {campaign.status} · {campaign.sent}/{campaign.total}
+                  </Text>
+                ))}
+              </Card>
+            )}
+
+            <Text style={styles.heading}>{ADMIN.system.config}</Text>
+            <Card>
+              <Text style={system.config.maintenance.enabled ? styles.bad : styles.row}>
+                {ADMIN.system.maintenance}:{' '}
+                {system.config.maintenance.enabled
+                  ? ADMIN.system.maintenanceOn
+                  : ADMIN.system.maintenanceOff}
+              </Text>
+              <Text style={styles.row}>
+                {ADMIN.system.minVersion}: ios {system.config.minVersion.ios} · android{' '}
+                {system.config.minVersion.android} · web {system.config.minVersion.web}
+              </Text>
+              <Text style={styles.row}>
+                {ADMIN.system.flags}:{' '}
+                {Object.entries(system.config.flags)
+                  .map(([name, on]) => `${name} ${on ? 'on' : 'off'}`)
+                  .join(' · ')}
+              </Text>
+            </Card>
+            <Callout tone="info">{ADMIN.system.readOnly}</Callout>
+          </>
+        )}
+      </Screen>
+    </AdminGate>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  loading: { gap: 12, marginTop: 16 },
+  heading: {
+    marginTop: 24,
+    marginBottom: 8,
+    fontSize: 13,
+    fontWeight: '700',
+    color: theme.colors.textMuted,
+    textTransform: 'uppercase',
+  },
+  row: { fontSize: 14, color: theme.colors.text, lineHeight: 22 },
+  bad: { fontSize: 14, color: theme.colors.danger, lineHeight: 22, fontWeight: '700' },
+  muted: { fontSize: 14, color: theme.colors.textMuted },
+}))

--- a/apps/mobile/app/(app)/admin/users.tsx
+++ b/apps/mobile/app/(app)/admin/users.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Text, View } from 'react-native'
 import { REPORT_REASONS, SUSPENSION_MAX_DAYS } from '@langx/shared'
 import {
@@ -35,9 +35,22 @@ import { showToast } from '../../../src/lib/toast'
  */
 export default function AdminUsersScreen() {
   useScreenInteractive()
+  const styles = useStyles()
   const [query, setQuery] = useState('')
-  const [submitted, setSubmitted] = useState('')
-  const found = useAdminUser(submitted)
+  const [debounced, setDebounced] = useState('')
+  const found = useAdminUser(debounced)
+
+  /*
+   * Searches as it is typed rather than on submit. `onSubmitEditing` was the
+   * first shape and it does not fire on the web build — the field keeps the
+   * text and nothing happens, which is the worst of the three possible
+   * behaviours. A delay is enough to keep this to one request per search, and
+   * react-query dedupes what gets through.
+   */
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(query.trim()), 400)
+    return () => clearTimeout(timer)
+  }, [query])
 
   return (
     <AdminGate>
@@ -50,11 +63,17 @@ export default function AdminUsersScreen() {
           onChangeText={setQuery}
           autoCapitalize="none"
           autoCorrect={false}
-          onSubmitEditing={() => setSubmitted(query.trim())}
           returnKeyType="search"
         />
 
-        {found.isError ? <Callout tone="info">{ADMIN.users.notFound}</Callout> : null}
+        {found.isError ? (
+          <Callout tone="info">
+            <Text style={styles.calloutBody}>{ADMIN.users.notFound}</Text>
+          </Callout>
+        ) : null}
+        {found.isFetching && !found.data ? (
+          <Text style={styles.searching}>{ADMIN.common.loading}</Text>
+        ) : null}
         {found.data ? <Found data={found.data} /> : null}
       </Screen>
     </AdminGate>
@@ -149,8 +168,16 @@ function Found({ data }: { data: AdminUserDto }) {
         {ADMIN.users.blockedBy}
       </Text>
 
-      {user.suspension ? <Callout tone="error">{ADMIN.users.suspended}</Callout> : null}
-      {user.tokenFrozenAt ? <Callout tone="warning">{ADMIN.users.tokensFrozen}</Callout> : null}
+      {user.suspension ? (
+        <Callout tone="error">
+          <Text style={styles.calloutBody}>{ADMIN.users.suspended}</Text>
+        </Callout>
+      ) : null}
+      {user.tokenFrozenAt ? (
+        <Callout tone="warning">
+          <Text style={styles.calloutBody}>{ADMIN.users.tokensFrozen}</Text>
+        </Callout>
+      ) : null}
 
       {/* ── why Discover looks the way it does ── */}
       <Text style={styles.heading}>{ADMIN.diagnose.discovery}</Text>
@@ -163,7 +190,9 @@ function Found({ data }: { data: AdminUserDto }) {
         ))}
       </Card>
       {data.discovery.discoverable ? null : (
-        <Callout tone="warning">{ADMIN.diagnose.notDiscoverable}</Callout>
+        <Callout tone="warning">
+          <Text style={styles.calloutBody}>{ADMIN.diagnose.notDiscoverable}</Text>
+        </Callout>
       )}
       <Text style={styles.muted}>
         {ADMIN.diagnose.languages}: {data.discovery.nativeLanguages.join(', ')} →{' '}
@@ -173,7 +202,9 @@ function Found({ data }: { data: AdminUserDto }) {
       {/* ── why no notification arrives ── */}
       <Text style={styles.heading}>{ADMIN.diagnose.push}</Text>
       {data.push.devices.length === 0 ? (
-        <Callout tone="warning">{ADMIN.diagnose.noDevices}</Callout>
+        <Callout tone="warning">
+          <Text style={styles.calloutBody}>{ADMIN.diagnose.noDevices}</Text>
+        </Callout>
       ) : (
         <Card>
           {data.push.devices.map((device, index) => (
@@ -186,7 +217,9 @@ function Found({ data }: { data: AdminUserDto }) {
       )}
       {data.push.suppression ? (
         <Callout tone="error">
-          {ADMIN.diagnose.suppressed} ({data.push.suppression.reason})
+          <Text style={styles.calloutBody}>
+            {ADMIN.diagnose.suppressed} ({data.push.suppression.reason})
+          </Text>
         </Callout>
       ) : null}
       <Card>
@@ -261,6 +294,8 @@ function Found({ data }: { data: AdminUserDto }) {
 
 const useStyles = makeStyles((theme) => ({
   found: { gap: 8, paddingBottom: 48 },
+  calloutBody: { fontSize: 14, color: theme.colors.text, lineHeight: 20 },
+  searching: { fontSize: 14, color: theme.colors.textMuted, marginTop: 8 },
   name: { fontSize: 22, fontWeight: '700', color: theme.colors.text, marginTop: 12 },
   muted: { fontSize: 14, color: theme.colors.textMuted },
   heading: {

--- a/apps/mobile/app/(app)/admin/users.tsx
+++ b/apps/mobile/app/(app)/admin/users.tsx
@@ -1,0 +1,277 @@
+import { useState } from 'react'
+import { Text, View } from 'react-native'
+import { REPORT_REASONS, SUSPENSION_MAX_DAYS } from '@langx/shared'
+import {
+  useAdminDecision,
+  useAdminUser,
+  useAdminUserAction,
+  type AdminUserDto,
+} from '../../../src/api/queries'
+import { AdminGate } from '../../../src/components/AdminGate'
+import { Button } from '../../../src/components/ui/Button'
+import { Callout } from '../../../src/components/ui/Callout'
+import { Card } from '../../../src/components/ui/Card'
+import { FormField } from '../../../src/components/ui/FormField'
+import { Screen } from '../../../src/components/ui/Screen'
+import { ScreenHeader } from '../../../src/components/ui/ScreenHeader'
+import { useScreenInteractive } from '../../../src/hooks/useScreenInteractive'
+import { ADMIN } from '../../../src/lib/adminStrings'
+import { chooseAlert, confirmAlert } from '../../../src/lib/alert'
+import { goBackTo } from '../../../src/lib/navigation'
+import { makeStyles } from '../../../src/lib/theme'
+import { showToast } from '../../../src/lib/toast'
+
+/**
+ * One account, and the four questions the support mailbox actually asks.
+ *
+ * The diagnosis blocks are the reason this screen exists at all: "my Discover
+ * is empty", "I get no notifications", "my mail never arrives" and "my old
+ * data did not come back" are all answerable from the database with an indexed
+ * read, and until now answering one meant opening a shell.
+ *
+ * A permanent suspension is deliberately **not** offered here. One should be
+ * reached from the report that justifies it, where the evidence is on the same
+ * screen; a search box is the wrong place to end somebody's account forever.
+ */
+export default function AdminUsersScreen() {
+  useScreenInteractive()
+  const [query, setQuery] = useState('')
+  const [submitted, setSubmitted] = useState('')
+  const found = useAdminUser(submitted)
+
+  return (
+    <AdminGate>
+      <Screen scroll fluid>
+        <ScreenHeader title={ADMIN.users.title} onBack={() => goBackTo('/(app)/admin')} />
+
+        <FormField
+          label={ADMIN.users.search}
+          value={query}
+          onChangeText={setQuery}
+          autoCapitalize="none"
+          autoCorrect={false}
+          onSubmitEditing={() => setSubmitted(query.trim())}
+          returnKeyType="search"
+        />
+
+        {found.isError ? <Callout tone="info">{ADMIN.users.notFound}</Callout> : null}
+        {found.data ? <Found data={found.data} /> : null}
+      </Screen>
+    </AdminGate>
+  )
+}
+
+function Found({ data }: { data: AdminUserDto }) {
+  const styles = useStyles()
+  const action = useAdminUserAction()
+  const decide = useAdminDecision()
+  const [message, setMessage] = useState('')
+  const [days, setDays] = useState('7')
+
+  const user = data.user
+  const who = `@${user.handle}`
+
+  async function suspend() {
+    const reason = await chooseAlert(
+      ADMIN.users.reason,
+      undefined,
+      REPORT_REASONS.map((value) => ({ value, label: value.replace(/_/g, ' ') })),
+    )
+    if (!reason) return
+    const numberOfDays = Math.min(SUSPENSION_MAX_DAYS, Math.max(1, Number.parseInt(days, 10) || 1))
+    const ok = await confirmAlert({
+      title: ADMIN.reports.confirmSuspend(who, numberOfDays),
+      confirmLabel: ADMIN.users.suspend,
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await action.mutateAsync({
+        userId: user.userId,
+        action: 'suspend',
+        body: { reason, days: numberOfDays },
+      })
+    } catch {
+      showToast(ADMIN.common.failed)
+    }
+  }
+
+  async function lift() {
+    const ok = await confirmAlert({
+      title: ADMIN.appeals.confirmLift(who),
+      confirmLabel: ADMIN.users.lift,
+    })
+    if (!ok) return
+    await decide.mutateAsync({ kind: 'appeal', id: user.userId, action: 'lift' }).catch(() => {
+      showToast(ADMIN.common.failed)
+    })
+  }
+
+  async function run(name: string, confirm?: string, body?: unknown) {
+    if (confirm) {
+      const ok = await confirmAlert({
+        title: confirm,
+        confirmLabel: ADMIN.common.confirm,
+        destructive: true,
+      })
+      if (!ok) return
+    }
+    try {
+      await action.mutateAsync({ userId: user.userId, action: name, ...(body ? { body } : {}) })
+      showToast(name === 'message' ? ADMIN.users.sent : ADMIN.users.unfrozen)
+      if (name === 'message') setMessage('')
+    } catch {
+      showToast(ADMIN.common.failed)
+    }
+  }
+
+  return (
+    <View style={styles.found}>
+      <Text style={styles.name}>
+        {user.displayName} {who}
+      </Text>
+      <Text style={styles.muted}>
+        {ADMIN.users.plan}: {user.tier} · {ADMIN.users.joined} {user.createdAt.slice(0, 10)} ·{' '}
+        {ADMIN.users.lastSeen} {user.lastActiveAt?.slice(0, 10) ?? ADMIN.users.never}
+      </Text>
+      <Text style={styles.muted}>
+        {ADMIN.users.email}: {user.email ?? '—'}
+        {user.emailVerified ? '' : ` (${ADMIN.users.unverified})`}
+      </Text>
+      {user.build ? (
+        <Text style={styles.muted}>
+          {ADMIN.users.build}: {user.build.platform} {user.build.version}
+        </Text>
+      ) : null}
+      <Text style={styles.muted}>
+        {ADMIN.users.counts}: {user.counts.reportsAgainst} {ADMIN.users.reportsAgainst} ·{' '}
+        {user.counts.reportsFiled} {ADMIN.users.reportsFiled} · {user.counts.blockedBy}{' '}
+        {ADMIN.users.blockedBy}
+      </Text>
+
+      {user.suspension ? <Callout tone="error">{ADMIN.users.suspended}</Callout> : null}
+      {user.tokenFrozenAt ? <Callout tone="warning">{ADMIN.users.tokensFrozen}</Callout> : null}
+
+      {/* ── why Discover looks the way it does ── */}
+      <Text style={styles.heading}>{ADMIN.diagnose.discovery}</Text>
+      <Text style={styles.hint}>{ADMIN.diagnose.discoveryHint}</Text>
+      <Card>
+        {data.discovery.steps.map((step) => (
+          <Text key={step.filter} style={styles.row}>
+            {step.filter} · {step.remaining}
+          </Text>
+        ))}
+      </Card>
+      {data.discovery.discoverable ? null : (
+        <Callout tone="warning">{ADMIN.diagnose.notDiscoverable}</Callout>
+      )}
+      <Text style={styles.muted}>
+        {ADMIN.diagnose.languages}: {data.discovery.nativeLanguages.join(', ')} →{' '}
+        {data.discovery.learning.join(', ')}
+      </Text>
+
+      {/* ── why no notification arrives ── */}
+      <Text style={styles.heading}>{ADMIN.diagnose.push}</Text>
+      {data.push.devices.length === 0 ? (
+        <Callout tone="warning">{ADMIN.diagnose.noDevices}</Callout>
+      ) : (
+        <Card>
+          {data.push.devices.map((device, index) => (
+            <Text key={`${device.platform}-${index}`} style={styles.row}>
+              {device.platform} · {device.pushEnabled ? 'on' : ADMIN.diagnose.deviceOff} ·{' '}
+              {device.locale ?? '—'}
+            </Text>
+          ))}
+        </Card>
+      )}
+      {data.push.suppression ? (
+        <Callout tone="error">
+          {ADMIN.diagnose.suppressed} ({data.push.suppression.reason})
+        </Callout>
+      ) : null}
+      <Card>
+        {data.push.prefs.map((pref) => (
+          <Text key={pref.type} style={styles.row}>
+            {pref.type} · push {pref.push ? 'on' : 'off'} · email {pref.email ? 'on' : 'off'}
+          </Text>
+        ))}
+      </Card>
+
+      {/* ── did their old account come back ── */}
+      <Text style={styles.heading}>{ADMIN.diagnose.legacy}</Text>
+      <Text style={styles.row}>
+        {data.legacy.staged
+          ? `${ADMIN.diagnose.staged} · ${
+              data.legacy.reserved ? ADMIN.diagnose.reserved : '—'
+            } · ${data.legacy.restored ? ADMIN.diagnose.restored : '—'}`
+          : ADMIN.diagnose.nothingStaged}
+      </Text>
+
+      {/* ── what can be done ── */}
+      <Text style={styles.heading}>{ADMIN.users.message}</Text>
+      <Text style={styles.hint}>{ADMIN.users.messageHint}</Text>
+      <FormField value={message} onChangeText={setMessage} multiline numberOfLines={4} />
+      <Button
+        label={ADMIN.users.send}
+        variant="secondary"
+        disabled={message.trim().length === 0}
+        onPress={() => run('message', undefined, { body: message.trim() })}
+      />
+
+      <FormField
+        label={ADMIN.reports.days}
+        value={days}
+        onChangeText={setDays}
+        keyboardType="number-pad"
+      />
+      <View style={styles.actions}>
+        <Button label={ADMIN.users.suspend} variant="danger" onPress={suspend} />
+        {user.suspension ? (
+          <Button label={ADMIN.users.lift} variant="secondary" onPress={lift} />
+        ) : null}
+        {user.tokenFrozenAt ? (
+          <Button
+            label={ADMIN.users.unfreeze}
+            variant="secondary"
+            onPress={() => run('unfreeze-tokens')}
+          />
+        ) : null}
+        <Button
+          label={ADMIN.users.signOut}
+          variant="neutral"
+          onPress={() => run('sign-out', ADMIN.users.confirmSignOut(who))}
+        />
+      </View>
+
+      <Text style={styles.heading}>{ADMIN.users.history}</Text>
+      {user.actions.length === 0 ? (
+        <Text style={styles.muted}>{ADMIN.users.noHistory}</Text>
+      ) : (
+        <Card>
+          {user.actions.map((entry) => (
+            <Text key={`${entry.at}-${entry.action}`} style={styles.row}>
+              {entry.at.slice(0, 16).replace('T', ' ')} · {entry.action}
+            </Text>
+          ))}
+        </Card>
+      )}
+    </View>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  found: { gap: 8, paddingBottom: 48 },
+  name: { fontSize: 22, fontWeight: '700', color: theme.colors.text, marginTop: 12 },
+  muted: { fontSize: 14, color: theme.colors.textMuted },
+  heading: {
+    marginTop: 24,
+    marginBottom: 4,
+    fontSize: 13,
+    fontWeight: '700',
+    color: theme.colors.textMuted,
+    textTransform: 'uppercase',
+  },
+  hint: { fontSize: 13, color: theme.colors.textMuted, marginBottom: 8 },
+  row: { fontSize: 14, color: theme.colors.text, lineHeight: 22 },
+  actions: { gap: 12, marginTop: 12 },
+}))

--- a/apps/mobile/app/(app)/settings/index.tsx
+++ b/apps/mobile/app/(app)/settings/index.tsx
@@ -10,6 +10,7 @@ import { ScreenHeader } from '../../../src/components/ui/ScreenHeader'
 import { appVersion } from '../../../src/hooks/useAppConfig'
 import { useSettingsModel } from '../../../src/hooks/useSettingsModel'
 import { useT } from '../../../src/i18n'
+import { ADMIN } from '../../../src/lib/adminStrings'
 import { goBackTo } from '../../../src/lib/navigation'
 import { matchSettings, SETTINGS_SECTIONS } from '../../../src/lib/settingsRegistry'
 import { makeStyles, useTheme } from '../../../src/lib/theme'
@@ -89,6 +90,19 @@ export default function SettingsScreen() {
               onPress={() => router.push(section.route)}
             />
           ))}
+          {/*
+           * Drawn here rather than added to `SETTINGS_SECTIONS`, and that is
+           * not tidiness: `settingsRegistry.test.ts` asserts every row in that
+           * list resolves in all eight catalogues, and the panel is English by
+           * design (`src/lib/adminStrings.ts`). Keeping it out also keeps
+           * operator vocabulary out of the search index above.
+           *
+           * `model.profile` is `useMe()`'s data, already loaded — so no extra
+           * request — and the flag only ever appears on your own profile.
+           */}
+          {model.profile?.admin ? (
+            <ListRow title={ADMIN.entryRow} onPress={() => router.push('/(app)/admin')} last />
+          ) : null}
         </View>
       )}
 

--- a/apps/mobile/src/api/queries.ts
+++ b/apps/mobile/src/api/queries.ts
@@ -203,6 +203,21 @@ export const keys = {
   contributors: ['contributors'] as const,
   streakLeaderboard: (metric: string) => ['leaderboard', 'streak', metric] as const,
   blocks: ['blocks'] as const,
+  /*
+   * The operator panel, all of it under one prefix so a decision can
+   * invalidate every queue it might have changed with a single call. Nothing
+   * patches this prefix with `setQueriesData`, so the page-walking trap the
+   * two comments above describe does not apply here.
+   */
+  adminStats: ['admin', 'stats'] as const,
+  adminReports: (status: string) => ['admin', 'reports', status] as const,
+  adminReport: (id: string) => ['admin', 'reports', 'one', id] as const,
+  adminAppeals: ['admin', 'appeals'] as const,
+  adminFeedback: (status: string) => ['admin', 'feedback', status] as const,
+  adminFeedbackItem: (id: string) => ['admin', 'feedback', 'one', id] as const,
+  adminBroadcasts: ['admin', 'broadcasts'] as const,
+  adminBroadcast: (id: string) => ['admin', 'broadcasts', id] as const,
+  adminUser: (q: string) => ['admin', 'user', q] as const,
 }
 
 /**
@@ -313,6 +328,12 @@ function apiPut<T>(path: string, body: unknown): Promise<T> {
 export interface MeProfile {
   _id: string
   handle: string
+  /**
+   * A moderator. Only ever present on your own profile — the public and shared
+   * projections are allow-lists and do not name it — and set only by
+   * `scripts/grant-admin.ts` on the server.
+   */
+  admin?: true
   /**
    * The username this account held in v1, kept after its owner swapped it for
    * one of their own. Its presence is what says the one claim has been spent —
@@ -2186,6 +2207,308 @@ export function useRevokeOtherSessions() {
     },
     onSuccess: () => {
       void client.invalidateQueries({ queryKey: keys.sessions })
+    },
+  })
+}
+
+/*
+ * ── The operator panel ──────────────────────────────────────────────────────
+ *
+ * Every one of these is refused with `ADMIN_REQUIRED` for anybody without the
+ * flag, which is the real gate — `AdminGate` only decides whether a screen is
+ * drawn. The DTOs are deliberately loose here: these shapes are read by five
+ * screens nobody else sees, and mirroring them field for field from the server
+ * would be a second place to update every time a diagnosis gains a line.
+ */
+
+export interface AdminStatsDto {
+  generatedAt: string
+  queue: { reports: number; appeals: number; feedback: number }
+  audience: {
+    profiles: number
+    messages: number
+    activeToday: number
+    activeDaily: { day: string; count: number }[]
+    seenLastWeek: number
+    joinedToday: number
+    joinedLastWeek: number
+    builds: { platform: string; version: string; count: number }[]
+  }
+  money: {
+    tiers: { total: number; pro: number; proPlus: number; free: number }
+    pool: { day: string; paid: number; distributed: number; active: number } | null
+    tokensDaily: { day: string; count: number }[]
+  }
+  system: {
+    jobs: {
+      _id: string
+      lastFinishedAt?: string
+      lastDurationMs?: number
+      lastError?: string | null
+      runs: number
+      failures: number
+    }[]
+    suppressions: { total: number; unsubscribed: number; bounced: number; complained: number }
+    purge: { accounts: number; analytics: number }
+    assistantCallsToday: number
+    campaigns: { id: string; status: string; sent: number; total: number }[]
+    config: {
+      maintenance: { enabled: boolean; message: string }
+      minVersion: { ios: string; android: string; web: string }
+      flags: Record<string, boolean>
+    }
+  }
+}
+
+export interface AdminPartyDto {
+  userId: string
+  handle: string | null
+  displayName: string | null
+  avatarUrl: string | null
+  suspended: boolean
+}
+
+export interface AdminReportDto {
+  id: string
+  reason: string
+  details: string | null
+  status: string
+  createdAt: string
+  reported: AdminPartyDto
+  reporter: AdminPartyDto
+  aboutPost: boolean
+  post?: { id: string; body: string; language: string; hiddenAt: string | null } | null
+  suspension?: { until: string; permanent: boolean; reason: string } | null
+  otherOpenReports?: number
+}
+
+export interface AdminAppealDto {
+  userId: string
+  handle: string | null
+  displayName: string | null
+  text: string
+  appealedAt: string
+  until: string | null
+  permanent: boolean
+  reason: string
+}
+
+export interface AdminFeedbackDto {
+  _id: string
+  kind: 'bug' | 'feature'
+  body: string
+  attachmentUrls: string[]
+  issueUrl?: string
+  status: 'open' | 'triaged' | 'closed'
+  bounty: { amount: number; at: string } | null
+  createdAt: string
+  sender: { userId: string; handle: string | null; displayName: string | null }
+}
+
+export interface AdminBroadcastDto {
+  _id: string
+  bodies: Record<string, string>
+  pushTitle: string
+  status: 'draft' | 'queued' | 'sending' | 'paused' | 'done'
+  total: number
+  sent: number
+  failed: number
+  createdAt: string
+  startedAt?: string
+  finishedAt?: string
+}
+
+export interface AdminUserDto {
+  user: {
+    userId: string
+    handle: string
+    previousHandle: string | null
+    displayName: string
+    avatarUrl: string | null
+    country: string | null
+    createdAt: string
+    lastActiveAt: string | null
+    build: { version: string; platform: string } | null
+    tier: string
+    admin: boolean
+    email: string | null
+    emailVerified: boolean
+    deletedAt: string | null
+    tokenFrozenAt: string | null
+    suspension: { until: string; permanent: boolean; reason: string } | null
+    counts: { reportsAgainst: number; reportsFiled: number; blockedBy: number }
+    actions: { action: string; adminId: string; at: string }[]
+  }
+  discovery: {
+    matches: number
+    steps: { filter: string; remaining: number }[]
+    discoverable: boolean
+    nativeLanguages: string[]
+    learning: string[]
+  }
+  push: {
+    devices: { platform: string; pushEnabled: boolean; locale: string | null }[]
+    prefs: { type: string; push: boolean; email: boolean }[]
+    suppression: { reason: string; at: string } | null
+  }
+  legacy: { staged: boolean; reserved: boolean; restored: boolean; previousHandle: string | null }
+}
+
+export function useAdminStats(enabled = true) {
+  return useQuery({
+    queryKey: keys.adminStats,
+    queryFn: () => api.get<AdminStatsDto>('/admin/stats'),
+    enabled,
+  })
+}
+
+export function useAdminReports(status: string) {
+  return useQuery({
+    queryKey: keys.adminReports(status),
+    queryFn: () => api.get<{ items: AdminReportDto[] }>(`/admin/reports?status=${status}`),
+  })
+}
+
+export function useAdminReport(id: string) {
+  return useQuery({
+    queryKey: keys.adminReport(id),
+    queryFn: () => api.get<AdminReportDto>(`/admin/reports/${id}`),
+    enabled: id.length > 0,
+  })
+}
+
+export function useAdminAppeals() {
+  return useQuery({
+    queryKey: keys.adminAppeals,
+    queryFn: () => api.get<{ items: AdminAppealDto[] }>('/admin/appeals'),
+  })
+}
+
+/**
+ * One decision, whichever queue it came from.
+ *
+ * Invalidates the whole `['admin']` prefix rather than the one list it
+ * changed: a suspension moves a report between two tabs, empties an appeal,
+ * changes the dashboard's counts and rewrites that account's history. Naming
+ * them individually is how one of them goes stale.
+ */
+export function useAdminDecision() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { kind: 'report' | 'appeal'; id: string; action: string; days?: number }) =>
+      api.post<unknown>(
+        input.kind === 'report'
+          ? `/admin/reports/${input.id}/decision`
+          : `/admin/appeals/${input.id}/decision`,
+        { action: input.action, ...(input.days === undefined ? {} : { days: input.days }) },
+      ),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ['admin'] })
+    },
+  })
+}
+
+export function useAdminFeedback(status: string) {
+  return useQuery({
+    queryKey: keys.adminFeedback(status),
+    queryFn: () => api.get<{ items: AdminFeedbackDto[] }>(`/admin/feedback?status=${status}`),
+  })
+}
+
+export function useAdminPayBounty() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { id: string; amount: number }) =>
+      api.post<{ awarded: boolean; amount: number }>(`/admin/feedback/${input.id}/award`, {
+        amount: input.amount,
+      }),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ['admin'] })
+    },
+  })
+}
+
+export function useAdminCloseFeedback() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { id: string; closeReason: string; note?: string }) =>
+      api.patch<AdminFeedbackDto>(`/admin/feedback/${input.id}`, {
+        status: 'closed',
+        closeReason: input.closeReason,
+        ...(input.note ? { note: input.note } : {}),
+      }),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ['admin'] })
+    },
+  })
+}
+
+export function useAdminBroadcasts() {
+  return useQuery({
+    queryKey: keys.adminBroadcasts,
+    queryFn: () => api.get<{ items: AdminBroadcastDto[]; audience: number }>('/admin/broadcasts'),
+  })
+}
+
+/**
+ * While it is going out, this is the only thing that says how far it has got —
+ * so it polls, and only then. A finished broadcast asking every two seconds
+ * forever is a battery bug on a screen somebody left open.
+ */
+export function useAdminBroadcast(id: string) {
+  return useQuery({
+    queryKey: keys.adminBroadcast(id),
+    queryFn: () => api.get<AdminBroadcastDto>(`/admin/broadcasts/${id}`),
+    enabled: id.length > 0,
+    refetchInterval: (query) =>
+      query.state.data?.status === 'sending' || query.state.data?.status === 'queued'
+        ? 2000
+        : false,
+  })
+}
+
+export function useAdminCreateBroadcast() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { id: string; bodies: Record<string, string> }) =>
+      api.post<AdminBroadcastDto>('/admin/broadcasts', input),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: keys.adminBroadcasts })
+    },
+  })
+}
+
+export function useAdminBroadcastAction() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { id: string; action: 'test' | 'start' | 'pause' | 'resume' }) =>
+      api.post<AdminBroadcastDto | { delivered: boolean }>(
+        `/admin/broadcasts/${input.id}/${input.action}`,
+        {},
+      ),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ['admin'] })
+    },
+  })
+}
+
+export function useAdminUser(q: string) {
+  return useQuery({
+    queryKey: keys.adminUser(q),
+    queryFn: () => api.get<AdminUserDto>(`/admin/users?q=${encodeURIComponent(q)}`),
+    enabled: q.trim().length >= 2,
+    retry: false,
+  })
+}
+
+/** The account actions that are not a moderation decision: thaw, sign out, write to. */
+export function useAdminUserAction() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { userId: string; action: string; body?: unknown }) =>
+      api.post<unknown>(`/admin/users/${input.userId}/${input.action}`, input.body ?? {}),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: ['admin'] })
     },
   })
 }

--- a/apps/mobile/src/components/AdminGate.tsx
+++ b/apps/mobile/src/components/AdminGate.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react'
+import { Redirect } from 'expo-router'
+import { View } from 'react-native'
+import { useMe } from '../api/queries'
+import { Screen } from './ui/Screen'
+import { ScreenHeader } from './ui/ScreenHeader'
+import { Skeleton } from './ui/Skeleton'
+
+/**
+ * Draws an operator screen only for an operator.
+ *
+ * **This is cosmetic.** The real gate is `requireAdmin` on the server, which
+ * refuses every `/admin/*` route with `ADMIN_REQUIRED`; what this decides is
+ * whether a screen is worth drawing, not whether the data can be had. The web
+ * build exports every route as a static shell anyway (`web: { output:
+ * 'static' }`), so the existence of these paths is public and nothing here
+ * pretends otherwise.
+ *
+ * The pending branch draws a skeleton rather than redirecting. A cold deep
+ * link on the web resolves `useMe` after the first render, and redirecting on
+ * "not yet" would throw a real operator out of the screen they just opened.
+ */
+export function AdminGate({ children }: { children: ReactNode }) {
+  const me = useMe()
+
+  if (me.isPending) {
+    return (
+      <Screen fluid>
+        <ScreenHeader />
+        <View style={{ gap: 12, padding: 16 }}>
+          <Skeleton height={64} />
+          <Skeleton height={64} />
+          <Skeleton height={64} />
+        </View>
+      </Screen>
+    )
+  }
+
+  // Settled and not an operator — including a 401 or a 404, which the root
+  // gate has its own answer for.
+  if (!me.data?.admin) return <Redirect href="/(app)/(tabs)/me" />
+
+  return <>{children}</>
+}

--- a/apps/mobile/src/lib/adminStrings.test.ts
+++ b/apps/mobile/src/lib/adminStrings.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { ADMIN } from './adminStrings'
+
+/**
+ * The operator panel is English, and this is what makes that a fact rather
+ * than a habit.
+ *
+ * There are three layers keeping it that way — a lint rule pointing the
+ * opposite direction to the project's own convention, a note at the top of
+ * `adminStrings.ts`, and this. The lint rule catches the import; this catches
+ * the other half, a screen that reaches for `t()` through some path the rule
+ * did not name, and it also catches a string table with a hole in it.
+ *
+ * Mobile vitest cannot load `react-native` (`vitest.config.ts` restricts it to
+ * `src/lib` and `src/i18n`, and Flow syntax is why), so the screens themselves
+ * are unreachable from a test. Reading them off disk is what is left, and it
+ * is the same thing `routeLiterals.test.ts` does for the same reason.
+ */
+
+const ADMIN_SCREENS = path.join(__dirname, '../../app/(app)/admin')
+
+function screenFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) return screenFiles(full)
+    return entry.name.endsWith('.tsx') ? [full] : []
+  })
+}
+
+/** Every leaf of the table, so a missing one is found rather than rendered blank. */
+function leaves(value: unknown, trail: string[] = []): { path: string; value: unknown }[] {
+  if (typeof value === 'object' && value !== null) {
+    return Object.entries(value).flatMap(([key, child]) => leaves(child, [...trail, key]))
+  }
+  return [{ path: trail.join('.'), value }]
+}
+
+describe('the operator panel’s words', () => {
+  it('has no empty or missing entry', () => {
+    for (const leaf of leaves(ADMIN)) {
+      if (typeof leaf.value === 'function') continue
+      expect(typeof leaf.value, leaf.path).toBe('string')
+      expect(String(leaf.value).trim().length, leaf.path).toBeGreaterThan(0)
+    }
+  })
+
+  it('every function in it returns something', () => {
+    // The interpolating entries — `Pay 1500 tokens`, `3 other reports`. A
+    // typo in one of these is a screen that renders "undefined" at a person.
+    for (const leaf of leaves(ADMIN)) {
+      if (typeof leaf.value !== 'function') continue
+      const rendered = (leaf.value as (...args: unknown[]) => string)(1, 'x')
+      expect(typeof rendered, leaf.path).toBe('string')
+      expect(rendered, leaf.path).not.toContain('undefined')
+    }
+  })
+
+  it('is the only place the admin screens get words from', () => {
+    const files = screenFiles(ADMIN_SCREENS)
+    // If this is ever zero the assertions below pass vacuously, which would be
+    // the quietest possible way for this test to stop meaning anything.
+    expect(files.length).toBeGreaterThan(0)
+
+    for (const file of files) {
+      const source = readFileSync(file, 'utf8')
+      const where = path.relative(ADMIN_SCREENS, file)
+      expect(source, where).not.toMatch(/from '[^']*\/i18n['/]/)
+      expect(source, where).not.toMatch(/\buseT\b/)
+      expect(source, where).not.toMatch(/\bt\(['"]/)
+      expect(source, where).toContain('adminStrings')
+    }
+  })
+})

--- a/apps/mobile/src/lib/adminStrings.ts
+++ b/apps/mobile/src/lib/adminStrings.ts
@@ -1,0 +1,231 @@
+/**
+ * Every word in the operator panel.
+ *
+ * **English, and no locale anywhere near it** — the same sentence
+ * `apps/api/src/routes/operatorPage.ts` carries, because this is the same
+ * surface moved inside the app. Every other screen this app draws is read by
+ * the person it is about; this one is read by us.
+ *
+ * So it is deliberately *not* in `src/i18n/messages/en.ts`. A key there is a
+ * key in eight catalogues, and "Suspend permanently" is not a sentence worth
+ * translating seven times — but the real cost is the other direction:
+ * operator vocabulary would ship in everybody's bundle and land in the
+ * Settings search index, where somebody would eventually find "Suspend" while
+ * looking for something else.
+ *
+ * It lives in `src/lib/` because that is the only directory the mobile vitest
+ * config can load (see `apps/mobile/vitest.config.ts`), and
+ * `adminStrings.test.ts` asserts both halves of this decision: that nothing is
+ * missing here, and that no admin screen reaches for `t()`. The lint rule in
+ * `eslint.config.mjs` refuses the import outright.
+ *
+ * If you are here to "finish the translations": this is finished.
+ */
+export const ADMIN = {
+  entryRow: 'Operator panel',
+
+  warning: 'Operator surface. English only. What you do here affects live accounts.',
+
+  home: {
+    title: 'Operator',
+    reports: 'Reports',
+    appeals: 'Appeals',
+    feedback: 'Bug reports & ideas',
+    broadcast: 'Broadcast',
+    users: 'Find someone',
+    system: 'System',
+    waiting: 'waiting',
+    sections: { queue: 'Waiting', audience: 'People', money: 'Plans & tokens' },
+    joinedToday: 'Joined today',
+    joinedWeek: 'Joined this week',
+    activeToday: 'Active today',
+    seenWeek: 'Seen this week',
+    profiles: 'Profiles',
+    messages: 'Messages',
+    pro: 'Pro',
+    proPlus: 'Pro+',
+    free: 'Free',
+    poolYesterday: 'Yesterday’s pool',
+    poolPaid: 'paid',
+    poolDistributed: 'distributed',
+    poolNone: 'No pool has run yet.',
+    builds: 'Builds',
+    failedToLoad: 'Could not load the dashboard.',
+  },
+
+  reports: {
+    title: 'Reports',
+    tabs: { open: 'Open', reviewing: 'Reviewing', actioned: 'Actioned', dismissed: 'Dismissed' },
+    empty: 'Nothing waiting.',
+    reportedBy: 'reported by',
+    aboutPost: 'About a post',
+    otherReports: (n: number) => `${n} other report${n === 1 ? '' : 's'} against this account`,
+    details: 'What they wrote',
+    noDetails: 'No details were given.',
+    post: 'The post',
+    postHidden: 'Hidden. Nobody can see it, its author included.',
+    account: 'The account',
+    inForce: 'Already suspended — deciding again replaces that.',
+    hide: 'Hide this post',
+    unhide: 'Show it again',
+    suspendDays: 'Suspend for N days',
+    suspendPermanent: 'Suspend permanently',
+    dismiss: 'Dismiss the report',
+    days: 'Days',
+    confirmSuspend: (who: string, days: number) => `Suspend ${who} for ${days} days?`,
+    confirmPermanent: (who: string) => `Suspend ${who} permanently?`,
+    permanentAgain: 'This one does not expire. Type the handle to confirm.',
+    confirmDismiss: 'Dismiss this report? Nothing changes on the account.',
+    done: 'Decided.',
+  },
+
+  appeals: {
+    title: 'Appeals',
+    empty: 'No appeals waiting.',
+    said: 'What they said',
+    shorten: 'Shorten to N days',
+    lift: 'Lift now',
+    keep: 'Keep as is',
+    confirmLift: (who: string) => `Lift the suspension on ${who}?`,
+    confirmKeep: 'Keep the suspension? They are told nothing.',
+  },
+
+  feedback: {
+    title: 'Bug reports & ideas',
+    tabs: { open: 'Open', triaged: 'Paid', closed: 'Closed' },
+    empty: 'Nothing waiting.',
+    from: 'from',
+    attachments: 'Attachments',
+    openIssue: 'Open on GitHub',
+    amount: 'Tokens',
+    pay: (amount: number) => `Pay ${amount} tokens`,
+    confirmPay: (amount: number, who: string) =>
+      `Pay ${amount} tokens to ${who}? This cannot be undone.`,
+    paid: (amount: number) => `Paid ${amount} tokens.`,
+    alreadyPaid: 'This report has already been paid.',
+    close: 'Close without paying',
+    closeReason: 'Why',
+    closeReasons: {
+      fixed: 'Fixed',
+      shipped: 'Shipped',
+      wontfix: 'Won’t fix',
+      duplicate: 'Duplicate',
+      invalid: 'Not a bug',
+    },
+    note: 'Note',
+  },
+
+  broadcast: {
+    title: 'Broadcast',
+    newTitle: 'New broadcast',
+    slug: 'Name',
+    slugHint: 'Lower case, digits and dashes. It is the id that stops it sending twice.',
+    body: 'Message (English)',
+    bodyHint: 'Everyone who speaks another language gets this unless a translation is added.',
+    audience: (n: number) => `${n} people`,
+    createDraft: 'Create draft',
+    empty: 'No broadcasts yet.',
+    status: {
+      draft: 'Draft',
+      queued: 'Queued',
+      sending: 'Sending',
+      paused: 'Paused',
+      done: 'Sent',
+    },
+    test: 'Send it to me first',
+    tested: 'Sent to you. Check the thread and the notification.',
+    confirmPrompt: (n: number) => `Type ${n} to confirm`,
+    confirmHint: 'The number of people this goes to.',
+    start: 'Start sending',
+    confirmStart: (n: number) =>
+      `Send to ${n} people, from @langx? Messages already delivered cannot be recalled.`,
+    pause: 'Stop sending',
+    resume: 'Carry on',
+    deleteDraft: 'Delete draft',
+    confirmDelete: 'Delete this draft?',
+    progress: (sent: number, total: number) => `${sent} of ${total}`,
+    failed: (n: number) => `${n} failed`,
+    stoppedNote: 'Stopped. What has already gone cannot be recalled.',
+  },
+
+  users: {
+    title: 'Find someone',
+    search: 'Handle, user id or email',
+    notFound: 'Nobody by that name or address.',
+    joined: 'Joined',
+    lastSeen: 'Last seen',
+    never: 'never',
+    build: 'Build',
+    plan: 'Plan',
+    email: 'Email',
+    unverified: 'unverified',
+    suspended: 'Suspended',
+    tokensFrozen: 'Earning frozen',
+    unfreeze: 'Unfreeze earning',
+    unfrozen: 'Earning unfrozen.',
+    signOut: 'Sign out everywhere',
+    confirmSignOut: (who: string) => `Sign ${who} out of every device?`,
+    signedOut: (n: number) => `${n} session${n === 1 ? '' : 's'} ended.`,
+    message: 'Message from @langx',
+    messageHint: 'One way — they cannot reply. Say where a reply should go.',
+    send: 'Send',
+    sent: 'Sent.',
+    suspend: 'Suspend',
+    lift: 'Lift suspension',
+    reason: 'Reason',
+    counts: 'Reports & blocks',
+    reportsAgainst: 'against',
+    reportsFiled: 'filed',
+    blockedBy: 'blocked by',
+    history: 'What we have done',
+    noHistory: 'Nothing yet.',
+  },
+
+  diagnose: {
+    discovery: 'Why Discover looks the way it does',
+    discoveryHint: 'Each row is the one above it, narrowed once more.',
+    matches: (n: number) => `${n} people match right now`,
+    notDiscoverable: 'They have turned themselves off in Discover.',
+    languages: 'Languages',
+    push: 'Notifications',
+    noDevices: 'No device has ever registered for push.',
+    deviceOff: 'Notifications switched off on this phone',
+    prefs: 'Switches',
+    suppressed: 'No mail can reach this address',
+    legacy: 'Coming back from v1',
+    staged: 'Old data is staged',
+    reserved: 'Handle was reserved',
+    restored: 'Restored',
+    nothingStaged: 'Nothing staged under either handle.',
+  },
+
+  system: {
+    title: 'System',
+    jobs: 'Scheduled work',
+    jobNever: 'never run',
+    jobFailed: 'last run failed',
+    runs: (n: number) => `${n} runs`,
+    suppressions: 'Addresses no mail may go to',
+    purge: 'Waiting to be purged',
+    purgeAccounts: 'accounts',
+    purgeAnalytics: 'analytics rows',
+    assistant: 'Copilot calls today',
+    campaigns: 'Email campaigns',
+    config: 'Config',
+    maintenance: 'Maintenance',
+    maintenanceOn: 'ON',
+    maintenanceOff: 'off',
+    readOnly:
+      'Read only. The kill switch is scripts/maintenance.ts — a panel served by the API cannot turn the API off.',
+    minVersion: 'Minimum version',
+    flags: 'Flags',
+  },
+
+  common: {
+    back: 'Back',
+    cancel: 'Cancel',
+    confirm: 'Confirm',
+    failed: 'That did not work',
+    loading: 'Loading…',
+  },
+} as const

--- a/apps/mobile/src/lib/adminStrings.ts
+++ b/apps/mobile/src/lib/adminStrings.ts
@@ -124,6 +124,10 @@ export const ADMIN = {
     bodyHint: 'Everyone who speaks another language gets this unless a translation is added.',
     audience: (n: number) => `${n} people`,
     createDraft: 'Create draft',
+    history: 'Past broadcasts',
+    people: 'People',
+    sent: 'Sent',
+    state: 'Status',
     empty: 'No broadcasts yet.',
     status: {
       draft: 'Draft',

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -601,11 +601,24 @@ threshold is visible in the public repo** — the defence is server-side
 enforcement and idempotency, not secrecy.
 
 **Suspension** is the step past a freeze, and it is a person's decision every
-time. The report email carries a signed review link (`email/reviewToken.ts`,
-the same capability-token trade the bug bounty makes) that opens a small HTML
-page: suspend for N days, suspend permanently, or dismiss. There is no admin
-route, no session and no console — the review happens in the mailbox the
-report already arrives in.
+time. There are two doors to that decision and they write the same thing.
+
+The first is the mailbox: the report email carries a signed review link
+(`email/reviewToken.ts`, the same capability-token trade the bug bounty makes)
+that opens a small HTML page — suspend for N days, suspend permanently, or
+dismiss. It needs no session, which is exactly why it is kept: it works when
+nobody can sign in, and it can be handed to somebody who has no account.
+
+The second is the operator panel (`routes/admin.ts`, and
+`app/(app)/admin/` in the app), behind `requireAdmin` — a flag on a profile,
+set by `scripts/grant-admin.ts` and by nothing else. It exists because the
+mailbox could only ever answer one report at a time and could not answer
+"what is still open".
+
+Both call `moderation/decide.ts`, which is the body of the emailed page's POST
+with the HTML taken off. That is what keeps them one decision rather than two
+that drift: the only difference in what they write is `suspension.by`, which
+the panel knows and a capability token cannot.
 
 The state is one field. `suspension.until > now` is the whole of "suspended",
 computed on every check, so expiry needs no cron and nothing to sweep;
@@ -623,7 +636,10 @@ shared link. The profile itself still opens for a signed-in member, carrying
 `accountStatus: 'suspended'` and nothing else: when it ends, why, and whether
 it was appealed belong to the person it is about. One appeal per suspension,
 enforced by the update's own filter, emailed to support with its own signed
-link that can shorten or lift.
+link that can shorten or lift. Answering it — with any of the three answers —
+stamps `suspension.appeal.decidedAt`, which is what takes it out of the
+panel's queue; before that stamp existed, a refused appeal was
+indistinguishable from an unread one and the queue could only grow.
 
 ### Copilot
 
@@ -1320,8 +1336,12 @@ only thing that matters is preserving store identity.
 **P1:** Copilot, badges, availability hours, discovery boost, the "New Users"
 and "Enthusiasts" sort presets. _(Voice messages moved into P0 — the message
 migration needs them.)_
-**P2:** video calls, groups, the **learning module**, moderation console, an
-on-chain distribution layer (after legal review). The learning module — spaced
+**P2:** video calls, groups, the **learning module**, an on-chain distribution
+layer (after legal review). _(The moderation console was on this list and was
+pulled forward: the mailbox flow could decide a report but could not show which
+ones were still open, and three separate things — a frozen `tokenFrozenAt` that
+nothing cleared, an appeal queue that never emptied, a bug report with no
+row — were only visible once somebody tried to build the screen.)_ The learning module — spaced
 repetition over curated per-language, per-level courses — is what this list
 used to call the vocabulary notebook, widened from a personal word list into a
 content product; it is planned in [`learn-module.md`](./learn-module.md).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4536,3 +4536,108 @@ two halves with `$and` instead, and a test pins it.
 Reverting is the constant, the tests named `cross-match fallback`, and the
 second case in the index-usage test. Do it once there are enough profiles for
 the honest rule to fill a page.
+
+## The operator panel, and why the mailbox stays
+
+Every operator decision this app has ever taken was made from `hi@langx.io`.
+A report, an appeal and a bug report each arrived as mail carrying a signed
+link to a small HTML page the API rendered, and that was deliberate: no admin
+route, no session, no console — see `email/reviewToken.ts` for the bargain,
+which is that a forwarded or stolen link can only do things a person can undo.
+
+It worked for deciding. It could not answer **"what is still open"**, and
+three things were only visible once somebody tried to build a screen that
+could:
+
+- `tokenFrozenAt`, which `reportUser` sets after three distinct reporters and
+  which **nothing in the codebase ever cleared**. A report that turned out to
+  be wrong left that person unable to earn a token, permanently and silently.
+- The appeal queue, which could only grow. `lift` removes the whole suspension
+  sub-document so an appeal answered that way disappears; `keep` and `shorten`
+  left the appeal exactly as they found it, so a refused appeal and an unread
+  one were the same row.
+- Bug reports, which had no row at all. `routes/feedback.ts` argued against a
+  collection and the argument was sound — "a copy of a decision taken in an
+  inbox, with no screen able to close a row and nobody looking at the ones left
+  open". The panel is that screen, and the row is not a copy: its `_id` is the
+  uuid `submit.ts` already minted for the emailed bounty link, which is also
+  the ledger's `refId`. One string in three places, so paying from the panel
+  and paying from a six-week-old forwarded mail are physically the same
+  payment.
+
+**The mailbox flow is not removed.** It is the path that still works when
+nobody can sign in, and the one that can be handed to somebody who has no
+account. Both doors call `moderation/decide.ts` — the emailed page's POST with
+the HTML taken off — so the only difference in what they write is
+`suspension.by`, which a capability token cannot know because it authorises
+whoever holds it.
+
+### The parts that were argued about
+
+**Authorisation is a flag on a profile, not `ADMIN_USER_IDS`.** That env var
+already existed and was tempting. It exists to let an id through the
+maintenance gate when the database may itself be the problem, which is a
+different question from who may decide a report — and reading it here would
+have made that depend on a redeploy. `requireAuth` already made one projected
+profile read per request for the suspension check; it projects one more field
+now, so the panel costs no extra round trip.
+
+**The panel is English, and a lint rule points the opposite way to the
+convention.** Every other string in this app comes from `t()` and exists in
+eight catalogues. These do not, for the reason `routes/operatorPage.ts` gives
+about the pages it renders: every other page and mail this service produces is
+read by the person it is about, and this one is read by us. The real cost of
+doing it the usual way is not seven translations of "Suspend permanently" — it
+is that operator vocabulary would ship in everybody's bundle and turn up in the
+Settings search index. `eslint.config.mjs` refuses the i18n import inside
+`app/(app)/admin/**`, `adminStrings.test.ts` asserts no screen reaches for `t()`
+by another route, and the note at the top of `src/lib/adminStrings.ts` says
+why — three layers, because a single one reads as an oversight and the obvious
+next move for whoever finds it is to "finish the translations".
+
+**Maintenance is read only.** `scripts/maintenance.ts` explains why the kill
+switch is a script: it is the control you reach for when something is wrong,
+and it must not depend on the API being healthy enough to authenticate you. On
+top of that, `ALWAYS_OPEN` does not include `/admin/*`, so the panel is already
+503 during maintenance — making it the maintenance switch would have put the
+key behind the door it locks. The feature flags are read only for the same
+reason at one remove: splitting them would make the panel "the thing that
+changes some config", and which half is which is not readable from the screen.
+
+**Job health is its own collection, not `jobRuns`.** `jobRuns` looked like the
+place — two schedulers already write to it. But its unique `{job, periodKey}`
+is a **lock**: the first inserter owns the tick. Giving the other eight passes
+a row there would have handed them lock semantics they were never written for
+and quietly changed which instance runs what. `jobHealth` is a record and only
+a record: one document per job, swallowed write failures, and it rethrows so
+every existing catch still runs. Until it existed, a scheduled pass that
+stopped firing said nothing at all — the first sign would have been somebody
+asking why their streak reminders had stopped.
+
+**The broadcast queue needs no claim collection.** `campaignQueue` has
+`emailCampaigns` beside it because an SMTP send leaves no row we own, so
+nothing can be asked afterwards whether a person was already written to. A chat
+message _is_ the row: `messages.sender_client_id_unique` on
+`{senderId, clientId}` refuses the second write for a recipient and lets every
+other one through. The cursor paces the work and the index makes it exactly
+once, so a batch lost to a crash is simply replayed. There is a test that rolls
+the cursor back and asserts on the **message count** rather than on what the
+pass returned, because `deliverOfficialMessage` hands back the message it found
+and a duplicate looks like success from the caller's side — which is exactly
+how a shared clientId once messaged 25 people and reported five thousand.
+
+**The confirmation for a broadcast is the recipient count, typed.** "SEND" is
+muscle memory. A number proves the preview above it was read, and unlike a word
+it does not depend on what language the operator thinks in. Beside it,
+`/test` delivers the real message to the operator alone first — the only
+preview that catches a broken line break in a translated body before everybody
+gets it.
+
+**A note from `@langx` is one way, and stays one way.** `OFFICIAL_WRITABLE.langx`
+is false, so nothing can be addressed back and the chat screen draws no
+composer on that thread. That was decided when the account was built — a
+broadcast account that sometimes replies is a promise about attention nobody
+can keep — and building a support surface was not the moment to quietly undo
+it. So the feature is right for "we got your report" and wrong for a
+conversation, and what is written should say where a reply goes. A test asserts
+the refusal, so opening that thread stays a decision somebody makes.

--- a/docs/insight.md
+++ b/docs/insight.md
@@ -33,6 +33,14 @@ The right-hand column is not a backlog. Publishing it hands pricing and channel
 strategy to anyone who asks, permanently — a share link can be switched off,
 what has already been read cannot be unread.
 
+Most of that column **is** computed, and is on the operator dashboard:
+`apps/api/src/modules/admin/stats.ts`, served as `GET /admin/stats` behind
+`requireAdmin`. That module is deliberately separate from `publicStats.ts`
+rather than a superset of it, and the separation is the safeguard: this file's
+module is served unauthenticated to the world, so a number added to it is
+published by that act alone. Add a private number to the admin module. The
+admin module reads this one rather than recomputing beside it.
+
 Everything on the left is a count over a whole collection. No document is read
 out, the smallest group is a language, and guests and deleted accounts are
 excluded from every number — a guest is a browsing session with no account

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -388,8 +388,31 @@ Written down so the next person does not have to re-derive them.
 | Scenario                                 | Blocked on                                      |
 | ---------------------------------------- | ----------------------------------------------- |
 | Editor's note as a standalone broadcast  | the monthly note covers it                      |
+| Two-way support in the @langx thread     | `OFFICIAL_WRITABLE.langx` is false on purpose   |
 | Chat messages in the notification centre | the Chats tab is already that inbox             |
 | Backfilled history in the centre         | nothing — it starts empty at deploy, on purpose |
+
+## Messages sent by hand
+
+Two of them, both from `@langx`, both landing in the same chat thread the
+welcome did — not an email and not a push-only broadcast, so they are still
+there next week.
+
+| Message                  | Sent from                                             | Once because                                                      |
+| ------------------------ | ----------------------------------------------------- | ----------------------------------------------------------------- |
+| **A broadcast**          | the operator panel, or `scripts/send-announcement.ts` | `messages.sender_client_id_unique` on `broadcast:<slug>:<userId>` |
+| **A note to one person** | the operator panel's user screen                      | nothing — the same words twice are two messages here              |
+
+A broadcast is a row in `broadcastQueue` that the notification scheduler works
+through, 500 recipients a tick inside 07–21 UTC. That ceiling is **not** a
+deliverability ramp like `campaignDayBudget` — an in-app message has no domain
+reputation to warm up; it bounds the Expo relay, the write rate, and how much
+of a broadcast is already gone by the time somebody presses stop.
+
+Neither can be replied to: `@langx` is a channel, `OFFICIAL_WRITABLE.langx` is
+false, and the chat screen draws no composer on that thread. So a note to one
+person is right for "we got your report" and wrong for a conversation — what
+is written should say where a reply goes.
 
 ## Every message is one format
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,6 +74,47 @@ export default tseslint.config(
     },
   },
   {
+    /*
+     * The operator panel is English, and this rule is the thing that keeps it
+     * that way. Every other screen in this app draws its words from
+     * `src/i18n`; these ones must not, because a key there is a key in eight
+     * catalogues and operator vocabulary would ship in everybody's bundle and
+     * land in the Settings search index. The words live in
+     * `src/lib/adminStrings.ts` — see the note at the top of that file.
+     *
+     * A rule pointing the opposite way to the project's own convention is
+     * deliberate: without it, "finish the translations" is the obvious and
+     * wrong thing for the next person to do here.
+     *
+     * The `Alert` entry is repeated because a file-scoped
+     * `no-restricted-imports` replaces the block above rather than adding to
+     * it — leave it out and `Alert`, which is a silent no-op on the web, is
+     * allowed again in exactly the screens with the most destructive buttons.
+     */
+    files: ['apps/mobile/app/(app)/admin/**/*.tsx', 'apps/mobile/src/lib/adminStrings.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'react-native',
+              importNames: ['Alert'],
+              message: 'Alert is a no-op on react-native-web. Use src/lib/alert.',
+            },
+          ],
+          patterns: [
+            {
+              group: ['**/i18n', '**/i18n/*'],
+              message:
+                'The operator panel is English by design. Its words are in src/lib/adminStrings.ts.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ['**/*.test.ts', '**/*.test.tsx', '**/vitest.config.ts'],
     rules: {
       '@typescript-eslint/no-non-null-assertion': 'off',

--- a/packages/shared/src/admin.ts
+++ b/packages/shared/src/admin.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod'
+import {
+  MODERATION_PAGE_SIZE_DEFAULT,
+  MODERATION_PAGE_SIZE_MAX,
+  REPORT_REASONS,
+  SUSPENSION_MAX_DAYS,
+} from './moderation'
+
+/**
+ * What the operator panel sends.
+ *
+ * The decisions themselves are not here: `reviewDecisionSchema` in
+ * `moderation.ts` is the shape the emailed review form already posts, and the
+ * panel posts the same object to the same function. A second schema saying the
+ * same thing is how the two surfaces would start to disagree.
+ *
+ * What is here is everything the panel needs that a mailbox never did —
+ * paging, searching, and the two actions a report was never behind.
+ */
+
+export const ADMIN_REPORT_TABS = ['open', 'reviewing', 'actioned', 'dismissed'] as const
+export type AdminReportTab = (typeof ADMIN_REPORT_TABS)[number]
+
+export const adminListQuerySchema = z.object({
+  cursor: z.string().trim().min(1).optional(),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(MODERATION_PAGE_SIZE_MAX)
+    .default(MODERATION_PAGE_SIZE_DEFAULT),
+})
+export type AdminListQuery = z.infer<typeof adminListQuerySchema>
+
+export const adminReportListQuerySchema = adminListQuerySchema.extend({
+  status: z.enum(ADMIN_REPORT_TABS).default('open'),
+})
+export type AdminReportListQuery = z.infer<typeof adminReportListQuerySchema>
+
+export const ADMIN_FEEDBACK_TABS = ['open', 'triaged', 'closed'] as const
+export type AdminFeedbackTab = (typeof ADMIN_FEEDBACK_TABS)[number]
+
+export const adminFeedbackListQuerySchema = adminListQuerySchema.extend({
+  status: z.enum(ADMIN_FEEDBACK_TABS).default('open'),
+})
+export type AdminFeedbackListQuery = z.infer<typeof adminFeedbackListQuerySchema>
+
+/**
+ * Finding one person. A handle, a previous handle, a user id or an email
+ * address — whichever the operator happens to have, which in a support thread
+ * is usually the address.
+ */
+export const adminUserSearchSchema = z.object({
+  q: z.string().trim().min(2).max(120),
+})
+export type AdminUserSearch = z.infer<typeof adminUserSearchSchema>
+
+/**
+ * Suspending somebody the panel found rather than somebody a report named.
+ *
+ * No `permanent` here, deliberately. A suspension that never ends should be
+ * reached from the report that justifies it, where the reason and the evidence
+ * are on the same screen — not from a search box. The panel offers permanence
+ * on the report screen and a number of days here.
+ */
+export const adminSuspendSchema = z.object({
+  reason: z.enum(REPORT_REASONS),
+  days: z.coerce.number().int().min(1).max(SUSPENSION_MAX_DAYS),
+})
+export type AdminSuspendInput = z.infer<typeof adminSuspendSchema>
+
+/** A message sent from `@langx` to one person, from the panel. */
+export const ADMIN_MESSAGE_MAX_LENGTH = 2000
+export const adminMessageSchema = z.object({
+  body: z.string().trim().min(1).max(ADMIN_MESSAGE_MAX_LENGTH),
+})
+export type AdminMessageInput = z.infer<typeof adminMessageSchema>
+
+/**
+ * Every mutating thing the panel can do, as the audit log names it.
+ *
+ * A closed list rather than free text: these end up in a collection nobody
+ * deletes from, and "what has been done to this account" is only answerable if
+ * the answers are drawn from a fixed vocabulary.
+ */
+export const ADMIN_ACTIONS = [
+  'report.decide',
+  'appeal.decide',
+  'user.suspend',
+  'user.lift',
+  'user.unfreeze',
+  'user.signOut',
+  'user.message',
+  'post.hide',
+  'post.unhide',
+  'feedback.update',
+  'feedback.award',
+  'broadcast.create',
+  'broadcast.test',
+  'broadcast.start',
+  'broadcast.pause',
+  'broadcast.resume',
+  'broadcast.delete',
+] as const
+export type AdminActionName = (typeof ADMIN_ACTIONS)[number]

--- a/packages/shared/src/admin.ts
+++ b/packages/shared/src/admin.ts
@@ -103,3 +103,62 @@ export const ADMIN_ACTIONS = [
   'broadcast.delete',
 ] as const
 export type AdminActionName = (typeof ADMIN_ACTIONS)[number]
+
+/**
+ * How many people one scheduler tick messages.
+ *
+ * Not a deliverability ramp. `campaignDayBudget` exists because mailbox
+ * providers judge a domain by how suddenly it starts sending, and an in-app
+ * message has no reputation to warm up — copying that ramp here would be
+ * cargo cult. What this bounds is the Expo relay, the write rate, and the
+ * blast radius of a broadcast somebody wants to stop halfway.
+ */
+export const BROADCAST_PER_TICK = 500
+
+/**
+ * The hours a broadcast may go out in, UTC.
+ *
+ * The *message* could land at any hour; the push beside it could not, and
+ * there is one push per message. Recipients have timezones on file, but
+ * batching by timezone would mean an audience query per zone per tick for a
+ * gain nobody has asked for — so this is the same blunt compromise
+ * `CAMPAIGN_SEND_WINDOW_UTC` makes, widened by an hour at each end because a
+ * chat message is a smaller intrusion than a marketing mail.
+ */
+export const BROADCAST_SEND_WINDOW_UTC = { from: 7, to: 21 } as const
+
+/**
+ * How many this tick may send: the per-tick ceiling inside the window, zero
+ * outside it.
+ */
+export function broadcastTickShare(now: Date): number {
+  const hour = now.getUTCHours()
+  if (hour < BROADCAST_SEND_WINDOW_UTC.from || hour >= BROADCAST_SEND_WINDOW_UTC.to) return 0
+  return BROADCAST_PER_TICK
+}
+
+export const BROADCAST_STATUSES = ['draft', 'queued', 'sending', 'paused', 'done'] as const
+export type BroadcastStatus = (typeof BROADCAST_STATUSES)[number]
+
+/**
+ * The slug is the primary key, so "you cannot start the same broadcast twice"
+ * is the database's answer rather than a check. Same shape as the `--id` the
+ * announcement script has always taken.
+ */
+export const broadcastCreateSchema = z
+  .object({
+    id: z
+      .string()
+      .trim()
+      .min(3)
+      .max(64)
+      .regex(/^[a-z0-9][a-z0-9-]*$/, 'Lower case, digits and dashes'),
+    /** One body per locale. `en` is required — it is the fallback. */
+    bodies: z.record(z.string(), z.string().trim().min(1).max(4000)),
+    pushTitle: z.string().trim().min(1).max(60).default('LangX'),
+  })
+  .refine((input) => typeof input.bodies.en === 'string', {
+    message: 'An English body is required — it is the fallback',
+    path: ['bodies', 'en'],
+  })
+export type BroadcastCreateInput = z.infer<typeof broadcastCreateSchema>

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -29,6 +29,20 @@ export const ERROR_CODES = {
    * second request, the way `retryAt` rides on `RATE_LIMITED`.
    */
   ACCOUNT_SUSPENDED: 'ACCOUNT_SUSPENDED',
+  /**
+   * A signed-in account that is not a moderator asked for something under
+   * `/admin`.
+   *
+   * Its own code rather than `FORBIDDEN` because the client's answer is to
+   * hide the entry and forget it ever drew one — the flag on
+   * `GET /profiles/me` is what normally decides that, and this is the stale
+   * client and the hostile one.
+   *
+   * The message carries no detail on purpose. The repository is public, so the
+   * routes are already known, and confirming which of them exist for whom
+   * gains nothing.
+   */
+  ADMIN_REQUIRED: 'ADMIN_REQUIRED',
 
   // entitlement + quota
   UPGRADE_REQUIRED: 'UPGRADE_REQUIRED',
@@ -159,6 +173,7 @@ export const ERROR_STATUS: Record<ErrorCode, number> = {
   GUEST_ACCOUNT: 403,
   UNDERAGE: 403,
   ACCOUNT_SUSPENDED: 403,
+  ADMIN_REQUIRED: 403,
   UPGRADE_REQUIRED: 403,
   QUOTA_EXCEEDED: 402,
   MEDIA_LOCKED: 409,

--- a/packages/shared/src/feedback.ts
+++ b/packages/shared/src/feedback.ts
@@ -5,12 +5,17 @@ import { z } from 'zod'
  * What somebody sends us from inside the app: a bug they hit, or a feature
  * they want.
  *
- * It is **mail and an issue, not a record of ours**: the message is sent to
- * the address the API's `SUPPORT_EMAIL` names and opened as an issue on the
- * repository, and nothing is written to our database. Whoever reads that
- * mailbox is the one who confirms it and decides what the sender is paid, so a
- * collection here would be a second copy of a decision made somewhere else —
- * and one nobody would ever go back and close.
+ * It goes three places: a row in `feedback`, a mail to the address the API's
+ * `SUPPORT_EMAIL` names, and a prefilled link to open it as an issue on the
+ * repository.
+ *
+ * The row is the newest of the three and was argued against for a long time —
+ * "a second copy of a decision made somewhere else, and one nobody would ever
+ * go back and close". What changed is that there is now a screen that closes
+ * it, and that the row is not a copy: its `_id` is the id the bounty link
+ * carries, so the row, the link and the ledger's `refId` are one string, and a
+ * report paid from the panel and the same report paid from a forwarded mail
+ * are the same payment rather than two.
  *
  * That is also why no amount appears on the screen that posts here. What a
  * confirmed report is worth is a judgement made per report; the bounds below

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from './account'
 export * from './accountAge'
+export * from './admin'
 export * from './age'
 export * from './appConfig'
 export * from './appIdentity'


### PR DESCRIPTION
Every operator decision LangX has ever taken was made from `hi@langx.io`: a
report, an appeal and a bug report each arrived as mail carrying a signed link
to a small HTML page the API rendered. That worked for *deciding*. It could not
answer **"what is still open"** — and three things turned out to be broken only
once there was a screen that could.

## What was quietly wrong

- **`tokenFrozenAt` was never cleared by anything.** `reportUser` sets it after
  three distinct reporters; grep the repo and there is no `$unset`. A report
  that turned out to be wrong left that person unable to earn a token,
  permanently and silently.
- **The appeal queue could only grow.** `lift` removes the whole suspension
  sub-document so an appeal answered that way disappears — but `keep` and
  `shorten` left the appeal exactly as they found it, so a refused appeal and
  an unread one were the same row.
- **Bug reports had no row at all.** Only a mail and a prefilled GitHub link.
  Delete the mail and the report is gone.

## What this adds

| | |
| --- | --- |
| **Dashboard** | queue depths, signups, DAU, plan mix, yesterday's pool, build spread, job health |
| **Reports + appeals** | the same decisions the emailed link makes, as a queue |
| **Bug reports** | a real collection, oldest-open-first, with the bounty payment |
| **Broadcast** | `@langx` to everybody, paced by the scheduler instead of a laptop |
| **One account** | search by handle/id/email, suspend, lift, thaw, sign out, write to |
| **Diagnosis** | why Discover is empty · devices and push · notification switches · v1 restore |
| **System** | scheduled jobs, mail suppressions, purge queue, config (read only) |

## The decisions worth reviewing

**The mailbox flow is not removed.** It is the path that still works when
nobody can sign in, and the one that can be handed to somebody with no account.
Both doors call `moderation/decide.ts` — the emailed page's POST with the HTML
taken off — so the only difference in what they write is `suspension.by`, which
a capability token cannot know. There is a test that suspends the same way
through both and compares the sub-documents.

**Authorisation is `profiles.admin`, not `ADMIN_USER_IDS`.** That env var
exists to let an id through the maintenance gate when the database may itself
be the problem; reading it here would make who can moderate depend on a
redeploy. `requireAuth` already made one projected profile read per request, so
this costs no extra round trip. `scripts/grant-admin.ts` prefers flipping the
flag on an account that already exists over minting a credential.

**The panel is English, and a lint rule points the opposite way to the
convention.** Words live in `src/lib/adminStrings.ts`. The cost of doing it the
usual way is not seven translations of "Suspend permanently" — it is that
operator vocabulary ships in everybody's bundle and lands in the Settings
search index.

**Job health is its own collection.** `jobRuns` looked like the place, but its
unique `{job, periodKey}` is a *lock* — giving the other eight schedulers a row
there would have handed them lock semantics they were never written for.

**The broadcast queue has no claim collection.** A chat message *is* the row:
`messages.sender_client_id_unique` refuses the second write per recipient. A
test rolls the cursor back mid-broadcast and asserts on the **message count**,
not on what the pass returned — `deliverOfficialMessage` hands back the message
it found, which is how a shared clientId once messaged 25 people and reported
five thousand.

**A note from `@langx` is one way and stays one way.**
`OFFICIAL_WRITABLE.langx` is false; the test asserts the refusal, so opening
that thread stays a decision somebody makes.

**Maintenance is read only.** `ALWAYS_OPEN` does not include `/admin/*`, so the
panel is already 503 during maintenance — making it the maintenance switch
would put the key behind the door it locks.

## Not in scope, deliberately

Granting a plan tier (a DB-only grant is wiped by `/billing/refresh`; it would
be a broken button), deleting a post, impersonation, PostHog numbers (no
server-side read client, and adding one means a personal API key on the API),
starting email campaigns, and broadcast targeting.

## Before this is useful on production

```bash
ADMIN_PASSWORD=… pnpm --filter @langx/api exec tsx --env-file=../../.env \
  --env-file=../../.env.prod scripts/grant-admin.ts --email <your address> --confirm
```

Then the row appears at the foot of Settings. The API needs a deploy; the
panel itself rides the OTA.

## Verification

`pnpm -r typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` — all green:
**2627 tests**, 19 of them new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)